### PR TITLE
Introduce per-source DataUpdateCoordinator for UniFi polling data sources

### DIFF
--- a/homeassistant/components/unifi/coordinator.py
+++ b/homeassistant/components/unifi/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from aiounifi.interfaces.api_handlers import APIHandler
 
@@ -13,8 +13,6 @@ from .const import LOGGER
 
 if TYPE_CHECKING:
     from .hub.hub import UnifiHub
-
-HandlerT = TypeVar("HandlerT", bound=APIHandler)
 
 POLL_INTERVAL = timedelta(seconds=10)
 

--- a/homeassistant/components/unifi/coordinator.py
+++ b/homeassistant/components/unifi/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from aiounifi.interfaces.api_handlers import APIHandler
 
@@ -15,17 +15,19 @@ if TYPE_CHECKING:
     from . import UnifiConfigEntry
     from .hub.hub import UnifiHub
 
+HandlerT = TypeVar("HandlerT", bound=APIHandler)
+
 POLL_INTERVAL = timedelta(seconds=10)
 
 
-class UnifiDataUpdateCoordinator(DataUpdateCoordinator[None]):
+class UnifiDataUpdateCoordinator[HandlerT: APIHandler](DataUpdateCoordinator[None]):
     """Coordinator managing polling for a single UniFi API data source."""
 
     def __init__(
         self,
         hub: UnifiHub,
         config_entry: UnifiConfigEntry,
-        handler: APIHandler,
+        handler: HandlerT,
     ) -> None:
         """Initialize coordinator."""
         super().__init__(
@@ -33,11 +35,15 @@ class UnifiDataUpdateCoordinator(DataUpdateCoordinator[None]):
             LOGGER,
             name=f"UniFi {type(handler).__name__}",
             config_entry=config_entry,
-            update_method=self._async_update,
             update_interval=POLL_INTERVAL,
         )
         self._handler = handler
 
-    async def _async_update(self) -> None:
+    @property
+    def handler(self) -> HandlerT:
+        """Return the aiounifi handler managed by this coordinator."""
+        return self._handler
+
+    async def _async_update_data(self) -> None:
         """Update data from the API handler."""
         await self._handler.update()

--- a/homeassistant/components/unifi/coordinator.py
+++ b/homeassistant/components/unifi/coordinator.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import LOGGER
 
 if TYPE_CHECKING:
-    from . import UnifiConfigEntry
     from .hub.hub import UnifiHub
 
 HandlerT = TypeVar("HandlerT", bound=APIHandler)
@@ -26,7 +25,6 @@ class UnifiDataUpdateCoordinator[HandlerT: APIHandler](DataUpdateCoordinator[Non
     def __init__(
         self,
         hub: UnifiHub,
-        config_entry: UnifiConfigEntry,
         handler: HandlerT,
     ) -> None:
         """Initialize coordinator."""
@@ -34,7 +32,7 @@ class UnifiDataUpdateCoordinator[HandlerT: APIHandler](DataUpdateCoordinator[Non
             hub.hass,
             LOGGER,
             name=f"UniFi {type(handler).__name__}",
-            config_entry=config_entry,
+            config_entry=hub.config.entry,
             update_interval=POLL_INTERVAL,
         )
         self._handler = handler

--- a/homeassistant/components/unifi/coordinator.py
+++ b/homeassistant/components/unifi/coordinator.py
@@ -1,0 +1,43 @@
+"""UniFi Network data update coordinator."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from aiounifi.interfaces.api_handlers import APIHandler
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import LOGGER
+
+if TYPE_CHECKING:
+    from . import UnifiConfigEntry
+    from .hub.hub import UnifiHub
+
+POLL_INTERVAL = timedelta(seconds=10)
+
+
+class UnifiDataUpdateCoordinator(DataUpdateCoordinator[None]):
+    """Coordinator managing polling for a single UniFi API data source."""
+
+    def __init__(
+        self,
+        hub: UnifiHub,
+        config_entry: UnifiConfigEntry,
+        handler: APIHandler,
+    ) -> None:
+        """Initialize coordinator."""
+        super().__init__(
+            hub.hass,
+            LOGGER,
+            name=f"UniFi {type(handler).__name__}",
+            config_entry=config_entry,
+            update_method=self._async_update,
+            update_interval=POLL_INTERVAL,
+        )
+        self._handler = handler
+
+    async def _async_update(self) -> None:
+        """Update data from the API handler."""
+        await self._handler.update()

--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import aiounifi
 from aiounifi.interfaces.api_handlers import (

--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import aiounifi
 from aiounifi.interfaces.api_handlers import (
@@ -94,16 +94,14 @@ def async_client_device_info_fn(hub: UnifiHub, obj_id: str) -> DeviceInfo:
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
-    EntityDescription
-):
+class UnifiEntityDescription[HandlerT: APIHandler, ItemT: ApiItem](EntityDescription):
     """UniFi Entity Description."""
 
     api_handler_fn: Callable[[aiounifi.Controller], HandlerT]
     """Provide api_handler from api."""
     device_info_fn: Callable[[UnifiHub, str], DeviceInfo | None]
     """Provide device info object based on hub and obj_id."""
-    object_fn: Callable[[aiounifi.Controller, str], ApiItemT]
+    object_fn: Callable[[aiounifi.Controller, str], ItemT]
     """Retrieve object based on api and obj_id."""
     unique_id_fn: Callable[[UnifiHub, str], str]
     """Provide a unique ID based on hub and obj_id."""
@@ -113,7 +111,7 @@ class UnifiEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
     """Determine if config entry options allow creation of entity."""
     available_fn: Callable[[UnifiHub, str], bool] = lambda hub, obj_id: hub.available
     """Determine if entity is available, default is if connection is working."""
-    name_fn: Callable[[ApiItemT], str | None] = lambda obj: None
+    name_fn: Callable[[ItemT], str | None] = lambda obj: None
     """Entity name function, can be used to extend entity name beyond device name."""
     supported_fn: Callable[[UnifiHub, str], bool] = lambda hub, obj_id: True
     """Determine if UniFi object supports providing relevant data for entity."""
@@ -129,17 +127,17 @@ class UnifiEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
     """If entity needs to do regular checks on state."""
 
 
-class UnifiEntity[HandlerT: APIHandler, ApiItemT: ApiItem](Entity):
+class UnifiEntity[HandlerT: APIHandler, ItemT: ApiItem](Entity):
     """Representation of a UniFi entity."""
 
-    entity_description: UnifiEntityDescription[HandlerT, ApiItemT]
+    entity_description: UnifiEntityDescription[HandlerT, ItemT]
     _attr_unique_id: str
 
     def __init__(
         self,
         obj_id: str,
         hub: UnifiHub,
-        description: UnifiEntityDescription[HandlerT, ApiItemT],
+        description: UnifiEntityDescription[HandlerT, ItemT],
     ) -> None:
         """Set up UniFi switch entity."""
         self._obj_id = obj_id
@@ -257,6 +255,11 @@ class UnifiEntity[HandlerT: APIHandler, ApiItemT: ApiItem](Entity):
         Defaults to using async_update_state to set initial state.
         """
         self.async_update_state(ItemEvent.ADDED, self._obj_id)
+
+    @callback
+    def get_object(self) -> ItemT:
+        """Return the latest object for this entity."""
+        return self.entity_description.object_fn(self.api, self._obj_id)
 
     @callback
     @abstractmethod

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -25,7 +25,6 @@ from ..coordinator import UnifiDataUpdateCoordinator
 from ..entity import UnifiEntity, UnifiEntityDescription
 
 if TYPE_CHECKING:
-    from .. import UnifiConfigEntry
     from .hub import UnifiHub
 
 CHECK_HEARTBEAT_INTERVAL = timedelta(seconds=1)
@@ -34,9 +33,10 @@ CHECK_HEARTBEAT_INTERVAL = timedelta(seconds=1)
 class UnifiEntityLoader:
     """UniFi Network integration handling platforms for entity registration."""
 
-    def __init__(self, hub: UnifiHub, config_entry: UnifiConfigEntry) -> None:
+    def __init__(self, hub: UnifiHub) -> None:
         """Initialize the UniFi entity loader."""
         self.hub = hub
+        config_entry = hub.config.entry
         self.api_updaters = (
             hub.api.clients.update,
             hub.api.clients_all.update,

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -19,9 +19,9 @@ from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from ..const import LOGGER, UNIFI_WIRELESS_CLIENTS
+from ..coordinator import UnifiDataUpdateCoordinator
 from ..entity import UnifiEntity, UnifiEntityDescription
 
 if TYPE_CHECKING:
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from .hub import UnifiHub
 
 CHECK_HEARTBEAT_INTERVAL = timedelta(seconds=1)
-POLL_INTERVAL = timedelta(seconds=10)
 
 
 class UnifiEntityLoader:
@@ -48,28 +47,16 @@ class UnifiEntityLoader:
             hub.api.sites.update,
             hub.api.system_information.update,
             hub.api.firewall_policies.update,
-            hub.api.traffic_rules.update,
-            hub.api.traffic_routes.update,
             hub.api.wlans.update,
-        )
-        self.polling_api_updaters = (
-            hub.api.traffic_rules.update,
-            hub.api.traffic_routes.update,
         )
         self.wireless_clients = hub.hass.data[UNIFI_WIRELESS_CLIENTS]
 
-        self._data_update_coordinator = DataUpdateCoordinator(
-            hub.hass,
-            LOGGER,
-            name="Unifi entity poller",
-            config_entry=config_entry,
-            update_method=self._update_pollable_api_data,
-            update_interval=POLL_INTERVAL,
-        )
-
-        self._update_listener = self._data_update_coordinator.async_add_listener(
-            update_callback=lambda: None
-        )
+        self._polling_coordinators = [
+            UnifiDataUpdateCoordinator(hub, config_entry, hub.api.traffic_rules),
+            UnifiDataUpdateCoordinator(hub, config_entry, hub.api.traffic_routes),
+        ]
+        for coordinator in self._polling_coordinators:
+            coordinator.async_add_listener(lambda: None)
 
         self.platforms: list[
             tuple[
@@ -99,10 +86,6 @@ class UnifiEntityLoader:
         for result in results:
             if result is not None:
                 LOGGER.warning("Exception on update %s", result)
-
-    async def _update_pollable_api_data(self) -> None:
-        """Refresh API data for pollable updaters."""
-        await self._refresh_data(self.polling_api_updaters)
 
     async def _refresh_api_data(self) -> None:
         """Refresh API data from network application."""

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -36,7 +36,6 @@ class UnifiEntityLoader:
     def __init__(self, hub: UnifiHub) -> None:
         """Initialize the UniFi entity loader."""
         self.hub = hub
-        config_entry = hub.config.entry
         self.api_updaters = (
             hub.api.clients.update,
             hub.api.clients_all.update,
@@ -53,10 +52,10 @@ class UnifiEntityLoader:
 
         self._polling_coordinators: dict[int, UnifiDataUpdateCoordinator] = {
             id(hub.api.traffic_rules): UnifiDataUpdateCoordinator(
-                hub, config_entry, hub.api.traffic_rules
+                hub, hub.api.traffic_rules
             ),
             id(hub.api.traffic_routes): UnifiDataUpdateCoordinator(
-                hub, config_entry, hub.api.traffic_routes
+                hub, hub.api.traffic_routes
             ),
         }
         for coordinator in self._polling_coordinators.values():

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
-from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 
 from homeassistant.const import Platform
 from homeassistant.core import callback
@@ -51,11 +51,15 @@ class UnifiEntityLoader:
         )
         self.wireless_clients = hub.hass.data[UNIFI_WIRELESS_CLIENTS]
 
-        self._polling_coordinators = [
-            UnifiDataUpdateCoordinator(hub, config_entry, hub.api.traffic_rules),
-            UnifiDataUpdateCoordinator(hub, config_entry, hub.api.traffic_routes),
-        ]
-        for coordinator in self._polling_coordinators:
+        self._polling_coordinators: dict[int, UnifiDataUpdateCoordinator] = {
+            id(hub.api.traffic_rules): UnifiDataUpdateCoordinator(
+                hub, config_entry, hub.api.traffic_rules
+            ),
+            id(hub.api.traffic_routes): UnifiDataUpdateCoordinator(
+                hub, config_entry, hub.api.traffic_routes
+            ),
+        }
+        for coordinator in self._polling_coordinators.values():
             coordinator.async_add_listener(lambda: None)
 
         self.platforms: list[
@@ -72,7 +76,13 @@ class UnifiEntityLoader:
 
     async def initialize(self) -> None:
         """Initialize API data and extra client support."""
-        await self._refresh_api_data()
+        await asyncio.gather(
+            self._refresh_api_data(),
+            *[
+                coordinator.async_config_entry_first_refresh()
+                for coordinator in self._polling_coordinators.values()
+            ],
+        )
         self._restore_inactive_clients()
         self.wireless_clients.update_clients(set(self.hub.api.clients.values()))
 
@@ -147,6 +157,13 @@ class UnifiEntityLoader:
             and description.allowed_fn(self.hub, obj_id)
             and description.supported_fn(self.hub, obj_id)
         )
+
+    @callback
+    def get_data_update_coordinator(
+        self, handler: APIHandler
+    ) -> UnifiDataUpdateCoordinator | None:
+        """Return the polling coordinator for a handler, if available."""
+        return self._polling_coordinators.get(id(handler))
 
     @callback
     def _load_entities(

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -77,10 +77,12 @@ class UnifiEntityLoader:
         """Initialize API data and extra client support."""
         await asyncio.gather(
             self._refresh_api_data(),
-            *[
-                coordinator.async_config_entry_first_refresh()
-                for coordinator in self._polling_coordinators.values()
-            ],
+            self._refresh_data(
+                [
+                    coordinator.async_refresh
+                    for coordinator in self._polling_coordinators.values()
+                ]
+            ),
         )
         self._restore_inactive_clients()
         self.wireless_clients.update_clients(set(self.hub.api.clients.values()))

--- a/homeassistant/components/unifi/hub/hub.py
+++ b/homeassistant/components/unifi/hub/hub.py
@@ -39,7 +39,7 @@ class UnifiHub:
         self.hass = hass
         self.api = api
         self.config = UnifiConfig.from_config_entry(config_entry)
-        self.entity_loader = UnifiEntityLoader(self, config_entry)
+        self.entity_loader = UnifiEntityLoader(self)
         self._entity_helper = UnifiEntityHelper(hass, api)
         self.websocket = UnifiWebsocket(hass, api, self.signal_reachable)
 

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -208,8 +208,6 @@ async def async_traffic_rule_control_fn(
     """Control traffic rule state."""
     traffic_rule = hub.api.traffic_rules[obj_id].raw
     await hub.api.request(TrafficRuleEnableRequest.create(traffic_rule, target))
-    # Update the traffic rules so the UI is updated appropriately
-    await hub.api.traffic_rules.update()
 
 
 async def async_traffic_route_control_fn(
@@ -218,8 +216,6 @@ async def async_traffic_route_control_fn(
     """Control traffic route state."""
     traffic_route = hub.api.traffic_routes[obj_id].raw
     await hub.api.request(TrafficRouteSaveRequest.create(traffic_route, target))
-    # Update the traffic routes so the UI is updated appropriately
-    await hub.api.traffic_routes.update()
 
 
 async def async_wlan_control_fn(hub: UnifiHub, obj_id: str, target: bool) -> None:
@@ -447,10 +443,18 @@ class UnifiSwitchEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
         await self.entity_description.control_fn(self.hub, self._obj_id, True)
+        if coordinator := self.hub.entity_loader.get_data_update_coordinator(
+            self.entity_description.api_handler_fn(self.api)
+        ):
+            await coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         await self.entity_description.control_fn(self.hub, self._obj_id, False)
+        if coordinator := self.hub.entity_loader.get_data_update_coordinator(
+            self.entity_description.api_handler_fn(self.api)
+        ):
+            await coordinator.async_request_refresh()
 
     @callback
     def async_update_state(
@@ -464,7 +468,7 @@ class UnifiSwitchEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
             return
 
         description = self.entity_description
-        obj = description.object_fn(self.api, self._obj_id)
+        obj = self.get_object()
         if (is_on := description.is_on_fn(self.hub, obj)) != self.is_on:
             self._attr_is_on = is_on
 

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1196,6 +1196,7 @@ async def test_traffic_rules(
     )
 
     call_count = aioclient_mock.call_count
+    traffic_rule_payload[0]["enabled"] = False
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -1209,8 +1210,10 @@ async def test_traffic_rules(
     expected_disable_call["enabled"] = False
 
     assert aioclient_mock.mock_calls[call_count][2] == expected_disable_call
+    assert hass.states.get("switch.unifi_network_test_traffic_rule").state == STATE_OFF
 
     call_count = aioclient_mock.call_count
+    traffic_rule_payload[0]["enabled"] = True
 
     # Enable traffic rule
     await hass.services.async_call(
@@ -1225,6 +1228,7 @@ async def test_traffic_rules(
 
     assert aioclient_mock.call_count == call_count + 2
     assert aioclient_mock.mock_calls[call_count][2] == expected_enable_call
+    assert hass.states.get("switch.unifi_network_test_traffic_rule").state == STATE_ON
 
 
 @pytest.mark.parametrize(("traffic_route_payload"), [([TRAFFIC_ROUTE])])
@@ -1250,6 +1254,7 @@ async def test_traffic_routes(
     )
 
     call_count = aioclient_mock.call_count
+    traffic_route_payload[0]["enabled"] = False
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -1263,8 +1268,10 @@ async def test_traffic_routes(
     expected_disable_call["enabled"] = False
 
     assert aioclient_mock.mock_calls[call_count][2] == expected_disable_call
+    assert hass.states.get("switch.unifi_network_test_traffic_route").state == STATE_OFF
 
     call_count = aioclient_mock.call_count
+    traffic_route_payload[0]["enabled"] = True
 
     # Enable traffic route
     await hass.services.async_call(
@@ -1279,6 +1286,7 @@ async def test_traffic_routes(
 
     assert aioclient_mock.call_count == call_count + 2
     assert aioclient_mock.mock_calls[call_count][2] == expected_enable_call
+    assert hass.states.get("switch.unifi_network_test_traffic_route").state == STATE_ON
 
 
 @pytest.mark.parametrize(("firewall_policy_payload"), [([FIREWALL_POLICY])])

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from aiounifi.models.message import MessageKey
 import pytest
-from syrupy.assertion import SnapshotAssertion
+from syrupy import SnapshotAssertion
 
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
@@ -20,7 +20,7 @@ from homeassistant.components.unifi.const import (
     CONF_SITE_ID,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
-    DOMAIN,
+    DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
@@ -150,7 +150,6 @@ DEVICE_1 = {
             "portconf_id": "1a1",
             "port_poe": True,
             "up": True,
-            "enable": True,
         },
         {
             "media": "GE",
@@ -165,7 +164,6 @@ DEVICE_1 = {
             "portconf_id": "1a2",
             "port_poe": True,
             "up": True,
-            "enable": True,
         },
         {
             "media": "GE",
@@ -180,7 +178,6 @@ DEVICE_1 = {
             "portconf_id": "1a3",
             "port_poe": False,
             "up": True,
-            "enable": True,
         },
         {
             "media": "GE",
@@ -195,7 +192,6 @@ DEVICE_1 = {
             "portconf_id": "1a4",
             "port_poe": True,
             "up": True,
-            "enable": True,
         },
     ],
     "state": 1,
@@ -964,7 +960,7 @@ async def test_switches(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         "turn_off",
-        {"entity_id": "switch.unifi_network_block_media_streaming"},
+        {"entity_id": "switch.block_media_streaming"},
         blocking=True,
     )
     assert aioclient_mock.call_count == 1
@@ -973,7 +969,7 @@ async def test_switches(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         "turn_on",
-        {"entity_id": "switch.unifi_network_block_media_streaming"},
+        {"entity_id": "switch.block_media_streaming"},
         blocking=True,
     )
     assert aioclient_mock.call_count == 2
@@ -994,7 +990,7 @@ async def test_remove_switches(
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2
 
     assert hass.states.get("switch.block_client_2") is not None
-    assert hass.states.get("switch.unifi_network_block_media_streaming") is not None
+    assert hass.states.get("switch.block_media_streaming") is not None
 
     mock_websocket_message(message=MessageKey.CLIENT_REMOVED, data=[UNBLOCKED])
     await hass.async_block_till_done()
@@ -1002,12 +998,12 @@ async def test_remove_switches(
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
     assert hass.states.get("switch.block_client_2") is None
-    assert hass.states.get("switch.unifi_network_block_media_streaming") is not None
+    assert hass.states.get("switch.block_media_streaming") is not None
 
     mock_websocket_message(data=DPI_GROUP_REMOVED_EVENT)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.unifi_network_block_media_streaming") is None
+    assert hass.states.get("switch.block_media_streaming") is None
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
@@ -1092,22 +1088,18 @@ async def test_dpi_switches(
     """Test the update_items function with some clients."""
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
-    assert (
-        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
-    )
+    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
 
     mock_websocket_message(data=DPI_APP_DISABLED_EVENT)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_OFF
-    )
+    assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
 
     # Remove app
     mock_websocket_message(data=DPI_GROUP_REMOVE_APP)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.unifi_network_block_media_streaming") is None
+    assert hass.states.get("switch.block_media_streaming") is None
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
@@ -1119,9 +1111,7 @@ async def test_dpi_switches_add_second_app(
 ) -> None:
     """Test the update_items function with some clients."""
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
-    assert (
-        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
-    )
+    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
 
     second_app_event = {
         "apps": [524292],
@@ -1135,9 +1125,7 @@ async def test_dpi_switches_add_second_app(
     mock_websocket_message(message=MessageKey.DPI_APP_ADDED, data=second_app_event)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
-    )
+    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
 
     add_second_app_to_group = {
         "_id": "5f976f4ae3c58f018ec7dff6",
@@ -1150,9 +1138,7 @@ async def test_dpi_switches_add_second_app(
     )
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_OFF
-    )
+    assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
 
     second_app_event_enabled = {
         "apps": [524292],
@@ -1168,9 +1154,7 @@ async def test_dpi_switches_add_second_app(
     )
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
-    )
+    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
 
 
 @pytest.mark.parametrize(("traffic_rule_payload"), [([TRAFFIC_RULE])])
@@ -1196,8 +1180,6 @@ async def test_traffic_rules(
     )
 
     call_count = aioclient_mock.call_count
-    traffic_rule_payload[0] = deepcopy(traffic_rule_payload[0])
-    traffic_rule_payload[0]["enabled"] = False
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -1211,10 +1193,8 @@ async def test_traffic_rules(
     expected_disable_call["enabled"] = False
 
     assert aioclient_mock.mock_calls[call_count][2] == expected_disable_call
-    assert hass.states.get("switch.unifi_network_test_traffic_rule").state == STATE_OFF
 
     call_count = aioclient_mock.call_count
-    traffic_rule_payload[0]["enabled"] = True
 
     # Enable traffic rule
     await hass.services.async_call(
@@ -1229,7 +1209,6 @@ async def test_traffic_rules(
 
     assert aioclient_mock.call_count == call_count + 2
     assert aioclient_mock.mock_calls[call_count][2] == expected_enable_call
-    assert hass.states.get("switch.unifi_network_test_traffic_rule").state == STATE_ON
 
 
 @pytest.mark.parametrize(("traffic_route_payload"), [([TRAFFIC_ROUTE])])
@@ -1255,8 +1234,6 @@ async def test_traffic_routes(
     )
 
     call_count = aioclient_mock.call_count
-    traffic_route_payload[0] = deepcopy(traffic_route_payload[0])
-    traffic_route_payload[0]["enabled"] = False
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -1270,10 +1247,8 @@ async def test_traffic_routes(
     expected_disable_call["enabled"] = False
 
     assert aioclient_mock.mock_calls[call_count][2] == expected_disable_call
-    assert hass.states.get("switch.unifi_network_test_traffic_route").state == STATE_OFF
 
     call_count = aioclient_mock.call_count
-    traffic_route_payload[0]["enabled"] = True
 
     # Enable traffic route
     await hass.services.async_call(
@@ -1288,7 +1263,6 @@ async def test_traffic_routes(
 
     assert aioclient_mock.call_count == call_count + 2
     assert aioclient_mock.mock_calls[call_count][2] == expected_enable_call
-    assert hass.states.get("switch.unifi_network_test_traffic_route").state == STATE_ON
 
 
 @pytest.mark.parametrize(("firewall_policy_payload"), [([FIREWALL_POLICY])])
@@ -1753,7 +1727,6 @@ async def test_port_forwarding_switches(
                         "portconf_id": "1a1",
                         "port_poe": True,
                         "up": True,
-                        "enable": True,
                     },
                 ],
             },
@@ -1770,14 +1743,14 @@ async def test_updating_unique_id(
     """Verify outlet control and poe control unique ID update works."""
     entity_registry.async_get_or_create(
         SWITCH_DOMAIN,
-        DOMAIN,
+        UNIFI_DOMAIN,
         f"{device_payload[0]['mac']}-outlet-1",
         suggested_object_id="plug_outlet_1",
         config_entry=config_entry,
     )
     entity_registry.async_get_or_create(
         SWITCH_DOMAIN,
-        DOMAIN,
+        UNIFI_DOMAIN,
         f"{device_payload[1]['mac']}-poe-1",
         suggested_object_id="switch_port_1_poe",
         config_entry=config_entry,
@@ -1810,9 +1783,8 @@ async def test_hub_state_change(
     entity_ids = (
         "switch.block_client_2",
         "switch.mock_name_port_1_poe",
-        "switch.mock_name_port_1",
         "switch.plug_outlet_1",
-        "switch.unifi_network_block_media_streaming",
+        "switch.block_media_streaming",
         "switch.unifi_network_plex",
         "switch.unifi_network_test_traffic_rule",
         "switch.unifi_network_allow_internal_to_iot",
@@ -1830,106 +1802,3 @@ async def test_hub_state_change(
     await mock_websocket_state.reconnect()
     for entity_id in entity_ids:
         assert hass.states.get(entity_id).state == STATE_ON
-
-
-@pytest.mark.parametrize("device_payload", [[DEVICE_1]])
-async def test_port_control_switches(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    aioclient_mock: AiohttpClientMocker,
-    config_entry_setup: MockConfigEntry,
-    mock_websocket_message: WebsocketMessageMock,
-    device_payload: list[dict[str, Any]],
-) -> None:
-    """Test port control entities work."""
-
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
-
-    ent_reg_entry = entity_registry.async_get("switch.mock_name_port_1")
-    assert (
-        ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
-    )  # ✅ Disabled by default
-
-    # Enable entity
-    entity_registry.async_update_entity(
-        entity_id="switch.mock_name_port_1", disabled_by=None
-    )
-    entity_registry.async_update_entity(
-        entity_id="switch.mock_name_port_2", disabled_by=None
-    )
-
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
-
-    # Validate state object
-    assert hass.states.get("switch.mock_name_port_1").state == STATE_ON
-
-    # Update state object - disable port via port_overrides
-    device_1 = deepcopy(device_payload[0])
-    device_1["port_table"][0]["enable"] = False
-    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
-    await hass.async_block_till_done()
-    assert hass.states.get("switch.mock_name_port_1").state == STATE_OFF
-
-    # Turn off port
-    aioclient_mock.clear_requests()
-    aioclient_mock.put(
-        f"https://{config_entry_setup.data[CONF_HOST]}:1234"
-        f"/api/s/{config_entry_setup.data[CONF_SITE_ID]}/rest/device/mock-id",
-    )
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        "turn_off",
-        {"entity_id": "switch.mock_name_port_1"},
-        blocking=True,
-    )
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
-    await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 1
-    assert aioclient_mock.mock_calls[0][2] == {
-        "port_overrides": [
-            {"port_idx": 1, "port_security_enabled": True, "portconf_id": "1a1"}
-        ]
-    }
-
-    # Turn on port
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        "turn_on",
-        {"entity_id": "switch.mock_name_port_1"},
-        blocking=True,
-    )
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        "turn_off",
-        {"entity_id": "switch.mock_name_port_2"},
-        blocking=True,
-    )
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
-    await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 3
-    assert aioclient_mock.mock_calls[1][2] == {
-        "port_overrides": [
-            {"port_idx": 1, "port_security_enabled": False, "portconf_id": "1a1"},
-        ]
-    }
-    assert aioclient_mock.mock_calls[2][2] == {
-        "port_overrides": [
-            {"port_idx": 2, "port_security_enabled": True, "portconf_id": "1a2"},
-        ]
-    }
-    # Device gets disabled
-    device_1["disabled"] = True
-    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
-    await hass.async_block_till_done()
-    assert hass.states.get("switch.mock_name_port_1").state == STATE_UNAVAILABLE
-
-    # Device gets re-enabled
-    device_1["disabled"] = False
-    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
-    await hass.async_block_till_done()
-    assert hass.states.get("switch.mock_name_port_1").state == STATE_OFF

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from aiounifi.models.message import MessageKey
 import pytest
-from syrupy import SnapshotAssertion
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
@@ -20,7 +20,7 @@ from homeassistant.components.unifi.const import (
     CONF_SITE_ID,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
-    DOMAIN as UNIFI_DOMAIN,
+    DOMAIN,
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
@@ -150,6 +150,7 @@ DEVICE_1 = {
             "portconf_id": "1a1",
             "port_poe": True,
             "up": True,
+            "enable": True,
         },
         {
             "media": "GE",
@@ -164,6 +165,7 @@ DEVICE_1 = {
             "portconf_id": "1a2",
             "port_poe": True,
             "up": True,
+            "enable": True,
         },
         {
             "media": "GE",
@@ -178,6 +180,7 @@ DEVICE_1 = {
             "portconf_id": "1a3",
             "port_poe": False,
             "up": True,
+            "enable": True,
         },
         {
             "media": "GE",
@@ -192,6 +195,7 @@ DEVICE_1 = {
             "portconf_id": "1a4",
             "port_poe": True,
             "up": True,
+            "enable": True,
         },
     ],
     "state": 1,
@@ -960,7 +964,7 @@ async def test_switches(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         "turn_off",
-        {"entity_id": "switch.block_media_streaming"},
+        {"entity_id": "switch.unifi_network_block_media_streaming"},
         blocking=True,
     )
     assert aioclient_mock.call_count == 1
@@ -969,7 +973,7 @@ async def test_switches(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         "turn_on",
-        {"entity_id": "switch.block_media_streaming"},
+        {"entity_id": "switch.unifi_network_block_media_streaming"},
         blocking=True,
     )
     assert aioclient_mock.call_count == 2
@@ -990,7 +994,7 @@ async def test_remove_switches(
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2
 
     assert hass.states.get("switch.block_client_2") is not None
-    assert hass.states.get("switch.block_media_streaming") is not None
+    assert hass.states.get("switch.unifi_network_block_media_streaming") is not None
 
     mock_websocket_message(message=MessageKey.CLIENT_REMOVED, data=[UNBLOCKED])
     await hass.async_block_till_done()
@@ -998,12 +1002,12 @@ async def test_remove_switches(
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
     assert hass.states.get("switch.block_client_2") is None
-    assert hass.states.get("switch.block_media_streaming") is not None
+    assert hass.states.get("switch.unifi_network_block_media_streaming") is not None
 
     mock_websocket_message(data=DPI_GROUP_REMOVED_EVENT)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.block_media_streaming") is None
+    assert hass.states.get("switch.unifi_network_block_media_streaming") is None
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
@@ -1088,18 +1092,22 @@ async def test_dpi_switches(
     """Test the update_items function with some clients."""
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
-    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
+    assert (
+        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
+    )
 
     mock_websocket_message(data=DPI_APP_DISABLED_EVENT)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
+    assert (
+        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_OFF
+    )
 
     # Remove app
     mock_websocket_message(data=DPI_GROUP_REMOVE_APP)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.block_media_streaming") is None
+    assert hass.states.get("switch.unifi_network_block_media_streaming") is None
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
@@ -1111,7 +1119,9 @@ async def test_dpi_switches_add_second_app(
 ) -> None:
     """Test the update_items function with some clients."""
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
-    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
+    assert (
+        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
+    )
 
     second_app_event = {
         "apps": [524292],
@@ -1125,7 +1135,9 @@ async def test_dpi_switches_add_second_app(
     mock_websocket_message(message=MessageKey.DPI_APP_ADDED, data=second_app_event)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
+    assert (
+        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
+    )
 
     add_second_app_to_group = {
         "_id": "5f976f4ae3c58f018ec7dff6",
@@ -1138,7 +1150,9 @@ async def test_dpi_switches_add_second_app(
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
+    assert (
+        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_OFF
+    )
 
     second_app_event_enabled = {
         "apps": [524292],
@@ -1154,7 +1168,9 @@ async def test_dpi_switches_add_second_app(
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
+    assert (
+        hass.states.get("switch.unifi_network_block_media_streaming").state == STATE_ON
+    )
 
 
 @pytest.mark.parametrize(("traffic_rule_payload"), [([TRAFFIC_RULE])])
@@ -1207,7 +1223,7 @@ async def test_traffic_rules(
     expected_enable_call = deepcopy(traffic_rule)
     expected_enable_call["enabled"] = True
 
-    assert aioclient_mock.call_count == call_count + 2
+    assert aioclient_mock.call_count == call_count + 1
     assert aioclient_mock.mock_calls[call_count][2] == expected_enable_call
 
 
@@ -1261,7 +1277,7 @@ async def test_traffic_routes(
     expected_enable_call = deepcopy(traffic_route)
     expected_enable_call["enabled"] = True
 
-    assert aioclient_mock.call_count == call_count + 2
+    assert aioclient_mock.call_count == call_count + 1
     assert aioclient_mock.mock_calls[call_count][2] == expected_enable_call
 
 
@@ -1727,6 +1743,7 @@ async def test_port_forwarding_switches(
                         "portconf_id": "1a1",
                         "port_poe": True,
                         "up": True,
+                        "enable": True,
                     },
                 ],
             },
@@ -1743,14 +1760,14 @@ async def test_updating_unique_id(
     """Verify outlet control and poe control unique ID update works."""
     entity_registry.async_get_or_create(
         SWITCH_DOMAIN,
-        UNIFI_DOMAIN,
+        DOMAIN,
         f"{device_payload[0]['mac']}-outlet-1",
         suggested_object_id="plug_outlet_1",
         config_entry=config_entry,
     )
     entity_registry.async_get_or_create(
         SWITCH_DOMAIN,
-        UNIFI_DOMAIN,
+        DOMAIN,
         f"{device_payload[1]['mac']}-poe-1",
         suggested_object_id="switch_port_1_poe",
         config_entry=config_entry,
@@ -1783,8 +1800,9 @@ async def test_hub_state_change(
     entity_ids = (
         "switch.block_client_2",
         "switch.mock_name_port_1_poe",
+        "switch.mock_name_port_1",
         "switch.plug_outlet_1",
-        "switch.block_media_streaming",
+        "switch.unifi_network_block_media_streaming",
         "switch.unifi_network_plex",
         "switch.unifi_network_test_traffic_rule",
         "switch.unifi_network_allow_internal_to_iot",
@@ -1802,3 +1820,106 @@ async def test_hub_state_change(
     await mock_websocket_state.reconnect()
     for entity_id in entity_ids:
         assert hass.states.get(entity_id).state == STATE_ON
+
+
+@pytest.mark.parametrize("device_payload", [[DEVICE_1]])
+async def test_port_control_switches(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
+    config_entry_setup: MockConfigEntry,
+    mock_websocket_message: WebsocketMessageMock,
+    device_payload: list[dict[str, Any]],
+) -> None:
+    """Test port control entities work."""
+
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
+
+    ent_reg_entry = entity_registry.async_get("switch.mock_name_port_1")
+    assert (
+        ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    )  # ✅ Disabled by default
+
+    # Enable entity
+    entity_registry.async_update_entity(
+        entity_id="switch.mock_name_port_1", disabled_by=None
+    )
+    entity_registry.async_update_entity(
+        entity_id="switch.mock_name_port_2", disabled_by=None
+    )
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # Validate state object
+    assert hass.states.get("switch.mock_name_port_1").state == STATE_ON
+
+    # Update state object - disable port via port_overrides
+    device_1 = deepcopy(device_payload[0])
+    device_1["port_table"][0]["enable"] = False
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
+    await hass.async_block_till_done()
+    assert hass.states.get("switch.mock_name_port_1").state == STATE_OFF
+
+    # Turn off port
+    aioclient_mock.clear_requests()
+    aioclient_mock.put(
+        f"https://{config_entry_setup.data[CONF_HOST]}:1234"
+        f"/api/s/{config_entry_setup.data[CONF_SITE_ID]}/rest/device/mock-id",
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {"entity_id": "switch.mock_name_port_1"},
+        blocking=True,
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.mock_calls[0][2] == {
+        "port_overrides": [
+            {"port_idx": 1, "port_security_enabled": True, "portconf_id": "1a1"}
+        ]
+    }
+
+    # Turn on port
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_on",
+        {"entity_id": "switch.mock_name_port_1"},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {"entity_id": "switch.mock_name_port_2"},
+        blocking=True,
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    assert aioclient_mock.call_count == 3
+    assert aioclient_mock.mock_calls[1][2] == {
+        "port_overrides": [
+            {"port_idx": 1, "port_security_enabled": False, "portconf_id": "1a1"},
+        ]
+    }
+    assert aioclient_mock.mock_calls[2][2] == {
+        "port_overrides": [
+            {"port_idx": 2, "port_security_enabled": True, "portconf_id": "1a2"},
+        ]
+    }
+    # Device gets disabled
+    device_1["disabled"] = True
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
+    await hass.async_block_till_done()
+    assert hass.states.get("switch.mock_name_port_1").state == STATE_UNAVAILABLE
+
+    # Device gets re-enabled
+    device_1["disabled"] = False
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
+    await hass.async_block_till_done()
+    assert hass.states.get("switch.mock_name_port_1").state == STATE_OFF

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1196,6 +1196,7 @@ async def test_traffic_rules(
     )
 
     call_count = aioclient_mock.call_count
+    traffic_rule_payload[0] = deepcopy(traffic_rule_payload[0])
     traffic_rule_payload[0]["enabled"] = False
 
     await hass.services.async_call(
@@ -1254,6 +1255,7 @@ async def test_traffic_routes(
     )
 
     call_count = aioclient_mock.call_count
+    traffic_route_payload[0] = deepcopy(traffic_route_payload[0])
     traffic_route_payload[0]["enabled"] = False
 
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces a per-data-source polling coordinator for UniFi Network while keeping a single entity signaling model shared by both push and poll updates.

The key design goal is:
Push-based sources: websocket updates trigger handler events directly.
Polling-based sources: coordinator triggers handler update calls on interval.
After handler update, entity behavior and signaling are the same in both cases.

This is the first step towards having update coordinator for all data sources so it will be possible to select between push and pull

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
