### PR TITLE
Add diagnostics support to UniFi Access integration

### DIFF
--- a/homeassistant/components/unifi_access/diagnostics.py
+++ b/homeassistant/components/unifi_access/diagnostics.py
@@ -1,0 +1,41 @@
+"""Diagnostics support for UniFi Access."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_API_TOKEN
+from homeassistant.core import HomeAssistant
+
+from .coordinator import UnifiAccessConfigEntry
+
+TO_REDACT = {CONF_API_TOKEN}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: UnifiAccessConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    data = entry.runtime_data.data
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
+        "coordinator_data": {
+            "doors": {
+                door_id: door.model_dump(mode="json")
+                for door_id, door in data.doors.items()
+            },
+            "emergency": data.emergency.model_dump(mode="json"),
+            "door_lock_rules": {
+                door_id: rule.model_dump(mode="json")
+                for door_id, rule in data.door_lock_rules.items()
+            },
+            "unconfirmed_lock_rule_doors": list(data.unconfirmed_lock_rule_doors),
+            "supports_lock_rules": data.supports_lock_rules,
+            "lock_rule_support_complete": data.lock_rule_support_complete,
+            "door_thumbnails": {
+                door_id: thumb.model_dump(mode="json")
+                for door_id, thumb in data.door_thumbnails.items()
+            },
+        },
+    }

--- a/homeassistant/components/unifi_access/diagnostics.py
+++ b/homeassistant/components/unifi_access/diagnostics.py
@@ -30,7 +30,7 @@ async def async_get_config_entry_diagnostics(
                 door_id: rule.model_dump(mode="json")
                 for door_id, rule in data.door_lock_rules.items()
             },
-            "unconfirmed_lock_rule_doors": list(data.unconfirmed_lock_rule_doors),
+            "unconfirmed_lock_rule_doors": sorted(data.unconfirmed_lock_rule_doors),
             "supports_lock_rules": data.supports_lock_rules,
             "lock_rule_support_complete": data.lock_rule_support_complete,
             "door_thumbnails": {

--- a/homeassistant/components/unifi_access/quality_scale.yaml
+++ b/homeassistant/components/unifi_access/quality_scale.yaml
@@ -41,7 +41,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info: todo
   discovery: todo
   docs-data-update: todo

--- a/tests/components/unifi_access/snapshots/test_diagnostics.ambr
+++ b/tests/components/unifi_access/snapshots/test_diagnostics.ambr
@@ -1,0 +1,64 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'coordinator_data': dict({
+      'door_lock_rules': dict({
+        'door-001': dict({
+          'ended_time': 0,
+          'type': '',
+        }),
+        'door-002': dict({
+          'ended_time': 0,
+          'type': '',
+        }),
+      }),
+      'door_thumbnails': dict({
+        'door-001': dict({
+          'door_thumbnail_last_update': 1700000000,
+          'url': '/preview/front_door.png',
+        }),
+      }),
+      'doors': dict({
+        'door-001': dict({
+          'door_lock_relay_status': 'lock',
+          'door_position_status': 'close',
+          'door_thumbnail': '/preview/front_door.png',
+          'door_thumbnail_last_update': 1700000000,
+          'floor_id': '',
+          'full_name': '',
+          'id': 'door-001',
+          'is_bind_hub': False,
+          'lock_rule_status': None,
+          'name': 'Front Door',
+          'type': 'door',
+        }),
+        'door-002': dict({
+          'door_lock_relay_status': 'unlock',
+          'door_position_status': 'open',
+          'door_thumbnail': None,
+          'door_thumbnail_last_update': None,
+          'floor_id': '',
+          'full_name': '',
+          'id': 'door-002',
+          'is_bind_hub': False,
+          'lock_rule_status': None,
+          'name': 'Back Door',
+          'type': 'door',
+        }),
+      }),
+      'emergency': dict({
+        'evacuation': False,
+        'lockdown': False,
+      }),
+      'lock_rule_support_complete': True,
+      'supports_lock_rules': True,
+      'unconfirmed_lock_rule_doors': list([
+      ]),
+    }),
+    'entry_data': dict({
+      'api_token': '**REDACTED**',
+      'host': '192.168.1.1',
+      'verify_ssl': False,
+    }),
+  })
+# ---

--- a/tests/components/unifi_access/test_diagnostics.py
+++ b/tests/components/unifi_access/test_diagnostics.py
@@ -1,0 +1,29 @@
+"""Tests for the diagnostics data provided by the UniFi Access integration."""
+
+from unittest.mock import MagicMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
+        == snapshot
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add diagnostics support to the UniFi Access integration.

The diagnostics output includes:
- Config entry data (with `api_token` redacted)
- All coordinator data: doors, emergency status, door lock rules, lock rule support flags, unconfirmed lock rule doors, and door thumbnails

Pydantic models are serialized via `model_dump(mode="json")` for clean, structured output.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
