### PR TITLE
Add fixture for Tuya D825A dehumidifier

### DIFF
--- a/tests/components/tuya/fixtures/cs_biflejkeshx1sqig.json
+++ b/tests/components/tuya/fixtures/cs_biflejkeshx1sqig.json
@@ -1,0 +1,130 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "D825A I",
+  "category": "cs",
+  "product_id": "biflejkeshx1sqig",
+  "product_name": "D825A",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2024-11-21T16:23:08+00:00",
+  "create_time": "2024-11-21T16:23:08+00:00",
+  "update_time": "2024-11-21T16:23:08+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "dehumidify_set_enum": {
+      "type": "Enum",
+      "value": {
+        "range": ["40", "45", "50"]
+      }
+    },
+    "fan_speed_enum": {
+      "type": "Enum",
+      "value": {
+        "range": ["low", "mid", "high", "auto"]
+      }
+    },
+    "swing": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": {
+        "range": ["cancel", "1h", "2h", "3h"]
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "dehumidify_set_enum": {
+      "type": "Enum",
+      "value": {
+        "range": ["40", "45", "50"]
+      }
+    },
+    "fan_speed_enum": {
+      "type": "Enum",
+      "value": {
+        "range": ["low", "mid", "high", "auto"]
+      }
+    },
+    "humidity_indoor": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "temp_indoor": {
+      "type": "Integer",
+      "value": {
+        "unit": "℃",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "swing": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": {
+        "range": ["cancel", "1h", "2h", "3h"]
+      }
+    },
+    "countdown_left": {
+      "type": "Integer",
+      "value": {
+        "unit": "min",
+        "min": 0,
+        "max": 540,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": {
+        "label": ["C1", "C2", "P1", "P3", "P4", "water_full"]
+      }
+    }
+  },
+  "status": {
+    "switch": true,
+    "dehumidify_set_enum": "45",
+    "fan_speed_enum": "auto",
+    "humidity_indoor": 76,
+    "temp_indoor": 24,
+    "swing": true,
+    "child_lock": false,
+    "countdown_set": "cancel",
+    "countdown_left": 0,
+    "fault": 0
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_fan.ambr
+++ b/tests/components/tuya/snapshots/test_fan.ambr
@@ -234,6 +234,63 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[fan.d825a_i-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.d825a_i',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 49>,
+    'translation_key': None,
+    'unique_id': 'tuya.giqs1xhsekjelfibsc',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[fan.d825a_i-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'D825A I',
+      'percentage': 100,
+      'percentage_step': 25.0,
+      'preset_mode': None,
+      'preset_modes': None,
+      'supported_features': <FanEntityFeature: 49>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.d825a_i',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_platform_setup_and_discovery[fan.dehumidifer-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_humidifier.ambr
+++ b/tests/components/tuya/snapshots/test_humidifier.ambr
@@ -57,6 +57,64 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[humidifier.d825a_i-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max_humidity': 100,
+      'min_humidity': 0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'humidifier',
+    'entity_category': None,
+    'entity_id': 'humidifier.d825a_i',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <HumidifierDeviceClass.DEHUMIDIFIER: 'dehumidifier'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.giqs1xhsekjelfibscswitch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[humidifier.d825a_i-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_humidity': 76,
+      'device_class': 'dehumidifier',
+      'friendly_name': 'D825A I',
+      'max_humidity': 100,
+      'min_humidity': 0,
+      'supported_features': <HumidifierEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'humidifier.d825a_i',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_platform_setup_and_discovery[humidifier.dehumidifer-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -4060,6 +4060,37 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[giqs1xhsekjelfibsc]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'giqs1xhsekjelfibsc',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'D825A',
+    'model_id': 'biflejkeshx1sqig',
+    'name': 'D825A I',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[gjnpc0eojd]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -2499,7 +2499,6 @@
   })
 # ---
 # name: test_platform_setup_and_discovery[select.dolni_vchod_zapad_anti_flicker-entry]
-<<<<<<< Updated upstream
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2527,81 +2526,6 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Anti-flicker',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Anti-flicker',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'basic_anti_flicker',
-    'unique_id': 'tuya.o4hpbl5uarjfbzhepsbasic_anti_flicker',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[select.dolni_vchod_zapad_anti_flicker-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Dolní vchod - západ Anti-flicker',
-      'options': list([
-        '0',
-        '1',
-        '2',
-      ]),
-    }),
-    'context': <ANY>,
-    'entity_id': 'select.dolni_vchod_zapad_anti_flicker',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1',
-  })
-# ---
-# name: test_platform_setup_and_discovery[select.dolni_vchod_zapad_ipc_mode-entry]
-=======
->>>>>>> Stashed changes
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'options': list([
-        '0',
-        '1',
-<<<<<<< Updated upstream
-=======
-        '2',
->>>>>>> Stashed changes
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'select',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-<<<<<<< Updated upstream
-    'entity_id': 'select.dolni_vchod_zapad_ipc_mode',
-=======
-    'entity_id': 'select.dolni_vchod_zapad_anti_flicker',
->>>>>>> Stashed changes
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-<<<<<<< Updated upstream
-    'object_id_base': 'IPC mode',
-    'options': dict({
-    }),
-=======
     'object_id_base': 'Anti-flicker',
     'options': dict({
     }),
@@ -2665,7 +2589,6 @@
     'object_id_base': 'IPC mode',
     'options': dict({
     }),
->>>>>>> Stashed changes
     'original_device_class': None,
     'original_icon': None,
     'original_name': 'IPC mode',

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -2004,6 +2004,130 @@
     'state': 'unknown',
   })
 # ---
+# name: test_platform_setup_and_discovery[select.d825a_i_countdown-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'cancel',
+        '1h',
+        '2h',
+        '3h',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.d825a_i_countdown',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Countdown',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Countdown',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'countdown',
+    'unique_id': 'tuya.giqs1xhsekjelfibsccountdown_set',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.d825a_i_countdown-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'D825A I Countdown',
+      'options': list([
+        'cancel',
+        '1h',
+        '2h',
+        '3h',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.d825a_i_countdown',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cancel',
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.d825a_i_target_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '40',
+        '45',
+        '50',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.d825a_i_target_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Target humidity',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Target humidity',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'target_humidity',
+    'unique_id': 'tuya.giqs1xhsekjelfibscdehumidify_set_enum',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.d825a_i_target_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'D825A I Target humidity',
+      'options': list([
+        '40',
+        '45',
+        '50',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.d825a_i_target_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '45',
+  })
+# ---
 # name: test_platform_setup_and_discovery[select.dehumidifer_countdown-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -2375,6 +2499,7 @@
   })
 # ---
 # name: test_platform_setup_and_discovery[select.dolni_vchod_zapad_anti_flicker-entry]
+<<<<<<< Updated upstream
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2402,6 +2527,81 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Anti-flicker',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Anti-flicker',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'basic_anti_flicker',
+    'unique_id': 'tuya.o4hpbl5uarjfbzhepsbasic_anti_flicker',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.dolni_vchod_zapad_anti_flicker-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dolní vchod - západ Anti-flicker',
+      'options': list([
+        '0',
+        '1',
+        '2',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.dolni_vchod_zapad_anti_flicker',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.dolni_vchod_zapad_ipc_mode-entry]
+=======
+>>>>>>> Stashed changes
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+<<<<<<< Updated upstream
+=======
+        '2',
+>>>>>>> Stashed changes
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+<<<<<<< Updated upstream
+    'entity_id': 'select.dolni_vchod_zapad_ipc_mode',
+=======
+    'entity_id': 'select.dolni_vchod_zapad_anti_flicker',
+>>>>>>> Stashed changes
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+<<<<<<< Updated upstream
+    'object_id_base': 'IPC mode',
+    'options': dict({
+    }),
+=======
     'object_id_base': 'Anti-flicker',
     'options': dict({
     }),
@@ -2465,6 +2665,7 @@
     'object_id_base': 'IPC mode',
     'options': dict({
     }),
+>>>>>>> Stashed changes
     'original_device_class': None,
     'original_icon': None,
     'original_name': 'IPC mode',

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -3970,7 +3970,6 @@
     'name': None,
     'object_id_base': 'Battery',
     'options': dict({
-<<<<<<< Updated upstream
     }),
     'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
@@ -3992,29 +3991,6 @@
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-=======
-    }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-    'original_icon': None,
-    'original_name': 'Battery',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'battery',
-    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwbattery_percentage',
-    'unit_of_measurement': '%',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.c30_battery-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'C30 Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
->>>>>>> Stashed changes
     'context': <ANY>,
     'entity_id': 'sensor.c30_battery',
     'last_changed': <ANY>,
@@ -5232,8 +5208,6 @@
     'aliases': list([
       None,
     ]),
-<<<<<<< Updated upstream
-=======
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -5350,7 +5324,6 @@
     'aliases': list([
       None,
     ]),
->>>>>>> Stashed changes
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -5759,7 +5732,6 @@
     'icon': None,
     'id': <ANY>,
     'labels': set({
-<<<<<<< Updated upstream
     }),
     'name': None,
     'object_id_base': 'Battery',
@@ -5784,32 +5756,6 @@
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '',
     }),
-=======
-    }),
-    'name': None,
-    'object_id_base': 'Battery',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Battery',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'battery',
-    'unique_id': 'tuya.o4hpbl5uarjfbzhepswireless_electricity',
-    'unit_of_measurement': '',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.dolni_vchod_zapad_battery-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Dolní vchod - západ Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '',
-    }),
->>>>>>> Stashed changes
     'context': <ANY>,
     'entity_id': 'sensor.dolni_vchod_zapad_battery',
     'last_changed': <ANY>,
@@ -24559,7 +24505,6 @@
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-<<<<<<< Updated upstream
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -24582,30 +24527,6 @@
         'suggested_display_precision': 1,
       }),
     }),
-=======
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_conductivity',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Conductivity',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
->>>>>>> Stashed changes
     'original_device_class': <SensorDeviceClass.CONDUCTIVITY: 'conductivity'>,
     'original_icon': None,
     'original_name': 'Conductivity',

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -3970,6 +3970,7 @@
     'name': None,
     'object_id_base': 'Battery',
     'options': dict({
+<<<<<<< Updated upstream
     }),
     'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
@@ -3991,6 +3992,29 @@
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
+=======
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery',
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwbattery_percentage',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.c30_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'C30 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+>>>>>>> Stashed changes
     'context': <ANY>,
     'entity_id': 'sensor.c30_battery',
     'last_changed': <ANY>,
@@ -5090,11 +5114,126 @@
     'state': '241.6',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.d825a_i_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.d825a_i_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Humidity',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity',
+    'unique_id': 'tuya.giqs1xhsekjelfibschumidity_indoor',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.d825a_i_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'D825A I Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.d825a_i_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '76.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.d825a_i_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.d825a_i_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature',
+    'unique_id': 'tuya.giqs1xhsekjelfibsctemp_indoor',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.d825a_i_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'D825A I Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.d825a_i_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.dehumidifer_humidity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
     ]),
+<<<<<<< Updated upstream
+=======
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -5211,6 +5350,7 @@
     'aliases': list([
       None,
     ]),
+>>>>>>> Stashed changes
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -5619,6 +5759,7 @@
     'icon': None,
     'id': <ANY>,
     'labels': set({
+<<<<<<< Updated upstream
     }),
     'name': None,
     'object_id_base': 'Battery',
@@ -5643,6 +5784,32 @@
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '',
     }),
+=======
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery',
+    'unique_id': 'tuya.o4hpbl5uarjfbzhepswireless_electricity',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.dolni_vchod_zapad_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dolní vchod - západ Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+>>>>>>> Stashed changes
     'context': <ANY>,
     'entity_id': 'sensor.dolni_vchod_zapad_battery',
     'last_changed': <ANY>,
@@ -24392,6 +24559,7 @@
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+<<<<<<< Updated upstream
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -24414,6 +24582,30 @@
         'suggested_display_precision': 1,
       }),
     }),
+=======
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_conductivity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Conductivity',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+>>>>>>> Stashed changes
     'original_device_class': <SensorDeviceClass.CONDUCTIVITY: 'conductivity'>,
     'original_icon': None,
     'original_name': 'Conductivity',

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -2973,6 +2973,57 @@
     'state': 'off',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.d825a_i_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.d825a_i_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Child lock',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:account-lock',
+    'original_name': 'Child lock',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': 'tuya.giqs1xhsekjelfibscchild_lock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.d825a_i_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'D825A I Child lock',
+      'icon': 'mdi:account-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.d825a_i_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.dehumidifer_child_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -3505,6 +3556,7 @@
     'name': None,
     'object_id_base': 'Time watermark',
     'options': dict({
+<<<<<<< Updated upstream
     }),
     'original_device_class': None,
     'original_icon': None,
@@ -3523,6 +3575,26 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dolní vchod - západ Time watermark',
     }),
+=======
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Time watermark',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_watermark',
+    'unique_id': 'tuya.o4hpbl5uarjfbzhepsbasic_osd',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.dolni_vchod_zapad_time_watermark-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dolní vchod - západ Time watermark',
+    }),
+>>>>>>> Stashed changes
     'context': <ANY>,
     'entity_id': 'switch.dolni_vchod_zapad_time_watermark',
     'last_changed': <ANY>,

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -3556,7 +3556,6 @@
     'name': None,
     'object_id_base': 'Time watermark',
     'options': dict({
-<<<<<<< Updated upstream
     }),
     'original_device_class': None,
     'original_icon': None,
@@ -3575,26 +3574,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dolní vchod - západ Time watermark',
     }),
-=======
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Time watermark',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'time_watermark',
-    'unique_id': 'tuya.o4hpbl5uarjfbzhepsbasic_osd',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[switch.dolni_vchod_zapad_time_watermark-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Dolní vchod - západ Time watermark',
-    }),
->>>>>>> Stashed changes
     'context': <ANY>,
     'entity_id': 'switch.dolni_vchod_zapad_time_watermark',
     'last_changed': <ANY>,


### PR DESCRIPTION
## See also
https://github.com/home-assistant/core/pull/165365#pullrequestreview-3975460364

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change adds a D825A Tuya dehumidifier diagnostic fixture and updates the
existing Tuya platform snapshots for entities that are already created from
that fixture on current `dev`.

It intentionally does not add new runtime behavior. This is the preliminary PR
requested during review so the follow-up `water_full` binary sensor change can
be reviewed separately from the fixture and baseline snapshot churn.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #131338
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr