### PR TITLE
Clamp surepetcare battery percentage to 0-100

### DIFF
--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -73,8 +73,8 @@ class SureBattery(SurePetcareEntity, SensorEntity):
         try:
             per_battery_voltage = state["battery"] / 4
             voltage_diff = per_battery_voltage - SURE_BATT_VOLTAGE_LOW
-            self._attr_native_value = min(
-                int(voltage_diff / SURE_BATT_VOLTAGE_DIFF * 100), 100
+            self._attr_native_value = max(
+                0, min(int(voltage_diff / SURE_BATT_VOLTAGE_DIFF * 100), 100)
             )
         except KeyError, TypeError:
             self._attr_native_value = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
<!--
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `SureBattery` sensor in the surepetcare integration calculates battery percentage from voltage but only clamps the upper bound (`min(..., 100)`). When the per-battery voltage drops below `SURE_BATT_VOLTAGE_LOW` (1.25V), the calculated percentage goes negative (e.g. -6% as reported in #166546).

This PR wraps the existing `min()` call with `max(0, ...)` to ensure the battery percentage stays within the valid 0–100% range expected by `SensorDeviceClass.BATTERY`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely
  need to split it into multiple PRs. This makes things easier and faster
  to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details, additional context, or links that may be relevant.
-->

- Fixes #166546
- The existing tests in `test_sensor.py` only cover the happy path (battery = 100%). A test for the negative voltage edge case would be a good addition — happy to add one if requested.
- The change is a 2-line edit: wrap `min(...)` with `max(0, min(...))` and add the closing paren.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated at the [home-assistant.io site][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io