### PR TITLE
fix: pin 6 unpinned action(s)

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -49,16 +49,16 @@ jobs:
 
       - name: Get information
         id: info
-        uses: home-assistant/actions/helpers/info@master # zizmor: ignore[unpinned-uses]
+        uses: home-assistant/actions/helpers/info@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master # zizmor: ignore[unpinned-uses]
 
       - name: Get version
         id: version
-        uses: home-assistant/actions/helpers/version@master # zizmor: ignore[unpinned-uses]
+        uses: home-assistant/actions/helpers/version@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master # zizmor: ignore[unpinned-uses]
         with:
           type: ${{ env.BUILD_TYPE }}
 
       - name: Verify version
-        uses: home-assistant/actions/helpers/verify-version@master # zizmor: ignore[unpinned-uses]
+        uses: home-assistant/actions/helpers/verify-version@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master # zizmor: ignore[unpinned-uses]
         with:
           ignore-dev: true
 
@@ -301,14 +301,14 @@ jobs:
           persist-credentials: false
 
       - name: Initialize git
-        uses: home-assistant/actions/helpers/git-init@master # zizmor: ignore[unpinned-uses]
+        uses: home-assistant/actions/helpers/git-init@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master # zizmor: ignore[unpinned-uses]
         with:
           name: ${{ secrets.GIT_NAME }}
           email: ${{ secrets.GIT_EMAIL }}
           token: ${{ secrets.GIT_TOKEN }}
 
       - name: Update version file
-        uses: home-assistant/actions/helpers/version-push@master # zizmor: ignore[unpinned-uses]
+        uses: home-assistant/actions/helpers/version-push@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master # zizmor: ignore[unpinned-uses]
         with:
           key: "homeassistant[]"
           key-description: "Home Assistant Core"
@@ -318,7 +318,7 @@ jobs:
 
       - name: Update version file (stable -> beta)
         if: needs.init.outputs.channel == 'stable'
-        uses: home-assistant/actions/helpers/version-push@master # zizmor: ignore[unpinned-uses]
+        uses: home-assistant/actions/helpers/version-push@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master # zizmor: ignore[unpinned-uses]
         with:
           key: "homeassistant[]"
           key-description: "Home Assistant Core"


### PR DESCRIPTION
Re-submission of #166616. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins GitHub Actions to immutable commit SHAs instead of mutable version tags.

- Pin 6 unpinned actions to full 40-character SHAs
- Add version comments for readability

> **Note:** All pinned actions are `home-assistant/actions/*`, your own org's actions. Pinning is still recommended as defense-in-depth, but the supply chain risk is lower since you control the repositories.

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@master` becomes `action@abc123 # master`, original ref preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)