### PR TITLE
Add Off mode support for water_heater entities in HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -49,14 +49,21 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.components.water_heater import (
+    ATTR_OPERATION_LIST,
+    ATTR_OPERATION_MODE,
     DOMAIN as WATER_HEATER_DOMAIN,
+    SERVICE_SET_OPERATION_MODE,
     SERVICE_SET_TEMPERATURE as SERVICE_SET_TEMPERATURE_WATER_HEATER,
+    WaterHeaterEntityFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     PERCENTAGE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfTemperature,
@@ -745,12 +752,27 @@ class WaterHeater(HomeAccessory):
             (
                 ATTR_MAX_TEMP,
                 ATTR_MIN_TEMP,
+                ATTR_OPERATION_LIST,
             )
         )
         self._unit = self.hass.config.units.temperature_unit
         state = self.hass.states.get(self.entity_id)
         assert state
         min_temp, max_temp = self.get_temperature_range(state)
+
+        features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        operation_list = state.attributes.get(ATTR_OPERATION_LIST) or []
+        self._supports_on_off = bool(features & WaterHeaterEntityFeature.ON_OFF)
+        self._supports_operation_mode = bool(
+            features & WaterHeaterEntityFeature.OPERATION_MODE
+        )
+        self._off_mode_available = self._supports_on_off or (
+            self._supports_operation_mode and STATE_OFF in operation_list
+        )
+
+        valid_modes = dict(HC_HOMEKIT_VALID_MODES_WATER_HEATER)
+        if self._off_mode_available:
+            valid_modes["Off"] = HC_HEAT_COOL_OFF
 
         serv_thermostat = self.add_preload_service(SERV_THERMOSTAT)
 
@@ -761,7 +783,7 @@ class WaterHeater(HomeAccessory):
             CHAR_TARGET_HEATING_COOLING,
             value=1,
             setter_callback=self.set_heat_cool,
-            valid_values=HC_HOMEKIT_VALID_MODES_WATER_HEATER,
+            valid_values=valid_modes,
         )
 
         self.char_current_temp = serv_thermostat.configure_char(
@@ -795,8 +817,48 @@ class WaterHeater(HomeAccessory):
     def set_heat_cool(self, value: int) -> None:
         """Change operation mode to value if call came from HomeKit."""
         _LOGGER.debug("%s: Set heat-cool to %d", self.entity_id, value)
-        if HC_HOMEKIT_TO_HASS[value] != HVACMode.HEAT:
-            self.char_target_heat_cool.set_value(1)  # Heat
+        params: dict[str, Any] = {ATTR_ENTITY_ID: self.entity_id}
+        if value == HC_HEAT_COOL_OFF:
+            if self._supports_on_off:
+                self.async_call_service(
+                    WATER_HEATER_DOMAIN, SERVICE_TURN_OFF, params, "off"
+                )
+            elif self._off_mode_available and self._supports_operation_mode:
+                params[ATTR_OPERATION_MODE] = STATE_OFF
+                self.async_call_service(
+                    WATER_HEATER_DOMAIN,
+                    SERVICE_SET_OPERATION_MODE,
+                    params,
+                    STATE_OFF,
+                )
+            else:
+                self.char_target_heat_cool.set_value(HC_HEAT_COOL_HEAT)
+        elif value == HC_HEAT_COOL_HEAT:
+            if self._supports_on_off:
+                self.async_call_service(
+                    WATER_HEATER_DOMAIN, SERVICE_TURN_ON, params, "on"
+                )
+            elif self._off_mode_available and self._supports_operation_mode:
+                state = self.hass.states.get(self.entity_id)
+                if not state:
+                    return
+                current_operation_mode = state.attributes.get(ATTR_OPERATION_MODE)
+                if current_operation_mode and current_operation_mode != STATE_OFF:
+                    # Already in a non-off operation mode; do not change it.
+                    return
+                operation_list = state.attributes.get(ATTR_OPERATION_LIST) or []
+                for mode in operation_list:
+                    if mode != STATE_OFF:
+                        params[ATTR_OPERATION_MODE] = mode
+                        self.async_call_service(
+                            WATER_HEATER_DOMAIN,
+                            SERVICE_SET_OPERATION_MODE,
+                            params,
+                            mode,
+                        )
+                        break
+        else:
+            self.char_target_heat_cool.set_value(HC_HEAT_COOL_HEAT)
 
     def set_target_temperature(self, value: float) -> None:
         """Set target temperature to value if call came from HomeKit."""
@@ -829,7 +891,12 @@ class WaterHeater(HomeAccessory):
 
         # Update target operation mode
         if new_state.state:
-            self.char_target_heat_cool.set_value(1)  # Heat
+            if new_state.state == STATE_OFF and self._off_mode_available:
+                self.char_target_heat_cool.set_value(HC_HEAT_COOL_OFF)
+                self.char_current_heat_cool.set_value(HC_HEAT_COOL_OFF)
+            else:
+                self.char_target_heat_cool.set_value(HC_HEAT_COOL_HEAT)
+                self.char_current_heat_cool.set_value(HC_HEAT_COOL_HEAT)
 
 
 def _get_temperature_range_from_state(

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -43,6 +43,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.components.homekit.accessories import HomeDriver
 from homeassistant.components.homekit.const import (
     ATTR_VALUE,
     CHAR_CURRENT_FAN_STATE,
@@ -66,7 +67,11 @@ from homeassistant.components.homekit.type_thermostats import (
     Thermostat,
     WaterHeater,
 )
-from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
+from homeassistant.components.water_heater import (
+    ATTR_OPERATION_LIST,
+    DOMAIN as WATER_HEATER_DOMAIN,
+    WaterHeaterEntityFeature,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -1780,6 +1785,130 @@ async def test_water_heater(
         acc.char_target_heat_cool.set_value(3)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
+
+
+async def test_water_heater_off_mode_on_off(
+    hass: HomeAssistant, hk_driver: HomeDriver, events: list[Event]
+) -> None:
+    """Test water heater Off mode via ON_OFF feature."""
+    entity_id = "water_heater.test"
+
+    hass.states.async_set(
+        entity_id,
+        HVACMode.HEAT,
+        {ATTR_SUPPORTED_FEATURES: WaterHeaterEntityFeature.ON_OFF},
+    )
+    await hass.async_block_till_done()
+    acc = WaterHeater(hass, hk_driver, "WaterHeater", entity_id, 2, None)
+    acc.run()
+    await hass.async_block_till_done()
+
+    # Verify Off is exposed as a valid mode
+    valid_values = acc.char_target_heat_cool.properties.get("ValidValues", {})
+    assert valid_values == {"Off": 0, "Heat": 1}
+
+    # Set to Off from HomeKit
+    call_turn_off = async_mock_service(hass, WATER_HEATER_DOMAIN, "turn_off")
+
+    acc.char_target_heat_cool.client_update_value(0)
+    await hass.async_block_till_done()
+    assert call_turn_off
+    assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
+    assert len(events) == 1
+    assert events[-1].data[ATTR_VALUE] == "off"
+
+    # Set to Heat from HomeKit
+    call_turn_on = async_mock_service(hass, WATER_HEATER_DOMAIN, "turn_on")
+
+    acc.char_target_heat_cool.client_update_value(1)
+    await hass.async_block_till_done()
+    assert call_turn_on
+    assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
+    assert len(events) == 2
+    assert events[-1].data[ATTR_VALUE] == "on"
+
+    # Update HA state to off and verify HomeKit reflects it
+    hass.states.async_set(
+        entity_id,
+        "off",
+        {ATTR_SUPPORTED_FEATURES: WaterHeaterEntityFeature.ON_OFF},
+    )
+    await hass.async_block_till_done()
+    assert acc.char_target_heat_cool.value == HC_HEAT_COOL_OFF
+    assert acc.char_current_heat_cool.value == HC_HEAT_COOL_OFF
+
+    # Update HA state back to heat and verify HomeKit reflects it
+    hass.states.async_set(
+        entity_id,
+        HVACMode.HEAT,
+        {ATTR_SUPPORTED_FEATURES: WaterHeaterEntityFeature.ON_OFF},
+    )
+    await hass.async_block_till_done()
+    assert acc.char_target_heat_cool.value == HC_HEAT_COOL_HEAT
+    assert acc.char_current_heat_cool.value == HC_HEAT_COOL_HEAT
+
+
+async def test_water_heater_off_mode_operation_mode(
+    hass: HomeAssistant, hk_driver: HomeDriver, events: list[Event]
+) -> None:
+    """Test water heater Off mode via OPERATION_MODE feature."""
+    entity_id = "water_heater.test"
+
+    hass.states.async_set(
+        entity_id,
+        HVACMode.HEAT,
+        {
+            ATTR_SUPPORTED_FEATURES: WaterHeaterEntityFeature.OPERATION_MODE,
+            ATTR_OPERATION_LIST: ["off", "electric", "gas"],
+        },
+    )
+    await hass.async_block_till_done()
+    acc = WaterHeater(hass, hk_driver, "WaterHeater", entity_id, 2, None)
+    acc.run()
+    await hass.async_block_till_done()
+
+    # Verify Off is exposed as a valid mode
+    valid_values = acc.char_target_heat_cool.properties.get("ValidValues", {})
+    assert valid_values == {"Off": 0, "Heat": 1}
+
+    # Set to Off from HomeKit — should call set_operation_mode
+    call_set_op = async_mock_service(hass, WATER_HEATER_DOMAIN, "set_operation_mode")
+
+    acc.char_target_heat_cool.client_update_value(0)
+    await hass.async_block_till_done()
+    assert call_set_op
+    assert call_set_op[0].data[ATTR_ENTITY_ID] == entity_id
+    assert call_set_op[0].data["operation_mode"] == "off"
+    assert len(events) == 1
+    assert events[-1].data[ATTR_VALUE] == "off"
+
+    # Set to Heat from HomeKit — should pick first non-off operation mode
+    call_set_op.clear()
+
+    acc.char_target_heat_cool.client_update_value(1)
+    await hass.async_block_till_done()
+    assert call_set_op
+    assert call_set_op[0].data[ATTR_ENTITY_ID] == entity_id
+    assert call_set_op[0].data["operation_mode"] == "electric"
+    assert len(events) == 2
+    assert events[-1].data[ATTR_VALUE] == "electric"
+
+
+async def test_water_heater_no_off_mode(
+    hass: HomeAssistant, hk_driver: HomeDriver, events: list[Event]
+) -> None:
+    """Test water heater without ON_OFF or OPERATION_MODE does not expose Off."""
+    entity_id = "water_heater.test"
+
+    hass.states.async_set(entity_id, HVACMode.HEAT)
+    await hass.async_block_till_done()
+    acc = WaterHeater(hass, hk_driver, "WaterHeater", entity_id, 2, None)
+    acc.run()
+    await hass.async_block_till_done()
+
+    valid_values = acc.char_target_heat_cool.properties.get("ValidValues", {})
+    assert valid_values == {"Heat": 1}
+    assert "Off" not in valid_values
 
 
 async def test_water_heater_fahrenheit(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Water heater entities exposed to HomeKit currently only support Heat as a target mode. This adds Off (value 0) from Apple's HAP specification for [`TargetHeatingCoolingState`](https://github.com/apple/HomeKitADK/blob/master/HAP/HAPCharacteristicTypes.h#L687-L722), which allows water heater devices to be turned off and on through the Home app, correctly reflects the on/off state back to HomeKit when changed in HA, and also provides parity with [Thermostat](https://github.com/home-assistant/core/blob/dev/homeassistant/components/homekit/type_thermostats.py#L190).

Changes:

- Adds `Off` (0) to `HC_HOMEKIT_VALID_MODES_WATER_HEATER` ( added conditionally via a per-entity valid_modes dict )
- Updates `set_heat_cool` to call `water_heater.turn_off` / `turn_on`
- Updates `async_update_state` to report the actual state to HomeKit


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106610
- This PR is related to issue: #46411; see also #166039 (different scope — HA frontend, not HomeKit)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
