### PR TITLE
Add event platform for SMLIGHT integration

### DIFF
--- a/homeassistant/components/smlight/__init__.py
+++ b/homeassistant/components/smlight/__init__.py
@@ -18,6 +18,7 @@ from .coordinator import (
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.EVENT,
     Platform.LIGHT,
     Platform.REMOTE,
     Platform.SENSOR,

--- a/homeassistant/components/smlight/event.py
+++ b/homeassistant/components/smlight/event.py
@@ -1,0 +1,70 @@
+"""Event platform for SMLIGHT."""
+
+from __future__ import annotations
+
+import logging
+
+from pysmlight.const import Events as SmEvents
+from pysmlight.sse import MessageEvent
+
+from homeassistant.components.event import EventEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.json import json_loads_object
+
+from .coordinator import SmConfigEntry, SmDataUpdateCoordinator
+from .entity import SmEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+EVENT_TYPE_IR_CODE = "ir_code_received"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SmConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Initialize event platform for SMLIGHT device."""
+    coordinator = entry.runtime_data.data
+
+    if coordinator.data.info.has_peripherals:
+        async_add_entities([SmEventEntity(coordinator, [EVENT_TYPE_IR_CODE])])
+
+
+class SmEventEntity(SmEntity, EventEntity):
+    """Representation of a generic SLZB Event entity."""
+
+    _attr_translation_key = "event"
+    _attr_should_poll = False
+
+    def __init__(
+        self, coordinator: SmDataUpdateCoordinator, event_types: list[str]
+    ) -> None:
+        """Initialize the SLZB Event entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.unique_id}_event"
+        self._attr_event_types = event_types
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks when added to hass."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            self.coordinator.client.sse.register_callback(
+                SmEvents.IR_CODE, self._handle_ir_event
+            )
+        )
+
+    @callback
+    def _handle_ir_event(self, event: MessageEvent) -> None:
+        """Handle incoming SSE IR events."""
+        try:
+            data = json_loads_object(event.data)
+        except ValueError:
+            _LOGGER.debug("Received invalid IR event data: %s", event.data)
+            return
+        self._trigger_event(EVENT_TYPE_IR_CODE, data)
+        self.async_write_ha_state()

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -79,6 +79,18 @@
         "name": "Zigbee restart"
       }
     },
+    "event": {
+      "event": {
+        "name": "Events",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "ir_code_received": "IR code received"
+            }
+          }
+        }
+      }
+    },
     "light": {
       "ambilight": {
         "name": "Ambilight"

--- a/tests/components/smlight/snapshots/test_event.ambr
+++ b/tests/components/smlight/snapshots/test_event.ambr
@@ -1,0 +1,74 @@
+# serializer version: 1
+# name: test_event_setup_ultima[event.mock_title_events-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'ir_code_received',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.mock_title_events',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Events',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Events',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'event',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_event',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_event_setup_ultima[event.mock_title_events-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'event_type': None,
+      'event_types': list([
+        'ir_code_received',
+      ]),
+      'friendly_name': 'Mock Title Events',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.mock_title_events',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_ir_code_event
+  ReadOnlyDict({
+    'addr': '0xb683',
+    'cmd': '0x000b',
+    'event_type': 'ir_code_received',
+    'event_types': list([
+      'ir_code_received',
+    ]),
+    'friendly_name': 'Mock Title Events',
+    'proto': 8,
+    'raw': 'b5590d200d200c0b0c0a0c0a0d0a0c0a0d200d0a0c210c200d0a0c210c210c0a0c210c210c210c0a0c210c0a0d0a0c0a0d0a0c0a0c0b0c200d0a0c210c210c210c200d',
+    'repeat': 0,
+    'seq': 12,
+  })
+# ---

--- a/tests/components/smlight/test_event.py
+++ b/tests/components/smlight/test_event.py
@@ -1,0 +1,127 @@
+"""Tests for the SMLIGHT event platform."""
+
+from unittest.mock import MagicMock
+
+from pysmlight import Info
+from pysmlight.const import Events as SmEvents
+from pysmlight.sse import MessageEvent
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import get_mock_event_function
+from .conftest import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+MOCK_ULTIMA = Info(
+    MAC="AA:BB:CC:DD:EE:FF",
+    model="SLZB-Ultima3",
+)
+
+MOCK_IR_EVENT = MessageEvent(
+    type="IR_CODE",
+    message="IR_CODE",
+    data='{"raw":"b5590d200d200c0b0c0a0c0a0d0a0c0a0d200d0a0c210c200d0a0c210c210c0a0c210c210c210c0a0c210c0a0d0a0c0a0d0a0c0a0c0b0c200d0a0c210c210c210c200d","proto":8,"addr":"0xb683","cmd":"0x000b","repeat":0,"seq":12}',
+    origin="http://slzb-06.local",
+    last_event_id="",
+)
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Platforms, which should be loaded during the test."""
+    return [Platform.EVENT]
+
+
+async def test_event_setup_ultima(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test event entity is created for Ultima devices."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    entry = await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_event_not_created_non_ultima(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test event entity is not created for non-Ultima devices."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = Info(
+        MAC="AA:BB:CC:DD:EE:FF",
+        model="SLZB-MR1",
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("event.mock_title_events")
+    assert state is None
+
+
+@pytest.mark.freeze_time("2024-09-01 00:00:00+00:00")
+async def test_ir_code_event(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test IR code event entity."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("event.mock_title_events")
+    assert state.state == STATE_UNKNOWN
+
+    event_function = get_mock_event_function(mock_smlight_client, SmEvents.IR_CODE)
+    assert event_function is not None
+
+    event_function(MOCK_IR_EVENT)
+
+    state = hass.states.get("event.mock_title_events")
+    assert state.state == "2024-09-01T00:00:00.000+00:00"
+    assert state.attributes == snapshot
+
+
+async def test_ir_code_invalid_json(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test IR code event entity handles invalid json correctly."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("event.mock_title_events")
+    assert state.state == STATE_UNKNOWN
+
+    event_function = get_mock_event_function(mock_smlight_client, SmEvents.IR_CODE)
+    assert event_function is not None
+
+    invalid_event = MessageEvent(
+        type="ir_code",
+        message="ir_code",
+        data="invalid",
+        origin="http://slzb-06.local",
+        last_event_id="",
+    )
+    event_function(invalid_event)
+
+    state = hass.states.get("event.mock_title_events")
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SLZB-Ultima ha an IR receiver that can be used to receive codes from most IR remote controls. The IR codes received are sent to the SMLIGHT intregration over SSE stream. These events can be used to trigger automation actions associated with a particular button (code).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44390
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
