### PR TITLE
Bump fing_agent_api to 1.1.0

### DIFF
--- a/homeassistant/components/fing/config_flow.py
+++ b/homeassistant/components/fing/config_flow.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_API_KEY, CONF_IP_ADDRESS, CONF_PORT
+from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import DOMAIN, UPNP_AVAILABLE
 
@@ -40,6 +41,7 @@ class FingConfigFlow(ConfigFlow, domain=DOMAIN):
                 ip=user_input[CONF_IP_ADDRESS],
                 port=int(user_input[CONF_PORT]),
                 key=user_input[CONF_API_KEY],
+                client=get_async_client(self.hass),
             )
 
             try:

--- a/homeassistant/components/fing/coordinator.py
+++ b/homeassistant/components/fing/coordinator.py
@@ -11,6 +11,7 @@ import httpx
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, UPNP_AVAILABLE
@@ -38,6 +39,7 @@ class FingDataUpdateCoordinator(DataUpdateCoordinator[FingDataObject]):
             ip=config_entry.data[CONF_IP_ADDRESS],
             port=int(config_entry.data[CONF_PORT]),
             key=config_entry.data[CONF_API_KEY],
+            client=get_async_client(hass),
         )
         self._upnp_available = config_entry.data[UPNP_AVAILABLE]
         update_interval = timedelta(seconds=30)

--- a/homeassistant/components/fing/manifest.json
+++ b/homeassistant/components/fing/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["fing_agent_api==1.0.3"]
+  "requirements": ["fing_agent_api==1.1.0"]
 }

--- a/homeassistant/components/fing/quality_scale.yaml
+++ b/homeassistant/components/fing/quality_scale.yaml
@@ -68,5 +68,5 @@ rules:
 
   # Platinum
   async-dependency: todo
-  inject-websession: todo
+  inject-websession: done
   strict-typing: todo

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -963,7 +963,7 @@ feedparser==6.0.12
 file-read-backwards==2.0.0
 
 # homeassistant.components.fing
-fing_agent_api==1.0.3
+fing_agent_api==1.1.0
 
 # homeassistant.components.fints
 fints==3.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -854,7 +854,7 @@ feedparser==6.0.12
 file-read-backwards==2.0.0
 
 # homeassistant.components.fing
-fing_agent_api==1.0.3
+fing_agent_api==1.1.0
 
 # homeassistant.components.fints
 fints==3.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Blocking event loop (closes #156513, #164052): `fing_agent_api` was creating a new `httpx.AsyncClient` on every API call, triggering a synchronous `load_verify_locations` (SSL context init) inside the async event loop. Fixed by bumping to `fing_agent_api==1.1.0` (which now accepts an optional `httpx.AsyncClient`) and injecting the HA-managed shared client via `get_async_client(hass)` in both the coordinator and config flow.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156513, fixes #164052
- This PR is related to issue: #164052 is the same root cause as #156513
- Link to documentation pull request: N/A

Dependency diff (`fing_agent_api` 1.0.3 → 1.1.0): https://github.com/fingltd/fing-agent-pyapi/compare/1.0.3...1.1.0

- Added optional `client: httpx.AsyncClient | None = None` parameter to `FingAgent.__init__`
- Introduced internal `_get()` helper to reuse the injected client or fall back to a per-request client for non-HA usage
- Changelog/release: https://github.com/fingltd/fing-agent-pyapi

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
