### PR TITLE
Add Proxmox task-waiting power service

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -43,6 +43,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
+from .services import async_setup_services
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -101,6 +102,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Import the Proxmox configuration from YAML."""
+    async_setup_services(hass)
+
     if DOMAIN not in config:
         return True
 

--- a/homeassistant/components/proxmoxve/icons.json
+++ b/homeassistant/components/proxmoxve/icons.json
@@ -1,4 +1,9 @@
 {
+  "services": {
+    "vm_command_wait": {
+      "service": "mdi:timer-sand"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "storage_active": {

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+import logging
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -29,6 +30,24 @@ from .entity import (
 )
 
 PARALLEL_UPDATES = 0
+_LOGGER = logging.getLogger(__name__)
+
+
+def _safe_sensor_value(
+    value_fn: Callable[[Any], StateType | datetime],
+    source: Any,
+    unique_id: str,
+) -> StateType | datetime | None:
+    """Safely evaluate a sensor value against incomplete Proxmox payloads."""
+    try:
+        return value_fn(source)
+    except (KeyError, TypeError, ValueError, ZeroDivisionError) as err:
+        _LOGGER.debug(
+            "Skipping Proxmox sensor update for %s due to incomplete data: %s",
+            unique_id,
+            err,
+        )
+        return None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -528,7 +547,11 @@ class ProxmoxNodeSensor(ProxmoxNodeEntity, SensorEntity):
     @property
     def native_value(self) -> StateType | datetime:
         """Return the native value of the sensor."""
-        return self.entity_description.value_fn(self.coordinator.data[self.device_name])
+        return _safe_sensor_value(
+            self.entity_description.value_fn,
+            self.coordinator.data[self.device_name],
+            self.unique_id,
+        )
 
 
 class ProxmoxVMSensor(ProxmoxVMEntity, SensorEntity):
@@ -539,7 +562,11 @@ class ProxmoxVMSensor(ProxmoxVMEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the native value of the sensor."""
-        return self.entity_description.value_fn(self.vm_data)
+        return _safe_sensor_value(
+            self.entity_description.value_fn,
+            self.vm_data,
+            self.unique_id,
+        )
 
 
 class ProxmoxContainerSensor(ProxmoxContainerEntity, SensorEntity):
@@ -550,7 +577,11 @@ class ProxmoxContainerSensor(ProxmoxContainerEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the native value of the sensor."""
-        return self.entity_description.value_fn(self.container_data)
+        return _safe_sensor_value(
+            self.entity_description.value_fn,
+            self.container_data,
+            self.unique_id,
+        )
 
 
 class ProxmoxStorageSensor(ProxmoxStorageEntity, SensorEntity):
@@ -561,4 +592,8 @@ class ProxmoxStorageSensor(ProxmoxStorageEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the native value of the sensor."""
-        return self.entity_description.value_fn(self.storage_data)
+        return _safe_sensor_value(
+            self.entity_description.value_fn,
+            self.storage_data,
+            self.unique_id,
+        )

--- a/homeassistant/components/proxmoxve/services.py
+++ b/homeassistant/components/proxmoxve/services.py
@@ -1,0 +1,306 @@
+"""Services for Proxmox VE."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from time import monotonic
+from typing import Any, Final
+
+from proxmoxer import AuthenticationError, ProxmoxAPI
+from proxmoxer.core import ResourceException
+import requests
+from requests.exceptions import ConnectTimeout, SSLError
+import voluptuous as vol
+
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+
+from .const import CONF_NODE, DOMAIN, ProxmoxPermission
+from .coordinator import ProxmoxCoordinator
+from .helpers import is_granted
+
+SERVICE_VM_COMMAND_WAIT: Final = "vm_command_wait"
+CONF_COMMAND: Final = "command"
+CONF_ENTRY_ID: Final = "entry_id"
+CONF_POLL_INTERVAL: Final = "poll_interval"
+CONF_RESOURCE_TYPE: Final = "resource_type"
+CONF_TIMEOUT: Final = "timeout"
+CONF_VMID: Final = "vmid"
+
+RESOURCE_QEMU: Final = "qemu"
+RESOURCE_LXC: Final = "lxc"
+
+SUPPORTED_COMMANDS: Final[dict[str, dict[str, Callable[[Any], Any]]]] = {
+    RESOURCE_QEMU: {
+        "start": lambda resource: resource.status.start.post(),
+        "stop": lambda resource: resource.status.stop.post(),
+        "shutdown": lambda resource: resource.status.shutdown.post(),
+        "restart": lambda resource: resource.status.reboot.post(),
+        "reset": lambda resource: resource.status.reset.post(),
+        "hibernate": lambda resource: resource.status.hibernate.post(),
+    },
+    RESOURCE_LXC: {
+        "start": lambda resource: resource.status.start.post(),
+        "stop": lambda resource: resource.status.stop.post(),
+        "shutdown": lambda resource: resource.status.shutdown.post(),
+        "restart": lambda resource: resource.status.reboot.post(),
+    },
+}
+
+SERVICE_VM_COMMAND_WAIT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NODE): cv.string,
+        vol.Required(CONF_VMID): cv.positive_int,
+        vol.Required(CONF_COMMAND): vol.In(
+            sorted(
+                {
+                    command
+                    for commands in SUPPORTED_COMMANDS.values()
+                    for command in commands
+                }
+            )
+        ),
+        vol.Optional(CONF_RESOURCE_TYPE, default=RESOURCE_QEMU): vol.In(
+            (RESOURCE_QEMU, RESOURCE_LXC)
+        ),
+        vol.Optional(CONF_ENTRY_ID): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=120): vol.All(
+            vol.Coerce(float), vol.Range(min=1, max=3600)
+        ),
+        vol.Optional(CONF_POLL_INTERVAL, default=1): vol.All(
+            vol.Coerce(float), vol.Range(min=0.2, max=30)
+        ),
+    }
+)
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up Proxmox VE services."""
+    if hass.services.has_service(DOMAIN, SERVICE_VM_COMMAND_WAIT):
+        return
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_VM_COMMAND_WAIT,
+        _async_vm_command_wait,
+        schema=SERVICE_VM_COMMAND_WAIT_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+
+async def _async_vm_command_wait(call: ServiceCall) -> ServiceResponse:
+    """Run a VM or container command and wait for the task to complete."""
+    node = call.data[CONF_NODE]
+    vmid = call.data[CONF_VMID]
+    resource_type = call.data[CONF_RESOURCE_TYPE]
+    command = call.data[CONF_COMMAND]
+    timeout = float(call.data[CONF_TIMEOUT])
+    poll_interval = float(call.data[CONF_POLL_INTERVAL])
+
+    if command not in SUPPORTED_COMMANDS[resource_type]:
+        raise ServiceValidationError(
+            f"Command '{command}' is not supported for resource type '{resource_type}'."
+        )
+
+    coordinator = _resolve_coordinator(call.hass, node, call.data.get(CONF_ENTRY_ID))
+    _validate_target_and_permissions(coordinator, node, vmid, resource_type)
+
+    try:
+        upid = await call.hass.async_add_executor_job(
+            _execute_command,
+            coordinator.proxmox,
+            node,
+            vmid,
+            resource_type,
+            command,
+        )
+        await coordinator.async_refresh()
+
+        task_status = await _wait_for_task(
+            call.hass,
+            coordinator.proxmox,
+            node,
+            upid,
+            timeout,
+            poll_interval,
+        )
+        await coordinator.async_refresh()
+    except AuthenticationError as err:
+        raise HomeAssistantError(
+            "Authentication failed while talking to Proxmox."
+        ) from err
+    except SSLError as err:
+        raise HomeAssistantError("SSL error while talking to Proxmox.") from err
+    except ConnectTimeout as err:
+        raise HomeAssistantError("Timed out while talking to Proxmox.") from err
+    except (ResourceException, requests.exceptions.ConnectionError) as err:
+        raise HomeAssistantError(f"Proxmox API error: {err}") from err
+    except ValueError as err:
+        raise HomeAssistantError(str(err)) from err
+
+    exitstatus = str(task_status.get("exitstatus", ""))
+    if exitstatus != "OK":
+        raise HomeAssistantError(
+            f"Proxmox task {upid} failed with exit status '{exitstatus or 'unknown'}'."
+        )
+
+    return {
+        "command": command,
+        "entry_id": coordinator.config_entry.entry_id,
+        "exitstatus": exitstatus,
+        "node": node,
+        "resource_type": resource_type,
+        "status": task_status.get("status"),
+        "upid": upid,
+        "vmid": vmid,
+    }
+
+
+async def _wait_for_task(
+    hass: HomeAssistant,
+    proxmox: ProxmoxAPI,
+    node: str,
+    upid: str,
+    timeout: float,
+    poll_interval: float,
+) -> dict[str, Any]:
+    """Wait for a Proxmox task to finish and return the final status."""
+    deadline = monotonic() + timeout
+
+    while True:
+        task_status = await hass.async_add_executor_job(
+            _get_task_status,
+            proxmox,
+            node,
+            upid,
+        )
+        if task_status.get("status") != "running":
+            return task_status
+
+        if monotonic() >= deadline:
+            raise HomeAssistantError(
+                f"Timed out waiting for Proxmox task {upid} to finish."
+            )
+
+        await asyncio.sleep(poll_interval)
+
+
+def _resolve_coordinator(
+    hass: HomeAssistant,
+    node: str,
+    entry_id: str | None,
+) -> ProxmoxCoordinator:
+    """Resolve the coordinator for a given node and optional config entry id."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+
+    if entry_id is not None:
+        for entry in entries:
+            if entry.entry_id != entry_id:
+                continue
+            coordinator = getattr(entry, "runtime_data", None)
+            if coordinator is None:
+                raise ServiceValidationError(
+                    f"Config entry '{entry_id}' is not loaded for Proxmox VE."
+                )
+            if node not in coordinator.data:
+                raise ServiceValidationError(
+                    f"Node '{node}' is not managed by config entry '{entry_id}'."
+                )
+            return coordinator
+        raise ServiceValidationError(f"Config entry '{entry_id}' was not found.")
+
+    matches: list[ProxmoxCoordinator] = []
+    for entry in entries:
+        coordinator = getattr(entry, "runtime_data", None)
+        if coordinator is not None and node in coordinator.data:
+            matches.append(coordinator)
+
+    if not matches:
+        raise ServiceValidationError(
+            f"Node '{node}' is not managed by any Proxmox VE entry."
+        )
+
+    if len(matches) > 1:
+        raise ServiceValidationError(
+            f"Node '{node}' exists in multiple Proxmox VE entries; provide entry_id."
+        )
+
+    return matches[0]
+
+
+def _validate_target_and_permissions(
+    coordinator: ProxmoxCoordinator,
+    node: str,
+    vmid: int,
+    resource_type: str,
+) -> None:
+    """Validate that the target exists and the configured user can control it."""
+    node_data = coordinator.data[node]
+    resources = (
+        node_data.vms if resource_type == RESOURCE_QEMU else node_data.containers
+    )
+
+    if vmid not in resources:
+        raise ServiceValidationError(
+            f"{resource_type.upper()} '{vmid}' was not found on node '{node}'."
+        )
+
+    if not is_granted(
+        coordinator.permissions,
+        p_type="vms",
+        p_id=vmid,
+        permission=ProxmoxPermission.POWER,
+    ):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_permission_vm_lxc_power",
+        )
+
+
+def _execute_command(
+    proxmox: ProxmoxAPI,
+    node: str,
+    vmid: int,
+    resource_type: str,
+    command: str,
+) -> str:
+    """Execute a VM or container command and return the task UPID."""
+    resource = (
+        proxmox.nodes(node).qemu(vmid)
+        if resource_type == RESOURCE_QEMU
+        else proxmox.nodes(node).lxc(vmid)
+    )
+    response = SUPPORTED_COMMANDS[resource_type][command](resource)
+    return _extract_upid(response)
+
+
+def _get_task_status(
+    proxmox: ProxmoxAPI,
+    node: str,
+    upid: str,
+) -> dict[str, Any]:
+    """Fetch the current status for a Proxmox task."""
+    status = proxmox.nodes(node).tasks(upid).status.get()
+    if not isinstance(status, dict):
+        raise ValueError(f"Unexpected task status response for Proxmox task {upid!r}.")
+    return status
+
+
+def _extract_upid(response: Any) -> str:
+    """Extract the Proxmox task UPID from a command response."""
+    if isinstance(response, str) and response:
+        return response
+
+    if isinstance(response, dict):
+        upid = response.get("data") or response.get("upid") or response.get("taskid")
+        if isinstance(upid, str) and upid:
+            return upid
+
+    raise ValueError("Proxmox command did not return a task UPID.")

--- a/homeassistant/components/proxmoxve/services.yaml
+++ b/homeassistant/components/proxmoxve/services.yaml
@@ -1,0 +1,50 @@
+vm_command_wait:
+  fields:
+    node:
+      required: true
+      selector:
+        text:
+    vmid:
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+    command:
+      required: true
+      selector:
+        select:
+          options:
+            - start
+            - stop
+            - shutdown
+            - restart
+            - reset
+            - hibernate
+    resource_type:
+      default: qemu
+      selector:
+        select:
+          options:
+            - qemu
+            - lxc
+    entry_id:
+      selector:
+        text:
+    timeout:
+      default: 120
+      selector:
+        number:
+          min: 1
+          max: 3600
+          unit_of_measurement: seconds
+          mode: box
+    poll_interval:
+      default: 1
+      selector:
+        number:
+          min: 0.2
+          max: 30
+          step: 0.1
+          unit_of_measurement: seconds
+          mode: box

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -364,5 +364,41 @@
         "pve": "Proxmox user - Proxmox VE authentication server"
       }
     }
+  },
+  "services": {
+    "vm_command_wait": {
+      "name": "Run command and wait",
+      "description": "Run a VM or container power command and wait for the Proxmox task to finish.",
+      "fields": {
+        "node": {
+          "name": "Node",
+          "description": "The Proxmox node hosting the VM or container."
+        },
+        "vmid": {
+          "name": "VM ID",
+          "description": "The numeric VM or container ID."
+        },
+        "command": {
+          "name": "Command",
+          "description": "The power command to execute."
+        },
+        "resource_type": {
+          "name": "Resource type",
+          "description": "Whether the target is a QEMU virtual machine or an LXC container."
+        },
+        "entry_id": {
+          "name": "Config entry ID",
+          "description": "The Proxmox VE config entry to use when the same node exists in multiple entries."
+        },
+        "timeout": {
+          "name": "Timeout",
+          "description": "How long to wait for the Proxmox task to complete."
+        },
+        "poll_interval": {
+          "name": "Poll interval",
+          "description": "How often to poll the Proxmox task status while waiting."
+        }
+      }
+    }
   }
 }

--- a/tests/components/proxmoxve/test_services.py
+++ b/tests/components/proxmoxve/test_services.py
@@ -1,0 +1,112 @@
+"""Tests for Proxmox VE services."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.proxmoxve.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from . import setup_integration
+
+SERVICE_VM_COMMAND_WAIT = "vm_command_wait"
+
+
+async def test_vm_command_wait_success(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry,
+) -> None:
+    """Test waiting for a successful VM command task."""
+    await setup_integration(hass, mock_config_entry)
+
+    resource = mock_proxmox_client._node_mock.qemu(100)
+    resource.status.start.post.return_value = "UPID:qemu-start"
+    mock_proxmox_client._node_mock.tasks.return_value.status.get.side_effect = [
+        {"status": "running"},
+        {"status": "stopped", "exitstatus": "OK"},
+    ]
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_VM_COMMAND_WAIT,
+        {
+            "node": "pve1",
+            "vmid": 100,
+            "resource_type": "qemu",
+            "command": "start",
+            "poll_interval": 0.2,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response == {
+        "command": "start",
+        "entry_id": mock_config_entry.entry_id,
+        "exitstatus": "OK",
+        "node": "pve1",
+        "resource_type": "qemu",
+        "status": "stopped",
+        "upid": "UPID:qemu-start",
+        "vmid": 100,
+    }
+
+
+async def test_vm_command_wait_task_failure(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry,
+) -> None:
+    """Test surfacing a failed VM command task."""
+    await setup_integration(hass, mock_config_entry)
+
+    resource = mock_proxmox_client._node_mock.qemu(100)
+    resource.status.start.post.return_value = "UPID:qemu-start"
+    mock_proxmox_client._node_mock.tasks.return_value.status.get.return_value = {
+        "status": "stopped",
+        "exitstatus": "ERROR",
+    }
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="failed with exit status 'ERROR'",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_VM_COMMAND_WAIT,
+            {
+                "node": "pve1",
+                "vmid": 100,
+                "resource_type": "qemu",
+                "command": "start",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+
+async def test_vm_command_wait_permission_denied(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry,
+) -> None:
+    """Test validating VM power permissions before starting a task."""
+    await setup_integration(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_VM_COMMAND_WAIT,
+            {
+                "node": "pve1",
+                "vmid": 101,
+                "resource_type": "qemu",
+                "command": "start",
+            },
+            blocking=True,
+            return_response=True,
+        )


### PR DESCRIPTION
## Proposed change
This adds a `vm_command_wait` service to the Proxmox VE integration.

Right now the integration mostly gives you fire-and-forget power buttons, so if you want to start or stop a VM from automations or pyscript the UX is bad: you send the command and then just wait for polling to catch up later. The new service runs the power action, waits for the Proxmox task to finish, refreshes the coordinator, and returns the task result back to the caller. So its a lot easier to build something that can show "starting", "failed", and similar.

I also added a small safety guard for sensors. Some Proxmox responses seem to come back missing fields, and before that could break state updates completely. Now those sensors just return `None` instead of blowing up.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

## Validation notes
- `hassfest` passes for this integration with `--skip-plugins requirements`.
- Full `hassfest` still complains it cant resolve requirements for `proxmoxer`.
