### PR TITLE
Change fan_mode type when the fan_mode is int

### DIFF
--- a/homeassistant/components/lg_thinq/climate.py
+++ b/homeassistant/components/lg_thinq/climate.py
@@ -158,9 +158,8 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
 
         # Update fan, hvac and preset mode.
         if self.supported_features & ClimateEntityFeature.FAN_MODE:
-            self._attr_fan_mode = STR_TO_HA_FAN.get(
-                self.data.fan_mode, self.data.fan_mode
-            )
+            fan_mode = STR_TO_HA_FAN.get(self.data.fan_mode, self.data.fan_mode)
+            self._attr_fan_mode = str(fan_mode) if fan_mode is not None else None
         if self.supported_features & ClimateEntityFeature.SWING_MODE:
             self._attr_swing_mode = STR_TO_SWING.get(self.data.swing_mode)
         if self.supported_features & ClimateEntityFeature.SWING_HORIZONTAL_MODE:

--- a/tests/components/lg_thinq/conftest.py
+++ b/tests/components/lg_thinq/conftest.py
@@ -115,6 +115,7 @@ def mock_thinq_mqtt_client() -> Generator[None]:
 @pytest.fixture(
     params=[
         "air_conditioner",
+        "air_conditioner_step",
         "washer",
         "dehumidifier",
     ]

--- a/tests/components/lg_thinq/fixtures/air_conditioner_step/device.json
+++ b/tests/components/lg_thinq/fixtures/air_conditioner_step/device.json
@@ -1,0 +1,9 @@
+{
+  "deviceId": "MW2-A3F84FBB-469E-4E68-810B-55C3C8A4AB69",
+  "deviceInfo": {
+    "deviceType": "DEVICE_AIR_CONDITIONER",
+    "modelName": "RAC_056905_WW",
+    "alias": "Test step air conditioner",
+    "reportable": true
+  }
+}

--- a/tests/components/lg_thinq/fixtures/air_conditioner_step/energy_profile.json
+++ b/tests/components/lg_thinq/fixtures/air_conditioner_step/energy_profile.json
@@ -1,0 +1,6 @@
+{
+  "resultCode": "0000",
+  "result": {
+    "property": ["energyUsage"]
+  }
+}

--- a/tests/components/lg_thinq/fixtures/air_conditioner_step/profile.json
+++ b/tests/components/lg_thinq/fixtures/air_conditioner_step/profile.json
@@ -1,0 +1,240 @@
+{
+  "notification": {
+    "push": ["WATER_IS_FULL"]
+  },
+  "property": {
+    "airConJobMode": {
+      "currentJobMode": {
+        "mode": ["r", "w"],
+        "type": "enum",
+        "value": {
+          "r": ["AIR_CLEAN", "COOL", "AIR_DRY"],
+          "w": ["AIR_CLEAN", "COOL", "AIR_DRY"]
+        }
+      }
+    },
+    "airFlow": {
+      "windStep": {
+        "mode": ["r", "w"],
+        "type": "range",
+        "value": {
+          "r": {
+            "max": 5,
+            "min": 1,
+            "step": 1
+          },
+          "w": {
+            "max": 5,
+            "min": 1,
+            "step": 1
+          }
+        }
+      },
+      "windStrength": {
+        "mode": ["r", "w"],
+        "type": "enum",
+        "value": {
+          "r": ["LOW", "MID", "HIGH", "AUTO"],
+          "w": ["LOW", "MID", "HIGH", "AUTO"]
+        }
+      },
+      "windStrengthDetail": {
+        "mode": ["r", "w"],
+        "type": "enum",
+        "value": {
+          "r": ["NATURE", "LOW", "LOW_MID", "MID", "HIGH"],
+          "w": ["NATURE", "LOW", "LOW_MID", "MID", "HIGH"]
+        }
+      }
+    },
+    "airQualitySensor": {
+      "humidity": {
+        "mode": ["r"],
+        "type": "number"
+      },
+      "monitoringEnabled": {
+        "mode": ["r", "w"],
+        "type": "enum",
+        "value": {
+          "r": ["ON_WORKING", "ALWAYS"],
+          "w": ["ON_WORKING", "ALWAYS"]
+        }
+      },
+      "oder": {
+        "mode": ["r"],
+        "type": "number"
+      },
+      "totalPollution": {
+        "mode": ["r"],
+        "type": "number"
+      }
+    },
+    "filterInfo": {
+      "filterLifetime": {
+        "mode": ["r"],
+        "type": "number"
+      },
+      "usedTime": {
+        "mode": ["r"],
+        "type": "number"
+      }
+    },
+    "operation": {
+      "airCleanOperationMode": {
+        "mode": ["w"],
+        "type": "enum",
+        "value": {
+          "w": ["START", "STOP"]
+        }
+      },
+      "airConOperationMode": {
+        "mode": ["r", "w"],
+        "type": "enum",
+        "value": {
+          "r": ["POWER_ON", "POWER_OFF"],
+          "w": ["POWER_ON", "POWER_OFF"]
+        }
+      }
+    },
+    "powerSave": {
+      "powerSaveEnabled": {
+        "mode": ["r", "w"],
+        "type": "boolean",
+        "value": {
+          "r": [false, true],
+          "w": [false, true]
+        }
+      }
+    },
+    "temperature": {
+      "coolTargetTemperature": {
+        "mode": ["w"],
+        "type": "range",
+        "value": {
+          "w": {
+            "max": 30,
+            "min": 18,
+            "step": 1
+          }
+        }
+      },
+      "currentTemperature": {
+        "mode": ["r"],
+        "type": "number"
+      },
+      "targetTemperature": {
+        "mode": ["r", "w"],
+        "type": "range",
+        "value": {
+          "r": {
+            "max": 30,
+            "min": 18,
+            "step": 1
+          },
+          "w": {
+            "max": 30,
+            "min": 18,
+            "step": 1
+          }
+        }
+      },
+      "unit": {
+        "mode": ["r"],
+        "type": "enum",
+        "value": {
+          "r": ["C", "F"]
+        }
+      }
+    },
+    "temperatureInUnits": [
+      {
+        "currentTemperature": {
+          "type": "number",
+          "mode": ["r"]
+        },
+        "targetTemperature": {
+          "type": "number",
+          "mode": ["r"]
+        },
+        "coolTargetTemperature": {
+          "type": "range",
+          "mode": ["w"],
+          "value": {
+            "w": {
+              "max": 30,
+              "min": 18,
+              "step": 1
+            }
+          }
+        },
+        "unit": "C"
+      },
+      {
+        "currentTemperature": {
+          "type": "number",
+          "mode": ["r"]
+        },
+        "targetTemperature": {
+          "type": "number",
+          "mode": ["r"]
+        },
+        "coolTargetTemperature": {
+          "type": "range",
+          "mode": ["w"],
+          "value": {
+            "w": {
+              "max": 86,
+              "min": 64,
+              "step": 2
+            }
+          }
+        },
+        "unit": "F"
+      }
+    ],
+    "timer": {
+      "relativeHourToStart": {
+        "mode": ["r", "w"],
+        "type": "number"
+      },
+      "relativeHourToStop": {
+        "mode": ["r", "w"],
+        "type": "number"
+      },
+      "relativeMinuteToStart": {
+        "mode": ["r", "w"],
+        "type": "number"
+      },
+      "relativeMinuteToStop": {
+        "mode": ["r", "w"],
+        "type": "number"
+      },
+      "absoluteHourToStart": {
+        "mode": ["r", "w"],
+        "type": "number"
+      },
+      "absoluteMinuteToStart": {
+        "mode": ["r", "w"],
+        "type": "number"
+      }
+    },
+    "windDirection": {
+      "rotateUpDown": {
+        "type": "boolean",
+        "mode": ["r", "w"],
+        "value": {
+          "r": [true, false],
+          "w": [true, false]
+        }
+      },
+      "rotateLeftRight": {
+        "type": "boolean",
+        "mode": ["r", "w"],
+        "value": {
+          "r": [true, false],
+          "w": [true, false]
+        }
+      }
+    }
+  }
+}

--- a/tests/components/lg_thinq/fixtures/air_conditioner_step/status.json
+++ b/tests/components/lg_thinq/fixtures/air_conditioner_step/status.json
@@ -1,0 +1,58 @@
+{
+  "airConJobMode": {
+    "currentJobMode": "COOL"
+  },
+  "airFlow": {
+    "windStep": 5,
+    "windStrength": "HIGH",
+    "windStrengthDetail": "HIGH"
+  },
+  "airQualitySensor": {
+    "humidity": 40,
+    "monitoringEnabled": "ON_WORKING",
+    "totalPollution": 3,
+    "totalPollutionLevel": "GOOD"
+  },
+  "filterInfo": {
+    "filterLifetime": 540,
+    "usedTime": 180
+  },
+  "operation": {
+    "airConOperationMode": "POWER_ON"
+  },
+  "powerSave": {
+    "powerSaveEnabled": false
+  },
+  "sleepTimer": {
+    "relativeStopTimer": "UNSET"
+  },
+  "temperature": {
+    "currentTemperature": 25,
+    "targetTemperature": 19,
+    "unit": "C"
+  },
+  "temperatureInUnits": [
+    {
+      "currentTemperature": 25,
+      "targetTemperature": 19,
+      "unit": "C"
+    },
+    {
+      "currentTemperature": 77,
+      "targetTemperature": 66,
+      "unit": "F"
+    }
+  ],
+  "timer": {
+    "relativeStartTimer": "UNSET",
+    "relativeStopTimer": "UNSET",
+    "absoluteStartTimer": "SET",
+    "absoluteStopTimer": "UNSET",
+    "absoluteHourToStart": 13,
+    "absoluteMinuteToStart": 14
+  },
+  "windDirection": {
+    "rotateUpDown": false,
+    "rotateLeftRight": false
+  }
+}

--- a/tests/components/lg_thinq/snapshots/test_climate.ambr
+++ b/tests/components/lg_thinq/snapshots/test_climate.ambr
@@ -108,3 +108,116 @@
     'state': 'cool',
   })
 # ---
+# name: test_climate_entities[air_conditioner_step][climate.test_step_air_conditioner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'fan_modes': list([
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+      ]),
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': 86,
+      'min_temp': 64,
+      'preset_modes': list([
+        'none',
+        'air_clean',
+      ]),
+      'swing_horizontal_modes': list([
+        'on',
+        'off',
+      ]),
+      'swing_modes': list([
+        'on',
+        'off',
+      ]),
+      'target_temp_step': 2,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.test_step_air_conditioner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'lg_thinq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 953>,
+    'translation_key': <ExtendedProperty.CLIMATE_AIR_CONDITIONER: 'climate_air_conditioner'>,
+    'unique_id': 'MW2-A3F84FBB-469E-4E68-810B-55C3C8A4AB69_climate_air_conditioner',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_entities[air_conditioner_step][climate.test_step_air_conditioner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_humidity': 40,
+      'current_temperature': 77,
+      'fan_mode': '5',
+      'fan_modes': list([
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+      ]),
+      'friendly_name': 'Test step air conditioner',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': 86,
+      'min_temp': 64,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'none',
+        'air_clean',
+      ]),
+      'supported_features': <ClimateEntityFeature: 953>,
+      'swing_horizontal_mode': 'off',
+      'swing_horizontal_modes': list([
+        'on',
+        'off',
+      ]),
+      'swing_mode': 'off',
+      'swing_modes': list([
+        'on',
+        'off',
+      ]),
+      'target_temp_step': 2,
+      'temperature': 66,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.test_step_air_conditioner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---

--- a/tests/components/lg_thinq/test_climate.py
+++ b/tests/components/lg_thinq/test_climate.py
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-@pytest.mark.parametrize("device_fixture", ["air_conditioner"])
+@pytest.mark.parametrize("device_fixture", ["air_conditioner", "air_conditioner_step"])
 async def test_climate_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,

--- a/tests/components/lg_thinq/test_switch.py
+++ b/tests/components/lg_thinq/test_switch.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -13,6 +14,10 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    "device_fixture", ["air_conditioner", "dehumidifier", "washer"]
+)
 async def test_switch_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are devices where the fan mode is set to numbers like 1, 2, 3, but climate's fan_mode is of type str, so conversion is required.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
