### PR TITLE
Migrate Immich integration from aioimmich to immichpy

### DIFF
--- a/homeassistant/components/immich/config_flow.py
+++ b/homeassistant/components/immich/config_flow.py
@@ -6,10 +6,11 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-from aioimmich import Immich
-from aioimmich.const import CONNECT_ERRORS
-from aioimmich.exceptions import ImmichUnauthorizedError
-from aioimmich.users.models import ImmichUser
+from immichpy import AsyncClient
+from immichpy.client.generated.exceptions import UnauthorizedException
+from immichpy.client.generated.models.user_admin_response_dto import (
+    UserAdminResponseDto,
+)
 import voluptuous as vol
 from yarl import URL
 
@@ -31,7 +32,7 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .const import DEFAULT_VERIFY_SSL, DOMAIN
+from .const import CONNECT_ERRORS, DEFAULT_VERIFY_SSL, DOMAIN
 
 
 class InvalidUrl(HomeAssistantError):
@@ -67,11 +68,16 @@ def _parse_url(url: str) -> tuple[str, int, bool]:
 
 async def check_user_info(
     hass: HomeAssistant, host: str, port: int, ssl: bool, verify_ssl: bool, api_key: str
-) -> ImmichUser:
+) -> UserAdminResponseDto:
     """Test connection and fetch own user info."""
-    session = async_get_clientsession(hass, verify_ssl)
-    immich = Immich(session, api_key, host, port, ssl)
-    return await immich.users.async_get_my_user()
+    scheme = "https" if ssl else "http"
+    base_url = f"{scheme}://{host}:{port}/api"
+    immich = AsyncClient(
+        api_key=api_key,
+        base_url=base_url,
+        http_client=async_get_clientsession(hass, verify_ssl),
+    )
+    return await immich.users.get_my_user()
 
 
 class ImmichConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -102,7 +108,7 @@ class ImmichConfigFlow(ConfigFlow, domain=DOMAIN):
                         user_input[CONF_VERIFY_SSL],
                         user_input[CONF_API_KEY],
                     )
-                except ImmichUnauthorizedError:
+                except UnauthorizedException:
                     errors["base"] = "invalid_auth"
                 except CONNECT_ERRORS:
                     errors["base"] = "cannot_connect"
@@ -110,7 +116,7 @@ class ImmichConfigFlow(ConfigFlow, domain=DOMAIN):
                     _LOGGER.exception("Unexpected exception")
                     errors["base"] = "unknown"
                 else:
-                    await self.async_set_unique_id(my_user_info.user_id)
+                    await self.async_set_unique_id(my_user_info.id)
                     self._abort_if_unique_id_configured()
                     return self.async_create_entry(
                         title=my_user_info.name,
@@ -152,7 +158,7 @@ class ImmichConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._current_data[CONF_VERIFY_SSL],
                     user_input[CONF_API_KEY],
                 )
-            except ImmichUnauthorizedError:
+            except UnauthorizedException:
                 errors["base"] = "invalid_auth"
             except CONNECT_ERRORS:
                 errors["base"] = "cannot_connect"
@@ -160,7 +166,7 @@ class ImmichConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(my_user_info.user_id)
+                await self.async_set_unique_id(my_user_info.id)
                 self._abort_if_unique_id_mismatch()
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(), data_updates=user_input
@@ -202,7 +208,7 @@ class ImmichConfigFlow(ConfigFlow, domain=DOMAIN):
                         user_input[CONF_VERIFY_SSL],
                         current_data[CONF_API_KEY],
                     )
-                except ImmichUnauthorizedError:
+                except UnauthorizedException:
                     errors["base"] = "invalid_auth"
                 except CONNECT_ERRORS:
                     errors["base"] = "cannot_connect"

--- a/homeassistant/components/immich/const.py
+++ b/homeassistant/components/immich/const.py
@@ -1,7 +1,17 @@
 """Constants for the Immich integration."""
 
+import asyncio
+
+import aiohttp
+
 DOMAIN = "immich"
 
 DEFAULT_PORT = 2283
 DEFAULT_USE_SSL = False
 DEFAULT_VERIFY_SSL = False
+
+CONNECT_ERRORS = (
+    aiohttp.ClientError,
+    asyncio.TimeoutError,
+    OSError,
+)

--- a/homeassistant/components/immich/coordinator.py
+++ b/homeassistant/components/immich/coordinator.py
@@ -71,7 +71,9 @@ class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
         self.api = AsyncClient(
             api_key=config_entry.data[CONF_API_KEY],
             base_url=f"{base_url}/api",
-            http_client=async_get_clientsession(hass, config_entry.data[CONF_VERIFY_SSL]),
+            http_client=async_get_clientsession(
+                hass, config_entry.data[CONF_VERIFY_SSL]
+            ),
         )
         self.is_admin = False
         self.configuration_url = base_url
@@ -106,9 +108,7 @@ class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
             server_about = await self.api.server.get_about_info()
             server_storage = await self.api.server.get_storage()
             server_usage = (
-                await self.api.server.get_server_statistics()
-                if self.is_admin
-                else None
+                await self.api.server.get_server_statistics() if self.is_admin else None
             )
             server_version_check = (
                 await self.api.server.get_version_check()

--- a/homeassistant/components/immich/coordinator.py
+++ b/homeassistant/components/immich/coordinator.py
@@ -6,16 +6,21 @@ from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
-from aioimmich import Immich
-from aioimmich.const import CONNECT_ERRORS
-from aioimmich.exceptions import ImmichUnauthorizedError
-from aioimmich.server.models import (
-    ImmichServerAbout,
-    ImmichServerStatistics,
-    ImmichServerStorage,
-    ImmichServerVersionCheck,
-)
 from awesomeversion import AwesomeVersion
+from immichpy import AsyncClient
+from immichpy.client.generated.exceptions import UnauthorizedException
+from immichpy.client.generated.models.server_about_response_dto import (
+    ServerAboutResponseDto,
+)
+from immichpy.client.generated.models.server_stats_response_dto import (
+    ServerStatsResponseDto,
+)
+from immichpy.client.generated.models.server_storage_response_dto import (
+    ServerStorageResponseDto,
+)
+from immichpy.client.generated.models.version_check_state_response_dto import (
+    VersionCheckStateResponseDto,
+)
 from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
@@ -31,7 +36,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import CONNECT_ERRORS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,38 +45,36 @@ _LOGGER = logging.getLogger(__name__)
 class ImmichData:
     """Data class for storing data from the API."""
 
-    server_about: ImmichServerAbout
-    server_storage: ImmichServerStorage
-    server_usage: ImmichServerStatistics | None
-    server_version_check: ImmichServerVersionCheck | None
+    server_about: ServerAboutResponseDto
+    server_storage: ServerStorageResponseDto
+    server_usage: ServerStatsResponseDto | None
+    server_version_check: VersionCheckStateResponseDto | None
 
 
 type ImmichConfigEntry = ConfigEntry[ImmichDataUpdateCoordinator]
 
 
 class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
-    """Class to manage fetching IMGW-PIB data API."""
+    """Class to manage fetching Immich data from the API."""
 
     config_entry: ImmichConfigEntry
 
     def __init__(self, hass: HomeAssistant, config_entry: ImmichConfigEntry) -> None:
         """Initialize the data update coordinator."""
-        self.api = Immich(
-            async_get_clientsession(hass, config_entry.data[CONF_VERIFY_SSL]),
-            config_entry.data[CONF_API_KEY],
-            config_entry.data[CONF_HOST],
-            config_entry.data[CONF_PORT],
-            config_entry.data[CONF_SSL],
-            "home-assistant",
-        )
-        self.is_admin = False
-        self.configuration_url = str(
+        base_url = str(
             URL.build(
                 scheme="https" if config_entry.data[CONF_SSL] else "http",
                 host=config_entry.data[CONF_HOST],
                 port=config_entry.data[CONF_PORT],
             )
         )
+        self.api = AsyncClient(
+            api_key=config_entry.data[CONF_API_KEY],
+            base_url=f"{base_url}/api",
+            http_client=async_get_clientsession(hass, config_entry.data[CONF_VERIFY_SSL]),
+        )
+        self.is_admin = False
+        self.configuration_url = base_url
         super().__init__(
             hass,
             _LOGGER,
@@ -83,8 +86,8 @@ class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
     async def _async_setup(self) -> None:
         """Handle setup of the coordinator."""
         try:
-            user_info = await self.api.users.async_get_my_user()
-        except ImmichUnauthorizedError as err:
+            user_info = await self.api.users.get_my_user()
+        except UnauthorizedException as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_error",
@@ -100,19 +103,19 @@ class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
     async def _async_update_data(self) -> ImmichData:
         """Update data via internal method."""
         try:
-            server_about = await self.api.server.async_get_about_info()
-            server_storage = await self.api.server.async_get_storage_info()
+            server_about = await self.api.server.get_about_info()
+            server_storage = await self.api.server.get_storage()
             server_usage = (
-                await self.api.server.async_get_server_statistics()
+                await self.api.server.get_server_statistics()
                 if self.is_admin
                 else None
             )
             server_version_check = (
-                await self.api.server.async_get_version_check()
+                await self.api.server.get_version_check()
                 if AwesomeVersion(server_about.version) >= AwesomeVersion("v1.134.0")
                 else None
             )
-        except ImmichUnauthorizedError as err:
+        except UnauthorizedException as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_error",

--- a/homeassistant/components/immich/diagnostics.py
+++ b/homeassistant/components/immich/diagnostics.py
@@ -23,9 +23,17 @@ async def async_get_config_entry_diagnostics(
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
         "data": {
-            "server_about": data.server_about.model_dump() if data.server_about else None,
-            "server_storage": data.server_storage.model_dump() if data.server_storage else None,
-            "server_usage": data.server_usage.model_dump() if data.server_usage else None,
-            "server_version_check": data.server_version_check.model_dump() if data.server_version_check else None,
+            "server_about": data.server_about.model_dump()
+            if data.server_about
+            else None,
+            "server_storage": data.server_storage.model_dump()
+            if data.server_storage
+            else None,
+            "server_usage": data.server_usage.model_dump()
+            if data.server_usage
+            else None,
+            "server_version_check": data.server_version_check.model_dump()
+            if data.server_version_check
+            else None,
         },
     }

--- a/homeassistant/components/immich/diagnostics.py
+++ b/homeassistant/components/immich/diagnostics.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -19,8 +18,14 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
+    data = coordinator.data
 
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "data": asdict(coordinator.data),
+        "data": {
+            "server_about": data.server_about.model_dump() if data.server_about else None,
+            "server_storage": data.server_storage.model_dump() if data.server_storage else None,
+            "server_usage": data.server_usage.model_dump() if data.server_usage else None,
+            "server_version_check": data.server_version_check.model_dump() if data.server_version_check else None,
+        },
     }

--- a/homeassistant/components/immich/manifest.json
+++ b/homeassistant/components/immich/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["immichpy"],
   "quality_scale": "platinum",
-  "requirements": ["immichpy==4.0.3"]
+  "requirements": ["immichpy==1.6.5"]
 }

--- a/homeassistant/components/immich/manifest.json
+++ b/homeassistant/components/immich/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://www.home-assistant.io/integrations/immich",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "loggers": ["aioimmich"],
+  "loggers": ["immichpy"],
   "quality_scale": "platinum",
-  "requirements": ["aioimmich==0.12.1"]
+  "requirements": ["immichpy==4.0.3"]
 }

--- a/homeassistant/components/immich/media_source.py
+++ b/homeassistant/components/immich/media_source.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import cast
+from uuid import UUID
 
 from aiohttp.web import HTTPNotFound, Request, Response, StreamResponse
-from aioimmich.assets.models import ImmichAsset
-from aioimmich.exceptions import ImmichError
+from immichpy import AsyncClient
+from immichpy.client.generated.exceptions import ApiException
+from immichpy.client.generated.models.asset_media_size import AssetMediaSize
+from immichpy.client.generated.models.asset_response_dto import AssetResponseDto
+from immichpy.client.generated.models.metadata_search_dto import MetadataSearchDto
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.media_player import BrowseError, MediaClass
@@ -25,7 +30,6 @@ from .const import DOMAIN
 from .coordinator import ImmichConfigEntry
 
 LOGGER = getLogger(__name__)
-
 
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up Immich media source."""
@@ -114,7 +118,7 @@ class ImmichMediaSource(MediaSource):
             )
         )
         assert entry
-        immich_api = entry.runtime_data.api
+        immich_api: AsyncClient = entry.runtime_data.api
 
         if identifier.collection is None:
             LOGGER.debug("Render all collections for %s", entry.title)
@@ -138,14 +142,14 @@ class ImmichMediaSource(MediaSource):
             if identifier.collection == "albums":
                 LOGGER.debug("Render all albums for %s", entry.title)
                 try:
-                    albums = await immich_api.albums.async_get_all_albums()
-                except ImmichError:
+                    albums = await immich_api.albums.get_all_albums()
+                except ApiException:
                     return []
 
                 return [
                     BrowseMediaSource(
                         domain=DOMAIN,
-                        identifier=f"{identifier.unique_id}|albums|{album.album_id}",
+                        identifier=f"{identifier.unique_id}|albums|{album.id}",
                         media_class=MediaClass.DIRECTORY,
                         media_content_type=MediaClass.IMAGE,
                         title=album.album_name,
@@ -159,14 +163,14 @@ class ImmichMediaSource(MediaSource):
             if identifier.collection == "tags":
                 LOGGER.debug("Render all tags for %s", entry.title)
                 try:
-                    tags = await immich_api.tags.async_get_all_tags()
-                except ImmichError:
+                    tags = await immich_api.tags.get_all_tags()
+                except ApiException:
                     return []
 
                 return [
                     BrowseMediaSource(
                         domain=DOMAIN,
-                        identifier=f"{identifier.unique_id}|tags|{tag.tag_id}",
+                        identifier=f"{identifier.unique_id}|tags|{tag.id}",
                         media_class=MediaClass.DIRECTORY,
                         media_content_type=MediaClass.IMAGE,
                         title=tag.name,
@@ -179,29 +183,29 @@ class ImmichMediaSource(MediaSource):
             if identifier.collection == "people":
                 LOGGER.debug("Render all people for %s", entry.title)
                 try:
-                    people = await immich_api.people.async_get_all_people()
-                except ImmichError:
+                    people_response = await immich_api.people.get_all_people()
+                except ApiException:
                     return []
 
                 return [
                     BrowseMediaSource(
                         domain=DOMAIN,
-                        identifier=f"{identifier.unique_id}|people|{person.person_id}",
+                        identifier=f"{identifier.unique_id}|people|{person.id}",
                         media_class=MediaClass.DIRECTORY,
                         media_content_type=MediaClass.IMAGE,
                         title=person.name,
                         can_play=False,
                         can_expand=True,
-                        thumbnail=f"/immich/{identifier.unique_id}/{person.person_id}/person/image/jpg",
+                        thumbnail=f"/immich/{identifier.unique_id}/{person.id}/person/image/jpg",
                     )
-                    for person in people
+                    for person in people_response.people
                 ]
 
         # --------------------------------------------------------
         # final level, render assets
         # --------------------------------------------------------
         assert identifier.collection_id is not None
-        assets: list[ImmichAsset] = []
+        assets: list[AssetResponseDto] = []
         if identifier.collection == "albums":
             LOGGER.debug(
                 "Render all assets of album %s for %s",
@@ -209,11 +213,11 @@ class ImmichMediaSource(MediaSource):
                 entry.title,
             )
             try:
-                album_info = await immich_api.albums.async_get_album_info(
-                    identifier.collection_id
+                album_info = await immich_api.albums.get_album_info(
+                    id=identifier.collection_id
                 )
                 assets = album_info.assets
-            except ImmichError:
+            except ApiException:
                 return []
 
         elif identifier.collection == "tags":
@@ -222,10 +226,13 @@ class ImmichMediaSource(MediaSource):
                 identifier.collection_id,
             )
             try:
-                assets = await immich_api.search.async_get_all_by_tag_ids(
-                    [identifier.collection_id]
+                result = await immich_api.search.search_assets(
+                    metadata_search_dto=MetadataSearchDto(
+                        tag_ids=[UUID(identifier.collection_id)]
+                    )
                 )
-            except ImmichError:
+                assets = result.assets.items
+            except ApiException:
                 return []
 
         elif identifier.collection == "people":
@@ -234,10 +241,13 @@ class ImmichMediaSource(MediaSource):
                 identifier.collection_id,
             )
             try:
-                assets = await immich_api.search.async_get_all_by_person_ids(
-                    [identifier.collection_id]
+                result = await immich_api.search.search_assets(
+                    metadata_search_dto=MetadataSearchDto(
+                        person_ids=[UUID(identifier.collection_id)]
+                    )
                 )
-            except ImmichError:
+                assets = result.assets.items
+            except ApiException:
                 return []
 
         ret: list[BrowseMediaSource] = []
@@ -263,7 +273,7 @@ class ImmichMediaSource(MediaSource):
                         f"{identifier.unique_id}|"
                         f"{identifier.collection}|"
                         f"{identifier.collection_id}|"
-                        f"{asset.asset_id}|"
+                        f"{asset.id}|"
                         f"{asset.original_file_name}|"
                         f"{mime_type}"
                     ),
@@ -272,7 +282,7 @@ class ImmichMediaSource(MediaSource):
                     title=asset.original_file_name,
                     can_play=can_play,
                     can_expand=False,
-                    thumbnail=f"/immich/{identifier.unique_id}/{asset.asset_id}/thumbnail/{thumb_mime_type}",
+                    thumbnail=f"/immich/{identifier.unique_id}/{asset.id}/thumbnail/{thumb_mime_type}",
                 )
             )
 
@@ -332,15 +342,17 @@ class ImmichMediaView(HomeAssistantView):
             )
         )
         assert entry
-        immich_api = entry.runtime_data.api
+        immich_api: AsyncClient = entry.runtime_data.api
 
         # stream response for videos
         if mime_type_base == "video":
             try:
-                resp = await immich_api.assets.async_play_video_stream(asset_id)
-            except ImmichError as exc:
+                resp = await immich_api.assets.play_asset_video_without_preload_content(
+                    id=UUID(asset_id)
+                )
+            except ApiException as exc:
                 raise HTTPNotFound from exc
-            stream = ChunkAsyncStreamIterator(resp)
+            stream = ChunkAsyncStreamIterator(resp.content)
             response = StreamResponse()
             await response.prepare(request)
             async for chunk in stream:
@@ -350,9 +362,12 @@ class ImmichMediaView(HomeAssistantView):
         # web response for images
         try:
             if size == "person":
-                image = await immich_api.people.async_get_person_thumbnail(asset_id)
+                image = await immich_api.people.get_person_thumbnail(id=UUID(asset_id))
             else:
-                image = await immich_api.assets.async_view_asset(asset_id, size)
-        except ImmichError as exc:
+                image = await immich_api.assets.view_asset(
+                    id=UUID(asset_id),
+                    size=AssetMediaSize(size),
+                )
+        except ApiException as exc:
             raise HTTPNotFound from exc
-        return Response(body=image, content_type=f"{mime_type_base}/{mime_type_format}")
+        return Response(body=bytes(image), content_type=f"{mime_type_base}/{mime_type_format}")

--- a/homeassistant/components/immich/media_source.py
+++ b/homeassistant/components/immich/media_source.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import cast
 from uuid import UUID
 
 from aiohttp.web import HTTPNotFound, Request, Response, StreamResponse
@@ -30,6 +29,7 @@ from .const import DOMAIN
 from .coordinator import ImmichConfigEntry
 
 LOGGER = getLogger(__name__)
+
 
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up Immich media source."""
@@ -370,4 +370,6 @@ class ImmichMediaView(HomeAssistantView):
                 )
         except ApiException as exc:
             raise HTTPNotFound from exc
-        return Response(body=bytes(image), content_type=f"{mime_type_base}/{mime_type_format}")
+        return Response(
+            body=bytes(image), content_type=f"{mime_type_base}/{mime_type_format}"
+        )

--- a/homeassistant/components/immich/services.py
+++ b/homeassistant/components/immich/services.py
@@ -1,8 +1,11 @@
 """Services for the Immich integration."""
 
+from datetime import datetime, timezone
 import logging
+from pathlib import Path
 
-from aioimmich.exceptions import ImmichError
+from immichpy.client.generated.exceptions import ApiException
+from immichpy.client.generated.models.bulk_ids_dto import BulkIdsDto
 import voluptuous as vol
 
 from homeassistant.components.media_source import async_resolve_media
@@ -53,8 +56,8 @@ async def _async_upload_file(service_call: ServiceCall) -> None:
 
     if target_album := service_call.data.get(CONF_ALBUM_ID):
         try:
-            await coordinator.api.albums.async_get_album_info(target_album, True)
-        except ImmichError as ex:
+            await coordinator.api.albums.get_album_info(id=target_album, without_assets=True)
+        except ApiException as ex:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="album_not_found",
@@ -62,12 +65,25 @@ async def _async_upload_file(service_call: ServiceCall) -> None:
             ) from ex
 
     try:
-        upload_result = await coordinator.api.assets.async_upload_asset(str(media.path))
+        filepath = Path(media.path)
+        stats = filepath.stat()
+        file_created_at = datetime.fromtimestamp(stats.st_ctime, tz=timezone.utc)
+        file_modified_at = datetime.fromtimestamp(stats.st_mtime, tz=timezone.utc)
+        device_asset_id = f"{filepath.name}-{stats.st_size}"
+
+        upload_result = await coordinator.api.assets.upload_asset(
+            asset_data=str(filepath),
+            device_asset_id=device_asset_id,
+            device_id="home-assistant",
+            file_created_at=file_created_at,
+            file_modified_at=file_modified_at,
+        )
         if target_album:
-            await coordinator.api.albums.async_add_assets_to_album(
-                target_album, [upload_result.asset_id]
+            await coordinator.api.albums.add_assets_to_album(
+                id=target_album,
+                bulk_ids_dto=BulkIdsDto(ids=[upload_result.id]),
             )
-    except ImmichError as ex:
+    except ApiException as ex:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="upload_failed",

--- a/homeassistant/components/immich/services.py
+++ b/homeassistant/components/immich/services.py
@@ -1,6 +1,6 @@
 """Services for the Immich integration."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import logging
 from pathlib import Path
 
@@ -56,7 +56,9 @@ async def _async_upload_file(service_call: ServiceCall) -> None:
 
     if target_album := service_call.data.get(CONF_ALBUM_ID):
         try:
-            await coordinator.api.albums.get_album_info(id=target_album, without_assets=True)
+            await coordinator.api.albums.get_album_info(
+                id=target_album, without_assets=True
+            )
         except ApiException as ex:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -67,8 +69,8 @@ async def _async_upload_file(service_call: ServiceCall) -> None:
     try:
         filepath = Path(media.path)
         stats = filepath.stat()
-        file_created_at = datetime.fromtimestamp(stats.st_ctime, tz=timezone.utc)
-        file_modified_at = datetime.fromtimestamp(stats.st_mtime, tz=timezone.utc)
+        file_created_at = datetime.fromtimestamp(stats.st_ctime, tz=UTC)
+        file_modified_at = datetime.fromtimestamp(stats.st_mtime, tz=UTC)
         device_asset_id = f"{filepath.name}-{stats.st_size}"
 
         upload_result = await coordinator.api.assets.upload_asset(

--- a/homeassistant/components/immich/update.py
+++ b/homeassistant/components/immich/update.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing
+
 from homeassistant.components.update import UpdateEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -41,13 +43,15 @@ class ImmichUpdateEntity(ImmichEntity, UpdateEntity):
     @property
     def installed_version(self) -> str:
         """Current installed immich server version."""
-        return self.coordinator.data.server_about.version
+        return typing.cast(str, self.coordinator.data.server_about.version)
 
     @property
     def latest_version(self) -> str | None:
         """Available new immich server version."""
         assert self.coordinator.data.server_version_check
-        return self.coordinator.data.server_version_check.release_version
+        return typing.cast(
+            str | None, self.coordinator.data.server_version_check.release_version
+        )
 
     @property
     def release_url(self) -> str | None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -293,9 +293,6 @@ aiohue==4.8.0
 # homeassistant.components.imap
 aioimaplib==2.0.1
 
-# homeassistant.components.immich
-aioimmich==0.12.1
-
 # homeassistant.components.apache_kafka
 aiokafka==0.10.0
 
@@ -1308,6 +1305,9 @@ imeon_inverter_api==0.4.0
 
 # homeassistant.components.imgw_pib
 imgw_pib==2.0.2
+
+# homeassistant.components.immich
+immichpy==1.6.5
 
 # homeassistant.components.incomfort
 incomfort-client==0.6.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,9 +281,6 @@ aiohue==4.8.0
 # homeassistant.components.imap
 aioimaplib==2.0.1
 
-# homeassistant.components.immich
-aioimmich==0.12.1
-
 # homeassistant.components.apache_kafka
 aiokafka==0.10.0
 
@@ -1160,6 +1157,9 @@ imeon_inverter_api==0.4.0
 
 # homeassistant.components.imgw_pib
 imgw_pib==2.0.2
+
+# homeassistant.components.immich
+immichpy==1.6.5
 
 # homeassistant.components.incomfort
 incomfort-client==0.6.12


### PR DESCRIPTION
## Why

Replace **aioimmich** with **[immichpy](https://github.com/timonrieger/immichpy)** so the integration uses an OpenAPI-generated, typed client aligned with the official Immich API. Behavior for users (config flow, sensors, update entity, media source, upload service, diagnostics) stays the same.

See [Why immichpy?](https://immichpy.timonrieger.de/overview/why)

## How

- `AsyncClient` with shared HA `aiohttp` session and `/api` base URL; Pydantic models instead of mashumaro dataclasses; prefixed IDs (`album_id`, etc.) → plain `id`.
- Exceptions: `ApiException` / `UnauthorizedException`; connectivity errors use a local `CONNECT_ERRORS` tuple.
- Upload uses `upload_asset` with `device_asset_id`, `device_id`, and file timestamps from `Path.stat()`.
- Media: `search_assets` + `MetadataSearchDto` for tag/person browsing; video via `play_asset_video_without_preload_content` and stream iterator; thumbnails/fullsize via `view_asset` + `AssetMediaSize`.
- Diagnostics: `.model_dump()` for API payloads instead of `dataclasses.asdict`.

## Testing

- Docker Home Assistant against demo.immich.app: setup, browse media (albums/tags/people), image thumbnails, video playback, upload service, diagnostics download.

## Notes

@mib1185 I am open for any questions you have and obviously willing to help support with this integration. If you consider merging this, I will address remaining nitpicks and sign the CLA. Thank you!
