### PR TITLE
Handling missing unique id in Fing Integration

### DIFF
--- a/homeassistant/components/fing/config_flow.py
+++ b/homeassistant/components/fing/config_flow.py
@@ -83,7 +83,11 @@ class FingConfigFlow(ConfigFlow, domain=DOMAIN):
                         upnp_available = True
                         agent_name = agent_info_response.agent_id
                         await self.async_set_unique_id(agent_info_response.agent_id)
-                        self._abort_if_unique_id_configured()
+                    else:
+                        await self.async_set_unique_id(
+                            f"{user_input[CONF_IP_ADDRESS]}:{user_input[CONF_PORT]}"
+                        )
+                    self._abort_if_unique_id_configured()
 
                     data = {
                         CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],

--- a/tests/components/fing/test_config_flow.py
+++ b/tests/components/fing/test_config_flow.py
@@ -3,7 +3,7 @@
 import httpx
 import pytest
 
-from homeassistant.components.fing.const import DOMAIN
+from homeassistant.components.fing.const import DOMAIN, UPNP_AVAILABLE
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -134,7 +134,7 @@ async def test_duplicate_entries(
     mock_config_entry: MockConfigEntry,
     mocked_fing_agent: AsyncMock,
 ) -> None:
-    """Test detecting duplicate entries."""
+    """Test detecting duplicate entries by IP address."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -152,3 +152,65 @@ async def test_duplicate_entries(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_duplicate_entries_unique_id(
+    hass: HomeAssistant,
+    mocked_fing_agent: AsyncMock,
+) -> None:
+    """Test detecting duplicate entries by unique_id (agent_id)."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_IP_ADDRESS: "192.168.1.2",
+            CONF_PORT: "49090",
+            CONF_API_KEY: "other_key",
+            UPNP_AVAILABLE: True,
+        },
+        unique_id="0000000000XX",
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_IP_ADDRESS: "192.168.1.1",
+            CONF_PORT: "49090",
+            CONF_API_KEY: "test_key",
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_verify_connection_success_desktop_agent(
+    hass: HomeAssistant,
+    mocked_fing_agent: AsyncMock,
+) -> None:
+    """Test successful connection for desktop agent (no UPnP/agent_info)."""
+    mocked_fing_agent.get_agent_info.side_effect = httpx.ConnectError("not available")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_IP_ADDRESS: "192.168.1.1",
+            CONF_PORT: "49090",
+            CONF_API_KEY: "test_key",
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][UPNP_AVAILABLE] is False
+    assert result["title"] == "Fing Agent 192.168.1.1"
+
+    entry = result["result"]
+    assert entry.unique_id == "192.168.1.1:49090"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Missing unique ID for desktop agents: Fing desktop agents (PC/Mac) don't expose a UPnP agent ID, so config entries were created without a unique_id. Added IP:port as unique_id for desktop agents.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
