### PR TITLE
Fix authentication failure handling in Fing

### DIFF
--- a/homeassistant/components/fing/coordinator.py
+++ b/homeassistant/components/fing/coordinator.py
@@ -11,6 +11,7 @@ import httpx
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -67,7 +68,7 @@ class FingDataUpdateCoordinator(DataUpdateCoordinator[FingDataObject]):
             raise UpdateFailed("Timeout establishing connection") from err
         except httpx.HTTPStatusError as err:
             if err.response.status_code == 401:
-                raise UpdateFailed("Invalid API key") from err
+                raise ConfigEntryAuthFailed("Invalid API key") from err
             raise UpdateFailed(
                 f"Http request failed -> {err.response.status_code} - {err.response.reason_phrase}"
             ) from err

--- a/homeassistant/components/fing/device_tracker.py
+++ b/homeassistant/components/fing/device_tracker.py
@@ -8,8 +8,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import FingConfigEntry
-from .coordinator import FingDataUpdateCoordinator
+from .coordinator import FingConfigEntry, FingDataUpdateCoordinator
 from .utils import get_icon_from_type
 
 

--- a/tests/components/fing/test_init.py
+++ b/tests/components/fing/test_init.py
@@ -1,5 +1,8 @@
 """Test the Fing integration init."""
 
+from unittest.mock import MagicMock
+
+import httpx
 import pytest
 
 from homeassistant.components.fing.const import DOMAIN
@@ -29,7 +32,23 @@ async def test_setup_entry_new_api(
         assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-@pytest.mark.parametrize("api_type", ["new"])
+async def test_setup_entry_auth_failed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mocked_fing_agent: AsyncMock,
+) -> None:
+    """Test that HTTP 401 results in setup error and starts reauth."""
+    mocked_fing_agent.get_devices.side_effect = httpx.HTTPStatusError(
+        "HTTP status error - 401", request=None, response=httpx.Response(401)
+    )
+    mock_config_entry.async_start_reauth = MagicMock()
+
+    entry = await init_integration(hass, mock_config_entry, mocked_fing_agent)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    mock_config_entry.async_start_reauth.assert_called_once_with(hass)
+
+
 async def test_unload_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Auth error not surfaced correctly: HTTP 401 responses were raising UpdateFailed, causing HA to retry indefinitely. Changed to ConfigEntryAuthFailed so the entry is immediately marked as failed and the user is prompted to re-authenticate.

Wrong import path (common-modules): FingConfigEntry was imported via __init__ in device_tracker.py instead of directly from coordinator.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
