### PR TITLE
Make field description optional for non config flows

### DIFF
--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -402,7 +402,7 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                         cv.schema_with_slug_keys(
                             {
                                 vol.Required("name"): str,
-                                vol.Required(
+                                vol.Optional(
                                     "description"
                                 ): translation_value_validator,
                             },
@@ -508,7 +508,7 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     vol.Optional("fields"): cv.schema_with_slug_keys(
                         {
                             vol.Required("name"): str,
-                            vol.Required("description"): translation_value_validator,
+                            vol.Optional("description"): translation_value_validator,
                             vol.Optional("example"): translation_value_validator,
                         },
                         slug_validator=translation_key_validator,
@@ -530,7 +530,7 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     vol.Optional("fields"): cv.schema_with_slug_keys(
                         {
                             vol.Required("name"): str,
-                            vol.Required("description"): translation_value_validator,
+                            vol.Optional("description"): translation_value_validator,
                             vol.Optional("example"): translation_value_validator,
                         },
                         slug_validator=translation_key_validator,
@@ -545,7 +545,7 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     vol.Optional("fields"): cv.schema_with_slug_keys(
                         {
                             vol.Required("name"): str,
-                            vol.Required("description"): translation_value_validator,
+                            vol.Optional("description"): translation_value_validator,
                             vol.Optional("example"): translation_value_validator,
                         },
                         slug_validator=translation_key_validator,

--- a/tests/hassfest/test_translations.py
+++ b/tests/hassfest/test_translations.py
@@ -166,6 +166,9 @@ SAMPLE_STRINGS = {
                     "name": "Field one",
                     "description": "Description of field one",
                 },
+                "field_two": {
+                    "name": "Field two",
+                },
             },
         },
         "field_old": {
@@ -346,7 +349,6 @@ SAMPLE_STRINGS = {
                 },
                 "target": {
                     "name": "Target",
-                    "description": "The target device",
                 },
             },
             "sections": {
@@ -371,6 +373,9 @@ SAMPLE_STRINGS = {
                     "description": "The entity to check",
                     "example": "light.living_room",
                 },
+                "some_option": {
+                    "name": "Some option",
+                },
             },
         },
     },
@@ -383,6 +388,9 @@ SAMPLE_STRINGS = {
                     "name": "Entity",
                     "description": "The entity to monitor",
                     "example": "light.living_room",
+                },
+                "some_option": {
+                    "name": "Some option",
                 },
             },
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make field description optional for non config flows (fields for conditions, services, triggers and object selectors)

Rationale: We have a rule that data entry fields for config flows must have descriptions, but there's no such rule for conditions, services, triggers or object selectors

This PR will allow us to streamline the UI by removing redundant descriptions as in this screenshot:
<img width="1177" height="919" alt="image" src="https://github.com/user-attachments/assets/c7543988-d764-4102-a08d-a110efc0337f" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
