### PR TITLE
Add SMS inbox management services for Huawei LTE

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -13,6 +13,7 @@ from xml.parsers.expat import ExpatError
 
 from huawei_lte_api.Client import Client
 from huawei_lte_api.Connection import Connection
+from huawei_lte_api.enums.sms import BoxTypeEnum, SortTypeEnum
 from huawei_lte_api.exceptions import (
     LoginErrorInvalidCredentialsException,
     ResponseErrorException,
@@ -38,8 +39,13 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -78,6 +84,9 @@ from .const import (
     KEY_WLAN_HOST_LIST,
     KEY_WLAN_WIFI_FEATURE_SWITCH,
     KEY_WLAN_WIFI_GUEST_NETWORK_SWITCH,
+    SERVICE_DELETE_SMS,
+    SERVICE_GET_SMS_LIST,
+    SERVICE_MARK_SMS_READ,
     SERVICE_RESUME_INTEGRATION,
     SERVICE_SUSPEND_INTEGRATION,
     UPDATE_SIGNAL,
@@ -91,6 +100,54 @@ SCAN_INTERVAL = timedelta(seconds=30)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 SERVICE_SCHEMA = vol.Schema({vol.Optional(CONF_URL): cv.url})
+
+SERVICE_SCHEMA_SMS_LIST = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+        vol.Optional("page", default=1): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=100)
+        ),
+        vol.Optional("count", default=20): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=50)
+        ),
+    }
+)
+
+SERVICE_SCHEMA_SMS_INDEX = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+        vol.Required("index"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+    }
+)
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    """Safely convert a value to int."""
+    try:
+        return int(value)
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def parse_sms_list(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Parse SMS list response into a list of message dicts."""
+    messages_container = data.get("Messages")
+    if not messages_container:
+        return []
+    messages_raw = messages_container.get("Message", [])
+    if isinstance(messages_raw, dict):
+        messages_raw = [messages_raw]
+    return [
+        {
+            "index": _safe_int(msg.get("Index"), 0),
+            "phone": msg.get("Phone", ""),
+            "content": msg.get("Content", ""),
+            "date": msg.get("Date", ""),
+            "read": _safe_int(msg.get("Smstat"), 0) == 1,
+        }
+        for msg in messages_raw
+    ]
+
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -452,6 +509,20 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     return True
 
 
+def _get_router_from_service(hass: HomeAssistant, service: ServiceCall) -> Router:
+    """Get router from service call data."""
+    routers: dict[str, Router] = hass.data[DOMAIN].routers
+    entry_id: str = service.data[ATTR_CONFIG_ENTRY_ID]
+    router = routers.get(entry_id)
+    if not router:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="router_unavailable",
+            translation_placeholders={"entry_id": entry_id},
+        )
+    return router
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Huawei LTE component."""
 
@@ -504,6 +575,86 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             service_handler,
             schema=SERVICE_SCHEMA,
         )
+
+    def _get_router(service: ServiceCall) -> Router:
+        router = _get_router_from_service(hass, service)
+        if router.suspended:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="router_suspended",
+            )
+        return router
+
+    async def handle_get_sms_list(service: ServiceCall) -> dict[str, Any]:
+        """Handle get_sms_list service call."""
+        router = _get_router(service)
+        try:
+            response = await hass.async_add_executor_job(
+                router.client.sms.get_sms_list,
+                service.data["page"],
+                BoxTypeEnum.LOCAL_INBOX,
+                service.data["count"],
+                SortTypeEnum.DATE,
+                False,
+                True,
+            )
+        except (ResponseErrorException, ResponseErrorLoginRequiredException) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sms_list_failed",
+            ) from err
+        return {"messages": parse_sms_list(response)}
+
+    async def handle_delete_sms(service: ServiceCall) -> None:
+        """Handle delete_sms service call."""
+        router = _get_router(service)
+        try:
+            await hass.async_add_executor_job(
+                router.client.sms.delete_sms, service.data["index"]
+            )
+        except (ResponseErrorException, ResponseErrorLoginRequiredException) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sms_delete_failed",
+                translation_placeholders={"index": str(service.data["index"])},
+            ) from err
+
+    async def handle_mark_sms_read(service: ServiceCall) -> None:
+        """Handle mark_sms_read service call."""
+        router = _get_router(service)
+        try:
+            await hass.async_add_executor_job(
+                router.client.sms.set_read, service.data["index"]
+            )
+        except (ResponseErrorException, ResponseErrorLoginRequiredException) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sms_mark_read_failed",
+                translation_placeholders={"index": str(service.data["index"])},
+            ) from err
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_GET_SMS_LIST,
+        handle_get_sms_list,
+        schema=SERVICE_SCHEMA_SMS_LIST,
+        supports_response=SupportsResponse.ONLY,
+    )
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_DELETE_SMS,
+        handle_delete_sms,
+        schema=SERVICE_SCHEMA_SMS_INDEX,
+    )
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_MARK_SMS_READ,
+        handle_mark_sms_read,
+        schema=SERVICE_SCHEMA_SMS_INDEX,
+    )
 
     return True
 

--- a/homeassistant/components/huawei_lte/const.py
+++ b/homeassistant/components/huawei_lte/const.py
@@ -25,6 +25,10 @@ ADMIN_SERVICES = {
     SERVICE_SUSPEND_INTEGRATION,
 }
 
+SERVICE_DELETE_SMS = "delete_sms"
+SERVICE_GET_SMS_LIST = "get_sms_list"
+SERVICE_MARK_SMS_READ = "mark_sms_read"
+
 KEY_DEVICE_BASIC_INFORMATION = "device_basic_information"
 KEY_DEVICE_INFORMATION = "device_information"
 KEY_DEVICE_SIGNAL = "device_signal"

--- a/homeassistant/components/huawei_lte/icons.json
+++ b/homeassistant/components/huawei_lte/icons.json
@@ -187,6 +187,15 @@
     }
   },
   "services": {
+    "delete_sms": {
+      "service": "mdi:message-minus"
+    },
+    "get_sms_list": {
+      "service": "mdi:message-text"
+    },
+    "mark_sms_read": {
+      "service": "mdi:message-check"
+    },
     "resume_integration": {
       "service": "mdi:play-pause"
     },

--- a/homeassistant/components/huawei_lte/services.yaml
+++ b/homeassistant/components/huawei_lte/services.yaml
@@ -11,3 +11,53 @@ suspend_integration:
       example: http://192.168.100.1/
       selector:
         text:
+
+get_sms_list:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: huawei_lte
+    page:
+      default: 1
+      selector:
+        number:
+          min: 1
+          max: 100
+          mode: box
+    count:
+      default: 20
+      selector:
+        number:
+          min: 1
+          max: 50
+          mode: box
+
+delete_sms:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: huawei_lte
+    index:
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box
+
+mark_sms_read:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: huawei_lte
+    index:
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box

--- a/homeassistant/components/huawei_lte/strings.json
+++ b/homeassistant/components/huawei_lte/strings.json
@@ -381,6 +381,23 @@
       }
     }
   },
+  "exceptions": {
+    "router_suspended": {
+      "message": "Router is suspended. Resume it before using SMS services."
+    },
+    "router_unavailable": {
+      "message": "Router with entry ID {entry_id} is not available."
+    },
+    "sms_delete_failed": {
+      "message": "Failed to delete SMS message {index}."
+    },
+    "sms_list_failed": {
+      "message": "Failed to fetch SMS list from the router."
+    },
+    "sms_mark_read_failed": {
+      "message": "Failed to mark SMS message {index} as read."
+    }
+  },
   "options": {
     "step": {
       "init": {
@@ -400,6 +417,52 @@
     }
   },
   "services": {
+    "delete_sms": {
+      "description": "Deletes an SMS message by its index.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The config entry of the router to use.",
+          "name": "Config entry"
+        },
+        "index": {
+          "description": "The numeric ID of the SMS message as returned by the get_sms_list service.",
+          "name": "Message index"
+        }
+      },
+      "name": "Delete SMS"
+    },
+    "get_sms_list": {
+      "description": "Fetches a list of SMS messages from the router inbox.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The config entry of the router to use.",
+          "name": "Config entry"
+        },
+        "count": {
+          "description": "Number of messages per page.",
+          "name": "Count"
+        },
+        "page": {
+          "description": "Page number to fetch (starting from 1).",
+          "name": "Page"
+        }
+      },
+      "name": "Get SMS list"
+    },
+    "mark_sms_read": {
+      "description": "Marks an SMS message as read by its index.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The config entry of the router to use.",
+          "name": "Config entry"
+        },
+        "index": {
+          "description": "The numeric ID of the SMS message as returned by the get_sms_list service.",
+          "name": "Message index"
+        }
+      },
+      "name": "Mark SMS as read"
+    },
     "resume_integration": {
       "description": "Resumes suspended integration.",
       "fields": {

--- a/tests/components/huawei_lte/__init__.py
+++ b/tests/components/huawei_lte/__init__.py
@@ -302,7 +302,45 @@ def magic_client() -> MagicMock:
         traffic_statistics=traffic_statistics,
     )
     net = MagicMock(current_plmn=current_plmn, net_mode=net_mode)
-    sms = MagicMock(sms_count=sms_count)
+    get_sms_list = MagicMock(
+        return_value={
+            "Count": "2",
+            "Messages": {
+                "Message": [
+                    {
+                        "Smstat": "0",
+                        "Index": "40001",
+                        "Phone": "+1234567890",
+                        "Content": "Test message 1",
+                        "Date": "2026-03-29 10:00:00",
+                        "Sca": None,
+                        "SaveType": "4",
+                        "Priority": "0",
+                        "SmsType": "1",
+                    },
+                    {
+                        "Smstat": "1",
+                        "Index": "40002",
+                        "Phone": "+0987654321",
+                        "Content": "Test message 2",
+                        "Date": "2026-03-29 09:00:00",
+                        "Sca": None,
+                        "SaveType": "4",
+                        "Priority": "0",
+                        "SmsType": "1",
+                    },
+                ]
+            },
+        }
+    )
+    delete_sms = MagicMock(return_value="OK")
+    set_read = MagicMock(return_value="OK")
+    sms = MagicMock(
+        sms_count=sms_count,
+        get_sms_list=get_sms_list,
+        delete_sms=delete_sms,
+        set_read=set_read,
+    )
     dial_up = MagicMock(mobile_dataswitch=mobile_dataswitch)
     lan = MagicMock(host_info=lan_host_info)
     wlan = MagicMock(

--- a/tests/components/huawei_lte/test_sms_services.py
+++ b/tests/components/huawei_lte/test_sms_services.py
@@ -1,0 +1,267 @@
+"""Tests for the Huawei LTE SMS services."""
+
+from unittest.mock import MagicMock, patch
+
+from huawei_lte_api.exceptions import ResponseErrorException
+import pytest
+
+from homeassistant.components.huawei_lte.const import (
+    DOMAIN,
+    SERVICE_DELETE_SMS,
+    SERVICE_GET_SMS_LIST,
+    SERVICE_MARK_SMS_READ,
+)
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from . import magic_client
+
+from tests.common import MockConfigEntry
+
+MOCK_CONF_URL = "http://huawei-lte.example.com"
+
+
+async def _setup_integration(
+    hass: HomeAssistant,
+) -> tuple[MockConfigEntry, MagicMock]:
+    """Set up the integration with a mock client."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_URL: MOCK_CONF_URL})
+    entry.add_to_hass(hass)
+    client = magic_client()
+    with (
+        patch("homeassistant.components.huawei_lte.Connection", MagicMock()),
+        patch("homeassistant.components.huawei_lte.Client", return_value=client),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry, client
+
+
+async def test_get_sms_list(hass: HomeAssistant) -> None:
+    """Test get_sms_list service returns messages."""
+    entry, client = await _setup_integration(hass)
+
+    client.sms.get_sms_list.reset_mock()
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_SMS_LIST,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+    client.sms.get_sms_list.assert_called_once()
+    assert "messages" in result
+    assert len(result["messages"]) == 2
+    assert result["messages"][0]["phone"] == "+1234567890"
+    assert result["messages"][0]["content"] == "Test message 1"
+    assert result["messages"][0]["index"] == 40001
+    assert result["messages"][0]["read"] is False
+    assert result["messages"][1]["read"] is True
+
+
+async def test_get_sms_list_with_params(hass: HomeAssistant) -> None:
+    """Test get_sms_list service with page and count parameters."""
+    entry, client = await _setup_integration(hass)
+
+    client.sms.get_sms_list.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_SMS_LIST,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id, "page": 2, "count": 10},
+        blocking=True,
+        return_response=True,
+    )
+    args = client.sms.get_sms_list.call_args
+    assert args[0][0] == 2  # page
+    assert args[0][2] == 10  # count
+
+
+async def test_delete_sms(hass: HomeAssistant) -> None:
+    """Test delete_sms service calls the API."""
+    entry, client = await _setup_integration(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DELETE_SMS,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id, "index": 40001},
+        blocking=True,
+    )
+    client.sms.delete_sms.assert_called_once_with(40001)
+
+
+async def test_mark_sms_read(hass: HomeAssistant) -> None:
+    """Test mark_sms_read service calls the API."""
+    entry, client = await _setup_integration(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_MARK_SMS_READ,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id, "index": 40001},
+        blocking=True,
+    )
+    client.sms.set_read.assert_called_once_with(40001)
+
+
+async def test_get_sms_list_wrong_entry_id(hass: HomeAssistant) -> None:
+    """Test get_sms_list raises HomeAssistantError for unknown entry ID."""
+    await _setup_integration(hass)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SMS_LIST,
+            {ATTR_CONFIG_ENTRY_ID: "nonexistent_entry"},
+            blocking=True,
+            return_response=True,
+        )
+
+
+async def test_get_sms_list_suspended(hass: HomeAssistant) -> None:
+    """Test get_sms_list raises ServiceValidationError when router is suspended."""
+    entry, client = await _setup_integration(hass)
+
+    router = hass.data[DOMAIN].routers[entry.entry_id]
+    router.suspended = True
+
+    client.sms.get_sms_list.reset_mock()
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SMS_LIST,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+            blocking=True,
+            return_response=True,
+        )
+    client.sms.get_sms_list.assert_not_called()
+
+
+async def test_delete_sms_suspended(hass: HomeAssistant) -> None:
+    """Test delete_sms raises ServiceValidationError when router is suspended."""
+    entry, client = await _setup_integration(hass)
+
+    router = hass.data[DOMAIN].routers[entry.entry_id]
+    router.suspended = True
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_SMS,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id, "index": 40001},
+            blocking=True,
+        )
+    client.sms.delete_sms.assert_not_called()
+
+
+async def test_mark_sms_read_suspended(hass: HomeAssistant) -> None:
+    """Test mark_sms_read raises ServiceValidationError when router is suspended."""
+    entry, client = await _setup_integration(hass)
+
+    router = hass.data[DOMAIN].routers[entry.entry_id]
+    router.suspended = True
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_MARK_SMS_READ,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id, "index": 40001},
+            blocking=True,
+        )
+    client.sms.set_read.assert_not_called()
+
+
+async def test_get_sms_list_empty_response(hass: HomeAssistant) -> None:
+    """Test get_sms_list handles empty Messages."""
+    entry, client = await _setup_integration(hass)
+
+    client.sms.get_sms_list.reset_mock()
+    client.sms.get_sms_list.return_value = {"Count": "0", "Messages": None}
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_SMS_LIST,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+    assert result == {"messages": []}
+
+
+async def test_get_sms_list_single_message(hass: HomeAssistant) -> None:
+    """Test get_sms_list handles single message (dict instead of list)."""
+    entry, client = await _setup_integration(hass)
+
+    client.sms.get_sms_list.reset_mock()
+    client.sms.get_sms_list.return_value = {
+        "Count": "1",
+        "Messages": {
+            "Message": {
+                "Smstat": "0",
+                "Index": "40001",
+                "Phone": "+1234567890",
+                "Content": "Single message",
+                "Date": "2026-03-29 10:00:00",
+            }
+        },
+    }
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_SMS_LIST,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+    assert len(result["messages"]) == 1
+    assert result["messages"][0]["content"] == "Single message"
+
+
+async def test_get_sms_list_api_error(hass: HomeAssistant) -> None:
+    """Test get_sms_list raises HomeAssistantError on API error."""
+    entry, client = await _setup_integration(hass)
+
+    client.sms.get_sms_list.reset_mock()
+    client.sms.get_sms_list.side_effect = ResponseErrorException("API error", code=100)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SMS_LIST,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id},
+            blocking=True,
+            return_response=True,
+        )
+
+
+async def test_delete_sms_api_error(hass: HomeAssistant) -> None:
+    """Test delete_sms raises HomeAssistantError on API failure."""
+    entry, client = await _setup_integration(hass)
+
+    client.sms.delete_sms.side_effect = ResponseErrorException("API error", code=100)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_SMS,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id, "index": 40001},
+            blocking=True,
+        )
+    client.sms.delete_sms.assert_called_once_with(40001)
+
+
+async def test_mark_sms_read_api_error(hass: HomeAssistant) -> None:
+    """Test mark_sms_read raises HomeAssistantError on API failure."""
+    entry, client = await _setup_integration(hass)
+
+    client.sms.set_read.side_effect = ResponseErrorException("API error", code=100)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_MARK_SMS_READ,
+            {ATTR_CONFIG_ENTRY_ID: entry.entry_id, "index": 40001},
+            blocking=True,
+        )
+    client.sms.set_read.assert_called_once_with(40001)


### PR DESCRIPTION
## Proposed change

Adds three admin-only services for managing the SMS inbox on Huawei LTE routers:

- `huawei_lte.get_sms_list` — fetch messages from the router inbox with pagination support. Returns a list of messages with `phone`, `content`, `date`, `index`, and `read` fields.
- `huawei_lte.delete_sms` — delete a message by index.
- `huawei_lte.mark_sms_read` — mark a message as read by index.

All services require authenticated mode and use a `config_entry` selector for router selection (instead of URL). All services are admin-only (`async_register_admin_service`).

This PR builds on top of the polling infrastructure added in: https://github.com/home-assistant/core/pull/166811

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (non-backwards compatible or removes functionality)
- [ ] Deprecation (breaking change in a future release)
- [ ] Common tasks

## Additional information

* Depends on / related to: https://github.com/home-assistant/core/pull/166811