### PR TITLE
Fix Tesla Fleet OAuth scope refresh during reauth

### DIFF
--- a/homeassistant/components/tesla_fleet/oauth.py
+++ b/homeassistant/components/tesla_fleet/oauth.py
@@ -30,4 +30,8 @@ class TeslaUserImplementation(AuthImplementation):
     @property
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
-        return {"prompt": "login", "scope": " ".join(SCOPES)}
+        return {
+            "prompt": "login",
+            "prompt_missing_scopes": "true",
+            "scope": " ".join(SCOPES),
+        }

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -50,7 +50,7 @@
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       },
       "reauth_confirm": {
-        "description": "The {name} integration needs to re-authenticate your account",
+        "description": "The {name} integration needs to re-authenticate your account. Reauthentication refreshes the Tesla API permissions granted to Home Assistant, including any newly enabled scopes.",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
       "registration_complete": {
@@ -60,7 +60,7 @@
         "data_description": {
           "qr_code": "Scan this QR code with your phone to set up the virtual key."
         },
-        "description": "To enable command signing, you must open the Tesla app, select your vehicle, and then visit the following URL to set up a virtual key. You must repeat this process for each vehicle.\n\n{virtual_key_url}",
+        "description": "To enable command signing, you must open the Tesla app, select your vehicle, and then visit the following URL to set up a virtual key. You must repeat this process for each vehicle.\n\n{virtual_key_url}\n\nIf you later enable additional Tesla API permissions, reauthenticate the integration to refresh the granted scopes.",
         "title": "Command signing"
       }
     }

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -117,6 +117,7 @@ async def test_full_flow_with_domain_registration(
     assert parsed_query["client_id"][0] == "user_client_id"
     assert parsed_query["redirect_uri"][0] == REDIRECT
     assert parsed_query["state"][0] == state
+    assert parsed_query["prompt_missing_scopes"][0] == "true"
     assert parsed_query["scope"][0] == " ".join(SCOPES)
     assert "code_challenge" not in parsed_query
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Add `prompt_missing_scopes=true` to Tesla Fleet OAuth authorization requests so reauthentication can refresh newly enabled Tesla API scopes instead of silently reusing an older grant. Update the Tesla Fleet config-flow copy to explain that reauthentication refreshes granted scopes and that users should reauthenticate after enabling additional Tesla API permissions. Extend the config-flow test to assert the new authorization parameter.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: 
- This PR is related to issue: #166692
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
