### PR TITLE
Fix Tesla Fleet startup scopes after OAuth refresh

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -16,7 +16,7 @@ from tesla_fleet_api.exceptions import (
 from tesla_fleet_api.tesla import VehicleFleet
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN, Platform
+from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -121,15 +121,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         )
         raise ConfigEntryAuthFailed from e
 
-    access_token = entry.data[CONF_TOKEN][CONF_ACCESS_TOKEN]
+    oauth_session = OAuth2Session(hass, entry, implementation)
+    try:
+        await oauth_session.async_ensure_token_valid()
+    except OAuth2TokenRequestReauthError as err:
+        raise ConfigEntryAuthFailed from err
+    except OAuth2TokenRequestError as err:
+        raise ConfigEntryNotReady from err
+
+    access_token = oauth_session.token[CONF_ACCESS_TOKEN]
     session = async_get_clientsession(hass)
 
     token = jwt.decode(access_token, options={"verify_signature": False})
     scopes: list[Scope] = [Scope(s) for s in token["scp"]]
     region_code = token["ou_code"].lower()
     region = region_code if is_valid_region(region_code) else None
-
-    oauth_session = OAuth2Session(hass, entry, implementation)
 
     async def _get_access_token() -> str:
         await oauth_session.async_ensure_token_valid()

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -19,7 +19,7 @@ from tesla_fleet_api.exceptions import (
     VehicleOffline,
 )
 
-from homeassistant.components.tesla_fleet.const import DOMAIN
+from homeassistant.components.tesla_fleet.const import DOMAIN, SCOPES
 from homeassistant.components.tesla_fleet.coordinator import (
     ENERGY_HISTORY_INTERVAL,
     ENERGY_INTERVAL,
@@ -134,6 +134,30 @@ async def test_oauth_refresh_error(
 
         mock_async_ensure_token_valid.assert_called_once()
     assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_uses_scopes_from_refreshed_token(
+    hass: HomeAssistant,
+    noscope_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup uses scopes from the refreshed OAuth token."""
+    refreshed_token = create_config_entry(
+        expires_at=3600,
+        scopes=SCOPES,
+    ).data[CONF_TOKEN]
+
+    noscope_config_entry.data[CONF_TOKEN]["expires_at"] = 0
+
+    with patch(
+        "homeassistant.components.tesla_fleet.oauth.TeslaUserImplementation.async_refresh_token",
+        return_value=refreshed_token,
+    ) as mock_async_refresh_token:
+        await setup_platform(hass, noscope_config_entry)
+
+    mock_async_refresh_token.assert_awaited_once()
+    assert noscope_config_entry.state is ConfigEntryState.LOADED
+    assert noscope_config_entry.runtime_data.scopes == SCOPES
+    assert noscope_config_entry.runtime_data.vehicles
 
 
 async def test_invalidate_access_token_updates_when_not_expired(


### PR DESCRIPTION
## Proposed change
Refresh the Tesla Fleet OAuth session during config entry setup before decoding access token claims.
This makes startup derive scopes from the current token, so newly granted Tesla scopes are picked up on startup instead of using stale scope data from the previously stored access token.
Add a regression test covering setup with an expired token that refreshes to a token with the expected scopes.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
