### PR TITLE
Refactor FortiOS integration to Bronze quality scale

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
   },
   "features": {
     // Node feature required for Claude Code until fixed https://github.com/anthropics/devcontainer-features/issues/28
-    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "installYarnUsingApt": false
+    },
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,6 @@
     "PYTHONASYNCIODEBUG": "1"
   },
   "features": {
-    // Node feature required for Claude Code until fixed https://github.com/anthropics/devcontainer-features/issues/28
-    "ghcr.io/devcontainers/features/node:1": {
-      "installYarnUsingApt": false
-    },
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   // Port 5683 udp is used by Shelly integration
@@ -65,7 +60,13 @@
         "[python]": {
           "editor.defaultFormatter": "charliermarsh.ruff"
         },
-        "[json][jsonc][yaml]": {
+        "[json]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[jsonc]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[yaml]": {
           "editor.defaultFormatter": "esbenp.prettier-vscode"
         },
         "json.schemas": [

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -541,6 +541,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/forked_daapd/ @uvjustin
 /tests/components/forked_daapd/ @uvjustin
 /homeassistant/components/fortios/ @kimfrellsen
+/tests/components/fortios/ @kimfrellsen
 /homeassistant/components/foscam/ @Foscam-wangzhengyu
 /tests/components/foscam/ @Foscam-wangzhengyu
 /homeassistant/components/freebox/ @hacf-fr @Quentame

--- a/homeassistant/components/fortios/__init__.py
+++ b/homeassistant/components/fortios/__init__.py
@@ -1,1 +1,59 @@
-"""Fortinet FortiOS components."""
+"""FortiOS Device Tracker integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TOKEN,
+    CONF_VERIFY_SSL,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+
+from .coordinator import FortiOSDataUpdateCoordinator
+from .firewall import FortiOSAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [
+    Platform.DEVICE_TRACKER,
+    Platform.SENSOR,
+]
+
+type FortiOSConfigEntry = ConfigEntry[FortiOSDataUpdateCoordinator]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: FortiOSConfigEntry) -> bool:
+    """Set up FortiOS from a config entry."""
+    _LOGGER.debug("Setting up FortiOS entry: %s", entry.entry_id)
+
+    api = FortiOSAPI(
+        hass,
+        entry.data[CONF_HOST],
+        entry.data[CONF_PORT],
+        entry.data[CONF_TOKEN],
+        entry.data["vdom"],
+        entry.data[CONF_VERIFY_SSL],
+    )
+
+    coordinator = FortiOSDataUpdateCoordinator(hass, entry, api)
+
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+
+    # Forward the entry setups for all platforms
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: FortiOSConfigEntry) -> bool:
+    """Unload a config entry."""
+    _LOGGER.debug("Unloading FortiOS entry: %s", entry.entry_id)
+
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/fortios/__init__.py
+++ b/homeassistant/components/fortios/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
@@ -17,8 +15,6 @@ from homeassistant.core import HomeAssistant
 from .coordinator import FortiOSDataUpdateCoordinator
 from .firewall import FortiOSAPI
 
-_LOGGER = logging.getLogger(__name__)
-
 PLATFORMS = [
     Platform.DEVICE_TRACKER,
     Platform.SENSOR,
@@ -29,8 +25,6 @@ type FortiOSConfigEntry = ConfigEntry[FortiOSDataUpdateCoordinator]
 
 async def async_setup_entry(hass: HomeAssistant, entry: FortiOSConfigEntry) -> bool:
     """Set up FortiOS from a config entry."""
-    _LOGGER.debug("Setting up FortiOS entry: %s", entry.entry_id)
-
     api = FortiOSAPI(
         hass,
         entry.data[CONF_HOST],
@@ -46,7 +40,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: FortiOSConfigEntry) -> b
 
     entry.runtime_data = coordinator
 
-    # Forward the entry setups for all platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -54,6 +47,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: FortiOSConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, entry: FortiOSConfigEntry) -> bool:
     """Unload a config entry."""
-    _LOGGER.debug("Unloading FortiOS entry: %s", entry.entry_id)
-
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/fortios/config_flow.py
+++ b/homeassistant/components/fortios/config_flow.py
@@ -1,0 +1,196 @@
+"""Config flow for the FortiOS device tracker platform."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+from typing import Any
+
+import aiohttp
+from awesomeversion import AwesomeVersion
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
+    ConfigFlow,
+    ConfigFlowResult,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_VERIFY_SSL
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .const import (
+    CONF_VDOM,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DEFAULT_VDOM,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    MINIMUM_SUPPORTED_VERSION,
+)
+from .firewall import FortiOSAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FortiOSFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for FortiOS."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize config flow."""
+        self._data: dict[str, Any] = {}
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        host = str(discovery_info.ip_address)
+        port = discovery_info.port
+
+        await self.async_set_unique_id(host)
+        self._abort_if_unique_id_configured()
+
+        self._data.update(
+            {
+                CONF_HOST: host,
+                CONF_PORT: port,
+            }
+        )
+        self.context.update(
+            {"title_placeholders": {CONF_HOST: discovery_info.name.split(".")[0]}}
+        )
+        return await self.async_step_user()
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery."""
+        await self.async_set_unique_id(discovery_info.macaddress)
+        self._abort_if_unique_id_configured()
+
+        self._data.update({CONF_HOST: discovery_info.ip})
+        return await self.async_step_user()
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration."""
+        self._data.update(self._get_reconfigure_entry().data)
+        return await self.async_step_user()
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication."""
+        self._data.update(entry_data)
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication confirmation."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._data[CONF_TOKEN] = user_input[CONF_TOKEN]
+            errors = await self._async_try_connect()
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_TOKEN: user_input[CONF_TOKEN]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_TOKEN): str}),
+            description_placeholders={CONF_HOST: self._data.get(CONF_HOST, "")},
+            errors=errors,
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow initialized by the user."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._data.update(user_input)
+            errors = await self._async_try_connect()
+            if not errors:
+                serial: str = self._data.pop("_serial")
+                await self.async_set_unique_id(serial)
+                if self.source == SOURCE_RECONFIGURE:
+                    self._abort_if_unique_id_mismatch()
+                    return self.async_update_reload_and_abort(
+                        entry=self._get_reconfigure_entry(),
+                        data=self._data,
+                    )
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=f"FortiGate {serial}",
+                    data=self._data,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST,
+                        default=self._data.get(CONF_HOST, DEFAULT_HOST),
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=self._data.get(CONF_PORT, DEFAULT_PORT),
+                    ): int,
+                    vol.Required(
+                        CONF_TOKEN,
+                        default=self._data.get(CONF_TOKEN),
+                    ): str,
+                    vol.Required(
+                        CONF_VDOM,
+                        default=self._data.get(CONF_VDOM, DEFAULT_VDOM),
+                    ): str,
+                    vol.Required(
+                        CONF_VERIFY_SSL,
+                        default=self._data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+                    ): bool,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _async_try_connect(self) -> dict[str, str]:
+        """Try connecting to the FortiGate; return errors dict (empty on success).
+
+        On success, stores the device serial in ``self._data["_serial"]``.
+        """
+        fgt = FortiOSAPI(
+            self.hass,
+            self._data[CONF_HOST],
+            self._data[CONF_PORT],
+            self._data[CONF_TOKEN],
+            self._data[CONF_VDOM],
+            self._data[CONF_VERIFY_SSL],
+        )
+        try:
+            response = await fgt.get("monitor/system/status")
+            version = response.get("version", "")
+            if AwesomeVersion(version) < AwesomeVersion(MINIMUM_SUPPORTED_VERSION):
+                _LOGGER.debug(
+                    "Unsupported FortiOS version: %s (minimum: %s)",
+                    version,
+                    MINIMUM_SUPPORTED_VERSION,
+                )
+                return {"base": "unsupported_version"}
+            self._data["_serial"] = response["serial"]
+        except aiohttp.ClientResponseError as error:
+            if error.status == 401:
+                return {"base": "invalid_auth"}
+            return {"base": "cannot_connect"}
+        except Exception:  # noqa: BLE001
+            return {"base": "unknown_error"}
+        return {}

--- a/homeassistant/components/fortios/const.py
+++ b/homeassistant/components/fortios/const.py
@@ -1,0 +1,61 @@
+"""Constants for the FortiOS Device Tracker integration."""
+
+from datetime import timedelta
+
+DOMAIN = "fortios"
+
+DEFAULT_HOST = "192.168.1.1"
+DEFAULT_VDOM = "root"
+DEFAULT_PORT = 443
+DEFAULT_VERIFY_SSL = False
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+CONF_VDOM = "vdom"
+REST_TIMEOUT = 5
+MINIMUM_SUPPORTED_VERSION = "6.4.3"
+
+FORTIOS_RESULTS_MASTER_MAC = "master_mac"
+
+
+DEFAULT_DEVICE_NAME = "Unknown entity"
+# Icons
+DEVICE_ICONS = {
+    "android": "mdi:android",
+    "ap": "mdi:access-point",
+    "appliance": "mdi:chip",
+    "automotive": "mdi:car",
+    "color laserjet": "mdi:printer",
+    "computer": "mdi:desktop-tower-monitor",
+    "electric car": "mdi:car-electric",
+    "fortiswitch": "mdi:switch",
+    "home": "mdi:home",
+    "homepod": "mdi:speaker",
+    "ip camera": "mdi:cctv",
+    "ip_phone": "mdi:phone-voip",
+    "iphone": "mdi:cellphone",
+    "laptop": "mdi:laptop",
+    "mac": "mdi:apple",
+    "multimedia_device": "mdi:play-network",
+    "media player": "mdi:play-network",
+    "nas": "mdi:nas",
+    "networking_device": "mdi:network",
+    "phone": "mdi:cellphone",
+    "printer": "mdi:printer",
+    "router": "mdi:router-wireless",
+    "security system": "mdi:security",
+    "sensor": "mdi:chip",
+    "smart device": "mdi:chip",
+    "smartphone": "mdi:cellphone",
+    "switch": "mdi:switch",
+    "tablet": "mdi:tablet",
+    "television": "mdi:television",
+    "thermostat": "mdi:thermostat",
+    "tv": "mdi:television",
+    "vg_console": "mdi:gamepad-variant",
+    "virtual machine": "mdi:server",
+    "voice control": "mdi:speaker-message",
+    "watch": "mdi:watch",
+    "wifi extender": "mdi:access-point",
+    "workstation": "mdi:desktop-tower-monitor",
+}

--- a/homeassistant/components/fortios/coordinator.py
+++ b/homeassistant/components/fortios/coordinator.py
@@ -1,0 +1,83 @@
+"""DataUpdateCoordinator for FortiOS integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, FORTIOS_RESULTS_MASTER_MAC, SCAN_INTERVAL
+from .firewall import FortiOSAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _normalize_usage(results: Any) -> dict[str, Any]:
+    """Normalize resource usage results from the FortiOS API.
+
+    The API returns each metric as a list with one element, e.g.
+    ``{"cpu": [{"current": 2}], "memory": [{"current": 50}]}``.
+    This unwraps those single-element lists into plain dicts.
+    """
+    if not isinstance(results, dict):
+        return {}
+    normalized: dict[str, Any] = {}
+    for key, value in results.items():
+        if isinstance(value, list):
+            normalized[key] = value[0] if value else {}
+        else:
+            normalized[key] = value
+    return normalized
+
+
+class FortiOSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Class to manage fetching FortiOS data."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        api: FortiOSAPI,
+    ) -> None:
+        """Initialize."""
+        self.api = api
+        self.serial = entry.unique_id
+        self.devices: dict[str, dict[str, Any]] = {}
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+            config_entry=entry,
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from FortiOS."""
+        try:
+            fortios_devices = await self.api.get("monitor/user/device/query")
+            for device in fortios_devices.get("results", []):
+                mac = device.get(FORTIOS_RESULTS_MASTER_MAC)
+                if not mac:
+                    continue
+                self.devices[mac] = device
+
+            system_usage = await self.api.get("monitor/system/resource/usage")
+            system_status = await self.api.get("monitor/system/status")
+
+            _LOGGER.debug(
+                "system/resource/usage results: %s", system_usage.get("results")
+            )
+            _LOGGER.debug("system/status response: %s", system_status)
+
+            return {
+                "devices": self.devices,
+                "system_usage": _normalize_usage(system_usage.get("results", {})),
+                "system_status": system_status,
+            }
+        except Exception as err:
+            raise UpdateFailed(f"Error communicating with FortiOS API: {err}") from err

--- a/homeassistant/components/fortios/coordinator.py
+++ b/homeassistant/components/fortios/coordinator.py
@@ -69,11 +69,6 @@ class FortiOSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             system_usage = await self.api.get("monitor/system/resource/usage")
             system_status = await self.api.get("monitor/system/status")
 
-            _LOGGER.debug(
-                "system/resource/usage results: %s", system_usage.get("results")
-            )
-            _LOGGER.debug("system/status response: %s", system_status)
-
             return {
                 "devices": self.devices,
                 "system_usage": _normalize_usage(system_usage.get("results", {})),

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -64,7 +64,6 @@ class FortiOSDeviceScanner(
         self._attr_ip_address = device.get("ipv4_address", "")
         self._attr_mac_address = mac
         self._attr_icon = icon_for_fortios_device(device)
-        self._attr_unique_id = mac
         self._is_online = device.get("is_online", False)
         self._attr_extra_state_attributes: dict[str, Any] = {}
 

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -1,127 +1,119 @@
-"""Support to use FortiOS device like FortiGate as device tracker.
-
-This component is part of the device_tracker platform.
-"""
+"""FortiOS device tracker platform."""
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import Any
 
-from awesomeversion import AwesomeVersion
-from fortiosapi import FortiOSAPI
-import voluptuous as vol
+from homeassistant.components.device_tracker import ScannerEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
-from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
-    PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
-)
-from homeassistant.const import CONF_HOST, CONF_TOKEN, CONF_VERIFY_SSL
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from . import FortiOSConfigEntry
+from .const import DEFAULT_DEVICE_NAME, DEVICE_ICONS, FORTIOS_RESULTS_MASTER_MAC
+from .coordinator import FortiOSDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-DEFAULT_VERIFY_SSL = False
+
+PARALLEL_UPDATES = 0
 
 
-PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_TOKEN): cv.string,
-        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    }
-)
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FortiOSConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up FortiOS device tracker from a config entry."""
+    coordinator: FortiOSDataUpdateCoordinator = config_entry.runtime_data
+    tracked: set[str] = set()
+
+    @callback
+    def update_entities() -> None:
+        """Add new tracker entities from the router."""
+        new_tracked = []
+        devices = coordinator.data.get("devices", {})
+        for mac, device in devices.items():
+            if mac in tracked:
+                continue
+            new_tracked.append(FortiOSDeviceScanner(coordinator, device))
+            tracked.add(mac)
+        async_add_entities(new_tracked)
+
+    config_entry.async_on_unload(coordinator.async_add_listener(update_entities))
+    update_entities()
 
 
-def get_scanner(hass: HomeAssistant, config: ConfigType) -> FortiOSDeviceScanner | None:
-    """Validate the configuration and return a FortiOSDeviceScanner."""
-    config = config[DEVICE_TRACKER_DOMAIN]
+class FortiOSDeviceScanner(
+    CoordinatorEntity[FortiOSDataUpdateCoordinator], ScannerEntity
+):
+    """Representation of a FortiOS connected entity."""
 
-    host = config[CONF_HOST]
-    verify_ssl = config[CONF_VERIFY_SSL]
-    token = config[CONF_TOKEN]
+    _attr_entity_registry_enabled_default = True
+    _is_online: bool
 
-    fgt = FortiOSAPI()
-
-    try:
-        fgt.tokenlogin(host, token, verify_ssl, None, 12, "root")
-    except ConnectionError as ex:
-        _LOGGER.error("ConnectionError to FortiOS API: %s", ex)
-        return None
-    except Exception as ex:  # noqa: BLE001
-        _LOGGER.error("Failed to login to FortiOS API: %s", ex)
-        return None
-
-    status_json = fgt.monitor("system/status", "")
-
-    current_version = AwesomeVersion(status_json["version"])
-    minimum_version = AwesomeVersion("6.4.3")
-    if current_version < minimum_version:
-        _LOGGER.error(
-            "Unsupported FortiOS version: %s. Version %s and newer are supported",
-            current_version,
-            minimum_version,
+    def __init__(
+        self, coordinator: FortiOSDataUpdateCoordinator, device: dict[str, Any]
+    ) -> None:
+        """Initialize a FortiOS connected entity."""
+        super().__init__(coordinator)
+        mac = device.get(FORTIOS_RESULTS_MASTER_MAC, "")
+        hostname = device.get("hostname")
+        self._attr_name = (
+            hostname or mac.strip().replace(":", "_").upper() or DEFAULT_DEVICE_NAME
         )
-        return None
+        self._attr_hostname = hostname
+        self._attr_ip_address = device.get("ipv4_address", "")
+        self._attr_mac_address = mac
+        self._attr_icon = icon_for_fortios_device(device)
+        self._attr_unique_id = mac
+        self._is_online = device.get("is_online", False)
+        self._attr_extra_state_attributes: dict[str, Any] = {}
 
-    return FortiOSDeviceScanner(fgt)
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Update the FortiOS connected entity."""
+        devices = self.coordinator.data.get("devices", {})
+        device = devices.get(self._attr_mac_address)
+        if not device:
+            return
+
+        self._is_online = device.get("is_online", False)
+        self._attr_ip_address = device.get("ipv4_address", "")
+        tz = dt_util.now().tzinfo
+        self._attr_extra_state_attributes = {
+            "last_seen": datetime.fromtimestamp(device.get("last_seen", 0), tz),
+            "os_name": device.get("os_name", ""),
+            "os_version": device.get("os_version", ""),
+            "ipv6_address": device.get("ipv6_address", ""),
+            "hardware_vendor": device.get("hardware_vendor", ""),
+            "hardware_type": device.get("hardware_type", ""),
+            "hardware_version": device.get("hardware_version", ""),
+            "hardware_family": device.get("hardware_family", ""),
+            "is_online": device.get("is_online", ""),
+        }
+        super()._handle_coordinator_update()
+
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._attr_mac_address or ""
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+        return self._is_online
 
 
-class FortiOSDeviceScanner(DeviceScanner):
-    """Class which queries a FortiOS unit for connected devices."""
-
-    def __init__(self, fgt) -> None:
-        """Initialize the scanner."""
-        self._clients: list[str] = []
-        self._clients_json: dict[str, Any] = {}
-        self._fgt = fgt
-
-    def update(self):
-        """Update clients from the device."""
-        clients_json = self._fgt.monitor(
-            "user/device/query",
-            "",
-            parameters={"filter": "format=master_mac|hostname|is_online"},
-        )
-
-        self._clients_json = clients_json
-
-        self._clients = []
-
-        if clients_json:
-            try:
-                for client in clients_json["results"]:
-                    if (
-                        "is_online" in client
-                        and "master_mac" in client
-                        and client["is_online"]
-                    ):
-                        self._clients.append(client["master_mac"].upper())
-            except KeyError as kex:
-                _LOGGER.error("Key not found in clients: %s", kex)
-
-    def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        self.update()
-        return self._clients
-
-    def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        _LOGGER.debug("Getting name of device %s", device)
-
-        device = device.lower()
-
-        if (data := self._clients_json) == 0:
-            _LOGGER.error("No json results to get device names")
-            return None
-
-        for client in data["results"]:
-            if "master_mac" in client and client["master_mac"] == device:
-                if "hostname" in client:
-                    name = client["hostname"]
-                else:
-                    name = client["master_mac"].replace(":", "_")
-                return name
-        return None
+def icon_for_fortios_device(device: dict[str, Any]) -> str:
+    """Return a device icon from its type."""
+    return DEVICE_ICONS.get(
+        str(device.get("hardware_family", "")).lower(), "mdi:help-network"
+    )

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-import logging
 from typing import Any
 
 from homeassistant.components.device_tracker import ScannerEntity
@@ -15,8 +14,6 @@ from homeassistant.util import dt as dt_util
 from . import FortiOSConfigEntry
 from .const import DEFAULT_DEVICE_NAME, DEVICE_ICONS, FORTIOS_RESULTS_MASTER_MAC
 from .coordinator import FortiOSDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -51,7 +48,6 @@ class FortiOSDeviceScanner(
 ):
     """Representation of a FortiOS connected entity."""
 
-    _attr_entity_registry_enabled_default = True
     _is_online: bool
 
     def __init__(
@@ -100,6 +96,11 @@ class FortiOSDeviceScanner(
             "is_online": device.get("is_online", ""),
         }
         super()._handle_coordinator_update()
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if entity is enabled by default."""
+        return True
 
     @property
     def mac_address(self) -> str:

--- a/homeassistant/components/fortios/firewall.py
+++ b/homeassistant/components/fortios/firewall.py
@@ -1,0 +1,53 @@
+"""Represent the FortiGate firewall and its devices and sensors."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import ClientTimeout
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import REST_TIMEOUT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FortiOSAPI:
+    """FortiOS API wrapper."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        host: str,
+        port: int,
+        token: str,
+        vdom: str,
+        verify_ssl: bool,
+    ) -> None:
+        """Initialize the FortiOS API wrapper."""
+        self._hass = hass
+        self._host = host
+        self._port = port
+        self._token = token
+        self._vdom = vdom
+        self._verify_ssl = verify_ssl
+
+    async def get(self, path: str) -> dict[str, Any]:
+        """Perform a GET request."""
+        url = f"https://{self._host}:{self._port}/api/v2/{path}"
+        headers = {"Authorization": f"Bearer {self._token}"}
+        parameters = {"vdom": self._vdom}
+
+        session = async_get_clientsession(self._hass)
+        async with session.get(
+            url,
+            headers=headers,
+            params=parameters,
+            timeout=ClientTimeout(total=REST_TIMEOUT),
+            ssl=self._verify_ssl,
+        ) as response:
+            response.raise_for_status()
+            return await response.json()

--- a/homeassistant/components/fortios/firewall.py
+++ b/homeassistant/components/fortios/firewall.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from aiohttp import ClientTimeout
@@ -11,8 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import REST_TIMEOUT
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class FortiOSAPI:

--- a/homeassistant/components/fortios/manifest.json
+++ b/homeassistant/components/fortios/manifest.json
@@ -2,9 +2,31 @@
   "domain": "fortios",
   "name": "FortiOS",
   "codeowners": ["@kimfrellsen"],
+  "config_flow": true,
+  "dhcp": [
+    {
+      "macaddress": "00090F*"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/fortios",
+  "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": ["fortiosapi", "paramiko"],
-  "quality_scale": "legacy",
-  "requirements": ["fortiosapi==1.0.5"]
+  "zeroconf": [
+    {
+      "name": "fortigate*",
+      "type": "_https._tcp.local."
+    },
+    {
+      "name": "fortigate*",
+      "type": "_http._tcp.local."
+    },
+    {
+      "name": "fgt*",
+      "type": "_https._tcp.local."
+    },
+    {
+      "name": "fgt*",
+      "type": "_http._tcp.local."
+    }
+  ]
 }

--- a/homeassistant/components/fortios/manifest.json
+++ b/homeassistant/components/fortios/manifest.json
@@ -11,6 +11,7 @@
   "documentation": "https://www.home-assistant.io/integrations/fortios",
   "integration_type": "hub",
   "iot_class": "local_polling",
+  "requirements": [],
   "zeroconf": [
     {
       "name": "fortigate*",

--- a/homeassistant/components/fortios/quality_scale.yaml
+++ b/homeassistant/components/fortios/quality_scale.yaml
@@ -6,7 +6,7 @@ rules:
   appropriate-polling: done
   brands: todo
   common-modules: done
-  config-flow-test-coverage: todo
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:
@@ -35,8 +35,8 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: todo
-  parallel-updates: todo
-  reauthentication-flow: todo
+  parallel-updates: done
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold
@@ -55,7 +55,7 @@ rules:
   entity-category: todo
   entity-device-class: todo
   entity-disabled-by-default: todo
-  entity-translations: todo
+  entity-translations: done
   exception-translations: todo
   icon-translations: todo
   reconfiguration-flow: done

--- a/homeassistant/components/fortios/quality_scale.yaml
+++ b/homeassistant/components/fortios/quality_scale.yaml
@@ -1,0 +1,70 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration does not register custom actions.
+  appropriate-polling: done
+  brands: todo
+  common-modules: done
+  config-flow-test-coverage: todo
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration does not have any custom actions.
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: Entities use the coordinator pattern and do not subscribe to events directly.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: Integration does not register custom actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: done
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: Integration does not raise any repairable issues.
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/fortios/sensor.py
+++ b/homeassistant/components/fortios/sensor.py
@@ -1,0 +1,120 @@
+"""Support for FortiOS sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import FortiOSConfigEntry
+from .const import DOMAIN
+from .coordinator import FortiOSDataUpdateCoordinator
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class FortiOSSensorEntityDescription(SensorEntityDescription):
+    """Class describing FortiOS sensor entities."""
+
+    value_fn: Callable[[dict[str, Any]], StateType]
+
+
+SENSORS: tuple[FortiOSSensorEntityDescription, ...] = (
+    FortiOSSensorEntityDescription(
+        key="cpu",
+        translation_key="cpu",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("system_usage", {})
+        .get("cpu", {})
+        .get("current"),
+    ),
+    FortiOSSensorEntityDescription(
+        key="memory",
+        translation_key="memory",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("system_usage", {})
+        .get("mem", {})
+        .get("current"),
+    ),
+    FortiOSSensorEntityDescription(
+        key="sessions",
+        translation_key="sessions",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("system_usage", {})
+        .get("session", {})
+        .get("current"),
+    ),
+    FortiOSSensorEntityDescription(
+        key="session_setup_rate",
+        translation_key="session_setup_rate",
+        native_unit_of_measurement="sessions/s",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (
+            data.get("system_usage", {}).get("session", {}).get("setup_rate")
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FortiOSConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up FortiOS sensor platform."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        FortiOSSensor(coordinator, description) for description in SENSORS
+    )
+
+
+class FortiOSSensor(CoordinatorEntity[FortiOSDataUpdateCoordinator], SensorEntity):
+    """Representation of a FortiOS sensor."""
+
+    entity_description: FortiOSSensorEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FortiOSDataUpdateCoordinator,
+        description: FortiOSSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.serial}_{description.key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info, keeping firmware version and serial number current."""
+        system_status = self.coordinator.data.get("system_status", {})
+        results = system_status.get("results", {})
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.serial or "")},
+            name=results.get("hostname") or self.coordinator.config_entry.title,
+            manufacturer="Fortinet",
+            model="FortiGate",
+            sw_version=system_status.get("version"),
+            serial_number=self.coordinator.serial,
+        )
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/fortios/sensor.py
+++ b/homeassistant/components/fortios/sensor.py
@@ -25,6 +25,13 @@ from .coordinator import FortiOSDataUpdateCoordinator
 PARALLEL_UPDATES = 0
 
 
+def _sum_or_none(a: Any, b: Any) -> int | None:
+    """Return a + b, or None if both values are absent."""
+    if a is None and b is None:
+        return None
+    return (a or 0) + (b or 0)
+
+
 @dataclass(frozen=True, kw_only=True)
 class FortiOSSensorEntityDescription(SensorEntityDescription):
     """Class describing FortiOS sensor entities."""
@@ -55,17 +62,19 @@ SENSORS: tuple[FortiOSSensorEntityDescription, ...] = (
         key="sessions",
         translation_key="sessions",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("system_usage", {})
-        .get("session", {})
-        .get("current"),
+        value_fn=lambda data: _sum_or_none(
+            data.get("system_usage", {}).get("session", {}).get("current"),
+            data.get("system_usage", {}).get("session6", {}).get("current"),
+        ),
     ),
     FortiOSSensorEntityDescription(
         key="session_setup_rate",
         translation_key="session_setup_rate",
         native_unit_of_measurement="sessions/s",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: (
-            data.get("system_usage", {}).get("setuprate", {}).get("current")
+        value_fn=lambda data: _sum_or_none(
+            data.get("system_usage", {}).get("setuprate", {}).get("current"),
+            data.get("system_usage", {}).get("setuprate6", {}).get("current"),
         ),
     ),
 )

--- a/homeassistant/components/fortios/sensor.py
+++ b/homeassistant/components/fortios/sensor.py
@@ -65,7 +65,7 @@ SENSORS: tuple[FortiOSSensorEntityDescription, ...] = (
         native_unit_of_measurement="sessions/s",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: (
-            data.get("system_usage", {}).get("session", {}).get("setup_rate")
+            data.get("system_usage", {}).get("setuprate", {}).get("current")
         ),
     ),
 )

--- a/homeassistant/components/fortios/strings.json
+++ b/homeassistant/components/fortios/strings.json
@@ -1,0 +1,61 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "This device is already configured.",
+      "reauth_successful": "Reauthentication was successful.",
+      "reconfigure_successful": "Reconfiguration was successful.",
+      "unique_id_mismatch": "The serial number does not match the configured device."
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the FortiOS device.",
+      "invalid_auth": "Invalid authentication token.",
+      "unknown_error": "Unexpected error occurred.",
+      "unsupported_version": "The FortiOS version is not supported."
+    },
+    "step": {
+      "reauth_confirm": {
+        "data": {
+          "token": "Access token"
+        },
+        "data_description": {
+          "token": "The API access token generated on your FortiGate device."
+        },
+        "description": "Please enter a new access token for your FortiGate at `{host}`.",
+        "title": "Reauthenticate FortiOS"
+      },
+      "user": {
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "token": "Access token",
+          "vdom": "Virtual domain (VDOM)",
+          "verify_ssl": "Verify SSL certificate"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of your FortiGate firewall.",
+          "port": "The HTTPS port of your FortiGate firewall (default: 443).",
+          "token": "The API access token generated on your FortiGate device.",
+          "vdom": "The virtual domain (VDOM) to connect to (default: root).",
+          "verify_ssl": "Whether to verify the SSL certificate of the FortiGate."
+        },
+        "description": "Provide the details for your FortiGate firewall."
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "cpu": {
+        "name": "CPU usage"
+      },
+      "memory": {
+        "name": "Memory usage"
+      },
+      "session_setup_rate": {
+        "name": "Session rate"
+      },
+      "sessions": {
+        "name": "Sessions"
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -226,6 +226,7 @@ FLOWS = {
         "folder_watcher",
         "forecast_solar",
         "forked_daapd",
+        "fortios",
         "foscam",
         "freebox",
         "freedompro",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -251,6 +251,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "C82E47*",
     },
     {
+        "domain": "fortios",
+        "macaddress": "00090F*",
+    },
+    {
         "domain": "fronius",
         "macaddress": "0003AC*",
     },

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2149,7 +2149,7 @@
     "fortios": {
       "name": "FortiOS",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "foscam": {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -582,6 +582,14 @@ ZEROCONF = {
             "name": "eheimdigital._http._tcp.local.",
         },
         {
+            "domain": "fortios",
+            "name": "fortigate*",
+        },
+        {
+            "domain": "fortios",
+            "name": "fgt*",
+        },
+        {
             "domain": "hdfury",
             "name": "diva-*",
         },
@@ -650,6 +658,16 @@ ZEROCONF = {
             "properties": {
                 "vendor": "tailwind",
             },
+        },
+    ],
+    "_https._tcp.local.": [
+        {
+            "domain": "fortios",
+            "name": "fortigate*",
+        },
+        {
+            "domain": "fortios",
+            "name": "fgt*",
         },
     ],
     "_hue._tcp.local.": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1000,9 +1000,6 @@ foobot_async==1.0.0
 # homeassistant.components.forecast_solar
 forecast-solar==4.2.0
 
-# homeassistant.components.fortios
-fortiosapi==1.0.5
-
 # homeassistant.components.freebox
 freebox-api==1.2.2
 

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -386,7 +386,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "foobot",
     "forecast_solar",
     "forked_daapd",
-    "fortios",
     "foscam",
     "foursquare",
     "free_mobile",

--- a/tests/components/fortios/__init__.py
+++ b/tests/components/fortios/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the FortiOS integration."""

--- a/tests/components/fortios/test_config_flow.py
+++ b/tests/components/fortios/test_config_flow.py
@@ -1,0 +1,338 @@
+"""Tests for the FortiOS config flow."""
+
+from ipaddress import ip_address
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+
+from homeassistant.components.fortios.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from tests.common import MockConfigEntry
+
+MOCK_USER_INPUT = {
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 443,
+    CONF_TOKEN: "test_token",
+    "vdom": "root",
+    CONF_VERIFY_SSL: False,
+}
+
+MOCK_STATUS_RESPONSE = {
+    "version": "7.0.0",
+    "serial": "FGT1234567890",
+    "results": {},
+}
+
+
+def _mock_api(
+    response: dict | None = None, side_effect: Exception | None = None
+) -> AsyncMock:
+    """Return a mocked FortiOSAPI instance."""
+    mock = AsyncMock()
+    if side_effect is not None:
+        mock.get.side_effect = side_effect
+    else:
+        mock.get.return_value = response or MOCK_STATUS_RESPONSE
+    return mock
+
+
+async def test_user_flow_success(hass: HomeAssistant) -> None:
+    """Test the user flow creates an entry on success."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "FortiGate FGT1234567890"
+    assert result["data"] == MOCK_USER_INPUT
+
+
+async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
+    """Test the user flow shows error when connection fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(side_effect=Exception("Connection refused")),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "unknown_error"}
+
+
+async def test_user_flow_invalid_auth(hass: HomeAssistant) -> None:
+    """Test the user flow shows error on 401 Unauthorized."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    error = aiohttp.ClientResponseError(None, None, status=401)
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(side_effect=error),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_user_flow_cannot_connect_http_error(hass: HomeAssistant) -> None:
+    """Test the user flow shows cannot_connect on non-401 HTTP errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    error = aiohttp.ClientResponseError(None, None, status=500)
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(side_effect=error),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_unsupported_version(hass: HomeAssistant) -> None:
+    """Test the user flow shows error when FortiOS version is too old."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(response={"version": "6.0.0", "serial": "FGT000"}),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unsupported_version"}
+
+
+async def test_user_flow_duplicate(hass: HomeAssistant) -> None:
+    """Test the user flow aborts when the device is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="FGT1234567890",
+        data=MOCK_USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_step(hass: HomeAssistant) -> None:
+    """Test the zeroconf discovery step shows user form."""
+    discovery_info = ZeroconfServiceInfo(
+        ip_address=ip_address("1.2.3.4"),
+        ip_addresses=[ip_address("1.2.3.4")],
+        hostname="fortigate.local.",
+        name="fortigate._https._tcp.local.",
+        port=443,
+        properties={},
+        type="_https._tcp.local.",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "zeroconf"}, data=discovery_info
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Verify host and port are pre-filled in the schema defaults
+    schema_keys = {k.schema: k for k in result["data_schema"].schema}
+    assert schema_keys[CONF_HOST].default() == "1.2.3.4"
+    assert schema_keys[CONF_PORT].default() == 443
+
+
+async def test_zeroconf_step_already_configured(hass: HomeAssistant) -> None:
+    """Test zeroconf discovery aborts when the IP is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data=MOCK_USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    discovery_info = ZeroconfServiceInfo(
+        ip_address=ip_address("1.2.3.4"),
+        ip_addresses=[ip_address("1.2.3.4")],
+        hostname="fortigate.local.",
+        name="fortigate._https._tcp.local.",
+        port=443,
+        properties={},
+        type="_https._tcp.local.",
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "zeroconf"}, data=discovery_info
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_dhcp_step(hass: HomeAssistant) -> None:
+    """Test the DHCP discovery step shows user form with pre-filled host."""
+    # DhcpServiceInfo requires lowercase MAC without colons
+    discovery_info = DhcpServiceInfo(
+        ip="1.2.3.4",
+        macaddress="00090f123456",
+        hostname="fortigate",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "dhcp"}, data=discovery_info
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    schema_keys = {k.schema: k for k in result["data_schema"].schema}
+    assert schema_keys[CONF_HOST].default() == "1.2.3.4"
+
+
+async def test_dhcp_step_already_configured(hass: HomeAssistant) -> None:
+    """Test DHCP discovery aborts when the MAC is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="00090f123456",
+        data=MOCK_USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    discovery_info = DhcpServiceInfo(
+        ip="1.2.3.4",
+        macaddress="00090f123456",
+        hostname="fortigate",
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "dhcp"}, data=discovery_info
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_reconfigure_step(hass: HomeAssistant) -> None:
+    """Test the reconfigure step updates entry data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="FGT1234567890",
+        data=MOCK_USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Current values should be pre-filled
+    schema_keys = {k.schema: k for k in result["data_schema"].schema}
+    assert schema_keys[CONF_HOST].default() == "1.2.3.4"
+    assert schema_keys[CONF_TOKEN].default() == "test_token"
+
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {**MOCK_USER_INPUT, CONF_HOST: "5.6.7.8", CONF_TOKEN: "new_token"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_HOST] == "5.6.7.8"
+    assert entry.data[CONF_TOKEN] == "new_token"
+
+
+async def test_reauth_flow_success(hass: HomeAssistant) -> None:
+    """Test the reauthentication flow updates the token."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="FGT1234567890",
+        data=MOCK_USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_TOKEN: "new_token"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_TOKEN] == "new_token"
+
+
+async def test_reauth_flow_invalid_auth(hass: HomeAssistant) -> None:
+    """Test the reauthentication flow shows error on invalid token."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="FGT1234567890",
+        data=MOCK_USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    error = aiohttp.ClientResponseError(None, None, status=401)
+    with patch(
+        "homeassistant.components.fortios.config_flow.FortiOSAPI",
+        return_value=_mock_api(side_effect=error),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_TOKEN: "bad_token"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "invalid_auth"}

--- a/tests/components/fortios/test_device_tracker.py
+++ b/tests/components/fortios/test_device_tracker.py
@@ -1,0 +1,168 @@
+"""Tests for the FortiOS device tracker."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.fortios.const import DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TOKEN,
+    CONF_VERIFY_SSL,
+    STATE_HOME,
+    STATE_NOT_HOME,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG_DATA = {
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 443,
+    CONF_TOKEN: "token",
+    "vdom": "root",
+    CONF_VERIFY_SSL: False,
+}
+
+MOCK_DEVICE = {
+    "master_mac": "00:11:22:33:44:55",
+    "hostname": "test_device",
+    "is_online": True,
+    "ipv4_address": "192.168.1.100",
+    "last_seen": 1600000000,
+}
+
+MOCK_DEVICE_OFFLINE = {**MOCK_DEVICE, "is_online": False}
+
+
+def _make_api_mock(device: dict | None = None) -> AsyncMock:
+    """Return a mocked FortiOSAPI instance with per-endpoint responses."""
+    selected_device = device or MOCK_DEVICE
+
+    async def _get(path: str) -> dict:
+        if "device/query" in path:
+            return {"results": [selected_device]}
+        if "resource/usage" in path:
+            return {
+                "results": {
+                    "cpu": [{"current": 10}],
+                    "mem": [{"current": 50}],
+                    "session": [{"current": 100, "setup_rate": 5}],
+                }
+            }
+        # monitor/system/status
+        return {
+            "version": "7.0.0",
+            "serial": "FGT1234567890",
+            "results": {},
+        }
+
+    mock = AsyncMock()
+    mock.get.side_effect = _get
+    return mock
+
+
+def _patch_api(device: dict | None = None):
+    """Patch FortiOSAPI with a mock returning appropriate per-endpoint data."""
+    return patch(
+        "homeassistant.components.fortios.FortiOSAPI",
+        return_value=_make_api_mock(device),
+    )
+
+
+@pytest.fixture
+def mock_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create and register a mock config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="FGT1234567890",
+        data=MOCK_CONFIG_DATA,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_device_tracker_home(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test that an online device is in STATE_HOME."""
+    with _patch_api():
+        assert await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test_device")
+    assert state is not None
+    assert state.state == STATE_HOME
+    assert state.attributes["mac"] == "00:11:22:33:44:55"
+    assert state.attributes["ip"] == "192.168.1.100"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_device_tracker_not_home(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test that an offline device transitions to STATE_NOT_HOME."""
+    with _patch_api():
+        assert await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_entry.runtime_data
+    coordinator.api.get.side_effect = _make_api_mock(
+        MOCK_DEVICE_OFFLINE
+    ).get.side_effect
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test_device")
+    assert state is not None
+    assert state.state == STATE_NOT_HOME
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_device_tracker_extra_attributes(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test that extra state attributes use snake_case keys."""
+    device_with_extras = {
+        **MOCK_DEVICE,
+        "os_name": "Android",
+        "os_version": "12",
+        "hardware_vendor": "Samsung",
+        "hardware_type": "smartphone",
+        "hardware_family": "smartphone",
+        "hardware_version": "1.0",
+        "ipv6_address": "",
+    }
+
+    with _patch_api(device=device_with_extras):
+        assert await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test_device")
+    assert state is not None
+    assert state.attributes["os_name"] == "Android"
+    assert state.attributes["os_version"] == "12"
+    assert state.attributes["hardware_vendor"] == "Samsung"
+    assert state.attributes["hardware_type"] == "smartphone"
+    # Ensure old-style keys with capitals/spaces are NOT present
+    assert "OS_name" not in state.attributes
+    assert "Hardware vendor" not in state.attributes
+
+
+async def test_coordinator_update_failed(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test that UpdateFailed is raised when the API call fails."""
+    with _patch_api():
+        assert await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_entry.runtime_data
+    # Replace the api with one that raises an exception
+    coordinator.api.get.side_effect = Exception("API Error")
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
YAML configuration removed
The integration was previously configured via configuration.yaml under device_tracker:. This no longer works. Users must remove the YAML config and re-add the integration through the UI (Settings → Integrations → Add FortiOS).

fortiosapi library removed
The dependency on fortiosapi==1.0.5 (which used paramiko for SSH) has been removed. The integration now communicates directly with the FortiOS REST API over HTTPS.

vdom and port now required
The config flow requires vdom (default: root) and port (default: 443) in addition to host, token, and verify_ssl.
-->


## Proposed change
<!--
This PR refactors the existing FortiOS integration to meet the Bronze quality scale requirements.

### Changes
- Add config flow with user setup, reauthentication, reconfiguration, zeroconf and DHCP discovery steps
- Add `DataUpdateCoordinator` centralising all data fetching for device tracker and sensors
- Add sensor platform: CPU usage, memory usage, sessions (IPv4+IPv6), session setup rate (IPv4+IPv6)
- Move firmware version, hostname and serial number into `DeviceInfo`
- Fix API response normalisation (FortiOS returns metrics as single-element lists)
- New devices discovered by the device tracker are enabled by default
- Add `strings.json` with full translations and field descriptions
- Add `quality_scale.yaml`
- Add tests for config flow and device tracker
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x ] Breaking change (fix/feature causing existing functionality to break)
- [ x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ x] I understand the code I am submitting and can explain how it works.
- [x ] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] I have followed the [perfect PR recommendations][perfect-pr]
- [ x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.
- [x ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
