### PR TITLE
Add intent handlers for number, select, and text entity domains

### DIFF
--- a/homeassistant/components/input_number/intent.py
+++ b/homeassistant/components/input_number/intent.py
@@ -1,0 +1,32 @@
+"""Intents for the input_number integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from . import DOMAIN, SERVICE_SET_VALUE
+
+INTENT_SET_VALUE = "HassInputNumberSetValue"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the input_number intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_SET_VALUE,
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            description="Sets the value of an input number entity",
+            platforms={DOMAIN},
+            required_slots={
+                "value": intent.IntentSlotInfo(
+                    description="The numeric value to set",
+                    value_schema=vol.Coerce(float),
+                )
+            },
+        ),
+    )

--- a/homeassistant/components/input_select/intent.py
+++ b/homeassistant/components/input_select/intent.py
@@ -1,0 +1,56 @@
+"""Intents for the input_select integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import ATTR_OPTION, ATTR_OPTIONS, SERVICE_SELECT_OPTION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, intent
+
+from . import DOMAIN
+
+INTENT_SELECT_OPTION = "HassInputSelectSelectOption"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the input_select intents."""
+    intent.async_register(hass, InputSelectOptionIntentHandler())
+
+
+class InputSelectOptionIntentHandler(intent.ServiceIntentHandler):
+    """Handle input_select option intents."""
+
+    def __init__(self) -> None:
+        """Create input_select option handler."""
+        super().__init__(
+            INTENT_SELECT_OPTION,
+            DOMAIN,
+            SERVICE_SELECT_OPTION,
+            description="Selects an option for an input select entity",
+            platforms={DOMAIN},
+            required_slots={
+                ATTR_OPTION: intent.IntentSlotInfo(
+                    description="The option to select",
+                    value_schema=cv.string,
+                )
+            },
+        )
+
+    async def async_handle_states(
+        self,
+        intent_obj: intent.Intent,
+        match_result: intent.MatchTargetsResult,
+        match_constraints: intent.MatchTargetsConstraints,
+        match_preferences: intent.MatchTargetsPreferences | None = None,
+    ) -> intent.IntentResponse:
+        """Validate option against each matched entity before calling the service."""
+        option = intent_obj.slots[ATTR_OPTION]["value"]
+        for state in match_result.states:
+            valid_options = state.attributes.get(ATTR_OPTIONS) or []
+            if option not in valid_options:
+                raise intent.IntentHandleError(
+                    f"Entity {state.name} does not support option '{option}'. "
+                    f"Valid options are: {valid_options}"
+                )
+        return await super().async_handle_states(
+            intent_obj, match_result, match_constraints, match_preferences
+        )

--- a/homeassistant/components/input_select/intent.py
+++ b/homeassistant/components/input_select/intent.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from homeassistant.components.select import ATTR_OPTION, ATTR_OPTIONS, SERVICE_SELECT_OPTION
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    ATTR_OPTIONS,
+    SERVICE_SELECT_OPTION,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, intent
 

--- a/homeassistant/components/input_text/intent.py
+++ b/homeassistant/components/input_text/intent.py
@@ -1,0 +1,30 @@
+"""Intents for the input_text integration."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, intent
+
+from . import ATTR_VALUE, DOMAIN, SERVICE_SET_VALUE
+
+INTENT_SET_VALUE = "HassInputTextSetValue"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the input_text intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_SET_VALUE,
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            description="Sets the value of an input text entity",
+            platforms={DOMAIN},
+            required_slots={
+                ATTR_VALUE: intent.IntentSlotInfo(
+                    description="The text value to set",
+                    value_schema=cv.string,
+                )
+            },
+        ),
+    )

--- a/homeassistant/components/number/intent.py
+++ b/homeassistant/components/number/intent.py
@@ -1,0 +1,32 @@
+"""Intents for the number integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from .const import DOMAIN, SERVICE_SET_VALUE
+
+INTENT_SET_VALUE = "HassNumberSetValue"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the number intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_SET_VALUE,
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            description="Sets the value of a number entity",
+            platforms={DOMAIN},
+            required_slots={
+                "value": intent.IntentSlotInfo(
+                    description="The numeric value to set",
+                    value_schema=vol.Coerce(float),
+                )
+            },
+        ),
+    )

--- a/homeassistant/components/select/intent.py
+++ b/homeassistant/components/select/intent.py
@@ -1,0 +1,57 @@
+"""Intents for the select integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, intent
+
+from .const import ATTR_OPTION, ATTR_OPTIONS, DOMAIN, SERVICE_SELECT_OPTION
+
+INTENT_SELECT_OPTION = "HassSelectSelectOption"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the select intents."""
+    intent.async_register(hass, SelectOptionIntentHandler())
+
+
+class SelectOptionIntentHandler(intent.ServiceIntentHandler):
+    """Handle select option intents."""
+
+    def __init__(self) -> None:
+        """Create select option handler."""
+        super().__init__(
+            INTENT_SELECT_OPTION,
+            DOMAIN,
+            SERVICE_SELECT_OPTION,
+            description="Selects an option for a select entity",
+            platforms={DOMAIN},
+            required_slots={
+                ATTR_OPTION: intent.IntentSlotInfo(
+                    description="The option to select",
+                    value_schema=cv.string,
+                )
+            },
+        )
+
+    async def async_handle_states(
+        self,
+        intent_obj: intent.Intent,
+        match_result: intent.MatchTargetsResult,
+        match_constraints: intent.MatchTargetsConstraints,
+        match_preferences: intent.MatchTargetsPreferences | None = None,
+    ) -> intent.IntentResponse:
+        """Validate option against each matched entity before calling the service."""
+        option = intent_obj.slots[ATTR_OPTION]["value"]
+        for state in match_result.states:
+            valid_options = state.attributes.get(ATTR_OPTIONS) or []
+            if option not in valid_options:
+                raise intent.IntentHandleError(
+                    f"Entity {state.name} does not support option '{option}'. "
+                    f"Valid options are: {valid_options}"
+                )
+        return await super().async_handle_states(
+            intent_obj, match_result, match_constraints, match_preferences
+        )

--- a/homeassistant/components/select/intent.py
+++ b/homeassistant/components/select/intent.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import voluptuous as vol
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, intent
 

--- a/homeassistant/components/text/intent.py
+++ b/homeassistant/components/text/intent.py
@@ -1,0 +1,30 @@
+"""Intents for the text integration."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, intent
+
+from .const import ATTR_VALUE, DOMAIN, SERVICE_SET_VALUE
+
+INTENT_SET_VALUE = "HassTextSetValue"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the text intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_SET_VALUE,
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            description="Sets the value of a text entity",
+            platforms={DOMAIN},
+            required_slots={
+                ATTR_VALUE: intent.IntentSlotInfo(
+                    description="The text value to set",
+                    value_schema=cv.string,
+                )
+            },
+        ),
+    )

--- a/tests/components/input_number/test_intent.py
+++ b/tests/components/input_number/test_intent.py
@@ -1,0 +1,47 @@
+"""Tests for input_number intents."""
+
+import pytest
+
+from homeassistant.components.input_number import (
+    DOMAIN,
+    SERVICE_SET_VALUE,
+    intent as input_number_intent,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_set_value(hass: HomeAssistant) -> None:
+    """Test HassInputNumberSetValue intent."""
+    await input_number_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_input_number"
+    hass.states.async_set(entity_id, "50.0")
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SET_VALUE)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        input_number_intent.INTENT_SET_VALUE,
+        {"name": {"value": "test input number"}, "value": {"value": 25.0}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": entity_id, "value": 25.0}
+
+
+async def test_set_value_no_match(hass: HomeAssistant) -> None:
+    """Test HassInputNumberSetValue intent with no matching entity."""
+    await input_number_intent.async_setup_intents(hass)
+
+    with pytest.raises(intent.MatchFailedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            input_number_intent.INTENT_SET_VALUE,
+            {"name": {"value": "nonexistent"}, "value": {"value": 10.0}},
+        )

--- a/tests/components/input_select/test_intent.py
+++ b/tests/components/input_select/test_intent.py
@@ -15,9 +15,7 @@ async def test_select_option(hass: HomeAssistant) -> None:
     await input_select_intent.async_setup_intents(hass)
 
     entity_id = f"{DOMAIN}.test_input_select"
-    hass.states.async_set(
-        entity_id, "red", {ATTR_OPTIONS: ["red", "green", "blue"]}
-    )
+    hass.states.async_set(entity_id, "red", {ATTR_OPTIONS: ["red", "green", "blue"]})
     calls = async_mock_service(hass, DOMAIN, SERVICE_SELECT_OPTION)
 
     response = await intent.async_handle(
@@ -38,9 +36,7 @@ async def test_select_option_invalid(hass: HomeAssistant) -> None:
     await input_select_intent.async_setup_intents(hass)
 
     entity_id = f"{DOMAIN}.test_input_select"
-    hass.states.async_set(
-        entity_id, "red", {ATTR_OPTIONS: ["red", "green", "blue"]}
-    )
+    hass.states.async_set(entity_id, "red", {ATTR_OPTIONS: ["red", "green", "blue"]})
 
     with pytest.raises(intent.IntentHandleError) as exc_info:
         await intent.async_handle(

--- a/tests/components/input_select/test_intent.py
+++ b/tests/components/input_select/test_intent.py
@@ -1,0 +1,67 @@
+"""Tests for input_select intents."""
+
+import pytest
+
+from homeassistant.components.input_select import DOMAIN, intent as input_select_intent
+from homeassistant.components.select import ATTR_OPTIONS, SERVICE_SELECT_OPTION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_select_option(hass: HomeAssistant) -> None:
+    """Test HassInputSelectSelectOption intent."""
+    await input_select_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_input_select"
+    hass.states.async_set(
+        entity_id, "red", {ATTR_OPTIONS: ["red", "green", "blue"]}
+    )
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SELECT_OPTION)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        input_select_intent.INTENT_SELECT_OPTION,
+        {"name": {"value": "test input select"}, "option": {"value": "green"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": entity_id, "option": "green"}
+
+
+async def test_select_option_invalid(hass: HomeAssistant) -> None:
+    """Test HassInputSelectSelectOption intent with an invalid option."""
+    await input_select_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_input_select"
+    hass.states.async_set(
+        entity_id, "red", {ATTR_OPTIONS: ["red", "green", "blue"]}
+    )
+
+    with pytest.raises(intent.IntentHandleError) as exc_info:
+        await intent.async_handle(
+            hass,
+            "test",
+            input_select_intent.INTENT_SELECT_OPTION,
+            {"name": {"value": "test input select"}, "option": {"value": "yellow"}},
+        )
+
+    assert "yellow" in str(exc_info.value)
+    assert "red" in str(exc_info.value)
+
+
+async def test_select_option_no_match(hass: HomeAssistant) -> None:
+    """Test HassInputSelectSelectOption intent with no matching entity."""
+    await input_select_intent.async_setup_intents(hass)
+
+    with pytest.raises(intent.MatchFailedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            input_select_intent.INTENT_SELECT_OPTION,
+            {"name": {"value": "nonexistent"}, "option": {"value": "red"}},
+        )

--- a/tests/components/input_text/test_intent.py
+++ b/tests/components/input_text/test_intent.py
@@ -1,0 +1,47 @@
+"""Tests for input_text intents."""
+
+import pytest
+
+from homeassistant.components.input_text import (
+    DOMAIN,
+    SERVICE_SET_VALUE,
+    intent as input_text_intent,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_set_value(hass: HomeAssistant) -> None:
+    """Test HassInputTextSetValue intent."""
+    await input_text_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_input_text"
+    hass.states.async_set(entity_id, "hello")
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SET_VALUE)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        input_text_intent.INTENT_SET_VALUE,
+        {"name": {"value": "test input text"}, "value": {"value": "world"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": entity_id, "value": "world"}
+
+
+async def test_set_value_no_match(hass: HomeAssistant) -> None:
+    """Test HassInputTextSetValue intent with no matching entity."""
+    await input_text_intent.async_setup_intents(hass)
+
+    with pytest.raises(intent.MatchFailedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            input_text_intent.INTENT_SET_VALUE,
+            {"name": {"value": "nonexistent"}, "value": {"value": "hello"}},
+        )

--- a/tests/components/number/test_intent.py
+++ b/tests/components/number/test_intent.py
@@ -2,8 +2,11 @@
 
 import pytest
 
-from homeassistant.components.number import DOMAIN, SERVICE_SET_VALUE, intent as number_intent
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.components.number import (
+    DOMAIN,
+    SERVICE_SET_VALUE,
+    intent as number_intent,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 

--- a/tests/components/number/test_intent.py
+++ b/tests/components/number/test_intent.py
@@ -1,0 +1,44 @@
+"""Tests for number intents."""
+
+import pytest
+
+from homeassistant.components.number import DOMAIN, SERVICE_SET_VALUE, intent as number_intent
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_set_value(hass: HomeAssistant) -> None:
+    """Test HassNumberSetValue intent."""
+    await number_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_number"
+    hass.states.async_set(entity_id, "50.0")
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SET_VALUE)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        number_intent.INTENT_SET_VALUE,
+        {"name": {"value": "test number"}, "value": {"value": 75.0}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": entity_id, "value": 75.0}
+
+
+async def test_set_value_no_match(hass: HomeAssistant) -> None:
+    """Test HassNumberSetValue intent with no matching entity."""
+    await number_intent.async_setup_intents(hass)
+
+    with pytest.raises(intent.MatchFailedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            number_intent.INTENT_SET_VALUE,
+            {"name": {"value": "nonexistent"}, "value": {"value": 10.0}},
+        )

--- a/tests/components/select/test_intent.py
+++ b/tests/components/select/test_intent.py
@@ -42,9 +42,7 @@ async def test_select_option_invalid(hass: HomeAssistant) -> None:
     await select_intent.async_setup_intents(hass)
 
     entity_id = f"{DOMAIN}.test_select"
-    hass.states.async_set(
-        entity_id, "option1", {ATTR_OPTIONS: ["option1", "option2"]}
-    )
+    hass.states.async_set(entity_id, "option1", {ATTR_OPTIONS: ["option1", "option2"]})
 
     with pytest.raises(intent.IntentHandleError) as exc_info:
         await intent.async_handle(

--- a/tests/components/select/test_intent.py
+++ b/tests/components/select/test_intent.py
@@ -1,0 +1,72 @@
+"""Tests for select intents."""
+
+import pytest
+
+from homeassistant.components.select import (
+    ATTR_OPTIONS,
+    DOMAIN,
+    SERVICE_SELECT_OPTION,
+    intent as select_intent,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_select_option(hass: HomeAssistant) -> None:
+    """Test HassSelectSelectOption intent."""
+    await select_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_select"
+    hass.states.async_set(
+        entity_id, "option1", {ATTR_OPTIONS: ["option1", "option2", "option3"]}
+    )
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SELECT_OPTION)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        select_intent.INTENT_SELECT_OPTION,
+        {"name": {"value": "test select"}, "option": {"value": "option2"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": entity_id, "option": "option2"}
+
+
+async def test_select_option_invalid(hass: HomeAssistant) -> None:
+    """Test HassSelectSelectOption intent with an invalid option."""
+    await select_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_select"
+    hass.states.async_set(
+        entity_id, "option1", {ATTR_OPTIONS: ["option1", "option2"]}
+    )
+
+    with pytest.raises(intent.IntentHandleError) as exc_info:
+        await intent.async_handle(
+            hass,
+            "test",
+            select_intent.INTENT_SELECT_OPTION,
+            {"name": {"value": "test select"}, "option": {"value": "bad_option"}},
+        )
+
+    assert "bad_option" in str(exc_info.value)
+    assert "option1" in str(exc_info.value)
+    assert "option2" in str(exc_info.value)
+
+
+async def test_select_option_no_match(hass: HomeAssistant) -> None:
+    """Test HassSelectSelectOption intent with no matching entity."""
+    await select_intent.async_setup_intents(hass)
+
+    with pytest.raises(intent.MatchFailedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            select_intent.INTENT_SELECT_OPTION,
+            {"name": {"value": "nonexistent"}, "option": {"value": "option1"}},
+        )

--- a/tests/components/text/test_intent.py
+++ b/tests/components/text/test_intent.py
@@ -1,0 +1,43 @@
+"""Tests for text intents."""
+
+import pytest
+
+from homeassistant.components.text import DOMAIN, SERVICE_SET_VALUE, intent as text_intent
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_set_value(hass: HomeAssistant) -> None:
+    """Test HassTextSetValue intent."""
+    await text_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_text"
+    hass.states.async_set(entity_id, "hello")
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SET_VALUE)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        text_intent.INTENT_SET_VALUE,
+        {"name": {"value": "test text"}, "value": {"value": "world"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": entity_id, "value": "world"}
+
+
+async def test_set_value_no_match(hass: HomeAssistant) -> None:
+    """Test HassTextSetValue intent with no matching entity."""
+    await text_intent.async_setup_intents(hass)
+
+    with pytest.raises(intent.MatchFailedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            text_intent.INTENT_SET_VALUE,
+            {"name": {"value": "nonexistent"}, "value": {"value": "hello"}},
+        )

--- a/tests/components/text/test_intent.py
+++ b/tests/components/text/test_intent.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from homeassistant.components.text import DOMAIN, SERVICE_SET_VALUE, intent as text_intent
+from homeassistant.components.text import (
+    DOMAIN,
+    SERVICE_SET_VALUE,
+    intent as text_intent,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 


### PR DESCRIPTION
So, this PR adds `intent.py` to the `number`, `input_number`, `select`, `input_select`, `text`, and `input_text` components. Why? So that these domains are exposed as write tools via the MCP/LLM API (/api/mcp).

These domains had no intent handlers, meaning the `AssistAPI._async_get_tools()` pipeline never generated write tools for them despite all of them having `set_value`/`select_option` services. This mean that users interacting with Home Assistant via LLM assistants or MCP could see these entities in the `GetLiveContext` output but had no way to write to them. I wrote about this in 

I checked across issues and PRs and couldn't find a given reason why these were never implemented along with other domains, so I'm assuming it was an oversight rather than deliberate.

For select and input_select, the intent handler validates the requested option against the entity's options attribute before calling the service, and raises IntentHandleError with the list of valid options if the option is not supported. This allows the LLM to self-correct in the same conversation turn without requiring a second GetLiveContext call. Validation is performed in async_handle_states (before the per-entity service call loop) rather than in async_call_service, so the error message is not swallowed by the parent class exception handler.

BTW I didn't touch the alarm domain, as I wasn't sure how that could be handled with the whole PIN thing. 

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166981 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
