### PR TITLE
Migrate Tessie setup and coordinator to tesla_fleet_api

### DIFF
--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -92,7 +92,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
         vehicles.append(
             TessieVehicleData(
                 vin=vin,
-                api=vehicle_api,
                 data_coordinator=TessieStateUpdateCoordinator(
                     hass,
                     entry,

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -1,14 +1,17 @@
 """Tessie integration."""
 
 import asyncio
-from http import HTTPStatus
 import logging
 
-from aiohttp import ClientError, ClientResponseError
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
     Forbidden,
+    GatewayTimeout,
+    InvalidResponse,
     InvalidToken,
+    MissingToken,
+    RateLimited,
+    ServiceUnavailable,
     SubscriptionRequired,
     TeslaFleetError,
 )
@@ -53,6 +56,13 @@ _LOGGER = logging.getLogger(__name__)
 
 type TessieConfigEntry = ConfigEntry[TessieData]
 
+RETRY_EXCEPTIONS = (
+    InvalidResponse,
+    RateLimited,
+    ServiceUnavailable,
+    GatewayTimeout,
+)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bool:
     """Set up Tessie config."""
@@ -62,22 +72,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
 
     try:
         state_of_all_vehicles = await tessie.list_vehicles(only_active=True)
-    except InvalidToken as e:
+    except (InvalidToken, MissingToken) as e:
         raise ConfigEntryAuthFailed from e
+    except RETRY_EXCEPTIONS as e:
+        raise ConfigEntryNotReady from e
     except TeslaFleetError as e:
         raise ConfigEntryError(
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
         ) from e
-    except ClientResponseError as e:
-        if e.status == HTTPStatus.UNAUTHORIZED:
-            raise ConfigEntryAuthFailed from e
-        raise ConfigEntryError(
-            translation_domain=DOMAIN,
-            translation_key="cannot_connect",
-        ) from e
-    except ClientError as e:
-        raise ConfigEntryNotReady from e
 
     vehicles: list[TessieVehicleData] = []
     for vehicle in state_of_all_vehicles["results"]:

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -65,11 +65,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
     except InvalidToken as e:
         raise ConfigEntryAuthFailed from e
     except TeslaFleetError as e:
-        raise ConfigEntryError("Setup failed, unable to connect to Tessie") from e
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from e
     except ClientResponseError as e:
         if e.status == HTTPStatus.UNAUTHORIZED:
             raise ConfigEntryAuthFailed from e
-        raise ConfigEntryError("Setup failed, unable to connect to Tessie") from e
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from e
     except ClientError as e:
         raise ConfigEntryNotReady from e
 

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -13,7 +13,6 @@ from tesla_fleet_api.exceptions import (
     TeslaFleetError,
 )
 from tesla_fleet_api.tessie import Tessie
-from tessie_api import get_state_of_all_vehicles
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
@@ -59,13 +58,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
     """Set up Tessie config."""
     api_key = entry.data[CONF_ACCESS_TOKEN]
     session = async_get_clientsession(hass)
+    tessie = Tessie(session, api_key)
 
     try:
-        state_of_all_vehicles = await get_state_of_all_vehicles(
-            session=session,
-            api_key=api_key,
-            only_active=True,
-        )
+        state_of_all_vehicles = await tessie.list_vehicles(only_active=True)
+    except InvalidToken as e:
+        raise ConfigEntryAuthFailed from e
+    except TeslaFleetError as e:
+        raise ConfigEntryError("Setup failed, unable to connect to Tessie") from e
     except ClientResponseError as e:
         if e.status == HTTPStatus.UNAUTHORIZED:
             raise ConfigEntryAuthFailed from e
@@ -73,38 +73,44 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
     except ClientError as e:
         raise ConfigEntryNotReady from e
 
-    vehicles = [
-        TessieVehicleData(
-            vin=vehicle["vin"],
-            data_coordinator=TessieStateUpdateCoordinator(
-                hass,
-                entry,
-                api_key=api_key,
-                vin=vehicle["vin"],
-                data=vehicle["last_state"],
-            ),
-            device=DeviceInfo(
-                identifiers={(DOMAIN, vehicle["vin"])},
-                manufacturer="Tesla",
-                configuration_url="https://my.tessie.com/",
-                name=vehicle["last_state"]["display_name"],
-                model=MODELS.get(
-                    vehicle["last_state"]["vehicle_config"]["car_type"],
-                    vehicle["last_state"]["vehicle_config"]["car_type"],
+    vehicles: list[TessieVehicleData] = []
+    for vehicle in state_of_all_vehicles["results"]:
+        if vehicle["last_state"] is None:
+            continue
+
+        vin = vehicle["vin"]
+        vehicle_api = tessie.vehicles.create(vin)
+        vehicles.append(
+            TessieVehicleData(
+                vin=vin,
+                api=vehicle_api,
+                data_coordinator=TessieStateUpdateCoordinator(
+                    hass,
+                    entry,
+                    api=vehicle_api,
+                    api_key=api_key,
+                    vin=vin,
+                    data=vehicle["last_state"],
                 ),
-                sw_version=vehicle["last_state"]["vehicle_state"]["car_version"].split(
-                    " "
-                )[0],
-                hw_version=vehicle["last_state"]["vehicle_config"]["driver_assist"],
-                serial_number=vehicle["vin"],
-            ),
+                device=DeviceInfo(
+                    identifiers={(DOMAIN, vin)},
+                    manufacturer="Tesla",
+                    configuration_url="https://my.tessie.com/",
+                    name=vehicle["last_state"]["display_name"],
+                    model=MODELS.get(
+                        vehicle["last_state"]["vehicle_config"]["car_type"],
+                        vehicle["last_state"]["vehicle_config"]["car_type"],
+                    ),
+                    sw_version=vehicle["last_state"]["vehicle_state"][
+                        "car_version"
+                    ].split(" ")[0],
+                    hw_version=vehicle["last_state"]["vehicle_config"]["driver_assist"],
+                    serial_number=vin,
+                ),
+            )
         )
-        for vehicle in state_of_all_vehicles["results"]
-        if vehicle["last_state"] is not None
-    ]
 
     # Energy Sites
-    tessie = Tessie(session, api_key)
     energysites: list[TessieEnergyData] = []
 
     try:

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import ClientError, ClientResponseError
 from tesla_fleet_api.const import TeslaEnergyPeriod
 from tesla_fleet_api.exceptions import InvalidToken, MissingToken, TeslaFleetError
-from tesla_fleet_api.tessie import EnergySite
-from tessie_api import get_state
+from tesla_fleet_api.tessie import EnergySite, Vehicle
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -54,6 +53,7 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self,
         hass: HomeAssistant,
         config_entry: TessieConfigEntry,
+        api: Vehicle,
         api_key: str,
         vin: str,
         data: dict[str, Any],
@@ -66,6 +66,7 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             name="Tessie",
             update_interval=timedelta(seconds=TESSIE_SYNC_INTERVAL),
         )
+        self.api = api
         self.api_key = api_key
         self.vin = vin
         self.session = async_get_clientsession(hass)
@@ -74,12 +75,14 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Update vehicle data using Tessie API."""
         try:
-            vehicle = await get_state(
-                session=self.session,
-                api_key=self.api_key,
-                vin=self.vin,
-                use_cache=True,
-            )
+            vehicle = await self.api.state(use_cache=True)
+        except (InvalidToken, MissingToken) as e:
+            raise ConfigEntryAuthFailed from e
+        except TeslaFleetError as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
         except ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
                 raise ConfigEntryAuthFailed from e

--- a/homeassistant/components/tessie/models.py
+++ b/homeassistant/components/tessie/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tesla_fleet_api.tessie import EnergySite
+from tesla_fleet_api.tessie import EnergySite, Vehicle
 
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -43,3 +43,4 @@ class TessieVehicleData:
     data_coordinator: TessieStateUpdateCoordinator
     device: DeviceInfo
     vin: str
+    api: Vehicle | None = None

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -26,8 +26,9 @@ def mock_get_state():
     """Mock get_state function."""
     with patch(
         "tesla_fleet_api.tessie.Vehicle.state",
-        return_value=TEST_VEHICLE_STATE_ONLINE,
+        new_callable=AsyncMock,
     ) as mock_get_state:
+        mock_get_state.return_value = TEST_VEHICLE_STATE_ONLINE
         yield mock_get_state
 
 
@@ -36,8 +37,9 @@ def mock_get_state_of_all_vehicles():
     """Mock get_state_of_all_vehicles function."""
     with patch(
         "tesla_fleet_api.tessie.Tessie.list_vehicles",
-        return_value=TEST_STATE_OF_ALL_VEHICLES,
+        new_callable=AsyncMock,
     ) as mock_get_state_of_all_vehicles:
+        mock_get_state_of_all_vehicles.return_value = TEST_STATE_OF_ALL_VEHICLES
         yield mock_get_state_of_all_vehicles
 
 

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -25,7 +25,7 @@ from .common import (
 def mock_get_state():
     """Mock get_state function."""
     with patch(
-        "homeassistant.components.tessie.coordinator.get_state",
+        "tesla_fleet_api.tessie.Vehicle.state",
         return_value=TEST_VEHICLE_STATE_ONLINE,
     ) as mock_get_state:
         yield mock_get_state
@@ -35,7 +35,7 @@ def mock_get_state():
 def mock_get_state_of_all_vehicles():
     """Mock get_state_of_all_vehicles function."""
     with patch(
-        "homeassistant.components.tessie.get_state_of_all_vehicles",
+        "tesla_fleet_api.tessie.Tessie.list_vehicles",
         return_value=TEST_STATE_OF_ALL_VEHICLES,
     ) as mock_get_state_of_all_vehicles:
         yield mock_get_state_of_all_vehicles

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -25,7 +25,7 @@ async def test_load_unload(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_vehicle_api_handle_is_optional(hass: HomeAssistant) -> None:
+async def test_runtime_vehicle_api_handle_is_optional(hass: HomeAssistant) -> None:
     """Test the runtime vehicle API handle remains optional during migration."""
 
     entry = await setup_platform(hass)

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -25,6 +25,13 @@ async def test_load_unload(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
+async def test_vehicle_api_handle_is_optional(hass: HomeAssistant) -> None:
+    """Test the runtime vehicle API handle remains optional during migration."""
+
+    entry = await setup_platform(hass)
+    assert all(vehicle.api is None for vehicle in entry.runtime_data.vehicles)
+
+
 async def test_auth_failure(
     hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
 ) -> None:

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -2,12 +2,17 @@
 
 from unittest.mock import AsyncMock, patch
 
-from tesla_fleet_api.exceptions import TeslaFleetError
+from tesla_fleet_api.exceptions import (
+    InvalidRequest,
+    InvalidToken,
+    ServiceUnavailable,
+    TeslaFleetError,
+)
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .common import ERROR_AUTH, ERROR_CONNECTION, ERROR_UNKNOWN, setup_platform
+from .common import setup_platform
 
 
 async def test_load_unload(hass: HomeAssistant) -> None:
@@ -25,7 +30,7 @@ async def test_auth_failure(
 ) -> None:
     """Test init with an authentication error."""
 
-    mock_get_state_of_all_vehicles.side_effect = ERROR_AUTH
+    mock_get_state_of_all_vehicles.side_effect = InvalidToken()
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.SETUP_ERROR
 
@@ -33,31 +38,20 @@ async def test_auth_failure(
 async def test_unknown_failure(
     hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
 ) -> None:
-    """Test init with an client response error."""
+    """Test init with a non-retryable fleet API error."""
 
-    mock_get_state_of_all_vehicles.side_effect = ERROR_UNKNOWN
+    mock_get_state_of_all_vehicles.side_effect = InvalidRequest()
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.SETUP_ERROR
     assert entry.reason == "Failed to connect"
 
 
-async def test_api_failure(
+async def test_retryable_api_failure(
     hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
 ) -> None:
-    """Test init with a fleet API error."""
+    """Test init with a retryable fleet API error."""
 
-    mock_get_state_of_all_vehicles.side_effect = TeslaFleetError()
-    entry = await setup_platform(hass)
-    assert entry.state is ConfigEntryState.SETUP_ERROR
-    assert entry.reason == "Failed to connect"
-
-
-async def test_connection_failure(
-    hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
-) -> None:
-    """Test init with a network connection error."""
-
-    mock_get_state_of_all_vehicles.side_effect = ERROR_CONNECTION
+    mock_get_state_of_all_vehicles.side_effect = ServiceUnavailable()
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.SETUP_RETRY
 

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -1,6 +1,6 @@
 """Test the Tessie init."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from tesla_fleet_api.exceptions import TeslaFleetError
 
@@ -21,7 +21,7 @@ async def test_load_unload(hass: HomeAssistant) -> None:
 
 
 async def test_auth_failure(
-    hass: HomeAssistant, mock_get_state_of_all_vehicles
+    hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
 ) -> None:
     """Test init with an authentication error."""
 
@@ -31,17 +31,29 @@ async def test_auth_failure(
 
 
 async def test_unknown_failure(
-    hass: HomeAssistant, mock_get_state_of_all_vehicles
+    hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
 ) -> None:
     """Test init with an client response error."""
 
     mock_get_state_of_all_vehicles.side_effect = ERROR_UNKNOWN
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.reason == "Failed to connect"
+
+
+async def test_api_failure(
+    hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
+) -> None:
+    """Test init with a fleet API error."""
+
+    mock_get_state_of_all_vehicles.side_effect = TeslaFleetError()
+    entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.reason == "Failed to connect"
 
 
 async def test_connection_failure(
-    hass: HomeAssistant, mock_get_state_of_all_vehicles
+    hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
 ) -> None:
     """Test init with a network connection error."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Migrate the Tessie setup and coordinator core path onto `tesla_fleet_api.tessie` while keeping the temporary compatibility runner in place for unmigrated platforms. Setup now creates one `Tessie` client, fetches vehicles through `list_vehicles`, and stores per-VIN `Vehicle` handles on runtime data. The vehicle coordinator now refreshes through `Vehicle.state(use_cache=True)`, and the Tessie setup/coordinator fixtures were updated to mock the new library entry points.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
