### PR TITLE
Improve test coverage for Aurora integration

### DIFF
--- a/tests/components/aurora/snapshots/test_binary_sensor.ambr
+++ b/tests/components/aurora/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_binary_sensor_entities[binary_sensor.aurora_visibility_visibility_alert-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.aurora_visibility_visibility_alert',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Visibility alert',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Visibility alert',
+    'platform': 'aurora',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'visibility_alert',
+    'unique_id': '-10_10',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities[binary_sensor.aurora_visibility_visibility_alert-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by the National Oceanic and Atmospheric Administration',
+      'friendly_name': 'Aurora visibility Visibility alert',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.aurora_visibility_visibility_alert',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/aurora/snapshots/test_sensor.ambr
+++ b/tests/components/aurora/snapshots/test_sensor.ambr
@@ -1,0 +1,56 @@
+# serializer version: 1
+# name: test_sensor_entities[sensor.aurora_visibility_visibility-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aurora_visibility_visibility',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Visibility',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Visibility',
+    'platform': 'aurora',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'visibility',
+    'unique_id': '-10_10',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities[sensor.aurora_visibility_visibility-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by the National Oceanic and Atmospheric Administration',
+      'friendly_name': 'Aurora visibility Visibility',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aurora_visibility_visibility',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '42',
+  })
+# ---

--- a/tests/components/aurora/test_binary_sensor.py
+++ b/tests/components/aurora/test_binary_sensor.py
@@ -1,0 +1,104 @@
+"""Test the Aurora binary sensor platform."""
+
+from collections.abc import Generator
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from aiohttp import ClientError
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def binary_sensor_only() -> Generator[None]:
+    """Only set up the binary sensor platform."""
+    with patch(
+        "homeassistant.components.aurora.PLATFORMS",
+        [Platform.BINARY_SENSOR],
+    ):
+        yield
+
+
+async def test_binary_sensor_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_aurora_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the Aurora binary sensor entity."""
+    await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_binary_sensor_above_threshold(
+    hass: HomeAssistant,
+    mock_aurora_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensor is ON when forecast exceeds threshold."""
+    # Forecast is 42, threshold is 75 -> OFF
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("binary_sensor.aurora_visibility_visibility_alert")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    # Update forecast above threshold
+    mock_aurora_client.get_forecast_data.return_value = 80
+    freezer.tick(timedelta(minutes=6))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.aurora_visibility_visibility_alert")
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_binary_sensor_below_threshold(
+    hass: HomeAssistant,
+    mock_aurora_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test binary sensor is OFF when forecast is below threshold."""
+    # Forecast is 42, threshold is 75 -> OFF
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("binary_sensor.aurora_visibility_visibility_alert")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_binary_sensor_unavailable_on_error(
+    hass: HomeAssistant,
+    mock_aurora_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensor becomes unavailable when coordinator update fails."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("binary_sensor.aurora_visibility_visibility_alert")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    # Simulate API error
+    mock_aurora_client.get_forecast_data.side_effect = ClientError
+    freezer.tick(timedelta(minutes=6))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.aurora_visibility_visibility_alert")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/aurora/test_init.py
+++ b/tests/components/aurora/test_init.py
@@ -1,0 +1,43 @@
+"""Test the Aurora integration setup."""
+
+from unittest.mock import AsyncMock
+
+from aiohttp import ClientError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aurora_client: AsyncMock,
+) -> None:
+    """Test loading and unloading the config entry."""
+    await setup_integration(hass, mock_config_entry)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_entry_api_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aurora_client: AsyncMock,
+) -> None:
+    """Test setup entry when API raises an error."""
+    mock_aurora_client.get_forecast_data.side_effect = ClientError
+
+    await setup_integration(hass, mock_config_entry)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/aurora/test_sensor.py
+++ b/tests/components/aurora/test_sensor.py
@@ -1,0 +1,89 @@
+"""Test the Aurora sensor platform."""
+
+from collections.abc import Generator
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from aiohttp import ClientError
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def sensor_only() -> Generator[None]:
+    """Only set up the sensor platform."""
+    with patch(
+        "homeassistant.components.aurora.PLATFORMS",
+        [Platform.SENSOR],
+    ):
+        yield
+
+
+async def test_sensor_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_aurora_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the Aurora sensor entity."""
+    await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_sensor_update(
+    hass: HomeAssistant,
+    mock_aurora_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test sensor value updates on coordinator refresh."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.aurora_visibility_visibility")
+    assert state is not None
+    assert state.state == "42"
+
+    # Update the forecast data
+    mock_aurora_client.get_forecast_data.return_value = 85
+    freezer.tick(timedelta(minutes=6))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.aurora_visibility_visibility")
+    assert state is not None
+    assert state.state == "85"
+
+
+async def test_sensor_unavailable_on_coordinator_error(
+    hass: HomeAssistant,
+    mock_aurora_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test sensor becomes unavailable when coordinator update fails."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.aurora_visibility_visibility")
+    assert state is not None
+    assert state.state == "42"
+
+    # Simulate API error
+    mock_aurora_client.get_forecast_data.side_effect = ClientError
+    freezer.tick(timedelta(minutes=6))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.aurora_visibility_visibility")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

Add comprehensive test coverage for the Aurora (NOAA Aurora Forecast) integration. Previously, only `test_config_flow.py` existed. This PR adds tests for all entity platforms plus init setup/unload.

### New test files:
- **test_init.py** - Config entry load/unload, setup retry on API error
- **test_sensor.py** - Sensor entity snapshot, value updates on coordinator refresh, unavailable state on error
- **test_binary_sensor.py** - Binary sensor entity snapshot, threshold-based ON/OFF state transitions, unavailable state on error

**Total: 9 new test cases** covering entity states, coordinator updates, threshold behavior, and error handling.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Improvements to the test suite (no functional changes)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Uses snapshot testing for entity registry validation
- Tests coordinator update propagation with `freezer.tick` and `async_fire_time_changed`
- Tests binary sensor threshold behavior (42% forecast vs 75% threshold)
- Platform isolation via autouse fixtures patching `PLATFORMS`
- All tests leverage existing conftest mock fixtures

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr