### PR TITLE
Bump ZHA to 1.1.1

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==1.1.0", "serialx==0.6.2"],
+  "requirements": ["zha==1.1.1", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3383,7 +3383,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==1.1.0
+zha==1.1.1
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2865,7 +2865,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==1.1.0
+zha==1.1.1
 
 # homeassistant.components.zinvolt
 zinvolt==0.3.0


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [1.1.1](https://github.com/zigpy/zha/releases/tag/1.1.1) (full diff: https://github.com/zigpy/zha/compare/1.1.0...1.1.1).
These dependency upgrades are bundled with it: 

- `zigpy` [1.2.2](https://github.com/zigpy/zigpy/releases/tag/1.2.2)
full diff: https://github.com/zigpy/zigpy/compare/1.2.1...1.2.2

- `zha-quirks` [1.1.1](https://github.com/zigpy/zha-device-handlers/releases/tag/1.1.1)
full diff: https://github.com/zigpy/zha-device-handlers/compare/1.1.0...1.1.1

**This should go into the 2026.4.0 beta/release.** All changes were verified with physical devices.
This is a patch release, so **no** new (quirks v2) entities are added in this release.

A quick overview of the changes in this ZHA release:
- Fixed an issue where the `setpoint_change_source_timestamp` attribute on the `Thermostat` cluster was not initialized, leading to an "Unknown" timestamp entity on some TRVs
- Fixed long debug log messages for emitted OTA events
- Fixed Ubisys H1 TRV using the wrong datatype for the `season` attribute
- Fixed Third Reality curtain gen2 having a wrong `max_value`
- Improved the friendly name for Heiman smoke sensors (that use a different one on old firmwares)
- Improved support for a Sonoff remote variant

### Possible conflict with Serialx bump (outdated; see EDIT)

Depending on when this is merged, it may conflict with the Serialx bump (https://github.com/home-assistant/core/pull/167023).
Unlike the ZHA bump, the Serialx bump does NOT need to go into the beta/release.

However, I did verify that the new Serialx version also works fine. It doesn't really touch anything ZHA and the Connect hardware integrations use, so if it's easiest to also cherry-pick that, it *should* be fine to include as well.
Otherwise, I could also create another PR targeting `rc` with just this ZHA bump.

EDIT: I merged this PR first, so it can be cleanly cherry-picked into beta/`rc`. The conflict in the Serialx PR bump is fixed as well now (https://github.com/home-assistant/core/pull/167023).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
