### PR TITLE
Use runtime_data in octoprint integration

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 from typing import cast
 
@@ -10,7 +9,7 @@ import aiohttp
 from pyoctoprintapi import OctoprintClient
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_BINARY_SENSORS,
@@ -35,20 +34,13 @@ from homeassistant.util import slugify as util_slugify
 from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
 
 from .const import CONF_BAUDRATE, DOMAIN, SERVICE_CONNECT
-from .coordinator import OctoprintDataUpdateCoordinator
+from .coordinator import (
+    OctoprintConfigEntry,
+    OctoprintData,
+    OctoprintDataUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-
-@dataclass
-class OctoprintData:
-    """Runtime data for Octoprint."""
-
-    coordinator: OctoprintDataUpdateCoordinator
-    client: OctoprintClient
-
-
-type OctoprintConfigEntry = ConfigEntry[OctoprintData]
 
 
 def has_all_unique_names(value):

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -9,7 +9,7 @@ import aiohttp
 from pyoctoprintapi import OctoprintClient
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_BINARY_SENSORS,
@@ -34,11 +34,7 @@ from homeassistant.util import slugify as util_slugify
 from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
 
 from .const import CONF_BAUDRATE, DOMAIN, SERVICE_CONNECT
-from .coordinator import (
-    OctoprintConfigEntry,
-    OctoprintData,
-    OctoprintDataUpdateCoordinator,
-)
+from .coordinator import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -210,7 +206,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OctoprintConfigEntry) ->
 
     await coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = OctoprintData(coordinator=coordinator, client=client)
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -249,8 +245,8 @@ def async_get_client_for_service_call(
     if device_entry := device_registry.async_get(device_id):
         for entry_id in device_entry.config_entries:
             if entry := hass.config_entries.async_get_entry(entry_id):
-                if entry.domain == DOMAIN:
-                    return cast(OctoprintConfigEntry, entry).runtime_data.client
+                if entry.domain == DOMAIN and entry.state == ConfigEntryState.LOADED:
+                    return cast(OctoprintConfigEntry, entry).runtime_data.octoprint
 
     raise ServiceValidationError(
         translation_domain=DOMAIN,

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 from typing import cast
 
@@ -37,6 +38,17 @@ from .const import CONF_BAUDRATE, DOMAIN, SERVICE_CONNECT
 from .coordinator import OctoprintDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class OctoprintData:
+    """Runtime data for Octoprint."""
+
+    coordinator: OctoprintDataUpdateCoordinator
+    client: OctoprintClient
+
+
+type OctoprintConfigEntry = ConfigEntry[OctoprintData]
 
 
 def has_all_unique_names(value):
@@ -168,12 +180,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: OctoprintConfigEntry) -> bool:
     """Set up OctoPrint from a config entry."""
-
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
-
     if CONF_VERIFY_SSL not in entry.data:
         data = {**entry.data, CONF_VERIFY_SSL: True}
         hass.config_entries.async_update_entry(entry, data=data)
@@ -210,10 +218,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        "coordinator": coordinator,
-        "client": client,
-    }
+    entry.runtime_data = OctoprintData(coordinator=coordinator, client=client)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -237,14 +242,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: OctoprintConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 def async_get_client_for_service_call(
@@ -256,8 +256,9 @@ def async_get_client_for_service_call(
 
     if device_entry := device_registry.async_get(device_id):
         for entry_id in device_entry.config_entries:
-            if data := hass.data[DOMAIN].get(entry_id):
-                return cast(OctoprintClient, data["client"])
+            if entry := hass.config_entries.async_get_entry(entry_id):
+                if entry.domain == DOMAIN:
+                    return cast(OctoprintConfigEntry, entry).runtime_data.client
 
     raise ServiceValidationError(
         translation_domain=DOMAIN,

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -20,7 +20,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the available OctoPrint binary sensors."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
+from .coordinator import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -7,24 +7,20 @@ from abc import abstractmethod
 from pyoctoprintapi import OctoprintPrinterInfo
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintDataUpdateCoordinator
-from .const import DOMAIN
+from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: OctoprintConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the available OctoPrint binary sensors."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]["coordinator"]
+    coordinator = config_entry.runtime_data.coordinator
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/homeassistant/components/octoprint/button.py
+++ b/homeassistant/components/octoprint/button.py
@@ -17,8 +17,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Octoprint control buttons."""
-    coordinator = config_entry.runtime_data.coordinator
-    client = config_entry.runtime_data.client
+    coordinator = config_entry.runtime_data
+    client = coordinator.octoprint
     device_id = config_entry.unique_id
     assert device_id is not None
 

--- a/homeassistant/components/octoprint/button.py
+++ b/homeassistant/components/octoprint/button.py
@@ -8,7 +8,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
+from .coordinator import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/octoprint/button.py
+++ b/homeassistant/components/octoprint/button.py
@@ -3,26 +3,22 @@
 from pyoctoprintapi import OctoprintClient, OctoprintPrinterInfo
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintDataUpdateCoordinator
-from .const import DOMAIN
+from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: OctoprintConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Octoprint control buttons."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]["coordinator"]
-    client: OctoprintClient = hass.data[DOMAIN][config_entry.entry_id]["client"]
+    coordinator = config_entry.runtime_data.coordinator
+    client = config_entry.runtime_data.client
     device_id = config_entry.unique_id
     assert device_id is not None
 

--- a/homeassistant/components/octoprint/camera.py
+++ b/homeassistant/components/octoprint/camera.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
+from .coordinator import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/octoprint/camera.py
+++ b/homeassistant/components/octoprint/camera.py
@@ -2,29 +2,25 @@
 
 from __future__ import annotations
 
-from pyoctoprintapi import OctoprintClient, WebcamSettings
+from pyoctoprintapi import WebcamSettings
 
 from homeassistant.components.mjpeg import MjpegCamera
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintDataUpdateCoordinator
-from .const import DOMAIN
+from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: OctoprintConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the available OctoPrint camera."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]["coordinator"]
-    client: OctoprintClient = hass.data[DOMAIN][config_entry.entry_id]["client"]
+    coordinator = config_entry.runtime_data.coordinator
+    client = config_entry.runtime_data.client
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/homeassistant/components/octoprint/camera.py
+++ b/homeassistant/components/octoprint/camera.py
@@ -19,8 +19,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the available OctoPrint camera."""
-    coordinator = config_entry.runtime_data.coordinator
-    client = config_entry.runtime_data.client
+    coordinator = config_entry.runtime_data
+    client = coordinator.octoprint
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/homeassistant/components/octoprint/coordinator.py
+++ b/homeassistant/components/octoprint/coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import cast
@@ -21,16 +20,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
-
-@dataclass
-class OctoprintData:
-    """Runtime data for Octoprint."""
-
-    coordinator: OctoprintDataUpdateCoordinator
-    client: OctoprintClient
-
-
-type OctoprintConfigEntry = ConfigEntry[OctoprintData]
+type OctoprintConfigEntry = ConfigEntry[OctoprintDataUpdateCoordinator]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,13 +28,13 @@ _LOGGER = logging.getLogger(__name__)
 class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Octoprint data."""
 
-    config_entry: ConfigEntry
+    config_entry: OctoprintConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
         octoprint: OctoprintClient,
-        config_entry: ConfigEntry,
+        config_entry: OctoprintConfigEntry,
         interval: int,
     ) -> None:
         """Initialize."""
@@ -55,7 +45,7 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
             name=f"octoprint-{config_entry.entry_id}",
             update_interval=timedelta(seconds=interval),
         )
-        self._octoprint = octoprint
+        self.octoprint = octoprint
         self._printer_offline = False
         self.data = {"printer": None, "job": None, "last_read_time": None}
 
@@ -63,7 +53,7 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via API."""
         printer = None
         try:
-            job = await self._octoprint.get_job_info()
+            job = await self.octoprint.get_job_info()
         except UnauthorizedException as err:
             raise ConfigEntryAuthFailed from err
         except ApiError as err:
@@ -73,7 +63,7 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         # printer will return a 409, so continue using the last
         # reading if there is one
         try:
-            printer = await self._octoprint.get_printer_info()
+            printer = await self.octoprint.get_printer_info()
         except PrinterOffline:
             if not self._printer_offline:
                 _LOGGER.debug("Unable to retrieve printer information: Printer offline")

--- a/homeassistant/components/octoprint/coordinator.py
+++ b/homeassistant/components/octoprint/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import cast
@@ -19,6 +20,17 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
+
+
+@dataclass
+class OctoprintData:
+    """Runtime data for Octoprint."""
+
+    coordinator: OctoprintDataUpdateCoordinator
+    client: OctoprintClient
+
+
+type OctoprintConfigEntry = ConfigEntry[OctoprintData]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/octoprint/number.py
+++ b/homeassistant/components/octoprint/number.py
@@ -7,14 +7,13 @@ import logging
 from pyoctoprintapi import OctoprintClient
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintDataUpdateCoordinator
+from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,14 +36,12 @@ def is_first_extruder(tool_name: str) -> bool:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: OctoprintConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the OctoPrint number entities."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]["coordinator"]
-    client: OctoprintClient = hass.data[DOMAIN][config_entry.entry_id]["client"]
+    coordinator = config_entry.runtime_data.coordinator
+    client = config_entry.runtime_data.client
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/homeassistant/components/octoprint/number.py
+++ b/homeassistant/components/octoprint/number.py
@@ -40,8 +40,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the OctoPrint number entities."""
-    coordinator = config_entry.runtime_data.coordinator
-    client = config_entry.runtime_data.client
+    coordinator = config_entry.runtime_data
+    client = coordinator.octoprint
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/homeassistant/components/octoprint/number.py
+++ b/homeassistant/components/octoprint/number.py
@@ -13,8 +13,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 from .const import DOMAIN
+from .coordinator import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -12,14 +12,12 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfInformation, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintDataUpdateCoordinator
-from .const import DOMAIN
+from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,13 +33,11 @@ def _is_printer_printing(printer: OctoprintPrinterInfo) -> bool:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: OctoprintConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the available OctoPrint sensors."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]["coordinator"]
+    coordinator = config_entry.runtime_data.coordinator
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
+from .coordinator import OctoprintConfigEntry, OctoprintDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the available OctoPrint sensors."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
     device_id = config_entry.unique_id
 
     assert device_id is not None

--- a/tests/components/octoprint/test_button.py
+++ b/tests/components/octoprint/test_button.py
@@ -6,6 +6,7 @@ from pyoctoprintapi import OctoprintPrinterInfo
 import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.octoprint import OctoprintDataUpdateCoordinator
 from homeassistant.components.octoprint.button import InvalidPrinterState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
@@ -23,7 +24,7 @@ async def test_pause_job(
     hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test the pause job button."""
-    coordinator = init_integration.runtime_data.coordinator
+    coordinator: OctoprintDataUpdateCoordinator = init_integration.runtime_data
 
     # Test pausing the printer when it is printing
     with patch("pyoctoprintapi.OctoprintClient.pause_job") as pause_command:
@@ -80,7 +81,7 @@ async def test_resume_job(
     hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test the resume job button."""
-    coordinator = init_integration.runtime_data.coordinator
+    coordinator: OctoprintDataUpdateCoordinator = init_integration.runtime_data
 
     # Test resuming the printer when it is paused
     with patch("pyoctoprintapi.OctoprintClient.resume_job") as resume_command:
@@ -135,7 +136,7 @@ async def test_resume_job(
 
 async def test_stop_job(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
     """Test the stop job button."""
-    coordinator = init_integration.runtime_data.coordinator
+    coordinator: OctoprintDataUpdateCoordinator = init_integration.runtime_data
 
     # Test stopping the printer when it is paused
     with patch("pyoctoprintapi.OctoprintClient.cancel_job") as stop_command:

--- a/tests/components/octoprint/test_button.py
+++ b/tests/components/octoprint/test_button.py
@@ -6,11 +6,11 @@ from pyoctoprintapi import OctoprintPrinterInfo
 import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.components.octoprint import OctoprintDataUpdateCoordinator
 from homeassistant.components.octoprint.button import InvalidPrinterState
-from homeassistant.components.octoprint.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -19,12 +19,11 @@ def platform() -> Platform:
     return Platform.BUTTON
 
 
-@pytest.mark.usefixtures("init_integration")
-async def test_pause_job(hass: HomeAssistant) -> None:
+async def test_pause_job(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
     """Test the pause job button."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN]["uuid"][
-        "coordinator"
-    ]
+    coordinator = init_integration.runtime_data.coordinator
 
     # Test pausing the printer when it is printing
     with patch("pyoctoprintapi.OctoprintClient.pause_job") as pause_command:
@@ -77,12 +76,11 @@ async def test_pause_job(hass: HomeAssistant) -> None:
             )
 
 
-@pytest.mark.usefixtures("init_integration")
-async def test_resume_job(hass: HomeAssistant) -> None:
+async def test_resume_job(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
     """Test the resume job button."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN]["uuid"][
-        "coordinator"
-    ]
+    coordinator = init_integration.runtime_data.coordinator
 
     # Test resuming the printer when it is paused
     with patch("pyoctoprintapi.OctoprintClient.resume_job") as resume_command:
@@ -135,12 +133,9 @@ async def test_resume_job(hass: HomeAssistant) -> None:
             )
 
 
-@pytest.mark.usefixtures("init_integration")
-async def test_stop_job(hass: HomeAssistant) -> None:
+async def test_stop_job(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
     """Test the stop job button."""
-    coordinator: OctoprintDataUpdateCoordinator = hass.data[DOMAIN]["uuid"][
-        "coordinator"
-    ]
+    coordinator = init_integration.runtime_data.coordinator
 
     # Test stopping the printer when it is paused
     with patch("pyoctoprintapi.OctoprintClient.cancel_job") as stop_command:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the octoprint integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing runtime data. This introduces an `OctoPrintData` dataclass and `OctoPrintConfigEntry` type alias for type-safe access to the coordinator and client.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr