### PR TITLE
Move OVO Energy DataUpdateCoordinator to separate module

### DIFF
--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import aiohttp
 from ovoenergy import OVOEnergy
 
@@ -13,6 +15,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_ACCOUNT, DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 from .coordinator import OVOEnergyDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -36,6 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await client.bootstrap_accounts()
     except aiohttp.ClientError as exception:
+        _LOGGER.warning(exception)
         raise ConfigEntryNotReady from exception
 
     coordinator = OVOEnergyDataUpdateCoordinator(hass, entry, client)

--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -2,25 +2,17 @@
 
 from __future__ import annotations
 
-import asyncio
-from datetime import timedelta
-import logging
-
 import aiohttp
 from ovoenergy import OVOEnergy
-from ovoenergy.models import OVODailyUsage
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt as dt_util
 
 from .const import CONF_ACCOUNT, DATA_CLIENT, DATA_COORDINATOR, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .coordinator import OVOEnergyDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -44,36 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await client.bootstrap_accounts()
     except aiohttp.ClientError as exception:
-        _LOGGER.warning(exception)
         raise ConfigEntryNotReady from exception
 
-    async def async_update_data() -> OVODailyUsage:
-        """Fetch data from OVO Energy."""
-        if (custom_account := entry.data.get(CONF_ACCOUNT)) is not None:
-            client.custom_account_id = custom_account
-
-        async with asyncio.timeout(10):
-            try:
-                authenticated = await client.authenticate(
-                    entry.data[CONF_USERNAME],
-                    entry.data[CONF_PASSWORD],
-                )
-            except aiohttp.ClientError as exception:
-                raise UpdateFailed(exception) from exception
-            if not authenticated:
-                raise ConfigEntryAuthFailed("Not authenticated with OVO Energy")
-            return await client.get_daily_usage(dt_util.utcnow().strftime("%Y-%m"))
-
-    coordinator = DataUpdateCoordinator[OVODailyUsage](
-        hass,
-        _LOGGER,
-        config_entry=entry,
-        # Name of the data. For logging purposes.
-        name="sensor",
-        update_method=async_update_data,
-        # Polling interval. Will only be polled if there are subscribers.
-        update_interval=timedelta(seconds=3600),
-    )
+    coordinator = OVOEnergyDataUpdateCoordinator(hass, entry, client)
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {

--- a/homeassistant/components/ovo_energy/coordinator.py
+++ b/homeassistant/components/ovo_energy/coordinator.py
@@ -1,0 +1,61 @@
+"""Coordinator for the OVO Energy integration."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+import logging
+
+import aiohttp
+from ovoenergy import OVOEnergy
+from ovoenergy.models import OVODailyUsage
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_ACCOUNT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OVOEnergyDataUpdateCoordinator(DataUpdateCoordinator[OVODailyUsage]):
+    """Class to manage fetching OVO Energy data."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        client: OVOEnergy,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="sensor",
+            update_interval=timedelta(seconds=3600),
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> OVODailyUsage:
+        """Fetch data from OVO Energy."""
+        if (custom_account := self.config_entry.data.get(CONF_ACCOUNT)) is not None:
+            self.client.custom_account_id = custom_account
+
+        async with asyncio.timeout(10):
+            try:
+                authenticated = await self.client.authenticate(
+                    self.config_entry.data[CONF_USERNAME],
+                    self.config_entry.data[CONF_PASSWORD],
+                )
+            except aiohttp.ClientError as exception:
+                raise UpdateFailed(exception) from exception
+            if not authenticated:
+                raise ConfigEntryAuthFailed("Not authenticated with OVO Energy")
+            return await self.client.get_daily_usage(dt_util.utcnow().strftime("%Y-%m"))

--- a/homeassistant/components/ovo_energy/entity.py
+++ b/homeassistant/components/ovo_energy/entity.py
@@ -3,25 +3,22 @@
 from __future__ import annotations
 
 from ovoenergy import OVOEnergy
-from ovoenergy.models import OVODailyUsage
 
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import OVOEnergyDataUpdateCoordinator
 
 
-class OVOEnergyEntity(CoordinatorEntity[DataUpdateCoordinator[OVODailyUsage]]):
+class OVOEnergyEntity(CoordinatorEntity[OVOEnergyDataUpdateCoordinator]):
     """Defines a base OVO Energy entity."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[OVODailyUsage],
+        coordinator: OVOEnergyDataUpdateCoordinator,
         client: OVOEnergy,
     ) -> None:
         """Initialize the OVO Energy entity."""

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -21,10 +21,10 @@ from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
+from .coordinator import OVOEnergyDataUpdateCoordinator
 from .entity import OVOEnergyDeviceEntity
 
 SCAN_INTERVAL = timedelta(seconds=300)
@@ -118,9 +118,9 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up OVO Energy sensor based on a config entry."""
-    coordinator: DataUpdateCoordinator[OVODailyUsage] = hass.data[DOMAIN][
-        entry.entry_id
-    ][DATA_COORDINATOR]
+    coordinator: OVOEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
+        DATA_COORDINATOR
+    ]
     client: OVOEnergy = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
 
     entities = []
@@ -161,12 +161,11 @@ async def async_setup_entry(
 class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
     """Define a OVO Energy sensor."""
 
-    coordinator: DataUpdateCoordinator[DataUpdateCoordinator[OVODailyUsage]]
     entity_description: OVOEnergySensorEntityDescription
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[OVODailyUsage],
+        coordinator: OVOEnergyDataUpdateCoordinator,
         description: OVOEnergySensorEntityDescription,
         client: OVOEnergy,
     ) -> None:


### PR DESCRIPTION
## Proposed change
Move coordinator out of `__init__.py` into a dedicated `coordinator.py` module

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr