### PR TITLE
Add ConfigEntry method to get subentries by type

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -626,7 +626,7 @@ class ConfigEntry[_DataT = Any]:
         return self._supported_subentry_types or {}
 
     def get_subentries_of_type(self, subentry_type: str) -> list[ConfigSubentry]:
-        """Return subentries for a subentry type."""
+        """Return subentries of a specified subentry type."""
         return [
             subentry
             for subentry in self.subentries.values()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -625,7 +625,7 @@ class ConfigEntry[_DataT = Any]:
             )
         return self._supported_subentry_types or {}
 
-    def subentries_for_type(self, subentry_type: str) -> list[ConfigSubentry]:
+    def get_subentries_of_type(self, subentry_type: str) -> list[ConfigSubentry]:
         """Return subentries for a subentry type."""
         return [
             subentry

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -625,6 +625,14 @@ class ConfigEntry[_DataT = Any]:
             )
         return self._supported_subentry_types or {}
 
+    def subentries_for_type(self, subentry_type: str) -> list[ConfigSubentry]:
+        """Return subentries for a subentry type."""
+        return [
+            subentry
+            for subentry in self.subentries.values()
+            if subentry.subentry_type == subentry_type
+        ]
+
     def clear_state_cache(self) -> None:
         """Clear cached properties that are included in as_json_fragment."""
         self.__dict__.pop("as_json_fragment", None)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7771,7 +7771,7 @@ async def test_subentries_for_type(hass: HomeAssistant) -> None:
         ],
     )
 
-    test_subentries = entry.subentries_for_type("test")
+    test_subentries = entry.get_subentries_of_type("test")
     assert len(test_subentries) == 2
     assert [subentry.unique_id for subentry in test_subentries] == [
         "unique",
@@ -7782,12 +7782,14 @@ async def test_subentries_for_type(hass: HomeAssistant) -> None:
         test_subentries
     )
 
-    test_test_subentries = entry.subentries_for_type("test_test")
+    test_test_subentries = entry.get_subentries_of_type("test_test")
     assert len(test_test_subentries) == 1
     assert test_test_subentries[0].unique_id == "very_unique"
     assert test_test_subentries[0].subentry_type == "test_test"
 
-    assert entry.subentries_for_type("unknown") == []
+    assert entry.get_subentries_of_type("unknown") == []
+
+
 async def test_reload_during_setup(hass: HomeAssistant) -> None:
     """Test reload during setup waits."""
     entry = MockConfigEntry(domain="comp", data={"value": "initial"})

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7745,8 +7745,8 @@ async def test_updating_non_added_subentry_raises(hass: HomeAssistant) -> None:
         hass.config_entries.async_update_subentry(entry, subentry, unique_id="new_id")
 
 
-async def test_get_subentry_by_type(hass: HomeAssistant) -> None:
-    """Test getting subentry by type."""
+async def test_subentries_for_type(hass: HomeAssistant) -> None:
+    """Test getting subentries by type."""
     entry = MockConfigEntry(
         domain="test",
         subentries_data=[
@@ -7771,10 +7771,23 @@ async def test_get_subentry_by_type(hass: HomeAssistant) -> None:
         ],
     )
 
-    assert len(entry.subentries_for_type("test")) == 2
-    assert len(entry.subentries_for_type("test_test")) == 1
+    test_subentries = entry.subentries_for_type("test")
+    assert len(test_subentries) == 2
+    assert [subentry.unique_id for subentry in test_subentries] == [
+        "unique",
+        "very_very_unique",
+    ]
+    assert all(subentry.subentry_type == "test" for subentry in test_subentries)
+    assert len({subentry.subentry_id for subentry in test_subentries}) == len(
+        test_subentries
+    )
 
+    test_test_subentries = entry.subentries_for_type("test_test")
+    assert len(test_test_subentries) == 1
+    assert test_test_subentries[0].unique_id == "very_unique"
+    assert test_test_subentries[0].subentry_type == "test_test"
 
+    assert entry.subentries_for_type("unknown") == []
 async def test_reload_during_setup(hass: HomeAssistant) -> None:
     """Test reload during setup waits."""
     entry = MockConfigEntry(domain="comp", data={"value": "initial"})

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7745,6 +7745,36 @@ async def test_updating_non_added_subentry_raises(hass: HomeAssistant) -> None:
         hass.config_entries.async_update_subentry(entry, subentry, unique_id="new_id")
 
 
+async def test_get_subentry_by_type(hass: HomeAssistant) -> None:
+    """Test getting subentry by type."""
+    entry = MockConfigEntry(
+        domain="test",
+        subentries_data=[
+            config_entries.ConfigSubentryData(
+                data={},
+                subentry_type="test",
+                title="Mock title",
+                unique_id="unique",
+            ),
+            config_entries.ConfigSubentryData(
+                data={},
+                subentry_type="test",
+                title="Mock title 2",
+                unique_id="very_very_unique",
+            ),
+            config_entries.ConfigSubentryData(
+                data={},
+                subentry_type="test_test",
+                title="Mock title 3",
+                unique_id="very_unique",
+            ),
+        ],
+    )
+
+    assert len(entry.subentries_for_type("test")) == 2
+    assert len(entry.subentries_for_type("test_test")) == 1
+
+
 async def test_reload_during_setup(hass: HomeAssistant) -> None:
     """Test reload during setup waits."""
     entry = MockConfigEntry(domain="comp", data={"value": "initial"})

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7745,7 +7745,7 @@ async def test_updating_non_added_subentry_raises(hass: HomeAssistant) -> None:
         hass.config_entries.async_update_subentry(entry, subentry, unique_id="new_id")
 
 
-async def test_subentries_for_type(hass: HomeAssistant) -> None:
+async def test_get_subentries_of_type(hass: HomeAssistant) -> None:
     """Test getting subentries by type."""
     entry = MockConfigEntry(
         domain="test",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We commonly see places where intergations with only a single subentry type assert that that will be the only one, while that might not be true in the future. To encourage integrations to only count by the subentry type we add a helper to make sure it's easier to request a list of all the entries for a type

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
