### PR TITLE
Fix spelling of "Shut down" button label in `proxmoxve`

### DIFF
--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -141,7 +141,7 @@
         "name": "Reset"
       },
       "shutdown": {
-        "name": "Shutdown"
+        "name": "Shut down"
       },
       "snapshot_create": {
         "name": "Create snapshot"

--- a/tests/components/proxmoxve/snapshots/test_button.ambr
+++ b/tests/components/proxmoxve/snapshots/test_button.ambr
@@ -452,7 +452,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_all_button_entities[button.pve1_shutdown-entry]
+# name: test_all_button_entities[button.pve1_shut_down-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -466,7 +466,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.pve1_shutdown',
+    'entity_id': 'button.pve1_shut_down',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -474,12 +474,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Shutdown',
+    'object_id_base': 'Shut down',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Shutdown',
+    'original_name': 'Shut down',
     'platform': 'proxmoxve',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -489,13 +489,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_button_entities[button.pve1_shutdown-state]
+# name: test_all_button_entities[button.pve1_shut_down-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'pve1 Shutdown',
+      'friendly_name': 'pve1 Shut down',
     }),
     'context': <ANY>,
-    'entity_id': 'button.pve1_shutdown',
+    'entity_id': 'button.pve1_shut_down',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -853,7 +853,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_all_button_entities[button.vm_db_shutdown-entry]
+# name: test_all_button_entities[button.vm_db_shut_down-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -867,7 +867,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.vm_db_shutdown',
+    'entity_id': 'button.vm_db_shut_down',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -875,12 +875,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Shutdown',
+    'object_id_base': 'Shut down',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Shutdown',
+    'original_name': 'Shut down',
     'platform': 'proxmoxve',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -890,13 +890,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_button_entities[button.vm_db_shutdown-state]
+# name: test_all_button_entities[button.vm_db_shut_down-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'vm-db Shutdown',
+      'friendly_name': 'vm-db Shut down',
     }),
     'context': <ANY>,
-    'entity_id': 'button.vm_db_shutdown',
+    'entity_id': 'button.vm_db_shut_down',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1204,7 +1204,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_all_button_entities[button.vm_web_shutdown-entry]
+# name: test_all_button_entities[button.vm_web_shut_down-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1218,7 +1218,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.vm_web_shutdown',
+    'entity_id': 'button.vm_web_shut_down',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1226,12 +1226,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Shutdown',
+    'object_id_base': 'Shut down',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Shutdown',
+    'original_name': 'Shut down',
     'platform': 'proxmoxve',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1241,13 +1241,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_button_entities[button.vm_web_shutdown-state]
+# name: test_all_button_entities[button.vm_web_shut_down-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'vm-web Shutdown',
+      'friendly_name': 'vm-web Shut down',
     }),
     'context': <ANY>,
-    'entity_id': 'button.vm_web_shutdown',
+    'entity_id': 'button.vm_web_shut_down',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -50,7 +50,7 @@ async def test_all_button_entities(
     ("entity_id", "command"),
     [
         ("button.pve1_restart", "reboot"),
-        ("button.pve1_shutdown", "shutdown"),
+        ("button.pve1_shut_down", "shutdown"),
     ],
 )
 async def test_node_buttons(
@@ -230,7 +230,7 @@ async def test_container_buttons(
         ("button.pve1_restart", AuthenticationError("auth failed")),
         ("button.pve1_restart", SSLError("ssl error")),
         ("button.pve1_restart", ConnectTimeout("timeout")),
-        ("button.pve1_shutdown", ResourceException(500, "error", {})),
+        ("button.pve1_shut_down", ResourceException(500, "error", {})),
     ],
 )
 async def test_node_buttons_exceptions(

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -116,7 +116,7 @@ async def test_node_all_actions_buttons(
         ("button.vm_web_restart", 100, "reboot"),
         ("button.vm_web_hibernate", 100, "hibernate"),
         ("button.vm_web_reset", 100, "reset"),
-        ("button.vm_web_shutdown", 100, "shutdown"),
+        ("button.vm_web_shut_down", 100, "shutdown"),
     ],
 )
 async def test_vm_buttons(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

All button labels in ProxmoxVE are verbs, so the correct spelling for "[shut down](https://en.wiktionary.org/wiki/shut_down)" is with a space in the middle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
