### PR TITLE
Fix websocket calling `async_release_notes` in update component although unavailable

### DIFF
--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -531,7 +531,13 @@ async def websocket_release_notes(
             "Entity does not support release notes",
         )
         return
-
+    if entity.available is False:
+        connection.send_error(
+            msg["id"],
+            websocket_api.ERR_HOME_ASSISTANT_ERROR,
+            "Entity is not available",
+        )
+        return
     connection.send_result(
         msg["id"],
         await entity.async_release_notes(),

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -48,6 +48,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
+from .common import MockUpdateEntity
+
 from tests.common import (
     MockConfigEntry,
     MockEntityPlatform,
@@ -64,13 +66,9 @@ from tests.typing import WebSocketGenerator
 TEST_DOMAIN = "test"
 
 
-class MockUpdateEntity(UpdateEntity):
-    """Mock UpdateEntity to use in tests."""
-
-
 async def test_update(hass: HomeAssistant) -> None:
     """Test getting data from the mocked update entity."""
-    update = MockUpdateEntity()
+    update = UpdateEntity()
     update.hass = hass
     update.platform = MockEntityPlatform(hass)
 
@@ -795,6 +793,41 @@ async def test_release_notes_entity_does_not_support_release_notes(
     result = await client.receive_json()
     assert result["error"]["code"] == "not_supported"
     assert result["error"]["message"] == "Entity does not support release notes"
+
+
+async def test_release_notes_entity_unavailable(
+    hass: HomeAssistant,
+    mock_update_entities: list[MockUpdateEntity],
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test getting the release notes for entity that is unavailable."""
+    entity = MockUpdateEntity(
+        name="Update unavailable",
+        unique_id="unavailable",
+        installed_version="1.0.0",
+        latest_version="1.0.1",
+        available=False,
+        supported_features=UpdateEntityFeature.RELEASE_NOTES,
+    )
+
+    setup_test_component_platform(hass, DOMAIN, [entity])
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await hass.async_block_till_done()
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "update/release_notes",
+            "entity_id": "update.update_unavailable",
+        }
+    )
+    result = await client.receive_json()
+    assert result["error"]["code"] == "home_assistant_error"
+    assert result["error"]["message"] == "Entity is not available"
 
 
 class MockFlow(ConfigFlow):


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the release notes are fetched by the frontend via the websocket command, an error is returned if the entity was not found or if the entity doesn't support release notes. But it is not checked for availaility of the entity.  Integrations may raise exceptions if they try to access runtime data that is not available.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
