### PR TITLE
Exclude Python dependencies from backup

### DIFF
--- a/homeassistant/backup_restore.py
+++ b/homeassistant/backup_restore.py
@@ -19,6 +19,7 @@ from .const import __version__ as HA_VERSION
 RESTORE_BACKUP_FILE = ".HA_RESTORE"
 RESTORE_BACKUP_RESULT_FILE = ".HA_RESTORE_RESULT"
 KEEP_BACKUPS = ("backups",)
+KEEP_DEPS = ("deps",)
 KEEP_DATABASE = (
     "home-assistant_v2.db",
     "home-assistant_v2.db-wal",
@@ -121,7 +122,7 @@ def _extract_backup(
                 filter="fully_trusted",
             )
             if restore_content.restore_homeassistant:
-                keep = list(KEEP_BACKUPS)
+                keep = list(KEEP_BACKUPS + KEEP_DEPS)
                 if not restore_content.restore_database:
                     keep.extend(KEEP_DATABASE)
                 _clear_configuration_directory(config_dir, keep)

--- a/homeassistant/components/backup/const.py
+++ b/homeassistant/components/backup/const.py
@@ -27,6 +27,7 @@ EXCLUDE_FROM_BACKUP = [
     "OZW_Log.txt",
     "tts/*",
     ".cache/*",
+    "deps",
 ]
 
 EXCLUDE_DATABASE_FROM_BACKUP = [

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -264,9 +264,9 @@ def test_aborting_for_older_versions(restore_config: str, tmp_path: Path) -> Non
                 restore_database=True,
                 restore_homeassistant=True,
             ),
-            {"backups/test.tar"},
+            {"backups/test.tar", "deps/test.whl"},
             {"home-assistant_v2.db", "home-assistant_v2.db-wal"},
-            {"backups"},
+            {"backups", "deps"},
         ),
         (
             backup_restore.RestoreBackupFileContent(
@@ -276,9 +276,14 @@ def test_aborting_for_older_versions(restore_config: str, tmp_path: Path) -> Non
                 remove_after_restore=False,
                 restore_homeassistant=True,
             ),
-            {"backups/test.tar", "home-assistant_v2.db", "home-assistant_v2.db-wal"},
+            {
+                "backups/test.tar",
+                "deps/test.whl",
+                "home-assistant_v2.db",
+                "home-assistant_v2.db-wal",
+            },
             set(),
-            {"backups"},
+            {"backups", "deps"},
         ),
         (
             backup_restore.RestoreBackupFileContent(
@@ -288,9 +293,9 @@ def test_aborting_for_older_versions(restore_config: str, tmp_path: Path) -> Non
                 remove_after_restore=False,
                 restore_homeassistant=False,
             ),
-            {".HA_RESTORE", ".HA_VERSION", "backups/test.tar"},
+            {".HA_RESTORE", ".HA_VERSION", "backups/test.tar", "deps/test.whl"},
             {"home-assistant_v2.db", "home-assistant_v2.db-wal"},
-            {"backups", "tmp_backups", "www"},
+            {"backups", "deps", "tmp_backups", "www"},
         ),
     ],
 )
@@ -316,12 +321,14 @@ def test_restore_backup(
 
     existing_dirs = {
         "backups",
+        "deps",
         "tmp_backups",
         "www",
     }
     existing_files = {
         ".HA_RESTORE",
         ".HA_VERSION",
+        "deps/test.whl",
         "home-assistant_v2.db",
         "home-assistant_v2.db-wal",
     }
@@ -339,6 +346,8 @@ def test_restore_backup(
         ".HA_VERSION",
         "backups",
         "backups/test.tar",
+        "deps",
+        "deps/test.whl",
         "home-assistant_v2.db",
         "home-assistant_v2.db-wal",
         "tmp_backups",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

None, existing backups can be restored like before, the included `deps` directory is just not restored anymore.

## Proposed change

The Python dependencies, i.e. the `deps` dir, are currently included in Home Assistant backups, and restored as well. This can cause issues if:
- The backup was created with a different architecture.
- The backup was created with a different distro version => shared library versions.
- The backup was created before a breaking shared library upgrade was done.
- The backup was created with a different Python version.
- The Python dependencies of the backup are incompatible with the ones of the HA instance.

Generally, backing up Python dependencies is not necessary, since HA internally installs or upgrades all dependencies for all components and integrations automatically on startup.

This commit hence adds the `deps` directory to the list of excludes, when creating the backup as well as when restoring it, leaving the existing `deps` directory untouched.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130396
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
