### PR TITLE
Wrap hassio import in is_hassio check in get_system_info helper

### DIFF
--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -6,7 +6,7 @@ from functools import cache
 from getpass import getuser
 import logging
 import platform
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
@@ -15,7 +15,6 @@ from homeassistant.util.package import is_docker_env, is_virtual_env
 from homeassistant.util.system_info import is_official_image
 
 from .hassio import is_hassio
-from .importlib import async_import_module
 from .singleton import singleton
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -54,15 +54,6 @@ cached_get_user = cache(getuser)
 @bind_hass
 async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return info about the system."""
-    # Local import to avoid circular dependencies
-    # We use the import helper because hassio
-    # may not be loaded yet and we don't want to
-    # do blocking I/O in the event loop to import it.
-    if TYPE_CHECKING:
-        from homeassistant.components import hassio  # noqa: PLC0415
-    else:
-        hassio = await async_import_module(hass, "homeassistant.components.hassio")
-
     is_hassio_ = is_hassio(hass)
 
     info_object = {
@@ -105,6 +96,9 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
 
     # Enrich with Supervisor information
     if is_hassio_:
+        # Local import to avoid circular dependencies
+        from homeassistant.components import hassio  # noqa: PLC0415
+
         if not (info := hassio.get_info(hass)):
             _LOGGER.warning("No Home Assistant Supervisor info available")
             info = {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The `async_get_system_info` helper always loads the `hassio` component without consideration for whether Supervisor is in use in this system or not. This can create a secret dependency on the component and the `aiohasupervisor` library it uses. Most notably, bootstrap calls this helper in order to get various environment and system info cached:
https://github.com/home-assistant/core/blob/f74256db2da4a16486f1ad1331ebe4779ebc86f5/homeassistant/bootstrap.py#L486

This breaks on installations without Supervisor as shown in #166976 .

Normally we use the `is_hassio` helper  that checks if the `hassio` component has been loaded combined with a local import to solve this. This seems problematic because this early in bootstrap the `hassio` component has not been loaded, nothing has. However `hassio` is only needed to enrich the response of this helper and bootstrap tosses the entire response without caching it. So its still safe to use this pattern here, we aren't losing anything needed during bootstrap.

There's a short discussion [here](https://github.com/home-assistant/core/issues/166976#issuecomment-4172668734) and [in discord](https://discord.com/channels/330944238910963714/1488952602380075179/1488952650258190539) on some possible better alternative solutions that don't cause `aiohasupervisor` to be installed almost always even when there's no Supervisor. However this PR is takes the simplest fix so it can be safely included in current release, improved fixes can be tackled separately later if we wish.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166976 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
