### PR TITLE
Use runtime_data in ovo_energy

### DIFF
--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -7,21 +7,24 @@ import logging
 import aiohttp
 from ovoenergy import OVOEnergy
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_ACCOUNT, DATA_CLIENT, DATA_COORDINATOR, DOMAIN
-from .coordinator import OVOEnergyDataUpdateCoordinator
+from .const import CONF_ACCOUNT
+from .coordinator import (
+    OVOEnergyConfigEntry,
+    OVOEnergyData,
+    OVOEnergyDataUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: OVOEnergyConfigEntry) -> bool:
     """Set up OVO Energy from a config entry."""
 
     client = OVOEnergy(
@@ -45,26 +48,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = OVOEnergyDataUpdateCoordinator(hass, entry, client)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_CLIENT: client,
-        DATA_COORDINATOR: coordinator,
-    }
-
-    # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()
 
-    # Setup components
+    entry.runtime_data = OVOEnergyData(client=client, coordinator=coordinator)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: OVOEnergyConfigEntry) -> bool:
     """Unload OVO Energy config entry."""
-    # Unload sensors
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    del hass.data[DOMAIN][entry.entry_id]
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -13,11 +13,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_ACCOUNT
-from .coordinator import (
-    OVOEnergyConfigEntry,
-    OVOEnergyData,
-    OVOEnergyDataUpdateCoordinator,
-)
+from .coordinator import OVOEnergyConfigEntry, OVOEnergyDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OVOEnergyConfigEntry) ->
 
     await coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = OVOEnergyData(client=client, coordinator=coordinator)
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/ovo_energy/const.py
+++ b/homeassistant/components/ovo_energy/const.py
@@ -2,6 +2,4 @@
 
 DOMAIN = "ovo_energy"
 
-DATA_CLIENT = "ovo_client"
-DATA_COORDINATOR = "coordinator"
 CONF_ACCOUNT = "account"

--- a/homeassistant/components/ovo_energy/coordinator.py
+++ b/homeassistant/components/ovo_energy/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
@@ -21,16 +22,26 @@ from .const import CONF_ACCOUNT
 
 _LOGGER = logging.getLogger(__name__)
 
+type OVOEnergyConfigEntry = ConfigEntry[OVOEnergyData]
+
+
+@dataclass
+class OVOEnergyData:
+    """Runtime data for OVO Energy."""
+
+    client: OVOEnergy
+    coordinator: OVOEnergyDataUpdateCoordinator
+
 
 class OVOEnergyDataUpdateCoordinator(DataUpdateCoordinator[OVODailyUsage]):
     """Class to manage fetching OVO Energy data."""
 
-    config_entry: ConfigEntry
+    config_entry: OVOEnergyConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: OVOEnergyConfigEntry,
         client: OVOEnergy,
     ) -> None:
         """Initialize."""

--- a/homeassistant/components/ovo_energy/coordinator.py
+++ b/homeassistant/components/ovo_energy/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
@@ -22,15 +21,7 @@ from .const import CONF_ACCOUNT
 
 _LOGGER = logging.getLogger(__name__)
 
-type OVOEnergyConfigEntry = ConfigEntry[OVOEnergyData]
-
-
-@dataclass
-class OVOEnergyData:
-    """Runtime data for OVO Energy."""
-
-    client: OVOEnergy
-    coordinator: OVOEnergyDataUpdateCoordinator
+type OVOEnergyConfigEntry = ConfigEntry[OVOEnergyDataUpdateCoordinator]
 
 
 class OVOEnergyDataUpdateCoordinator(DataUpdateCoordinator[OVODailyUsage]):

--- a/homeassistant/components/ovo_energy/entity.py
+++ b/homeassistant/components/ovo_energy/entity.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from ovoenergy import OVOEnergy
-
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -16,15 +14,6 @@ class OVOEnergyEntity(CoordinatorEntity[OVOEnergyDataUpdateCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(
-        self,
-        coordinator: OVOEnergyDataUpdateCoordinator,
-        client: OVOEnergy,
-    ) -> None:
-        """Initialize the OVO Energy entity."""
-        super().__init__(coordinator)
-        self._client = client
-
 
 class OVOEnergyDeviceEntity(OVOEnergyEntity):
     """Defines a OVO Energy device entity."""
@@ -34,7 +23,7 @@ class OVOEnergyDeviceEntity(OVOEnergyEntity):
         """Return device information about this OVO Energy instance."""
         return DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self._client.account_id)},
+            identifiers={(DOMAIN, self.coordinator.client.account_id)},
             manufacturer="OVO Energy",
-            name=self._client.username,
+            name=self.coordinator.client.username,
         )

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -7,7 +7,6 @@ import dataclasses
 from datetime import datetime, timedelta
 from typing import Final
 
-from ovoenergy import OVOEnergy
 from ovoenergy.models import OVODailyUsage
 
 from homeassistant.components.sensor import (
@@ -117,8 +116,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up OVO Energy sensor based on a config entry."""
-    coordinator = entry.runtime_data.coordinator
-    client = entry.runtime_data.client
+    coordinator = entry.runtime_data
 
     entities = []
 
@@ -136,7 +134,7 @@ async def async_setup_entry(
                             coordinator.data.electricity[-1].cost.currency_unit
                         ),
                     )
-                entities.append(OVOEnergySensor(coordinator, description, client))
+                entities.append(OVOEnergySensor(coordinator, description))
         if coordinator.data.gas:
             for description in SENSOR_TYPES_GAS:
                 if (
@@ -150,7 +148,7 @@ async def async_setup_entry(
                             -1
                         ].cost.currency_unit,
                     )
-                entities.append(OVOEnergySensor(coordinator, description, client))
+                entities.append(OVOEnergySensor(coordinator, description))
 
     async_add_entities(entities, True)
 
@@ -164,11 +162,12 @@ class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
         self,
         coordinator: OVOEnergyDataUpdateCoordinator,
         description: OVOEnergySensorEntityDescription,
-        client: OVOEnergy,
     ) -> None:
         """Initialize."""
-        super().__init__(coordinator, client)
-        self._attr_unique_id = f"{DOMAIN}_{client.account_id}_{description.key}"
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{DOMAIN}_{coordinator.client.account_id}_{description.key}"
+        )
         self.entity_description = description
 
     @property

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -16,15 +16,14 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
-from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
-from .coordinator import OVOEnergyDataUpdateCoordinator
+from .const import DOMAIN
+from .coordinator import OVOEnergyConfigEntry, OVOEnergyDataUpdateCoordinator
 from .entity import OVOEnergyDeviceEntity
 
 SCAN_INTERVAL = timedelta(seconds=300)
@@ -114,14 +113,12 @@ SENSOR_TYPES_GAS: tuple[OVOEnergySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: OVOEnergyConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up OVO Energy sensor based on a config entry."""
-    coordinator: OVOEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        DATA_COORDINATOR
-    ]
-    client: OVOEnergy = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
+    coordinator = entry.runtime_data.coordinator
+    client = entry.runtime_data.client
 
     entities = []
 


### PR DESCRIPTION
## Proposed change

Migrate the `ovo_energy` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing runtime data.

- Add `OVOEnergyData` dataclass and `OVOEnergyConfigEntry` type alias in the coordinator module
- Replace `hass.data[DOMAIN][entry.entry_id]` dictionary access with typed `entry.runtime_data`
- Remove unused `DATA_CLIENT` and `DATA_COORDINATOR` constants from `const.py`
- Simplify `async_unload_entry` by removing manual `hass.data` cleanup (handled automatically by runtime_data)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr