### PR TITLE
Migrate peco to use runtime_data

### DIFF
--- a/homeassistant/components/peco/__init__.py
+++ b/homeassistant/components/peco/__init__.py
@@ -4,37 +4,39 @@ from __future__ import annotations
 
 from typing import Final
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_PHONE_NUMBER, DOMAIN
-from .coordinator import PecoOutageCoordinator, PecoSmartMeterCoordinator
+from .const import CONF_PHONE_NUMBER
+from .coordinator import (
+    PecoConfigEntry,
+    PecoOutageCoordinator,
+    PecoRuntimeData,
+    PecoSmartMeterCoordinator,
+)
 
 PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: PecoConfigEntry) -> bool:
     """Set up PECO Outage Counter from a config entry."""
     outage_coordinator = PecoOutageCoordinator(hass, entry)
     await outage_coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        "outage_count": outage_coordinator
-    }
-
+    meter_coordinator: PecoSmartMeterCoordinator | None = None
     if phone_number := entry.data.get(CONF_PHONE_NUMBER):
         meter_coordinator = PecoSmartMeterCoordinator(hass, entry, phone_number)
         await meter_coordinator.async_config_entry_first_refresh()
-        hass.data[DOMAIN][entry.entry_id]["smart_meter"] = meter_coordinator
+
+    entry.runtime_data = PecoRuntimeData(
+        outage_coordinator=outage_coordinator,
+        meter_coordinator=meter_coordinator,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: PecoConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/peco/binary_sensor.py
+++ b/homeassistant/components/peco/binary_sensor.py
@@ -8,28 +8,23 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
-from .coordinator import PecoSmartMeterCoordinator
+from .coordinator import PecoConfigEntry, PecoSmartMeterCoordinator
 
 PARALLEL_UPDATES: Final = 0
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PecoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up binary sensor for PECO."""
-    if "smart_meter" not in hass.data[DOMAIN][config_entry.entry_id]:
+    if (coordinator := config_entry.runtime_data.meter_coordinator) is None:
         return
-    coordinator: PecoSmartMeterCoordinator = hass.data[DOMAIN][config_entry.entry_id][
-        "smart_meter"
-    ]
 
     async_add_entities(
         [PecoBinarySensor(coordinator, phone_number=config_entry.data["phone_number"])]

--- a/homeassistant/components/peco/coordinator.py
+++ b/homeassistant/components/peco/coordinator.py
@@ -1,5 +1,7 @@
 """DataUpdateCoordinator for the PECO Outage Counter integration."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -28,12 +30,23 @@ class PECOCoordinatorData:
     alerts: AlertResults
 
 
+@dataclass
+class PecoRuntimeData:
+    """Runtime data for the PECO integration."""
+
+    outage_coordinator: PecoOutageCoordinator
+    meter_coordinator: PecoSmartMeterCoordinator | None = None
+
+
+type PecoConfigEntry = ConfigEntry[PecoRuntimeData]
+
+
 class PecoOutageCoordinator(DataUpdateCoordinator[PECOCoordinatorData]):
     """Coordinator for PECO outage data."""
 
-    config_entry: ConfigEntry
+    config_entry: PecoConfigEntry
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, entry: PecoConfigEntry) -> None:
         """Initialize the outage coordinator."""
         super().__init__(
             hass,
@@ -65,10 +78,10 @@ class PecoOutageCoordinator(DataUpdateCoordinator[PECOCoordinatorData]):
 class PecoSmartMeterCoordinator(DataUpdateCoordinator[bool]):
     """Coordinator for PECO smart meter data."""
 
-    config_entry: ConfigEntry
+    config_entry: PecoConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, entry: ConfigEntry, phone_number: str
+        self, hass: HomeAssistant, entry: PecoConfigEntry, phone_number: str
     ) -> None:
         """Initialize the smart meter coordinator."""
         super().__init__(

--- a/homeassistant/components/peco/sensor.py
+++ b/homeassistant/components/peco/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -19,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_CONTENT, CONF_COUNTY, DOMAIN
-from .coordinator import PECOCoordinatorData, PecoOutageCoordinator
+from .coordinator import PecoConfigEntry, PECOCoordinatorData, PecoOutageCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -72,12 +71,12 @@ SENSOR_LIST: tuple[PECOSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PecoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
     county: str = config_entry.data[CONF_COUNTY]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["outage_count"]
+    coordinator = config_entry.runtime_data.outage_coordinator
 
     async_add_entities(
         PecoSensor(sensor, county, coordinator) for sensor in SENSOR_LIST

--- a/tests/components/peco/test_init.py
+++ b/tests/components/peco/test_init.py
@@ -47,8 +47,6 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-    assert hass.data[DOMAIN]
-
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.LOADED

--- a/tests/components/peco/test_sensor.py
+++ b/tests/components/peco/test_sensor.py
@@ -53,8 +53,6 @@ async def test_sensor_available(
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-    assert hass.data[DOMAIN]
-
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert config_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
## Proposed change

Migrate the `peco` integration to use `runtime_data` instead of `hass.data[DOMAIN]`.

- Added `PecoRuntimeData` dataclass and `PecoConfigEntry` type alias in `coordinator.py`
- Updated `__init__.py` to store data in `entry.runtime_data` instead of `hass.data[DOMAIN]`, removing the need for manual cleanup in `async_unload_entry`
- Updated `sensor.py` and `binary_sensor.py` to read from `config_entry.runtime_data` instead of `hass.data[DOMAIN]`
- Updated coordinators to use `PecoConfigEntry` typed config entry
- Removed `assert hass.data[DOMAIN]` from tests since `hass.data` is no longer used

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr