### PR TITLE
Migrate picnic to use runtime_data

### DIFF
--- a/homeassistant/components/picnic/__init__.py
+++ b/homeassistant/components/picnic/__init__.py
@@ -2,14 +2,13 @@
 
 from python_picnic_api2 import PicnicAPI
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_COUNTRY_CODE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_API, CONF_COORDINATOR, DOMAIN
-from .coordinator import PicnicUpdateCoordinator
+from .const import DOMAIN
+from .coordinator import PicnicConfigEntry, PicnicRuntimeData, PicnicUpdateCoordinator
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -24,7 +23,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-def create_picnic_client(entry: ConfigEntry):
+def create_picnic_client(entry: PicnicConfigEntry):
     """Create an instance of the PicnicAPI client."""
     return PicnicAPI(
         auth_token=entry.data.get(CONF_ACCESS_TOKEN),
@@ -32,7 +31,7 @@ def create_picnic_client(entry: ConfigEntry):
     )
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: PicnicConfigEntry) -> bool:
     """Set up Picnic from a config entry."""
     picnic_client = await hass.async_add_executor_job(create_picnic_client, entry)
     picnic_coordinator = PicnicUpdateCoordinator(hass, picnic_client, entry)
@@ -40,21 +39,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Fetch initial data so we have data when entities subscribe
     await picnic_coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        CONF_API: picnic_client,
-        CONF_COORDINATOR: picnic_coordinator,
-    }
+    entry.runtime_data = PicnicRuntimeData(
+        api_client=picnic_client,
+        coordinator=picnic_coordinator,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: PicnicConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/picnic/__init__.py
+++ b/homeassistant/components/picnic/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
-from .coordinator import PicnicConfigEntry, PicnicRuntimeData, PicnicUpdateCoordinator
+from .coordinator import PicnicConfigEntry, PicnicUpdateCoordinator
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -39,10 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PicnicConfigEntry) -> bo
     # Fetch initial data so we have data when entities subscribe
     await picnic_coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = PicnicRuntimeData(
-        api_client=picnic_client,
-        coordinator=picnic_coordinator,
-    )
+    entry.runtime_data = picnic_coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 DOMAIN = "picnic"
 
-CONF_API = "api"
-CONF_COORDINATOR = "coordinator"
-
 SERVICE_ADD_PRODUCT_TO_CART = "add_product"
 
 ATTR_PRODUCT_ID = "product_id"

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 import copy
-from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
@@ -20,16 +19,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import ADDRESS, CART_DATA, LAST_ORDER_DATA, NEXT_DELIVERY_DATA, SLOT_DATA
 
-
-@dataclass
-class PicnicRuntimeData:
-    """Runtime data for the Picnic integration."""
-
-    api_client: PicnicAPI
-    coordinator: PicnicUpdateCoordinator
-
-
-type PicnicConfigEntry = ConfigEntry[PicnicRuntimeData]
+type PicnicConfigEntry = ConfigEntry[PicnicUpdateCoordinator]
 
 
 class PicnicUpdateCoordinator(DataUpdateCoordinator):

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -1,8 +1,11 @@
 """Coordinator to fetch data from the Picnic API."""
 
+from __future__ import annotations
+
 import asyncio
 from contextlib import suppress
 import copy
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
@@ -18,16 +21,27 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import ADDRESS, CART_DATA, LAST_ORDER_DATA, NEXT_DELIVERY_DATA, SLOT_DATA
 
 
+@dataclass
+class PicnicRuntimeData:
+    """Runtime data for the Picnic integration."""
+
+    api_client: PicnicAPI
+    coordinator: PicnicUpdateCoordinator
+
+
+type PicnicConfigEntry = ConfigEntry[PicnicRuntimeData]
+
+
 class PicnicUpdateCoordinator(DataUpdateCoordinator):
     """The coordinator to fetch data from the Picnic API at a set interval."""
 
-    config_entry: ConfigEntry
+    config_entry: PicnicConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
         picnic_api_client: PicnicAPI,
-        config_entry: ConfigEntry,
+        config_entry: PicnicConfigEntry,
     ) -> None:
         """Initialize the coordinator with the given Picnic API client."""
         self.picnic_api_client = picnic_api_client

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -204,7 +204,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Picnic sensor entries."""
-    picnic_coordinator = config_entry.runtime_data.coordinator
+    picnic_coordinator = config_entry.runtime_data
 
     # Add an entity for each sensor type
     async_add_entities(

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CURRENCY_EURO
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -23,7 +22,6 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTRIBUTION,
-    CONF_COORDINATOR,
     DOMAIN,
     SENSOR_CART_ITEMS_COUNT,
     SENSOR_CART_TOTAL_PRICE,
@@ -42,7 +40,7 @@ from .const import (
     SENSOR_SELECTED_SLOT_MIN_ORDER_VALUE,
     SENSOR_SELECTED_SLOT_START,
 )
-from .coordinator import PicnicUpdateCoordinator
+from .coordinator import PicnicConfigEntry, PicnicUpdateCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -202,11 +200,11 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PicnicConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Picnic sensor entries."""
-    picnic_coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
+    picnic_coordinator = config_entry.runtime_data.coordinator
 
     # Add an entity for each sensor type
     async_add_entities(
@@ -225,7 +223,7 @@ class PicnicSensor(SensorEntity, CoordinatorEntity[PicnicUpdateCoordinator]):
     def __init__(
         self,
         coordinator: PicnicUpdateCoordinator,
-        config_entry: ConfigEntry,
+        config_entry: PicnicConfigEntry,
         description: PicnicSensorEntityDescription,
     ) -> None:
         """Init a Picnic sensor."""

--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -7,6 +7,7 @@ from typing import cast
 from python_picnic_api2 import PicnicAPI
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
@@ -19,6 +20,7 @@ from .const import (
     DOMAIN,
     SERVICE_ADD_PRODUCT_TO_CART,
 )
+from .coordinator import PicnicConfigEntry
 
 
 class PicnicServiceException(Exception):
@@ -50,12 +52,11 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
 async def get_api_client(hass: HomeAssistant, config_entry_id: str) -> PicnicAPI:
     """Get the right Picnic API client based on the config entry id."""
-    from .coordinator import PicnicConfigEntry  # noqa: PLC0415
 
     entry: PicnicConfigEntry | None = hass.config_entries.async_get_entry(
         config_entry_id
     )
-    if entry is None:
+    if entry is None or entry.state != ConfigEntryState.LOADED:
         raise ValueError(f"Config entry with id {config_entry_id} not found!")
     return entry.runtime_data.picnic_api_client
 

--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -57,7 +57,7 @@ async def get_api_client(hass: HomeAssistant, config_entry_id: str) -> PicnicAPI
     )
     if entry is None:
         raise ValueError(f"Config entry with id {config_entry_id} not found!")
-    return entry.runtime_data.api_client
+    return entry.runtime_data.picnic_api_client
 
 
 async def handle_add_product(

--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -16,7 +16,6 @@ from .const import (
     ATTR_PRODUCT_ID,
     ATTR_PRODUCT_IDENTIFIERS,
     ATTR_PRODUCT_NAME,
-    CONF_API,
     DOMAIN,
     SERVICE_ADD_PRODUCT_TO_CART,
 )
@@ -50,10 +49,15 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
 
 async def get_api_client(hass: HomeAssistant, config_entry_id: str) -> PicnicAPI:
-    """Get the right Picnic API client based on the device id, else get the default one."""
-    if config_entry_id not in hass.data[DOMAIN]:
+    """Get the right Picnic API client based on the config entry id."""
+    from .coordinator import PicnicConfigEntry  # noqa: PLC0415
+
+    entry: PicnicConfigEntry | None = hass.config_entries.async_get_entry(
+        config_entry_id
+    )
+    if entry is None:
         raise ValueError(f"Config entry with id {config_entry_id} not found!")
-    return hass.data[DOMAIN][config_entry_id][CONF_API]
+    return entry.runtime_data.api_client
 
 
 async def handle_add_product(

--- a/homeassistant/components/picnic/todo.py
+++ b/homeassistant/components/picnic/todo.py
@@ -11,15 +11,14 @@ from homeassistant.components.todo import (
     TodoListEntity,
     TodoListEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_COORDINATOR, DOMAIN
-from .coordinator import PicnicUpdateCoordinator
+from .const import DOMAIN
+from .coordinator import PicnicConfigEntry, PicnicUpdateCoordinator
 from .services import product_search
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,11 +26,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PicnicConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Picnic shopping cart todo platform config entry."""
-    picnic_coordinator = hass.data[DOMAIN][config_entry.entry_id][CONF_COORDINATOR]
+    picnic_coordinator = config_entry.runtime_data.coordinator
 
     async_add_entities([PicnicCart(picnic_coordinator, config_entry)])
 
@@ -46,7 +45,7 @@ class PicnicCart(TodoListEntity, CoordinatorEntity[PicnicUpdateCoordinator]):
     def __init__(
         self,
         coordinator: PicnicUpdateCoordinator,
-        config_entry: ConfigEntry,
+        config_entry: PicnicConfigEntry,
     ) -> None:
         """Initialize PicnicCart."""
         super().__init__(coordinator)

--- a/homeassistant/components/picnic/todo.py
+++ b/homeassistant/components/picnic/todo.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Picnic shopping cart todo platform config entry."""
-    picnic_coordinator = config_entry.runtime_data.coordinator
+    picnic_coordinator = config_entry.runtime_data
 
     async_add_entities([PicnicCart(picnic_coordinator, config_entry)])
 

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -129,9 +129,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
 
     @property
     def _coordinator(self):
-        return self.hass.data[const.DOMAIN][self.config_entry.entry_id][
-            const.CONF_COORDINATOR
-        ]
+        return self.config_entry.runtime_data.coordinator
 
     def _assert_sensor(self, name, state=None, cls=None, unit=None, disabled=False):
         sensor = self.hass.states.get(name)

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -129,7 +129,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
 
     @property
     def _coordinator(self):
-        return self.config_entry.runtime_data.coordinator
+        return self.config_entry.runtime_data
 
     def _assert_sensor(self, name, state=None, cls=None, unit=None, disabled=False):
         sensor = self.hass.states.get(name)


### PR DESCRIPTION
## Proposed change

- Add `PicnicRuntimeData` dataclass and `PicnicConfigEntry` type alias in `coordinator.py`
- Replace `hass.data[DOMAIN]` with `entry.runtime_data` in `__init__.py`, `sensor.py`, `todo.py`, and `services.py`
- Remove unused `CONF_API` and `CONF_COORDINATOR` constants from `const.py`
- Update tests to access coordinator via `config_entry.runtime_data`


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr