### PR TITLE
Migrate progettihwsw to use runtime_data

### DIFF
--- a/homeassistant/components/progettihwsw/__init__.py
+++ b/homeassistant/components/progettihwsw/__init__.py
@@ -10,11 +10,11 @@ from homeassistant.core import HomeAssistant
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SWITCH]
 
-type ProgettihwswConfigEntry = ConfigEntry[ProgettiHWSWAPI]
+type ProgettiHWSWConfigEntry = ConfigEntry[ProgettiHWSWAPI]
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ProgettihwswConfigEntry
+    hass: HomeAssistant, entry: ProgettiHWSWConfigEntry
 ) -> bool:
     """Set up ProgettiHWSW Automation from a config entry."""
     api = ProgettiHWSWAPI(f"{entry.data['host']}:{entry.data['port']}")
@@ -30,7 +30,7 @@ async def async_setup_entry(
 
 
 async def async_unload_entry(
-    hass: HomeAssistant, entry: ProgettihwswConfigEntry
+    hass: HomeAssistant, entry: ProgettiHWSWConfigEntry
 ) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/progettihwsw/__init__.py
+++ b/homeassistant/components/progettihwsw/__init__.py
@@ -8,33 +8,32 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SWITCH]
 
+type ProgettihwswConfigEntry = ConfigEntry[ProgettiHWSWAPI]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ProgettihwswConfigEntry
+) -> bool:
     """Set up ProgettiHWSW Automation from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = ProgettiHWSWAPI(
-        f"{entry.data['host']}:{entry.data['port']}"
-    )
+    api = ProgettiHWSWAPI(f"{entry.data['host']}:{entry.data['port']}")
 
     # Check board validation again to load new values to API.
-    await hass.data[DOMAIN][entry.entry_id].check_board()
+    await api.check_board()
+
+    entry.runtime_data = api
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: ProgettihwswConfigEntry
+) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 def setup_input(api: ProgettiHWSWAPI, input_number: int) -> Input:

--- a/homeassistant/components/progettihwsw/binary_sensor.py
+++ b/homeassistant/components/progettihwsw/binary_sensor.py
@@ -7,7 +7,6 @@ import logging
 from ProgettiHWSW.input import Input
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -15,19 +14,19 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import setup_input
-from .const import DEFAULT_POLLING_INTERVAL_SEC, DOMAIN
+from . import ProgettihwswConfigEntry, setup_input
+from .const import DEFAULT_POLLING_INTERVAL_SEC
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ProgettihwswConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the binary sensors from a config entry."""
-    board_api = hass.data[DOMAIN][config_entry.entry_id]
+    board_api = config_entry.runtime_data
     input_count = config_entry.data["input_count"]
 
     async def async_update_data():

--- a/homeassistant/components/progettihwsw/binary_sensor.py
+++ b/homeassistant/components/progettihwsw/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import ProgettihwswConfigEntry, setup_input
+from . import ProgettiHWSWConfigEntry, setup_input
 from .const import DEFAULT_POLLING_INTERVAL_SEC
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ProgettihwswConfigEntry,
+    config_entry: ProgettiHWSWConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the binary sensors from a config entry."""

--- a/homeassistant/components/progettihwsw/switch.py
+++ b/homeassistant/components/progettihwsw/switch.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import ProgettihwswConfigEntry, setup_switch
+from . import ProgettiHWSWConfigEntry, setup_switch
 from .const import DEFAULT_POLLING_INTERVAL_SEC
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ProgettihwswConfigEntry,
+    config_entry: ProgettiHWSWConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the switches from a config entry."""

--- a/homeassistant/components/progettihwsw/switch.py
+++ b/homeassistant/components/progettihwsw/switch.py
@@ -8,7 +8,6 @@ from typing import Any
 from ProgettiHWSW.relay import Relay
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -16,19 +15,19 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import setup_switch
-from .const import DEFAULT_POLLING_INTERVAL_SEC, DOMAIN
+from . import ProgettihwswConfigEntry, setup_switch
+from .const import DEFAULT_POLLING_INTERVAL_SEC
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ProgettihwswConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the switches from a config entry."""
-    board_api = hass.data[DOMAIN][config_entry.entry_id]
+    board_api = config_entry.runtime_data
     relay_count = config_entry.data["relay_count"]
 
     async def async_update_data():


### PR DESCRIPTION
## Proposed change

Migrate the progettihwsw integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing the API instance. This simplifies data management by leveraging the built-in config entry runtime data storage, removing the need for manual dictionary cleanup in `async_unload_entry`. Also replaces `DOMAIN`-based logger with `__name__` in platform modules.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr