### PR TITLE
Migrate prosegur to use runtime_data

### DIFF
--- a/homeassistant/components/prosegur/__init__.py
+++ b/homeassistant/components/prosegur/__init__.py
@@ -10,25 +10,24 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN
-
 PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.CAMERA]
+
+type ProsegurConfigEntry = ConfigEntry[Auth]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ProsegurConfigEntry) -> bool:
     """Set up Prosegur Alarm from a config entry."""
     try:
         session = aiohttp_client.async_get_clientsession(hass)
-        hass.data.setdefault(DOMAIN, {})
-        hass.data[DOMAIN][entry.entry_id] = Auth(
+        auth = Auth(
             session,
             entry.data[CONF_USERNAME],
             entry.data[CONF_PASSWORD],
             entry.data[CONF_COUNTRY],
         )
-        await hass.data[DOMAIN][entry.entry_id].login()
+        await auth.login()
 
     except ConnectionRefusedError as error:
         _LOGGER.error("Configured credential are invalid, %s", error)
@@ -39,15 +38,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Could not connect with Prosegur backend: %s", error)
         raise ConfigEntryNotReady from error
 
+    entry.runtime_data = auth
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ProsegurConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/prosegur/alarm_control_panel.py
+++ b/homeassistant/components/prosegur/alarm_control_panel.py
@@ -12,12 +12,12 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN
+from . import ProsegurConfigEntry
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,12 +31,12 @@ STATE_MAPPING = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ProsegurConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Prosegur alarm control panel platform."""
     async_add_entities(
-        [ProsegurAlarm(entry.data["contract"], hass.data[DOMAIN][entry.entry_id])],
+        [ProsegurAlarm(entry.data["contract"], entry.runtime_data)],
         update_before_add=True,
     )
 

--- a/homeassistant/components/prosegur/camera.py
+++ b/homeassistant/components/prosegur/camera.py
@@ -9,7 +9,6 @@ from pyprosegur.exceptions import ProsegurException
 from pyprosegur.installation import Camera as InstallationCamera, Installation
 
 from homeassistant.components.camera import Camera
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
@@ -17,15 +16,15 @@ from homeassistant.helpers.entity_platform import (
     async_get_current_platform,
 )
 
-from . import DOMAIN
-from .const import SERVICE_REQUEST_IMAGE
+from . import ProsegurConfigEntry
+from .const import DOMAIN, SERVICE_REQUEST_IMAGE
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ProsegurConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Prosegur camera platform."""
@@ -38,12 +37,12 @@ async def async_setup_entry(
     )
 
     _installation = await Installation.retrieve(
-        hass.data[DOMAIN][entry.entry_id], entry.data["contract"]
+        entry.runtime_data, entry.data["contract"]
     )
 
     async_add_entities(
         [
-            ProsegurCamera(_installation, camera, hass.data[DOMAIN][entry.entry_id])
+            ProsegurCamera(_installation, camera, entry.runtime_data)
             for camera in _installation.cameras
         ],
         update_before_add=True,

--- a/homeassistant/components/prosegur/diagnostics.py
+++ b/homeassistant/components/prosegur/diagnostics.py
@@ -7,24 +7,24 @@ from typing import Any
 from pyprosegur.installation import Installation
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_CONTRACT, DOMAIN
+from . import ProsegurConfigEntry
+from .const import CONF_CONTRACT
 
 TO_REDACT = {"description", "latitude", "longitude", "contractId", "address"}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: ProsegurConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
 
     installation = await Installation.retrieve(
-        hass.data[DOMAIN][entry.entry_id], entry.data[CONF_CONTRACT]
+        entry.runtime_data, entry.data[CONF_CONTRACT]
     )
 
-    activity = await installation.activity(hass.data[DOMAIN][entry.entry_id])
+    activity = await installation.activity(entry.runtime_data)
 
     return {
         "installation": async_redact_data(installation.data, TO_REDACT),

--- a/tests/components/prosegur/conftest.py
+++ b/tests/components/prosegur/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from pyprosegur.installation import Camera
 import pytest
 
-from homeassistant.components.prosegur import DOMAIN
+from homeassistant.components.prosegur.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 


### PR DESCRIPTION
## Proposed change

Migrate the prosegur integration to use `entry.runtime_data` (typed as `ProsegurConfigEntry`) instead of storing data in `hass.data[DOMAIN][entry.entry_id]`.

This simplifies the setup and unload logic by removing the need to manually manage `hass.data` and ensures type safety through the `ProsegurConfigEntry` type alias.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr