### PR TITLE
Migrate pushbullet to use runtime_data

### DIFF
--- a/homeassistant/components/pushbullet/__init__.py
+++ b/homeassistant/components/pushbullet/__init__.py
@@ -21,6 +21,8 @@ from homeassistant.helpers.typing import ConfigType
 from .api import PushBulletNotificationProvider
 from .const import DATA_HASS_CONFIG, DOMAIN
 
+type PushbulletConfigEntry = ConfigEntry[PushBulletNotificationProvider]
+
 PLATFORMS = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,7 +37,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: PushbulletConfigEntry) -> bool:
     """Set up pushbullet from a config entry."""
 
     try:
@@ -49,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from err
 
     pb_provider = PushBulletNotificationProvider(hass, pushbullet)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = pb_provider
+    entry.runtime_data = pb_provider
 
     def start_listener(event: Event) -> None:
         """Start the listener thread."""
@@ -72,11 +74,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: PushbulletConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        pb_provider: PushBulletNotificationProvider = hass.data[DOMAIN].pop(
-            entry.entry_id
-        )
-        await hass.async_add_executor_job(pb_provider.close)
+        await hass.async_add_executor_job(entry.runtime_data.close)
     return unload_ok

--- a/homeassistant/components/pushbullet/notify.py
+++ b/homeassistant/components/pushbullet/notify.py
@@ -22,8 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .api import PushBulletNotificationProvider
-from .const import ATTR_FILE, ATTR_FILE_URL, ATTR_URL, DOMAIN
+from .const import ATTR_FILE, ATTR_FILE_URL, ATTR_URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,10 +35,10 @@ async def async_get_service(
     """Get the Pushbullet notification service."""
     if TYPE_CHECKING:
         assert discovery_info is not None
-    pb_provider: PushBulletNotificationProvider = hass.data[DOMAIN][
-        discovery_info["entry_id"]
-    ]
-    return PushBulletNotificationService(hass, pb_provider.pushbullet)
+    entry = hass.config_entries.async_get_entry(discovery_info["entry_id"])
+    if TYPE_CHECKING:
+        assert entry is not None
+    return PushBulletNotificationService(hass, entry.runtime_data.pushbullet)
 
 
 class PushBulletNotificationService(BaseNotificationService):

--- a/homeassistant/components/pushbullet/sensor.py
+++ b/homeassistant/components/pushbullet/sensor.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, MAX_LENGTH_STATE_STATE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import PushbulletConfigEntry
 from .api import PushBulletNotificationProvider
 from .const import DATA_UPDATED, DOMAIN
 
@@ -69,12 +69,12 @@ SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: PushbulletConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Pushbullet sensors from config entry."""
 
-    pb_provider: PushBulletNotificationProvider = hass.data[DOMAIN][entry.entry_id]
+    pb_provider = entry.runtime_data
 
     entities = [
         PushBulletNotificationSensor(entry.data[CONF_NAME], pb_provider, description)


### PR DESCRIPTION
## Proposed change

Migrate the `pushbullet` integration to use `runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]` for storing the `PushBulletNotificationProvider` instance.

- Add `type PushbulletConfigEntry` alias for `ConfigEntry[PushBulletNotificationProvider]`
- Store `PushBulletNotificationProvider` as `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`
- Update `sensor.py` to use `entry.runtime_data`
- Update `notify.py` to look up the config entry and access `runtime_data`
- Remove unused imports

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr