### PR TITLE
Migrate pvoutput to use runtime_data

### DIFF
--- a/homeassistant/components/pvoutput/__init__.py
+++ b/homeassistant/components/pvoutput/__init__.py
@@ -2,26 +2,23 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, PLATFORMS
-from .coordinator import PVOutputDataUpdateCoordinator
+from .const import PLATFORMS
+from .coordinator import PvOutputConfigEntry, PVOutputDataUpdateCoordinator
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: PvOutputConfigEntry) -> bool:
     """Set up PVOutput from a config entry."""
     coordinator = PVOutputDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: PvOutputConfigEntry) -> bool:
     """Unload PVOutput config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        del hass.data[DOMAIN][entry.entry_id]
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/pvoutput/coordinator.py
+++ b/homeassistant/components/pvoutput/coordinator.py
@@ -13,13 +13,15 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import CONF_SYSTEM_ID, DOMAIN, LOGGER, SCAN_INTERVAL
 
+type PvOutputConfigEntry = ConfigEntry[PVOutputDataUpdateCoordinator]
+
 
 class PVOutputDataUpdateCoordinator(DataUpdateCoordinator[Status]):
     """The PVOutput Data Update Coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: PvOutputConfigEntry
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, entry: PvOutputConfigEntry) -> None:
         """Initialize the PVOutput coordinator."""
         self.pvoutput = PVOutput(
             api_key=entry.data[CONF_API_KEY],

--- a/homeassistant/components/pvoutput/diagnostics.py
+++ b/homeassistant/components/pvoutput/diagnostics.py
@@ -4,16 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-from .coordinator import PVOutputDataUpdateCoordinator
+from .coordinator import PvOutputConfigEntry
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: PvOutputConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: PVOutputDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    return coordinator.data.to_dict()
+    return entry.runtime_data.data.to_dict()

--- a/homeassistant/components/pvoutput/sensor.py
+++ b/homeassistant/components/pvoutput/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -26,7 +25,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_SYSTEM_ID, DOMAIN
-from .coordinator import PVOutputDataUpdateCoordinator
+from .coordinator import PvOutputConfigEntry, PVOutputDataUpdateCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -97,11 +96,11 @@ SENSORS: tuple[PVOutputSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: PvOutputConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a PVOutput sensors based on a config entry."""
-    coordinator: PVOutputDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     system = await coordinator.pvoutput.system()
 
     async_add_entities(


### PR DESCRIPTION
## Proposed change

Migrate the `pvoutput` integration to use `runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]` for storing the `PVOutputDataUpdateCoordinator` instance.

- Added `type PvOutputConfigEntry` alias in `coordinator.py`
- Updated coordinator to use typed config entry
- Store coordinator as `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]` in `__init__.py`
- Updated `sensor.py` and `diagnostics.py` to use `entry.runtime_data`
- Simplified `async_unload_entry` (no need to clean up `hass.data`)
- Removed unused imports (`DOMAIN`, `ConfigEntry`)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr