### PR TITLE
Migrate permobil to use runtime_data

### DIFF
--- a/homeassistant/components/permobil/__init__.py
+++ b/homeassistant/components/permobil/__init__.py
@@ -6,7 +6,6 @@ import logging
 
 from mypermobil import MyPermobil, MyPermobilClientException
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_CODE,
     CONF_EMAIL,
@@ -19,15 +18,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import APPLICATION, DOMAIN
-from .coordinator import MyPermobilCoordinator
+from .const import APPLICATION
+from .coordinator import MyPermobilCoordinator, PermobilConfigEntry
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: PermobilConfigEntry) -> bool:
     """Set up MyPermobil from a config entry."""
 
     # create the API object from the config and save it in hass
@@ -51,15 +50,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = MyPermobilCoordinator(hass, entry, p_api)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: PermobilConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/permobil/binary_sensor.py
+++ b/homeassistant/components/permobil/binary_sensor.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from mypermobil import BATTERY_CHARGING
 
-from homeassistant import config_entries
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -16,8 +15,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import MyPermobilCoordinator
+from .coordinator import PermobilConfigEntry
 from .entity import PermobilEntity
 
 
@@ -41,12 +39,12 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PermobilBinarySensorEntityDescription, ...] = 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: config_entries.ConfigEntry,
+    config_entry: PermobilConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Create and setup the binary sensor."""
 
-    coordinator: MyPermobilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         PermobilbinarySensor(coordinator=coordinator, description=description)

--- a/homeassistant/components/permobil/coordinator.py
+++ b/homeassistant/components/permobil/coordinator.py
@@ -13,6 +13,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 _LOGGER = logging.getLogger(__name__)
 
+type PermobilConfigEntry = ConfigEntry[MyPermobilCoordinator]
+
 
 @dataclass
 class MyPermobilData:
@@ -26,10 +28,10 @@ class MyPermobilData:
 class MyPermobilCoordinator(DataUpdateCoordinator[MyPermobilData]):
     """MyPermobil coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: PermobilConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, p_api: MyPermobil
+        self, hass: HomeAssistant, config_entry: PermobilConfigEntry, p_api: MyPermobil
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(

--- a/homeassistant/components/permobil/sensor.py
+++ b/homeassistant/components/permobil/sensor.py
@@ -23,7 +23,6 @@ from mypermobil import (
     USAGE_DISTANCE,
 )
 
-from homeassistant import config_entries
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -34,8 +33,8 @@ from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfLength, UnitOfTi
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import BATTERY_ASSUMED_VOLTAGE, DOMAIN, KM, MILES
-from .coordinator import MyPermobilCoordinator
+from .const import BATTERY_ASSUMED_VOLTAGE, KM, MILES
+from .coordinator import PermobilConfigEntry
 from .entity import PermobilEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -176,12 +175,12 @@ DISTANCE_UNITS: dict[Any, UnitOfLength] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: config_entries.ConfigEntry,
+    config_entry: PermobilConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Create sensors from a config entry created in the integrations UI."""
 
-    coordinator: MyPermobilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         PermobilSensor(coordinator=coordinator, description=description)


### PR DESCRIPTION
## Proposed change

Migrate the `permobil` integration to use `runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]` for storing the `MyPermobilCoordinator` instance.

- Add `type PermobilConfigEntry` alias in `coordinator.py`
- Update coordinator to use typed config entry
- Store coordinator as `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]` in `__init__.py`
- Update `sensor.py` and `binary_sensor.py` to use `config_entry.runtime_data`
- Simplify `async_unload_entry` (no need to clean up `hass.data`)
- Remove unused imports (`DOMAIN` from `const`, `config_entries`/`ConfigEntry` from `homeassistant`)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr