### PR TITLE
Migrate panasonic_viera to use runtime_data

### DIFF
--- a/homeassistant/components/panasonic_viera/__init__.py
+++ b/homeassistant/components/panasonic_viera/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ATTR_DEVICE_INFO,
-    ATTR_REMOTE,
     ATTR_UDN,
     CONF_APP_ID,
     CONF_ENCRYPTION_KEY,
@@ -28,6 +27,8 @@ from .const import (
     DEFAULT_PORT,
     DOMAIN,
 )
+
+type PanasonicVieraConfigEntry = ConfigEntry[Remote]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,10 +69,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: PanasonicVieraConfigEntry
+) -> bool:
     """Set up Panasonic Viera from a config entry."""
-    panasonic_viera_data = hass.data.setdefault(DOMAIN, {})
-
     config = config_entry.data
 
     host = config[CONF_HOST]
@@ -88,7 +89,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     remote = Remote(hass, host, port, on_action, **params)
     await remote.async_create_remote_control(during_setup=True)
 
-    panasonic_viera_data[config_entry.entry_id] = {ATTR_REMOTE: remote}
+    config_entry.runtime_data = remote
 
     # Add device_info to older config entries
     if ATTR_DEVICE_INFO not in config or config[ATTR_DEVICE_INFO] is None:
@@ -112,15 +113,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, config_entry: PanasonicVieraConfigEntry
+) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        config_entry, PLATFORMS
-    )
-    if unload_ok:
-        hass.data[DOMAIN].pop(config_entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
 
 class Remote:

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -17,17 +17,16 @@ from homeassistant.components.media_player import (
     MediaType,
     async_process_play_media_url,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import PanasonicVieraConfigEntry
 from .const import (
     ATTR_DEVICE_INFO,
     ATTR_MANUFACTURER,
     ATTR_MODEL_NUMBER,
-    ATTR_REMOTE,
     ATTR_UDN,
     DEFAULT_MANUFACTURER,
     DEFAULT_MODEL_NUMBER,
@@ -39,14 +38,14 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PanasonicVieraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Panasonic Viera TV from a config entry."""
 
     config = config_entry.data
 
-    remote = hass.data[DOMAIN][config_entry.entry_id][ATTR_REMOTE]
+    remote = config_entry.runtime_data
     name = config[CONF_NAME]
     device_info = config[ATTR_DEVICE_INFO]
 

--- a/homeassistant/components/panasonic_viera/remote.py
+++ b/homeassistant/components/panasonic_viera/remote.py
@@ -6,18 +6,16 @@ from collections.abc import Iterable
 from typing import Any
 
 from homeassistant.components.remote import RemoteEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import Remote
+from . import PanasonicVieraConfigEntry, Remote
 from .const import (
     ATTR_DEVICE_INFO,
     ATTR_MANUFACTURER,
     ATTR_MODEL_NUMBER,
-    ATTR_REMOTE,
     ATTR_UDN,
     DEFAULT_MANUFACTURER,
     DEFAULT_MODEL_NUMBER,
@@ -27,14 +25,14 @@ from .const import (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PanasonicVieraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Panasonic Viera TV Remote from a config entry."""
 
     config = config_entry.data
 
-    remote = hass.data[DOMAIN][config_entry.entry_id][ATTR_REMOTE]
+    remote = config_entry.runtime_data
     name = config[CONF_NAME]
     device_info = config[ATTR_DEVICE_INFO]
 


### PR DESCRIPTION
## Proposed change

Migrate the `panasonic_viera` integration to use `runtime_data` instead of `hass.data[DOMAIN][config_entry.entry_id]` for storing the `Remote` instance.

- Add `type PanasonicVieraConfigEntry = ConfigEntry[Remote]` in `__init__.py`
- Store `Remote` directly as `config_entry.runtime_data` instead of wrapping in a dict in `hass.data[DOMAIN][entry_id]`
- Update `media_player.py` and `remote.py` to use `config_entry.runtime_data`
- Simplify `async_unload_entry` (no `hass.data` cleanup needed)
- Remove unused imports (`ATTR_REMOTE`, `DOMAIN` where no longer needed)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr