### PR TITLE
Migrate mutesync to use runtime_data

### DIFF
--- a/homeassistant/components/mutesync/__init__.py
+++ b/homeassistant/components/mutesync/__init__.py
@@ -2,32 +2,26 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-from .coordinator import MutesyncUpdateCoordinator
+from .coordinator import MutesyncConfigEntry, MutesyncUpdateCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: MutesyncConfigEntry) -> bool:
     """Set up mütesync from a config entry."""
-    coordinator = hass.data.setdefault(DOMAIN, {})[entry.entry_id] = (
-        MutesyncUpdateCoordinator(hass, entry)
-    )
+    coordinator = MutesyncUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: MutesyncConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/mutesync/binary_sensor.py
+++ b/homeassistant/components/mutesync/binary_sensor.py
@@ -1,14 +1,13 @@
 """mütesync binary sensor entities."""
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import MutesyncUpdateCoordinator
+from .coordinator import MutesyncConfigEntry, MutesyncUpdateCoordinator
 
 SENSORS = (
     "in_meeting",
@@ -18,11 +17,11 @@ SENSORS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MutesyncConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the mütesync button."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     async_add_entities(
         [MuteStatus(coordinator, sensor_type) for sensor_type in SENSORS], True
     )

--- a/homeassistant/components/mutesync/binary_sensor.py
+++ b/homeassistant/components/mutesync/binary_sensor.py
@@ -20,7 +20,7 @@ async def async_setup_entry(
     config_entry: MutesyncConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the mütesync button."""
+    """Set up the mütesync binary sensors."""
     coordinator = config_entry.runtime_data
     async_add_entities(
         [MuteStatus(coordinator, sensor_type) for sensor_type in SENSORS], True

--- a/homeassistant/components/mutesync/coordinator.py
+++ b/homeassistant/components/mutesync/coordinator.py
@@ -15,18 +15,20 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN, UPDATE_INTERVAL_IN_MEETING, UPDATE_INTERVAL_NOT_IN_MEETING
 
+type MutesyncConfigEntry = ConfigEntry[MutesyncUpdateCoordinator]
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class MutesyncUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator for the mütesync integration."""
 
-    config_entry: ConfigEntry
+    config_entry: MutesyncConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: ConfigEntry,
+        entry: MutesyncConfigEntry,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(


### PR DESCRIPTION
## Proposed change

Migrate the mutesync integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

- Add `MutesyncConfigEntry` type alias in `coordinator.py`
- Update `__init__.py` to store coordinator in `entry.runtime_data`
- Update `binary_sensor.py` to read coordinator from `config_entry.runtime_data`
- Remove unused `DOMAIN` import from `__init__.py` and `ConfigEntry` import from `binary_sensor.py`
- Simplify `async_unload_entry` by removing manual `hass.data` cleanup

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr