### PR TITLE
Migrate nibe_heatpump to use runtime_data

### DIFF
--- a/homeassistant/components/nibe_heatpump/__init__.py
+++ b/homeassistant/components/nibe_heatpump/__init__.py
@@ -7,7 +7,6 @@ from nibe.connection.modbus import Modbus
 from nibe.connection.nibegw import NibeGW, ProductInfo
 from nibe.heatpump import HeatPump, Model
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_MODEL,
@@ -30,7 +29,7 @@ from .const import (
     CONF_WORD_SWAP,
     DOMAIN,
 )
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -45,7 +44,9 @@ PLATFORMS: list[Platform] = [
 COIL_READ_RETRIES = 5
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: NibeHeatpumpConfigEntry
+) -> bool:
     """Set up Nibe Heat Pump from a config entry."""
 
     heatpump = HeatPump(Model[entry.data[CONF_MODEL]])
@@ -83,8 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = CoilCoordinator(hass, entry, heatpump, connection)
 
-    data = hass.data.setdefault(DOMAIN, {})
-    data[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     reg = dr.async_get(hass)
     device_entry = reg.async_get_or_create(
@@ -113,9 +113,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: NibeHeatpumpConfigEntry
+) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/nibe_heatpump/binary_sensor.py
+++ b/homeassistant/components/nibe_heatpump/binary_sensor.py
@@ -5,24 +5,22 @@ from __future__ import annotations
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 from .entity import CoilEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         BinarySensor(coordinator, coil)

--- a/homeassistant/components/nibe_heatpump/button.py
+++ b/homeassistant/components/nibe_heatpump/button.py
@@ -6,24 +6,23 @@ from nibe.coil_groups import UNIT_COILGROUPS, UnitCoilGroup
 from nibe.exceptions import CoilNotFoundException
 
 from homeassistant.components.button import ButtonEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, LOGGER
-from .coordinator import CoilCoordinator
+from .const import LOGGER
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     def reset_buttons():
         if unit := UNIT_COILGROUPS.get(coordinator.series, {}).get("main"):

--- a/homeassistant/components/nibe_heatpump/climate.py
+++ b/homeassistant/components/nibe_heatpump/climate.py
@@ -24,31 +24,29 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    DOMAIN,
     LOGGER,
     VALUES_COOL_WITH_ROOM_SENSOR_OFF,
     VALUES_MIXING_VALVE_CLOSED_STATE,
     VALUES_PRIORITY_COOLING,
     VALUES_PRIORITY_HEATING,
 )
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     main_unit = UNIT_COILGROUPS[coordinator.series]["main"]
 

--- a/homeassistant/components/nibe_heatpump/coordinator.py
+++ b/homeassistant/components/nibe_heatpump/coordinator.py
@@ -28,6 +28,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN, LOGGER
 
+type NibeHeatpumpConfigEntry = ConfigEntry[CoilCoordinator]
+
 
 class ContextCoordinator[_DataTypeT, _ContextTypeT](DataUpdateCoordinator[_DataTypeT]):
     """Update coordinator with context adjustments."""
@@ -73,12 +75,12 @@ class ContextCoordinator[_DataTypeT, _ContextTypeT](DataUpdateCoordinator[_DataT
 class CoilCoordinator(ContextCoordinator[dict[int, CoilData], int]):
     """Update coordinator for nibe heat pumps."""
 
-    config_entry: ConfigEntry
+    config_entry: NibeHeatpumpConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: NibeHeatpumpConfigEntry,
         heatpump: HeatPump,
         connection: Connection,
     ) -> None:

--- a/homeassistant/components/nibe_heatpump/number.py
+++ b/homeassistant/components/nibe_heatpump/number.py
@@ -5,24 +5,22 @@ from __future__ import annotations
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.number import ENTITY_ID_FORMAT, NumberEntity, NumberMode
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 from .entity import CoilEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         Number(coordinator, coil)

--- a/homeassistant/components/nibe_heatpump/select.py
+++ b/homeassistant/components/nibe_heatpump/select.py
@@ -5,24 +5,22 @@ from __future__ import annotations
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.select import ENTITY_ID_FORMAT, SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 from .entity import CoilEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         Select(coordinator, coil)

--- a/homeassistant/components/nibe_heatpump/sensor.py
+++ b/homeassistant/components/nibe_heatpump/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
@@ -28,8 +27,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 from .entity import CoilEntity
 
 UNIT_DESCRIPTIONS = {
@@ -185,12 +183,12 @@ UNIT_DESCRIPTIONS = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         Sensor(coordinator, coil, UNIT_DESCRIPTIONS.get(coil.unit))

--- a/homeassistant/components/nibe_heatpump/switch.py
+++ b/homeassistant/components/nibe_heatpump/switch.py
@@ -7,24 +7,22 @@ from typing import Any
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 from .entity import CoilEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         Switch(coordinator, coil)

--- a/homeassistant/components/nibe_heatpump/water_heater.py
+++ b/homeassistant/components/nibe_heatpump/water_heater.py
@@ -14,29 +14,27 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    DOMAIN,
     LOGGER,
     VALUES_TEMPORARY_LUX_INACTIVE,
     VALUES_TEMPORARY_LUX_ONE_TIME_INCREASE,
 )
-from .coordinator import CoilCoordinator
+from .coordinator import CoilCoordinator, NibeHeatpumpConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NibeHeatpumpConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform."""
 
-    coordinator: CoilCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     def water_heaters():
         for key, group in WATER_HEATER_COILGROUPS.get(coordinator.series, ()).items():


### PR DESCRIPTION
## Proposed change

Migrate the `nibe_heatpump` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator.

- Add `NibeHeatpumpConfigEntry` type alias in `coordinator.py`
- Update `__init__.py` to store the coordinator in `entry.runtime_data`
- Update all 8 platform files to read the coordinator from `config_entry.runtime_data`
- Simplify `async_unload_entry` by removing manual `hass.data` cleanup
- Remove unused `ConfigEntry` and `DOMAIN` imports from platform files

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr