### PR TITLE
Migrate openexchangerates to use runtime_data

### DIFF
--- a/homeassistant/components/openexchangerates/__init__.py
+++ b/homeassistant/components/openexchangerates/__init__.py
@@ -2,31 +2,28 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_BASE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import BASE_UPDATE_INTERVAL, DOMAIN, LOGGER
-from .coordinator import OpenexchangeratesCoordinator
+from .coordinator import OpenexchangeratesConfigEntry, OpenexchangeratesCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: OpenexchangeratesConfigEntry
+) -> bool:
     """Set up Open Exchange Rates from a config entry."""
     api_key: str = entry.data[CONF_API_KEY]
     base: str = entry.data[CONF_BASE]
 
     # Create one coordinator per base currency per API key.
-    existing_coordinators: dict[str, OpenexchangeratesCoordinator] = hass.data.get(
-        DOMAIN, {}
-    )
     existing_coordinator_for_api_key = {
-        existing_coordinator
-        for config_entry_id, existing_coordinator in existing_coordinators.items()
-        if (config_entry := hass.config_entries.async_get_entry(config_entry_id))
-        and config_entry.data[CONF_API_KEY] == api_key
+        existing_entry.runtime_data
+        for existing_entry in hass.config_entries.async_loaded_entries(DOMAIN)
+        if existing_entry.data[CONF_API_KEY] == api_key
     }
 
     # Adjust update interval by coordinators per API key.
@@ -48,16 +45,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: OpenexchangeratesConfigEntry
+) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/openexchangerates/coordinator.py
+++ b/homeassistant/components/openexchangerates/coordinator.py
@@ -20,16 +20,18 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import CLIENT_TIMEOUT, DOMAIN, LOGGER
 
+type OpenexchangeratesConfigEntry = ConfigEntry[OpenexchangeratesCoordinator]
+
 
 class OpenexchangeratesCoordinator(DataUpdateCoordinator[Latest]):
     """Represent a coordinator for Open Exchange Rates API."""
 
-    config_entry: ConfigEntry
+    config_entry: OpenexchangeratesConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: OpenexchangeratesConfigEntry,
         session: ClientSession,
         api_key: str,
         base: str,

--- a/homeassistant/components/openexchangerates/sensor.py
+++ b/homeassistant/components/openexchangerates/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_QUOTE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -11,19 +10,19 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import OpenexchangeratesCoordinator
+from .coordinator import OpenexchangeratesConfigEntry, OpenexchangeratesCoordinator
 
 ATTRIBUTION = "Data provided by openexchangerates.org"
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: OpenexchangeratesConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Open Exchange Rates sensor."""
     quote: str = config_entry.data.get(CONF_QUOTE, "EUR")
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         OpenexchangeratesSensor(
@@ -43,7 +42,7 @@ class OpenexchangeratesSensor(
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: OpenexchangeratesConfigEntry,
         coordinator: OpenexchangeratesCoordinator,
         quote: str,
         enabled: bool,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `openexchangerates` integration to use `runtime_data` on the config entry instead of storing the coordinator in `hass.data[DOMAIN]`.

- Add `OpenexchangeratesConfigEntry` type alias in `coordinator.py`
- Store coordinator in `entry.runtime_data` instead of `hass.data[DOMAIN]`
- Replace `hass.data.get(DOMAIN, {})` lookup with `hass.config_entries.async_loaded_entries(DOMAIN)` to find existing coordinators by API key
- Read coordinator from `config_entry.runtime_data` in `sensor.py`
- Simplify `async_unload_entry` by removing manual `hass.data` cleanup
- Remove unused `ConfigEntry` import from `sensor.py`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr