### PR TITLE
Bump aiopvpc to 4.3.1

### DIFF
--- a/homeassistant/components/pvpc_hourly_pricing/manifest.json
+++ b/homeassistant/components/pvpc_hourly_pricing/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aiopvpc"],
-  "requirements": ["aiopvpc==4.2.2"]
+  "requirements": ["aiopvpc==4.3.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -366,7 +366,7 @@ aiopurpleair==2025.08.1
 aiopvapi==3.3.0
 
 # homeassistant.components.pvpc_hourly_pricing
-aiopvpc==4.2.2
+aiopvpc==4.3.1
 
 # homeassistant.components.lidarr
 # homeassistant.components.radarr

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -351,7 +351,7 @@ aiopurpleair==2025.08.1
 aiopvapi==3.3.0
 
 # homeassistant.components.pvpc_hourly_pricing
-aiopvpc==4.2.2
+aiopvpc==4.3.1
 
 # homeassistant.components.lidarr
 # homeassistant.components.radarr


### PR DESCRIPTION
## Proposed change
Bumps `aiopvpc` from 4.2.2 to 4.3.1 to fix a `KeyError` 2026 in pvpc_hourly_pricing integration. This exception is thrown because of missing holiday mappings for the year 2026 in `aiopvpc` versions prior to 4.3.1.

`aiopvpc`  [CHANGELOG](https://github.com/azogue/aiopvpc/blob/master/CHANGELOG.md) / [diff](https://github.com/azogue/aiopvpc/compare/v4.2.2...v4.3.1) 

## Issue
`2026-04-02 12:07:07.515 ERROR (MainThread) [homeassistant.components.pvpc_hourly_pricing.coordinator] Unexpected error fetching pvpc_hourly_pricing data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 426, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/pvpc_hourly_pricing/coordinator.py", line 60, in _async_update_data
    api_data = await self.api.async_update_all(self.data, dt_util.utcnow())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/aiopvpc/pvpc_data.py", line 277, in async_update_all
    self.process_state_and_attributes(current_data, sensor_key, now)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/aiopvpc/pvpc_data.py", line 410, in process_state_and_attributes
    ) = get_current_and_next_tariff_periods(
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        local_time, zone_ceuta_melilla=self.tariff != TARIFFS[0]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/aiopvpc/pvpc_tariff.py", line 97, in get_current_and_next_tariff_periods
    current_period = _tariff_period_key(local_ts, zone_ceuta_melilla)
  File "/usr/local/lib/python3.14/site-packages/aiopvpc/pvpc_tariff.py", line 83, in _tariff_period_key
    national_holiday = day in _NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD[day.year]
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 2026
2026-04-02 12:07:07.517 INFO (MainThread) [homeassistant.config_entries] Config entry 'PVPC' for pvpc_hourly_pricing integration not ready yet: 2026; Retrying in 80 seconds`

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
