### PR TITLE
Propagate the in_zones attribute from device trackers in person entities

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.auth import EVENT_USER_REMOVED
 from homeassistant.components import persistent_notification, websocket_api
 from homeassistant.components.device_tracker import (
+    ATTR_IN_ZONES,
     ATTR_SOURCE_TYPE,
     DOMAIN as DEVICE_TRACKER_DOMAIN,
     SourceType,
@@ -435,6 +436,7 @@ class Person(
         self._unsub_track_device: Callable[[], None] | None = None
         self._attr_state: str | None = None
         self.device_trackers: list[str] = []
+        self._in_zones: list[str] = []
 
         self._attr_unique_id = config[CONF_ID]
         self._set_attrs_from_config()
@@ -552,6 +554,7 @@ class Person(
             self._latitude = None
             self._longitude = None
             self._gps_accuracy = None
+            self._in_zones = []
 
         self._update_extra_state_attributes()
         self.async_write_ha_state()
@@ -567,6 +570,7 @@ class Person(
         self._latitude = coordinates.attributes.get(ATTR_LATITUDE)
         self._longitude = coordinates.attributes.get(ATTR_LONGITUDE)
         self._gps_accuracy = coordinates.attributes.get(ATTR_GPS_ACCURACY)
+        self._in_zones = coordinates.attributes.get(ATTR_IN_ZONES, [])
 
     @callback
     def _update_extra_state_attributes(self) -> None:
@@ -575,6 +579,7 @@ class Person(
             ATTR_EDITABLE: self.editable,
             ATTR_ID: self.unique_id,
             ATTR_DEVICE_TRACKERS: self.device_trackers,
+            ATTR_IN_ZONES: self._in_zones,
         }
 
         if self._latitude is not None:

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -6,7 +6,11 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import person
-from homeassistant.components.device_tracker import ATTR_SOURCE_TYPE, SourceType
+from homeassistant.components.device_tracker import (
+    ATTR_IN_ZONES,
+    ATTR_SOURCE_TYPE,
+    SourceType,
+)
 from homeassistant.components.person import (
     ATTR_DEVICE_TRACKERS,
     ATTR_SOURCE,
@@ -119,6 +123,7 @@ async def test_setup_tracker(hass: HomeAssistant, hass_admin_user: MockUser) -> 
         ATTR_EDITABLE: False,
         ATTR_FRIENDLY_NAME: "tracked person",
         ATTR_ID: "1234",
+        ATTR_IN_ZONES: [],
         ATTR_USER_ID: user_id,
     }
 
@@ -223,10 +228,17 @@ async def test_setup_two_trackers(
     # gps_accuracy, but we want to assert that the person entity uses latitude
     # longitude and accuracy from the home zone, not from the state attributes
     # of the device tracker.
+    # Router tracker at home — person gets coordinates from the home zone,
+    # not from the router tracker. The router tracker has gps_accuracy=99
+    # and in_zones=["zone.fake"] to verify these are NOT propagated.
     hass.states.async_set(
         DEVICE_TRACKER,
         "home",
-        {ATTR_SOURCE_TYPE: SourceType.ROUTER, ATTR_GPS_ACCURACY: 99},
+        {
+            ATTR_SOURCE_TYPE: SourceType.ROUTER,
+            ATTR_GPS_ACCURACY: 99,
+            ATTR_IN_ZONES: ["zone.fake"],
+        },
     )
     await hass.async_block_till_done()
 
@@ -235,9 +247,10 @@ async def test_setup_two_trackers(
     assert state.attributes.get(ATTR_ID) == "1234"
     assert state.attributes.get(ATTR_LATITUDE) == 32.87336
     assert state.attributes.get(ATTR_LONGITUDE) == -117.22743
-    # GPS accuracy comes from the coordinates source (home zone), not from
-    # the state source (router tracker which reported gps_accuracy=99).
+    # GPS accuracy and in_zones come from the coordinates source (home zone),
+    # not from the state source (router tracker).
     assert state.attributes.get(ATTR_GPS_ACCURACY) is None
+    assert state.attributes.get(ATTR_IN_ZONES) == []
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
     assert state.attributes.get(ATTR_USER_ID) == user_id
     assert state.attributes.get(ATTR_DEVICE_TRACKERS) == [
@@ -252,6 +265,7 @@ async def test_setup_two_trackers(
             ATTR_LATITUDE: 12.123456,
             ATTR_LONGITUDE: 13.123456,
             ATTR_GPS_ACCURACY: 12,
+            ATTR_IN_ZONES: ["zone.work"],
             ATTR_SOURCE_TYPE: SourceType.GPS,
         },
     )
@@ -267,6 +281,7 @@ async def test_setup_two_trackers(
     assert state.attributes.get(ATTR_LATITUDE) == 12.123456
     assert state.attributes.get(ATTR_LONGITUDE) == 13.123456
     assert state.attributes.get(ATTR_GPS_ACCURACY) == 12
+    assert state.attributes.get(ATTR_IN_ZONES) == ["zone.work"]
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER_2
     assert state.attributes.get(ATTR_USER_ID) == user_id
     assert state.attributes.get(ATTR_DEVICE_TRACKERS) == [
@@ -346,6 +361,7 @@ async def test_setup_router_ble_trackers(
             ATTR_LATITUDE: 12.123456,
             ATTR_LONGITUDE: 13.123456,
             ATTR_GPS_ACCURACY: 12,
+            ATTR_IN_ZONES: ["zone.office"],
             ATTR_SOURCE_TYPE: SourceType.BLUETOOTH_LE,
         },
     )
@@ -358,6 +374,7 @@ async def test_setup_router_ble_trackers(
     assert state.attributes.get(ATTR_LATITUDE) == 12.123456
     assert state.attributes.get(ATTR_LONGITUDE) == 13.123456
     assert state.attributes.get(ATTR_GPS_ACCURACY) == 12
+    assert state.attributes.get(ATTR_IN_ZONES) == ["zone.office"]
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER_2
     assert state.attributes.get(ATTR_USER_ID) == user_id
     assert state.attributes.get(ATTR_DEVICE_TRACKERS) == [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Propagate the `in_zones` attribute from device trackers in person entities

The `in_zones` attribute was added to device trackers by PR #166573

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
