### PR TITLE
Tessie: use Vehicle methods for button commands

### DIFF
--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -91,6 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
         vehicle_api = tessie.vehicles.create(vin)
         vehicles.append(
             TessieVehicleData(
+                api=vehicle_api,
                 vin=vin,
                 data_coordinator=TessieStateUpdateCoordinator(
                     hass,

--- a/homeassistant/components/tessie/button.py
+++ b/homeassistant/components/tessie/button.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 
-from tessie_api import (
-    boombox,
-    enable_keyless_driving,
-    flash_lights,
-    honk,
-    trigger_homelink,
-    wake,
-)
+from tesla_fleet_api.tessie import Vehicle
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -29,21 +23,22 @@ PARALLEL_UPDATES = 0
 class TessieButtonEntityDescription(ButtonEntityDescription):
     """Describes a Tessie Button entity."""
 
-    func: Callable
+    func: Callable[[Vehicle], Awaitable[dict[str, Any]]]
 
 
 DESCRIPTIONS: tuple[TessieButtonEntityDescription, ...] = (
-    TessieButtonEntityDescription(key="wake", func=lambda: wake),
-    TessieButtonEntityDescription(key="flash_lights", func=lambda: flash_lights),
-    TessieButtonEntityDescription(key="honk", func=lambda: honk),
+    TessieButtonEntityDescription(key="wake", func=lambda api: api.wake()),
+    TessieButtonEntityDescription(key="flash_lights", func=lambda api: api.flash()),
+    TessieButtonEntityDescription(key="honk", func=lambda api: api.honk()),
     TessieButtonEntityDescription(
-        key="trigger_homelink", func=lambda: trigger_homelink
+        key="trigger_homelink",
+        func=lambda api: api.tessie_trigger_homelink(),
     ),
     TessieButtonEntityDescription(
         key="enable_keyless_driving",
-        func=lambda: enable_keyless_driving,
+        func=lambda api: api.remote_start(),
     ),
-    TessieButtonEntityDescription(key="boombox", func=lambda: boombox),
+    TessieButtonEntityDescription(key="boombox", func=lambda api: api.remote_boombox()),
 )
 
 
@@ -78,4 +73,4 @@ class TessieButtonEntity(TessieEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self.run(self.entity_description.func())
+        await self.run(self.entity_description.func(self.api))

--- a/homeassistant/components/tessie/entity.py
+++ b/homeassistant/components/tessie/entity.py
@@ -77,6 +77,7 @@ class TessieEntity(TessieBaseEntity):
         data_key: str | None = None,
     ) -> None:
         """Initialize common aspects of a Tessie vehicle entity."""
+        self.api = vehicle.api
         self.vin = vehicle.vin
         self._session = vehicle.data_coordinator.session
         self._api_key = vehicle.data_coordinator.api_key

--- a/homeassistant/components/tessie/helpers.py
+++ b/homeassistant/components/tessie/helpers.py
@@ -16,6 +16,11 @@ async def handle_command(command: Awaitable[dict[str, Any]]) -> dict[str, Any]:
     """Handle an awaitable Vehicle/EnergySite command."""
     try:
         result = await command
+    except ClientError as e:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from e
     except TeslaFleetError as e:
         raise HomeAssistantError(
             translation_domain=DOMAIN,

--- a/homeassistant/components/tessie/models.py
+++ b/homeassistant/components/tessie/models.py
@@ -40,7 +40,7 @@ class TessieEnergyData:
 class TessieVehicleData:
     """Data for a Tessie vehicle."""
 
+    api: Vehicle
     data_coordinator: TessieStateUpdateCoordinator
     device: DeviceInfo
     vin: str
-    api: Vehicle | None = None

--- a/tests/components/tessie/test_button.py
+++ b/tests/components/tessie/test_button.py
@@ -23,14 +23,14 @@ async def test_buttons(
 
     for entity_id, func in (
         ("button.test_wake", "wake"),
-        ("button.test_flash_lights", "flash_lights"),
+        ("button.test_flash_lights", "flash"),
         ("button.test_honk_horn", "honk"),
-        ("button.test_homelink", "trigger_homelink"),
-        ("button.test_keyless_driving", "enable_keyless_driving"),
-        ("button.test_play_fart", "boombox"),
+        ("button.test_homelink", "tessie_trigger_homelink"),
+        ("button.test_keyless_driving", "remote_start"),
+        ("button.test_play_fart", "remote_boombox"),
     ):
         with patch(
-            f"homeassistant.components.tessie.button.{func}",
+            f"tesla_fleet_api.tessie.Vehicle.{func}",
         ) as mock_press:
             await hass.services.async_call(
                 BUTTON_DOMAIN,

--- a/tests/components/tessie/test_button.py
+++ b/tests/components/tessie/test_button.py
@@ -2,14 +2,16 @@
 
 from unittest.mock import patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import assert_entities, setup_platform
+from .common import ERROR_UNKNOWN, assert_entities, setup_platform
 
 
 async def test_buttons(
@@ -39,3 +41,28 @@ async def test_buttons(
                 blocking=True,
             )
             mock_press.assert_called_once()
+
+
+async def test_button_error(hass: HomeAssistant) -> None:
+    """Test button transport errors are translated."""
+
+    await setup_platform(hass, [Platform.BUTTON])
+
+    with (
+        patch(
+            "tesla_fleet_api.tessie.Vehicle.wake",
+            side_effect=ERROR_UNKNOWN,
+        ) as mock_press,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: ["button.test_wake"]},
+            blocking=True,
+        )
+
+    mock_press.assert_called_once()
+    assert error.value.__cause__ == ERROR_UNKNOWN
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -25,13 +25,6 @@ async def test_load_unload(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_runtime_vehicle_api_handle_is_optional(hass: HomeAssistant) -> None:
-    """Test the runtime vehicle API handle remains optional during migration."""
-
-    entry = await setup_platform(hass)
-    assert all(vehicle.api is None for vehicle in entry.runtime_data.vehicles)
-
-
 async def test_auth_failure(
     hass: HomeAssistant, mock_get_state_of_all_vehicles: AsyncMock
 ) -> None:
@@ -81,13 +74,3 @@ async def test_scopes_error(hass: HomeAssistant) -> None:
     ):
         entry = await setup_platform(hass)
         assert entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_vehicle_api_handle_is_optional(hass: HomeAssistant) -> None:
-    """Test runtime vehicle API handle defaults to None during scaffold stage."""
-
-    entry = await setup_platform(hass)
-    assert entry.state is ConfigEntryState.LOADED
-    vehicles = entry.runtime_data.vehicles
-    assert vehicles
-    assert all(vehicle.api is None for vehicle in vehicles)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Store a `tesla_fleet_api.tessie.Vehicle` client in Tessie vehicle runtime data and route button entities through the corresponding `Vehicle` methods instead of the legacy module-level `tessie_api` helpers. Update the button tests to patch `tesla_fleet_api.tessie.Vehicle.*` directly so the exercised command path matches the integration implementation.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
