### PR TITLE
Migrate qbittorrent to use runtime_data

### DIFF
--- a/homeassistant/components/qbittorrent/__init__.py
+++ b/homeassistant/components/qbittorrent/__init__.py
@@ -96,7 +96,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     ) -> dict[str, Any] | None:
         torrents = {}
 
-        for entry in hass.config_entries.async_entries(DOMAIN):
+        for entry in hass.config_entries.async_loaded_entries(DOMAIN):
             coordinator: QBittorrentDataCoordinator = entry.runtime_data
             items = await coordinator.get_torrents(service_call.data[TORRENT_FILTER])
             torrents[entry.entry_id] = format_torrents(items)

--- a/homeassistant/components/qbittorrent/__init__.py
+++ b/homeassistant/components/qbittorrent/__init__.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from qbittorrentapi import APIConnectionError, Forbidden403Error, LoginFailed
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_DEVICE_ID,
     CONF_PASSWORD,
@@ -27,7 +26,7 @@ from .const import (
     STATE_ATTR_TORRENTS,
     TORRENT_FILTER,
 )
-from .coordinator import QBittorrentDataCoordinator
+from .coordinator import QBittorrentConfigEntry, QBittorrentDataCoordinator
 from .helpers import format_torrents, setup_client
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,7 +67,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 translation_placeholders={"device_id": entry_id or ""},
             )
 
-        coordinator: QBittorrentDataCoordinator = hass.data[DOMAIN][entry_id]
+        entry: QBittorrentConfigEntry | None = hass.config_entries.async_get_entry(
+            entry_id
+        )
+        if entry is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_entry_id",
+                translation_placeholders={"device_id": entry_id},
+            )
+        coordinator: QBittorrentDataCoordinator = entry.runtime_data
         items = await coordinator.get_torrents(service_call.data[TORRENT_FILTER])
         info = format_torrents(items)
         return {
@@ -87,10 +95,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     ) -> dict[str, Any] | None:
         torrents = {}
 
-        for key, value in hass.data[DOMAIN].items():
-            coordinator: QBittorrentDataCoordinator = value
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            coordinator: QBittorrentDataCoordinator = entry.runtime_data
             items = await coordinator.get_torrents(service_call.data[TORRENT_FILTER])
-            torrents[key] = format_torrents(items)
+            torrents[entry.entry_id] = format_torrents(items)
 
         return {
             STATE_ATTR_ALL_TORRENTS: torrents,
@@ -106,7 +114,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: QBittorrentConfigEntry
+) -> bool:
     """Set up qBittorrent from a config entry."""
 
     try:
@@ -127,19 +137,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     coordinator = QBittorrentDataCoordinator(hass, config_entry, client)
 
     await coordinator.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
+    config_entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, config_entry: QBittorrentConfigEntry
+) -> bool:
     """Unload qBittorrent config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(
-        config_entry, PLATFORMS
-    ):
-        del hass.data[DOMAIN][config_entry.entry_id]
-        if not hass.data[DOMAIN]:
-            del hass.data[DOMAIN]
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/qbittorrent/__init__.py
+++ b/homeassistant/components/qbittorrent/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from qbittorrentapi import APIConnectionError, Forbidden403Error, LoginFailed
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_ID,
     CONF_PASSWORD,
@@ -70,13 +71,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         entry: QBittorrentConfigEntry | None = hass.config_entries.async_get_entry(
             entry_id
         )
-        if entry is None:
+        if entry is None or entry.state != ConfigEntryState.LOADED:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="invalid_entry_id",
                 translation_placeholders={"device_id": entry_id},
             )
-        coordinator: QBittorrentDataCoordinator = entry.runtime_data
+        coordinator = entry.runtime_data
         items = await coordinator.get_torrents(service_call.data[TORRENT_FILTER])
         info = format_torrents(items)
         return {

--- a/homeassistant/components/qbittorrent/coordinator.py
+++ b/homeassistant/components/qbittorrent/coordinator.py
@@ -24,14 +24,16 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+type QBittorrentConfigEntry = ConfigEntry[QBittorrentDataCoordinator]
+
 
 class QBittorrentDataCoordinator(DataUpdateCoordinator[SyncMainDataDictionary]):
     """Coordinator for updating QBittorrent data."""
 
-    config_entry: ConfigEntry
+    config_entry: QBittorrentConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, client: Client
+        self, hass: HomeAssistant, config_entry: QBittorrentConfigEntry, client: Client
     ) -> None:
         """Initialize coordinator."""
         self.client = client

--- a/homeassistant/components/qbittorrent/sensor.py
+++ b/homeassistant/components/qbittorrent/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_IDLE, UnitOfDataRate, UnitOfInformation
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -22,7 +21,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, STATE_DOWNLOADING, STATE_SEEDING, STATE_UP_DOWN
-from .coordinator import QBittorrentDataCoordinator
+from .coordinator import QBittorrentConfigEntry, QBittorrentDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -236,12 +235,12 @@ SENSOR_TYPES: tuple[QBittorrentSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: QBittorrentConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up qBittorrent sensor entries."""
 
-    coordinator: QBittorrentDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         QBittorrentSensor(coordinator, config_entry, description)
@@ -258,7 +257,7 @@ class QBittorrentSensor(CoordinatorEntity[QBittorrentDataCoordinator], SensorEnt
     def __init__(
         self,
         coordinator: QBittorrentDataCoordinator,
-        config_entry: ConfigEntry,
+        config_entry: QBittorrentConfigEntry,
         entity_description: QBittorrentSensorEntityDescription,
     ) -> None:
         """Initialize the qBittorrent sensor."""

--- a/homeassistant/components/qbittorrent/switch.py
+++ b/homeassistant/components/qbittorrent/switch.py
@@ -7,14 +7,13 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import QBittorrentDataCoordinator
+from .coordinator import QBittorrentConfigEntry, QBittorrentDataCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -42,12 +41,12 @@ SWITCH_TYPES: tuple[QBittorrentSwitchEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: QBittorrentConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up qBittorrent switch entries."""
 
-    coordinator: QBittorrentDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         QBittorrentSwitch(coordinator, config_entry, description)
@@ -64,7 +63,7 @@ class QBittorrentSwitch(CoordinatorEntity[QBittorrentDataCoordinator], SwitchEnt
     def __init__(
         self,
         coordinator: QBittorrentDataCoordinator,
-        config_entry: ConfigEntry,
+        config_entry: QBittorrentConfigEntry,
         entity_description: QBittorrentSwitchEntityDescription,
     ) -> None:
         """Initialize qBittorrent switch."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the qbittorrent integration to use `config_entry.runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

Changes:
- Add `QBittorrentConfigEntry` type alias in `coordinator.py`
- Update `__init__.py`, `sensor.py`, and `switch.py` to use `config_entry.runtime_data`
- Remove manual `hass.data` cleanup from `async_unload_entry`
- Update service handlers to use `config_entries.async_get_entry()` and `entry.runtime_data`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr