### PR TITLE
Add device_tracker triggers left_zone and entered_zone

### DIFF
--- a/homeassistant/components/device_tracker/icons.json
+++ b/homeassistant/components/device_tracker/icons.json
@@ -24,8 +24,14 @@
     "entered_home": {
       "trigger": "mdi:account-arrow-left"
     },
+    "entered_zone": {
+      "trigger": "mdi:map-marker-plus"
+    },
     "left_home": {
       "trigger": "mdi:account-arrow-right"
+    },
+    "left_zone": {
+      "trigger": "mdi:map-marker-minus"
     }
   }
 }

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -130,6 +130,19 @@
       },
       "name": "Entered home"
     },
+    "entered_zone": {
+      "description": "Triggers when one or more device trackers enter a zone.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::device_tracker::common::trigger_behavior_name%]"
+        },
+        "zone": {
+          "description": "The zones to trigger on.",
+          "name": "Zones"
+        }
+      },
+      "name": "Entered zone"
+    },
     "left_home": {
       "description": "Triggers when one or more device trackers leave home.",
       "fields": {
@@ -138,6 +151,19 @@
         }
       },
       "name": "Left home"
+    },
+    "left_zone": {
+      "description": "Triggers when one or more device trackers leave a zone.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::device_tracker::common::trigger_behavior_name%]"
+        },
+        "zone": {
+          "description": "The zones to trigger on.",
+          "name": "Zones"
+        }
+      },
+      "name": "Left zone"
     }
   }
 }

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "condition_behavior_name": "Condition passes if",
-    "trigger_behavior_name": "Trigger when"
+    "trigger_behavior_name": "Trigger when",
+    "trigger_zone_description": "The zones to trigger on.",
+    "trigger_zone_name": "Zone"
   },
   "conditions": {
     "is_home": {
@@ -137,8 +139,8 @@
           "name": "[%key:component::device_tracker::common::trigger_behavior_name%]"
         },
         "zone": {
-          "description": "The zones to trigger on.",
-          "name": "Zones"
+          "description": "[%key:component::device_tracker::common::trigger_zone_description%]",
+          "name": "[%key:component::device_tracker::common::trigger_zone_name%]"
         }
       },
       "name": "Entered zone"
@@ -159,8 +161,8 @@
           "name": "[%key:component::device_tracker::common::trigger_behavior_name%]"
         },
         "zone": {
-          "description": "The zones to trigger on.",
-          "name": "Zones"
+          "description": "[%key:component::device_tracker::common::trigger_zone_description%]",
+          "name": "[%key:component::device_tracker::common::trigger_zone_name%]"
         }
       },
       "name": "Left zone"

--- a/homeassistant/components/device_tracker/trigger.py
+++ b/homeassistant/components/device_tracker/trigger.py
@@ -1,18 +1,93 @@
 """Provides triggers for device_trackers."""
 
-from homeassistant.const import STATE_HOME
-from homeassistant.core import HomeAssistant
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_OPTIONS,
+    CONF_ZONE,
+    STATE_HOME,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
+    ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    EntityTriggerBase,
     Trigger,
+    TriggerConfig,
     make_entity_origin_state_trigger,
     make_entity_target_state_trigger,
 )
 
-from .const import DOMAIN
+from .const import ATTR_IN_ZONES, DOMAIN
+
+ZONE_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_ZONE): vol.All(
+                cv.ensure_list,
+                vol.Length(min=1),
+                [cv.entity_domain("zone")],
+            ),
+        },
+    }
+)
+
+_IN_ZONES_SPEC = {DOMAIN: DomainSpec(value_source=ATTR_IN_ZONES)}
+
+
+class ZoneTriggerBase(EntityTriggerBase):
+    """Base for zone-based device tracker triggers."""
+
+    _domain_specs = _IN_ZONES_SPEC
+    _schema = ZONE_TRIGGER_SCHEMA
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        self._zones: set[str] = set(self._options[CONF_ZONE])
+
+    def _is_valid(self, state: State) -> bool:
+        """Check if the state is valid (not unavailable/unknown)."""
+        return state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+
+    def _in_target_zones(self, state: State) -> bool:
+        """Check if the device is in any of the selected zones."""
+        in_zones = set(self._get_tracked_value(state) or [])
+        return bool(in_zones.intersection(self._zones))
+
+
+class EnteredZoneTrigger(ZoneTriggerBase):
+    """Trigger when a device tracker enters one of the selected zones."""
+
+    def is_valid_transition(self, from_state: State, to_state: State) -> bool:
+        """Check that the device was not already in any of the selected zones."""
+        return self._is_valid(from_state) and not self._in_target_zones(from_state)
+
+    def is_valid_state(self, state: State) -> bool:
+        """Check that the device is now in at least one of the selected zones."""
+        return self._is_valid(state) and self._in_target_zones(state)
+
+
+class LeftZoneTrigger(ZoneTriggerBase):
+    """Trigger when a device tracker leaves all of the selected zones."""
+
+    def is_valid_transition(self, from_state: State, to_state: State) -> bool:
+        """Check that the device was previously in at least one of the selected zones."""
+        return self._is_valid(from_state) and self._in_target_zones(from_state)
+
+    def is_valid_state(self, state: State) -> bool:
+        """Check that the device is no longer in any of the selected zones."""
+        return self._is_valid(state) and not self._in_target_zones(state)
+
 
 TRIGGERS: dict[str, type[Trigger]] = {
     "entered_home": make_entity_target_state_trigger(DOMAIN, STATE_HOME),
+    "entered_zone": EnteredZoneTrigger,
     "left_home": make_entity_origin_state_trigger(DOMAIN, from_state=STATE_HOME),
+    "left_zone": LeftZoneTrigger,
 }
 
 

--- a/homeassistant/components/device_tracker/trigger.py
+++ b/homeassistant/components/device_tracker/trigger.py
@@ -2,6 +2,7 @@
 
 import voluptuous as vol
 
+from homeassistant.components.zone import ENTITY_ID_HOME as ENTITY_ID_HOME_ZONE
 from homeassistant.const import (
     CONF_OPTIONS,
     CONF_ZONE,
@@ -54,9 +55,18 @@ class ZoneTriggerBase(EntityTriggerBase):
         return state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
 
     def _in_target_zones(self, state: State) -> bool:
-        """Check if the device is in any of the selected zones."""
-        in_zones = set(self._get_tracked_value(state) or [])
-        return bool(in_zones.intersection(self._zones))
+        """Check if the device is in any of the selected zones.
+
+        For GPS-based trackers, uses the in_zones attribute.
+        For scanner-based trackers (no in_zones attribute), infers from
+        state: 'home' means the device is in zone.home.
+        """
+        if (in_zones := self._get_tracked_value(state)) is not None:
+            return bool(set(in_zones).intersection(self._zones))
+        # Scanner tracker: state 'home' means in zone.home
+        if state.state == STATE_HOME:
+            return ENTITY_ID_HOME_ZONE in self._zones
+        return False
 
 
 class EnteredZoneTrigger(ZoneTriggerBase):

--- a/homeassistant/components/device_tracker/triggers.yaml
+++ b/homeassistant/components/device_tracker/triggers.yaml
@@ -14,5 +14,27 @@
             - any
           translation_key: trigger_behavior
 
+.trigger_zone: &trigger_zone
+  <<: *trigger_common
+  fields:
+    behavior:
+      required: true
+      default: any
+      selector:
+        select:
+          options:
+            - first
+            - last
+            - any
+          translation_key: trigger_behavior
+    zone:
+      required: true
+      selector:
+        entity:
+          domain: zone
+          multiple: true
+
 entered_home: *trigger_common
+entered_zone: *trigger_zone
 left_home: *trigger_common
+left_zone: *trigger_zone

--- a/tests/components/device_tracker/test_trigger.py
+++ b/tests/components/device_tracker/test_trigger.py
@@ -1,11 +1,22 @@
 """Test device_tracker trigger."""
 
+from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from typing import Any
 
 import pytest
+import voluptuous as vol
 
-from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.components.device_tracker.const import ATTR_IN_ZONES
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    CONF_OPTIONS,
+    CONF_TARGET,
+    CONF_ZONE,
+    STATE_HOME,
+    STATE_NOT_HOME,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.trigger import async_validate_trigger_config
 
 from tests.components.common import (
     TriggerStateDescription,
@@ -21,6 +32,51 @@ from tests.components.common import (
 STATE_WORK_ZONE = "work"
 
 
+def _dt_state(state: str, in_zones: list[str]) -> tuple[str, dict[str, list[str]]]:
+    """Create a device tracker state tuple with in_zones attribute."""
+    return (state, {ATTR_IN_ZONES: in_zones})
+
+
+ZONE_TRIGGERS = [
+    *parametrize_trigger_states(
+        trigger="device_tracker.entered_zone",
+        trigger_options={CONF_ZONE: ["zone.home", "zone.work"]},
+        target_states=[
+            # In zone.home
+            _dt_state(STATE_HOME, ["zone.home"]),
+            # In zone.work
+            _dt_state(STATE_WORK_ZONE, ["zone.work"]),
+            # In both zones
+            _dt_state(STATE_HOME, ["zone.home", "zone.work"]),
+        ],
+        other_states=[
+            # Not in any selected zone
+            _dt_state(STATE_NOT_HOME, []),
+            # In an unrelated zone
+            _dt_state("school", ["zone.school"]),
+        ],
+    ),
+    *parametrize_trigger_states(
+        trigger="device_tracker.left_zone",
+        trigger_options={CONF_ZONE: ["zone.home", "zone.work"]},
+        target_states=[
+            # Not in any selected zone
+            _dt_state(STATE_NOT_HOME, []),
+            # In an unrelated zone only
+            _dt_state("school", ["zone.school"]),
+        ],
+        other_states=[
+            # In zone.home
+            _dt_state(STATE_HOME, ["zone.home"]),
+            # In zone.work
+            _dt_state(STATE_WORK_ZONE, ["zone.work"]),
+            # In both zones
+            _dt_state(STATE_HOME, ["zone.home", "zone.work"]),
+        ],
+    ),
+]
+
+
 @pytest.fixture
 async def target_device_trackers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple device_trackers entities associated with different targets."""
@@ -29,7 +85,12 @@ async def target_device_trackers(hass: HomeAssistant) -> dict[str, list[str]]:
 
 @pytest.mark.parametrize(
     "trigger_key",
-    ["device_tracker.entered_home", "device_tracker.left_home"],
+    [
+        "device_tracker.entered_home",
+        "device_tracker.entered_zone",
+        "device_tracker.left_home",
+        "device_tracker.left_zone",
+    ],
 )
 async def test_device_tracker_triggers_gated_by_labs_flag(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, trigger_key: str
@@ -155,6 +216,152 @@ async def test_device_tracker_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test that the device_tracker home triggers when the last device_tracker changes to a specific state."""
+    await assert_trigger_behavior_last(
+        hass,
+        target_entities=target_device_trackers,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "expected_result"),
+    [
+        # Valid configurations
+        (
+            "device_tracker.entered_zone",
+            {CONF_ZONE: ["zone.home", "zone.work"]},
+            does_not_raise(),
+        ),
+        (
+            "device_tracker.entered_zone",
+            {CONF_ZONE: "zone.home"},
+            does_not_raise(),
+        ),
+        (
+            "device_tracker.left_zone",
+            {CONF_ZONE: ["zone.home"]},
+            does_not_raise(),
+        ),
+        # Invalid configurations
+        (
+            "device_tracker.entered_zone",
+            {CONF_ZONE: []},
+            pytest.raises(vol.Invalid),
+        ),
+        (
+            "device_tracker.entered_zone",
+            {},
+            pytest.raises(vol.Invalid),
+        ),
+        (
+            "device_tracker.entered_zone",
+            # Not a zone entity
+            {CONF_ZONE: ["light.living_room"]},
+            pytest.raises(vol.Invalid),
+        ),
+    ],
+)
+async def test_device_tracker_zone_trigger_validation(
+    hass: HomeAssistant,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    expected_result: AbstractContextManager,
+) -> None:
+    """Test device_tracker zone trigger config validation."""
+    with expected_result:
+        await async_validate_trigger_config(
+            hass,
+            [
+                {
+                    "platform": trigger,
+                    CONF_TARGET: {CONF_ENTITY_ID: "device_tracker.test"},
+                    CONF_OPTIONS: trigger_options,
+                }
+            ],
+        )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("device_tracker"),
+)
+@pytest.mark.parametrize(("trigger", "trigger_options", "states"), ZONE_TRIGGERS)
+async def test_device_tracker_zone_trigger_behavior_any(
+    hass: HomeAssistant,
+    target_device_trackers: dict[str, list[str]],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the zone triggers fire when any device_tracker enters/leaves a zone."""
+    await assert_trigger_behavior_any(
+        hass,
+        target_entities=target_device_trackers,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("device_tracker"),
+)
+@pytest.mark.parametrize(("trigger", "trigger_options", "states"), ZONE_TRIGGERS)
+async def test_device_tracker_zone_trigger_behavior_first(
+    hass: HomeAssistant,
+    target_device_trackers: dict[str, list[str]],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the zone triggers fire when the first device_tracker enters/leaves a zone."""
+    await assert_trigger_behavior_first(
+        hass,
+        target_entities=target_device_trackers,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("device_tracker"),
+)
+@pytest.mark.parametrize(("trigger", "trigger_options", "states"), ZONE_TRIGGERS)
+async def test_device_tracker_zone_trigger_behavior_last(
+    hass: HomeAssistant,
+    target_device_trackers: dict[str, list[str]],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the zone triggers fire when the last device_tracker enters/leaves a zone."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_device_trackers,

--- a/tests/components/device_tracker/test_trigger.py
+++ b/tests/components/device_tracker/test_trigger.py
@@ -32,28 +32,29 @@ from tests.components.common import (
 STATE_WORK_ZONE = "work"
 
 
-def _dt_state(state: str, in_zones: list[str]) -> tuple[str, dict[str, list[str]]]:
-    """Create a device tracker state tuple with in_zones attribute."""
+def _gps_state(state: str, in_zones: list[str]) -> tuple[str, dict[str, list[str]]]:
+    """Create a GPS-based device tracker state with in_zones attribute."""
     return (state, {ATTR_IN_ZONES: in_zones})
 
 
-ZONE_TRIGGERS = [
+# Zone triggers for GPS-based trackers (have in_zones attribute)
+GPS_ZONE_TRIGGERS = [
     *parametrize_trigger_states(
         trigger="device_tracker.entered_zone",
         trigger_options={CONF_ZONE: ["zone.home", "zone.work"]},
         target_states=[
             # In zone.home
-            _dt_state(STATE_HOME, ["zone.home"]),
+            _gps_state(STATE_HOME, ["zone.home"]),
             # In zone.work
-            _dt_state(STATE_WORK_ZONE, ["zone.work"]),
+            _gps_state(STATE_WORK_ZONE, ["zone.work"]),
             # In both zones
-            _dt_state(STATE_HOME, ["zone.home", "zone.work"]),
+            _gps_state(STATE_HOME, ["zone.home", "zone.work"]),
         ],
         other_states=[
             # Not in any selected zone
-            _dt_state(STATE_NOT_HOME, []),
+            _gps_state(STATE_NOT_HOME, []),
             # In an unrelated zone
-            _dt_state("school", ["zone.school"]),
+            _gps_state("school", ["zone.school"]),
         ],
     ),
     *parametrize_trigger_states(
@@ -61,17 +62,42 @@ ZONE_TRIGGERS = [
         trigger_options={CONF_ZONE: ["zone.home", "zone.work"]},
         target_states=[
             # Not in any selected zone
-            _dt_state(STATE_NOT_HOME, []),
+            _gps_state(STATE_NOT_HOME, []),
             # In an unrelated zone only
-            _dt_state("school", ["zone.school"]),
+            _gps_state("school", ["zone.school"]),
         ],
         other_states=[
             # In zone.home
-            _dt_state(STATE_HOME, ["zone.home"]),
+            _gps_state(STATE_HOME, ["zone.home"]),
             # In zone.work
-            _dt_state(STATE_WORK_ZONE, ["zone.work"]),
+            _gps_state(STATE_WORK_ZONE, ["zone.work"]),
             # In both zones
-            _dt_state(STATE_HOME, ["zone.home", "zone.work"]),
+            _gps_state(STATE_HOME, ["zone.home", "zone.work"]),
+        ],
+    ),
+]
+
+# Zone triggers for scanner-based trackers (no in_zones attribute,
+# state is 'home' or 'not_home')
+SCANNER_ZONE_TRIGGERS = [
+    *parametrize_trigger_states(
+        trigger="device_tracker.entered_zone",
+        trigger_options={CONF_ZONE: ["zone.home"]},
+        target_states=[
+            STATE_HOME,
+        ],
+        other_states=[
+            STATE_NOT_HOME,
+        ],
+    ),
+    *parametrize_trigger_states(
+        trigger="device_tracker.left_zone",
+        trigger_options={CONF_ZONE: ["zone.home"]},
+        target_states=[
+            STATE_NOT_HOME,
+        ],
+        other_states=[
+            STATE_HOME,
         ],
     ),
 ]
@@ -292,7 +318,10 @@ async def test_device_tracker_zone_trigger_validation(
     ("trigger_target_config", "entity_id", "entities_in_target"),
     parametrize_target_entities("device_tracker"),
 )
-@pytest.mark.parametrize(("trigger", "trigger_options", "states"), ZONE_TRIGGERS)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [*GPS_ZONE_TRIGGERS, *SCANNER_ZONE_TRIGGERS],
+)
 async def test_device_tracker_zone_trigger_behavior_any(
     hass: HomeAssistant,
     target_device_trackers: dict[str, list[str]],
@@ -321,7 +350,10 @@ async def test_device_tracker_zone_trigger_behavior_any(
     ("trigger_target_config", "entity_id", "entities_in_target"),
     parametrize_target_entities("device_tracker"),
 )
-@pytest.mark.parametrize(("trigger", "trigger_options", "states"), ZONE_TRIGGERS)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [*GPS_ZONE_TRIGGERS, *SCANNER_ZONE_TRIGGERS],
+)
 async def test_device_tracker_zone_trigger_behavior_first(
     hass: HomeAssistant,
     target_device_trackers: dict[str, list[str]],
@@ -350,7 +382,10 @@ async def test_device_tracker_zone_trigger_behavior_first(
     ("trigger_target_config", "entity_id", "entities_in_target"),
     parametrize_target_entities("device_tracker"),
 )
-@pytest.mark.parametrize(("trigger", "trigger_options", "states"), ZONE_TRIGGERS)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [*GPS_ZONE_TRIGGERS, *SCANNER_ZONE_TRIGGERS],
+)
 async def test_device_tracker_zone_trigger_behavior_last(
     hass: HomeAssistant,
     target_device_trackers: dict[str, list[str]],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add device_tracker triggers `device_tracker.left_zone` and `device_tracker.entered_zone`

Scanner entities support only the home zone

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes https://github.com/home-assistant/core/issues/158403
  - fixes https://github.com/home-assistant/core/issues/158404
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
