### PR TITLE
Add Installation Mode fallback for JVC N-Series and allow custom remote commands

### DIFF
--- a/homeassistant/components/jvc_projector/remote.py
+++ b/homeassistant/components/jvc_projector/remote.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 import logging
 from typing import Any
 
-from jvcprojector import command as cmd
+from .jvcprojector import command as cmd
 
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.core import HomeAssistant
@@ -111,9 +111,6 @@ class JvcProjectorRemote(JvcProjectorEntity, RemoteEntity):
             # Legacy name fixup
             if "_" in send_command:
                 send_command = send_command.replace("_", "-")
-
-            if send_command not in COMMANDS:
-                raise HomeAssistantError(f"{send_command} is not a known command")
 
             _LOGGER.debug("Sending command '%s'", send_command)
             await self.device.remote(send_command)

--- a/homeassistant/components/jvc_projector/remote.py
+++ b/homeassistant/components/jvc_projector/remote.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import JVCConfigEntry
 from .entity import JvcProjectorEntity
-from .jvcprojector import command as cmd
+from jvcprojector import command as cmd
 
 COMMANDS: list[str] = [
     cmd.Remote.MENU,

--- a/homeassistant/components/jvc_projector/remote.py
+++ b/homeassistant/components/jvc_projector/remote.py
@@ -7,15 +7,13 @@ from collections.abc import Iterable
 import logging
 from typing import Any
 
-from .jvcprojector import command as cmd
-
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import JVCConfigEntry
 from .entity import JvcProjectorEntity
+from .jvcprojector import command as cmd
 
 COMMANDS: list[str] = [
     cmd.Remote.MENU,

--- a/homeassistant/components/jvc_projector/select.py
+++ b/homeassistant/components/jvc_projector/select.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from jvcprojector import Command, command as cmd
+from .jvcprojector import Command, command as cmd
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
@@ -28,7 +28,7 @@ SELECTS: Final[tuple[JvcProjectorSelectDescription, ...]] = (
     JvcProjectorSelectDescription(
         key="installation_mode",
         command=cmd.InstallationMode,
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
     ),
     JvcProjectorSelectDescription(
         key="light_power",
@@ -76,7 +76,7 @@ async def async_setup_entry(
     async_add_entities(
         JvcProjectorSelectEntity(coordinator, description)
         for description in SELECTS
-        if coordinator.supports(description.command)
+        if coordinator.supports(description.command) or description.key == "installation_mode"
     )
 
 

--- a/homeassistant/components/jvc_projector/select.py
+++ b/homeassistant/components/jvc_projector/select.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from .jvcprojector import Command, command as cmd
+from jvcprojector import Command, command as cmd
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Proposed change
This PR enables Installation Mode (Lens Memory) for older JVC N-Series projectors (like the DLA-N7) and relaxes the remote command validation to allow users to send unmapped custom commands.

1. **select.py**: The `installation_mode` entity is not created for N-series projectors because the initial `coordinator.supports()` handshake returns `False`. This PR explicitly bypasses that check for `installation_mode` so the dropdown generates correctly for these models, and sets `entity_registry_enabled_default=True`.
2. **remote.py**: Removed the strict `if send_command not in COMMANDS:` validation block. This empowers users to utilize `remote.send_command` to pass arbitrary JVC ASCII strings (e.g., `INMD1`) directly to `device.remote(send_command)` for unmapped features without throwing a `HomeAssistantError`.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This issue was discovered and tested on a local JVC DLA-N7B.
- Tagging code owners for visibility: @SteveEasley @msavazzi

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: