### PR TITLE
Add test for Met.no API failure handling

### DIFF
--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -1,5 +1,7 @@
 """Test the Met integration init."""
 
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.components.met.const import (
@@ -8,11 +10,14 @@ from homeassistant.components.met.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.helpers import device_registry as dr
 
 from . import init_integration
+
+from tests.common import MockConfigEntry
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:
@@ -77,3 +82,25 @@ async def test_removing_incorrect_devices(
     assert not device_registry.async_get_device(identifiers={(DOMAIN,)})
     assert device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
     assert "Removing improper device Forecast_legacy" in caplog.text
+
+
+async def test_api_failure(hass: HomeAssistant) -> None:
+    """Test that entry goes to SETUP_RETRY when API fails."""
+    with patch(
+        "homeassistant.components.met.coordinator.metno.MetWeatherData.fetching_data",
+        return_value=False,
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_NAME: "test",
+                CONF_LATITUDE: 0,
+                CONF_LONGITUDE: 1.0,
+                CONF_ELEVATION: 1.0,
+            },
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -1,7 +1,5 @@
 """Test the Met integration init."""
 
-from unittest.mock import patch
-
 import pytest
 
 from homeassistant.components.met.const import (
@@ -84,23 +82,31 @@ async def test_removing_incorrect_devices(
     assert "Removing improper device Forecast_legacy" in caplog.text
 
 
-async def test_api_failure(hass: HomeAssistant) -> None:
+async def test_api_failure(hass: HomeAssistant, mock_weather) -> None:
     """Test that entry goes to SETUP_RETRY when API fails."""
-    with patch(
-        "homeassistant.components.met.coordinator.metno.MetWeatherData.fetching_data",
-        return_value=False,
-    ):
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={
-                CONF_NAME: "test",
-                CONF_LATITUDE: 0,
-                CONF_LONGITUDE: 1.0,
-                CONF_ELEVATION: 1.0,
-            },
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    mock_weather.fetching_data.side_effect = Exception("API error")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "test",
+            CONF_LATITUDE: 0,
+            CONF_LONGITUDE: 1.0,
+            CONF_ELEVATION: 1.0,
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_track_home_called_twice(hass: HomeAssistant, mock_weather) -> None:
+    """Test that calling track_home twice does not register duplicate listeners."""
+    entry = await init_integration(hass, track_home=True)
+    coordinator = entry.runtime_data
+
+    coordinator.track_home()
+    coordinator.track_home()  # druhé volání by mělo hned vrátit
+
+    assert coordinator._unsub_track_home is not None

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -106,11 +106,14 @@ async def test_api_failure(hass: HomeAssistant, mock_weather: MagicMock) -> None
 async def test_track_home_called_twice(
     hass: HomeAssistant, mock_weather: MagicMock
 ) -> None:
-    """Test that calling track_home twice does not register duplicate listeners."""
+    """Test track_home does not register duplicate listeners when called twice."""
     entry = await init_integration(hass, track_home=True)
     coordinator = entry.runtime_data
 
-    coordinator.track_home()
-    coordinator.track_home()  # second call should return immediately without registering a duplicate listener
+    # First call registers the listener
+    unsub_first = coordinator._unsub_track_home
+    assert unsub_first is not None
 
-    assert coordinator._unsub_track_home is not None
+    # Second call should not register a new listener
+    coordinator.track_home()
+    assert coordinator._unsub_track_home is unsub_first

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -85,8 +85,8 @@ async def test_removing_incorrect_devices(
 
 
 async def test_api_failure(hass: HomeAssistant, mock_weather: MagicMock) -> None:
-    """Test that entry goes to SETUP_RETRY when fetching_data returns False."""
-    mock_weather.fetching_data.return_value = False
+    """Test that entry goes to SETUP_RETRY when fetching_data raises an exception."""
+    mock_weather.fetching_data.side_effect = Exception("API error")
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -1,5 +1,7 @@
 """Test the Met integration init."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from homeassistant.components.met.const import (
@@ -82,7 +84,7 @@ async def test_removing_incorrect_devices(
     assert "Removing improper device Forecast_legacy" in caplog.text
 
 
-async def test_api_failure(hass: HomeAssistant, mock_weather) -> None:
+async def test_api_failure(hass: HomeAssistant, mock_weather: MagicMock) -> None:
     """Test that entry goes to SETUP_RETRY when API fails."""
     mock_weather.fetching_data.side_effect = Exception("API error")
     entry = MockConfigEntry(
@@ -101,7 +103,9 @@ async def test_api_failure(hass: HomeAssistant, mock_weather) -> None:
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_track_home_called_twice(hass: HomeAssistant, mock_weather) -> None:
+async def test_track_home_called_twice(
+    hass: HomeAssistant, mock_weather: MagicMock
+) -> None:
     """Test that calling track_home twice does not register duplicate listeners."""
     entry = await init_integration(hass, track_home=True)
     coordinator = entry.runtime_data

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -85,8 +85,8 @@ async def test_removing_incorrect_devices(
 
 
 async def test_api_failure(hass: HomeAssistant, mock_weather: MagicMock) -> None:
-    """Test that entry goes to SETUP_RETRY when API fails."""
-    mock_weather.fetching_data.side_effect = Exception("API error")
+    """Test that entry goes to SETUP_RETRY when fetching_data returns False."""
+    mock_weather.fetching_data.return_value = False
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -111,6 +111,6 @@ async def test_track_home_called_twice(
     coordinator = entry.runtime_data
 
     coordinator.track_home()
-    coordinator.track_home()  # druhé volání by mělo hned vrátit
+    coordinator.track_home()  # second call should return immediately without registering a duplicate listener
 
     assert coordinator._unsub_track_home is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
 Add a test to verify that when the Met.no API raises an exception 
 during data fetch, the config entry correctly transitions 
 to SETUP_RETRY state.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
