### PR TITLE
Bump holiday library to 0.93

### DIFF
--- a/homeassistant/components/holiday/manifest.json
+++ b/homeassistant/components/holiday/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/holiday",
   "iot_class": "local_polling",
-  "requirements": ["holidays==0.84", "babel==2.15.0"]
+  "requirements": ["holidays==0.93", "babel==2.15.0"]
 }

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["holidays"],
   "quality_scale": "internal",
-  "requirements": ["holidays==0.84"]
+  "requirements": ["holidays==0.93"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1226,7 +1226,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.84
+holidays==0.93
 
 # homeassistant.components.frontend
 home-assistant-frontend==20260325.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1090,7 +1090,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.84
+holidays==0.93
 
 # homeassistant.components.frontend
 home-assistant-frontend==20260325.5

--- a/tests/components/holiday/test_config_flow.py
+++ b/tests/components/holiday/test_config_flow.py
@@ -66,15 +66,15 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: "SE",
+            CONF_COUNTRY: "AL",
         },
     )
     await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Sweden"
+    assert result2["title"] == "Albania"
     assert result2["data"] == {
-        "country": "SE",
+        "country": "AL",
     }
 
 
@@ -90,12 +90,12 @@ async def test_form_translated_title(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: "SE",
+            CONF_COUNTRY: "AL",
         },
     )
     await hass.async_block_till_done()
 
-    assert result2["title"] == "Schweden"
+    assert result2["title"] == "Albanien"
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -106,7 +106,7 @@ async def test_single_combination_country_province(hass: HomeAssistant) -> None:
         CONF_PROVINCE: "BW",
     }
     data_se = {
-        CONF_COUNTRY: "SE",
+        CONF_COUNTRY: "AL",
     }
     MockConfigEntry(domain=DOMAIN, data=data_de).add_to_hass(hass)
     MockConfigEntry(domain=DOMAIN, data=data_se).add_to_hass(hass)
@@ -150,12 +150,12 @@ async def test_form_babel_unresolved_language(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: "SE",
+            CONF_COUNTRY: "AL",
         },
     )
     await hass.async_block_till_done()
 
-    assert result["title"] == "Sweden"
+    assert result["title"] == "Albania"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -197,12 +197,12 @@ async def test_form_babel_replace_dash_with_underscore(hass: HomeAssistant) -> N
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: "SE",
+            CONF_COUNTRY: "AL",
         },
     )
     await hass.async_block_till_done()
 
-    assert result["title"] == "Sweden"
+    assert result["title"] == "Albania"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -430,8 +430,8 @@ async def test_options_abort_no_categories(hass: HomeAssistant) -> None:
     """Test the options flow abort if no categories to select."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_COUNTRY: "SE"},
-        title="Sweden",
+        data={CONF_COUNTRY: "AL"},
+        title="Albania",
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/holiday/test_config_flow.py
+++ b/tests/components/holiday/test_config_flow.py
@@ -105,20 +105,20 @@ async def test_single_combination_country_province(hass: HomeAssistant) -> None:
         CONF_COUNTRY: "DE",
         CONF_PROVINCE: "BW",
     }
-    data_se = {
+    data_al = {
         CONF_COUNTRY: "AL",
     }
     MockConfigEntry(domain=DOMAIN, data=data_de).add_to_hass(hass)
-    MockConfigEntry(domain=DOMAIN, data=data_se).add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN, data=data_al).add_to_hass(hass)
 
     # Test for country without subdivisions
-    result_se = await hass.config_entries.flow.async_init(
+    result_al = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
-        data=data_se,
+        data=data_al,
     )
-    assert result_se["type"] is FlowResultType.ABORT
-    assert result_se["reason"] == "already_configured"
+    assert result_al["type"] is FlowResultType.ABORT
+    assert result_al["reason"] == "already_configured"
 
     # Test for country with subdivisions
     result_de_step1 = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Update holiday library to 0.93
https://github.com/vacanza/holidays/releases/tag/v0.93
https://github.com/vacanza/holidays/compare/v0.84...v0.93
https://github.com/vacanza/holidays/blob/dev/CHANGES.md

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 