### PR TITLE
Fix Sonos reporting wrong state when media title is whitespace

### DIFF
--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -132,7 +132,8 @@ class SonosMedia:
 
         self.artist = track_info.get("artist")
         self.album_name = track_info.get("album")
-        self.title = track_info.get("title")
+        title = track_info.get("title") or ""
+        self.title = title.strip() or None
         self.image_url = track_info.get("album_art")
 
         playlist_position = int(track_info.get("playlist_position", -1))

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1175,6 +1175,46 @@ async def test_media_transport(
     assert getattr(soco, client_call).call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("transport_state", "title", "expected_state"),
+    [
+        ("PAUSED_PLAYBACK", "Something", "paused"),
+        ("PAUSED_PLAYBACK", None, "idle"),
+        ("PAUSED_PLAYBACK", " ", "idle"),
+        ("STOPPED", "Something", "paused"),
+        ("STOPPED", None, "idle"),
+        ("STOPPED", " ", "idle"),
+    ],
+)
+async def test_state_paused_idle(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    no_media_event: SonosMockEvent,
+    transport_state: str,
+    title: str | None,
+    expected_state: str,
+) -> None:
+    """Test that idle is returned when title is None or whitespace, paused otherwise."""
+    soco.get_current_track_info.return_value = {
+        "title": title,
+        "artist": "",
+        "album": "",
+        "album_art": "",
+        "position": "NOT_IMPLEMENTED",
+        "playlist_position": "1",
+        "duration": "NOT_IMPLEMENTED",
+        "uri": "x-file-cifs://192.168.42.10/music/track.mp3",
+        "metadata": "NOT_IMPLEMENTED",
+    }
+    no_media_event.variables["transport_state"] = transport_state
+    soco.avTransport.subscribe.return_value.callback(no_media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("media_player.zone_a")
+    assert state.state == expected_state
+
+
 async def test_play_media_announce(
     hass: HomeAssistant,
     soco: MockSoCo,


### PR DESCRIPTION
## Proposed change

When no media is present on the speaker Sonos will sometimes report a single whitespace as the track title. This is causing the media_player to report "Paused" rather than "Idle".

Add missing tests for media title.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164573
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
