### PR TITLE
Validate entity ID domain

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -787,7 +787,7 @@ class EntityPlatform:
                 already_exists = True
         return (already_exists, restored)
 
-    async def _async_add_entity(
+    async def _async_add_entity(  # noqa: C901
         self,
         entity: Entity,
         update_before_add: bool,
@@ -822,29 +822,41 @@ class EntityPlatform:
 
         # An entity may suggest the entity_id by setting entity_id itself
         if not hasattr(entity, "internal_integration_suggested_object_id"):
-            if entity.entity_id is not None and not valid_entity_id(entity.entity_id):
-                if entity.unique_id is not None:
-                    report_usage(
-                        f"sets an invalid entity ID: '{entity.entity_id}'. "
-                        "In most cases, entities should not set entity_id,"
-                        " but if they do, it should be a valid entity ID.",
-                        integration_domain=self.platform_name,
-                        breaks_in_ha_version="2027.2.0",
+            if entity.entity_id is None:
+                entity.internal_integration_suggested_object_id = None  # type: ignore[unreachable]
+            else:
+                if not valid_entity_id(entity.entity_id):
+                    if entity.unique_id is not None:
+                        report_usage(
+                            f"sets an invalid entity ID: '{entity.entity_id}'. "
+                            "In most cases, entities should not set entity_id,"
+                            " but if they do, it should be a valid entity ID",
+                            integration_domain=self.platform_name,
+                            breaks_in_ha_version="2027.2.0",
+                        )
+                    else:
+                        entity.add_to_platform_abort()
+                        raise HomeAssistantError(
+                            f"Invalid entity ID: {entity.entity_id}"
+                        )
+                try:
+                    domain, entity.internal_integration_suggested_object_id = (
+                        split_entity_id(entity.entity_id)
                     )
-                else:
+                    if domain != self.domain:
+                        report_usage(
+                            f"sets an entity ID with wrong domain: '{entity.entity_id}'. "
+                            f"Expected domain is '{self.domain}'",
+                            integration_domain=self.platform_name,
+                            breaks_in_ha_version="2027.5.0",
+                        )
+                except ValueError:
+                    # This error handling should be removed once we remove
+                    # the invalid entity ID deprecation above.
                     entity.add_to_platform_abort()
-                    raise HomeAssistantError(f"Invalid entity ID: {entity.entity_id}")
-            try:
-                entity.internal_integration_suggested_object_id = (
-                    split_entity_id(entity.entity_id)[1]
-                    if entity.entity_id is not None
-                    else None
-                )
-            except ValueError:
-                entity.add_to_platform_abort()
-                raise HomeAssistantError(
-                    f"Invalid entity ID: {entity.entity_id}"
-                ) from None
+                    raise HomeAssistantError(
+                        f"Invalid entity ID: {entity.entity_id}"
+                    ) from None
 
         # Get entity_id from unique ID registration
         if entity.unique_id is not None:

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1638,7 +1638,7 @@ async def test_repr(hass: HomeAssistant) -> None:
             """Return the state."""
             raise ValueError("Boom")
 
-    platform = MockEntityPlatform(hass, domain="hello")
+    platform = MockEntityPlatform(hass, domain="test")
     my_entity = MyEntity(entity_id="test.test", available=False)
 
     # Not yet added

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -301,13 +301,15 @@ async def test_extract_from_service_no_group_expand(hass: HomeAssistant) -> None
     """Test not expanding a group."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     await component.async_setup({})
-    await component.async_add_entities([MockEntity(entity_id="group.test_group")])
+    await component.async_add_entities([MockEntity(entity_id="test_domain.test_group")])
 
-    call = ServiceCall(hass, "test", "service", {"entity_id": ["group.test_group"]})
+    call = ServiceCall(
+        hass, "test", "service", {"entity_id": ["test_domain.test_group"]}
+    )
 
     extracted = await component.async_extract_from_service(call, expand_group=False)
     assert len(extracted) == 1
-    assert extracted[0].entity_id == "group.test_group"
+    assert extracted[0].entity_id == "test_domain.test_group"
 
 
 async def test_setup_dependencies_platform(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -2001,6 +2001,34 @@ async def test_invalid_entity_id_report_usage(
     assert entity.platform is not None
 
 
+async def test_wrong_domain_entity_id_report_usage(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that setting an entity_id with wrong domain reports usage."""
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(entity_id="wrong_domain.some_entity", unique_id="unique")
+
+    mock_integration = Mock(is_built_in=True, domain="test_platform")
+    with (
+        caplog.at_level(logging.WARNING),
+        patch(
+            "homeassistant.helpers.frame.async_get_issue_integration",
+            return_value=mock_integration,
+        ),
+    ):
+        await platform.async_add_entities([entity])
+
+    assert (
+        "Detected that integration 'test_platform' "
+        "sets an entity ID with wrong domain: 'wrong_domain.some_entity'. "
+        "Expected domain is 'test_domain'"
+    ) in caplog.text
+
+    # Ensure the entity was still added
+    assert entity.hass is not None
+    assert entity.platform is not None
+
+
 class MockBlockingEntity(MockEntity):
     """Class to mock an entity that will block adding entities."""
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -683,9 +683,9 @@ async def test_using_prescribed_entity_id(hass: HomeAssistant) -> None:
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     await component.async_setup({})
     await component.async_add_entities(
-        [MockEntity(name="bla", entity_id="hello.world")]
+        [MockEntity(name="bla", entity_id="test_domain.world")]
     )
-    assert "hello.world" in hass.states.async_entity_ids()
+    assert "test_domain.world" in hass.states.async_entity_ids()
 
 
 async def test_using_prescribed_entity_id_with_unique_id(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate entity ID domain.

We want to make sure that entity IDs provided by integrations have correct domain, for example it doesn't make sense to create a light entity with `cover.cover` entity ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3034
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
