### PR TITLE
Add IPv6 prefix sensor to FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/icons.json
+++ b/homeassistant/components/fritz/icons.json
@@ -29,6 +29,9 @@
       "gb_sent": {
         "default": "mdi:upload"
       },
+      "ipv6_prefix": {
+        "default": "mdi:earth"
+      },
       "kb_s_received": {
         "default": "mdi:download"
       },

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -76,6 +76,12 @@ def _retrieve_external_ipv6_state(status: FritzStatus, last_value: str) -> str:
     return str(status.external_ipv6)
 
 
+def _retrieve_ipv6_prefix_state(status: FritzStatus, last_value: str) -> str:
+    """Return ipv6 prefix from device."""
+    info = status.ipv6_prefix_info
+    return f"{info['NewIPv6Prefix']}/{info['NewPrefixLength']}"
+
+
 def _retrieve_kb_s_sent_state(status: FritzStatus, last_value: str) -> float:
     """Return upload transmission rate."""
     return round(status.transmission_rate[0] / 1000, 1)  # type: ignore[no-any-return]
@@ -195,6 +201,12 @@ CONNECTION_SENSOR_TYPES: tuple[FritzConnectionSensorEntityDescription, ...] = (
         key="external_ipv6",
         translation_key="external_ipv6",
         value_fn=_retrieve_external_ipv6_state,
+        is_suitable=lambda info: info.ipv6_active,
+    ),
+    FritzConnectionSensorEntityDescription(
+        key="ipv6_prefix",
+        translation_key="ipv6_prefix",
+        value_fn=_retrieve_ipv6_prefix_state,
         is_suitable=lambda info: info.ipv6_active,
     ),
     FritzConnectionSensorEntityDescription(

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -62,6 +62,12 @@ def _retrieve_external_ipv6_state(status: FritzStatus, last_value: str) -> str:
     return str(status.external_ipv6)
 
 
+def _retrieve_ipv6_prefix_state(status: FritzStatus, last_value: str) -> str:
+    """Return ipv6 prefix from device."""
+    info = status.ipv6_prefix_info
+    return f"{info['NewIPv6Prefix']}/{info['NewPrefixLength']}"
+
+
 def _retrieve_kb_s_sent_state(status: FritzStatus, last_value: str) -> float:
     """Return upload transmission rate."""
     return round(status.transmission_rate[0] / 1000, 1)  # type: ignore[no-any-return]
@@ -181,6 +187,12 @@ CONNECTION_SENSOR_TYPES: tuple[FritzConnectionSensorEntityDescription, ...] = (
         key="external_ipv6",
         translation_key="external_ipv6",
         value_fn=_retrieve_external_ipv6_state,
+        is_suitable=lambda info: info.ipv6_active,
+    ),
+    FritzConnectionSensorEntityDescription(
+        key="ipv6_prefix",
+        translation_key="ipv6_prefix",
+        value_fn=_retrieve_ipv6_prefix_state,
         is_suitable=lambda info: info.ipv6_active,
     ),
     FritzConnectionSensorEntityDescription(

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -135,6 +135,9 @@
       "gb_sent": {
         "name": "GB sent"
       },
+      "ipv6_prefix": {
+        "name": "IPv6 prefix"
+      },
       "kb_s_received": {
         "name": "Download throughput"
       },

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -132,6 +132,9 @@
       "gb_sent": {
         "name": "GB sent"
       },
+      "ipv6_prefix": {
+        "name": "IPv6 prefix"
+      },
       "kb_s_received": {
         "name": "Download throughput"
       },

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -154,6 +154,10 @@ MOCK_FB_SERVICES: dict[str, dict[str, Any]] = {
         },
         "GetExternalIPAddress": {"NewExternalIPAddress": "1.2.3.4"},
         "X_AVM_DE_GetExternalIPv6Address": {"NewExternalIPv6Address": "fec0::1"},
+        "X_AVM_DE_GetIPv6Prefix": {
+            "NewIPv6Prefix": "2001:db8::",
+            "NewPrefixLength": 32,
+        },
     },
     "WANPPPConnection1": {
         "GetInfo": {

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -149,6 +149,10 @@ MOCK_FB_SERVICES: dict[str, dict[str, Any]] = {
         },
         "GetExternalIPAddress": {"NewExternalIPAddress": "1.2.3.4"},
         "X_AVM_DE_GetExternalIPv6Address": {"NewExternalIPv6Address": "fec0::1"},
+        "X_AVM_DE_GetIPv6Prefix": {
+            "NewIPv6Prefix": "2001:db8::",
+            "NewPrefixLength": 32,
+        },
     },
     "WANPPPConnection1": {
         "GetInfo": {

--- a/tests/components/fritz/snapshots/test_sensor.ambr
+++ b/tests/components/fritz/snapshots/test_sensor.ambr
@@ -324,6 +324,56 @@
     'state': '1.7',
   })
 # ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values1][sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values1][sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
+  })
+# ---
 # name: test_sensor_cpu_temp_not_supported[None-return_values1][sensor.mock_title_last_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -1182,6 +1232,56 @@
     'state': '1.7',
   })
 # ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values2][sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values2][sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
+  })
+# ---
 # name: test_sensor_cpu_temp_not_supported[None-return_values2][sensor.mock_title_last_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -2038,6 +2138,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.7',
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[side_effect0-None][sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[side_effect0-None][sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
   })
 # ---
 # name: test_sensor_cpu_temp_not_supported[side_effect0-None][sensor.mock_title_last_restart-entry]
@@ -2954,6 +3104,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.7',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
   })
 # ---
 # name: test_sensor_setup[sensor.mock_title_last_restart-entry]

--- a/tests/components/fritz/snapshots/test_sensor.ambr
+++ b/tests/components/fritz/snapshots/test_sensor.ambr
@@ -324,6 +324,56 @@
     'state': '1.7',
   })
 # ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values1][sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values1][sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
+  })
+# ---
 # name: test_sensor_cpu_temp_not_supported[None-return_values1][sensor.mock_title_link_download_noise_margin-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -1180,6 +1230,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.7',
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values2][sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[None-return_values2][sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
   })
 # ---
 # name: test_sensor_cpu_temp_not_supported[None-return_values2][sensor.mock_title_link_download_noise_margin-entry]
@@ -2040,6 +2140,56 @@
     'state': '1.7',
   })
 # ---
+# name: test_sensor_cpu_temp_not_supported[side_effect0-None][sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[side_effect0-None][sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
+  })
+# ---
 # name: test_sensor_cpu_temp_not_supported[side_effect0-None][sensor.mock_title_link_download_noise_margin-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -2896,6 +3046,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.7',
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[side_effect3-None][sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_cpu_temp_not_supported[side_effect3-None][sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
   })
 # ---
 # name: test_sensor_cpu_temp_not_supported[side_effect3-None][sensor.mock_title_link_download_noise_margin-entry]
@@ -3812,6 +4012,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.7',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_ipv6_prefix-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'IPv6 prefix',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'IPv6 prefix',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ipv6_prefix',
+    'unique_id': '1CED6F123411-ipv6_prefix',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_ipv6_prefix-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title IPv6 prefix',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_ipv6_prefix',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2001:db8::/32',
   })
 # ---
 # name: test_sensor_setup[sensor.mock_title_link_download_noise_margin-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new sensor for the IPv6 Prefix to the Fritz integration.

My use case is monitoring the prefix my ISP provides me.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
