### PR TITLE
Improve Shopping List action naming consistency

### DIFF
--- a/homeassistant/components/shopping_list/strings.json
+++ b/homeassistant/components/shopping_list/strings.json
@@ -30,11 +30,11 @@
     },
     "clear_completed_items": {
       "description": "Removes completed items from the shopping list.",
-      "name": "Clear completed items"
+      "name": "Clear completed shopping list items"
     },
     "complete_all": {
       "description": "Marks all items as completed in the shopping list (without removing them from the list).",
-      "name": "Complete all"
+      "name": "Complete all shopping list items"
     },
     "complete_item": {
       "description": "Marks the first item with matching name as completed in the shopping list.",
@@ -44,11 +44,11 @@
           "name": "[%key:common::config_flow::data::name%]"
         }
       },
-      "name": "Complete item"
+      "name": "Complete shopping list item"
     },
     "incomplete_all": {
       "description": "Marks all items as incomplete in the shopping list.",
-      "name": "Incomplete all"
+      "name": "Incomplete all shopping list items"
     },
     "incomplete_item": {
       "description": "Marks the first item with matching name as incomplete in the shopping list.",
@@ -58,7 +58,7 @@
           "name": "[%key:common::config_flow::data::name%]"
         }
       },
-      "name": "Incomplete item"
+      "name": "Incomplete shopping list item"
     },
     "remove_item": {
       "description": "Removes the first item with matching name from the shopping list.",
@@ -68,7 +68,7 @@
           "name": "[%key:common::config_flow::data::name%]"
         }
       },
-      "name": "Remove item"
+      "name": "Remove shopping list item"
     },
     "sort": {
       "description": "Sorts all items by name in the shopping list.",
@@ -78,7 +78,7 @@
           "name": "Sort reverse"
         }
       },
-      "name": "Sort all items"
+      "name": "Sort shopping list"
     }
   },
   "title": "Shopping List"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Aligns the Shopping List integration's action names with the established naming patterns used across Home Assistant.

The action names did not include the integration name.

This PR updates all action names to include "shopping list" (e.g., "Clear completed shopping list items", "Complete all shopping list items"). For the "Sort all items" action the name is changed to "Sort shopping list".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
