### PR TITLE
Remove unnecessary None checks on coordinator data in Renault

### DIFF
--- a/homeassistant/components/renault/binary_sensor.py
+++ b/homeassistant/components/renault/binary_sensor.py
@@ -84,15 +84,12 @@ class RenaultBinarySensor(
 
 def _plugged_in_value_lambda(self: RenaultBinarySensor) -> bool | None:
     """Return true if the vehicle is plugged in."""
-
-    data = self.coordinator.data
-    plug_status = data.get_plug_status() if data else None
-
-    if plug_status is not None:
+    if (plug_status := self.coordinator.data.get_plug_status()) is not None:
         return plug_status == PlugState.PLUGGED
 
-    charging_status = data.get_charging_status() if data else None
-    if charging_status is not None and charging_status in _PLUG_FROM_CHARGE_STATUS:
+    if (
+        charging_status := self.coordinator.data.get_charging_status()
+    ) is not None and charging_status in _PLUG_FROM_CHARGE_STATUS:
         return True
 
     return None

--- a/homeassistant/components/renault/device_tracker.py
+++ b/homeassistant/components/renault/device_tracker.py
@@ -52,12 +52,16 @@ class RenaultDeviceTracker(
     @property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
-        return self.coordinator.data.gpsLatitude if self.coordinator.data else None
+        if not self.coordinator.last_update_success:
+            return None
+        return self.coordinator.data.gpsLatitude
 
     @property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
-        return self.coordinator.data.gpsLongitude if self.coordinator.data else None
+        if not self.coordinator.last_update_success:
+            return None
+        return self.coordinator.data.gpsLongitude
 
 
 DEVICE_TRACKER_TYPES: tuple[RenaultTrackerEntityDescription, ...] = (

--- a/homeassistant/components/renault/diagnostics.py
+++ b/homeassistant/components/renault/diagnostics.py
@@ -56,9 +56,7 @@ def _get_vehicle_diagnostics(vehicle: RenaultVehicleProxy) -> dict[str, Any]:
     return {
         "details": async_redact_data(vehicle.details.raw_data, TO_REDACT),
         "data": {
-            key: async_redact_data(
-                coordinator.data.raw_data if coordinator.data else None, TO_REDACT
-            )
+            key: async_redact_data(coordinator.data.raw_data, TO_REDACT)
             for key, coordinator in vehicle.coordinators.items()
         },
     }

--- a/homeassistant/components/renault/number.py
+++ b/homeassistant/components/renault/number.py
@@ -43,9 +43,7 @@ async def _set_charge_limit_min(entity: RenaultNumberEntity, value: float) -> No
 
     The target SOC is required to set the minimum SOC, so we need to fetch it first.
     """
-    if (data := entity.coordinator.data) is None or (
-        target_soc := data.socTarget
-    ) is None:
+    if (target_soc := entity.coordinator.data.socTarget) is None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="battery_soc_unavailable",
@@ -58,7 +56,7 @@ async def _set_charge_limit_target(entity: RenaultNumberEntity, value: float) ->
 
     The minimum SOC is required to set the target SOC, so we need to fetch it first.
     """
-    if (data := entity.coordinator.data) is None or (min_soc := data.socMin) is None:
+    if (min_soc := entity.coordinator.data.socMin) is None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="battery_soc_unavailable",


### PR DESCRIPTION
## Summary
- Remove unnecessary `None` checks on `coordinator.data` in binary_sensor, device_tracker, diagnostics, and number platforms
- The coordinator data is guaranteed to be non-`None` when entities are available

## Test plan
- [ ] Existing tests pass (`pytest tests/components/renault/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)