### PR TITLE
Improve Assist satellite action naming consistency

### DIFF
--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -156,7 +156,7 @@
   "title": "Assist satellite",
   "triggers": {
     "idle": {
-      "description": "Triggers after one or more Assistant satellites become idle after having processed a command.",
+      "description": "Triggers after one or more Assist satellites become idle after having processed a command.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -165,7 +165,7 @@
       "name": "Satellite became idle"
     },
     "listening": {
-      "description": "Triggers after one or more Assistant satellites start listening for a command from someone.",
+      "description": "Triggers after one or more Assist satellites start listening for a command from someone.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -174,7 +174,7 @@
       "name": "Satellite started listening"
     },
     "processing": {
-      "description": "Triggers after one or more Assistant satellites start processing a command after having heard it.",
+      "description": "Triggers after one or more Assist satellites start processing a command after having heard it.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -183,7 +183,7 @@
       "name": "Satellite started processing"
     },
     "responding": {
-      "description": "Triggers after one or more Assistant satellites start responding to a command after having processed it, or start announcing something.",
+      "description": "Triggers after one or more Assist satellites start responding to a command after having processed it, or start announcing something.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -97,7 +97,7 @@
       "name": "Announce on satellite"
     },
     "ask_question": {
-      "description": "Asks a question on an Assist satellite and gets the user's response.",
+      "description": "Lets an Assist satellite ask a question and get the user's response.",
       "fields": {
         "answers": {
           "description": "Possible answers to the question.",

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -75,7 +75,7 @@
   },
   "services": {
     "announce": {
-      "description": "Lets a satellite announce a message.",
+      "description": "Lets an Assist satellite announce a message.",
       "fields": {
         "media_id": {
           "description": "The media ID to announce instead of using text-to-speech.",
@@ -94,10 +94,10 @@
           "name": "Preannounce media ID"
         }
       },
-      "name": "Announce"
+      "name": "Announce on satellite"
     },
     "ask_question": {
-      "description": "Asks a question and gets the user's response.",
+      "description": "Asks a question on an Assist satellite and gets the user's response.",
       "fields": {
         "answers": {
           "description": "Possible answers to the question.",
@@ -124,10 +124,10 @@
           "name": "Question media ID"
         }
       },
-      "name": "Ask question"
+      "name": "Ask question on satellite"
     },
     "start_conversation": {
-      "description": "Starts a conversation from a satellite.",
+      "description": "Starts a conversation from an Assist satellite.",
       "fields": {
         "extra_system_prompt": {
           "description": "Provide background information to the AI about the request.",
@@ -150,7 +150,7 @@
           "name": "Message"
         }
       },
-      "name": "Start conversation"
+      "name": "Start conversation on satellite"
     }
   },
   "title": "Assist satellite",

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -156,7 +156,7 @@
   "title": "Assist satellite",
   "triggers": {
     "idle": {
-      "description": "Triggers after one or more voice assistant satellites become idle after having processed a command.",
+      "description": "Triggers after one or more Assistant satellites become idle after having processed a command.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -165,7 +165,7 @@
       "name": "Satellite became idle"
     },
     "listening": {
-      "description": "Triggers after one or more voice assistant satellites start listening for a command from someone.",
+      "description": "Triggers after one or more Assistant satellites start listening for a command from someone.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -174,7 +174,7 @@
       "name": "Satellite started listening"
     },
     "processing": {
-      "description": "Triggers after one or more voice assistant satellites start processing a command after having heard it.",
+      "description": "Triggers after one or more Assistant satellites start processing a command after having heard it.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -183,7 +183,7 @@
       "name": "Satellite started processing"
     },
     "responding": {
-      "description": "Triggers after one or more voice assistant satellites start responding to a command after having processed it, or start announcing something.",
+      "description": "Triggers after one or more Assistant satellites start responding to a command after having processed it, or start announcing something.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Aligns the Assist satellite integration's action names and descriptions with the established naming patterns used across Home Assistant.

The action names and the descriptions did not include the integration name.

This PR updates all action names to include "satellite" (e.g., "Announce on satellite") and uses "Assist satellite" in all descriptions. This matches the wording of the newly added conditions. The triggers are also updated to use "Assist satellite" (the integration name) instead of "voice assistant satellite".

The description of the `ask_question` action is made consistent with the wording of the `announce` action by changing it to: "Lets an Assist satellite ask a question and get the user's response."

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
