### PR TITLE
Handle UnicodeDecodeError in frontier_silicon media player update

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -153,18 +153,33 @@ class AFSAPIDevice(MediaPlayerEntity):
             self._max_volume = int(await afsapi.get_volume_steps() or 1) - 1
 
         if self._attr_state != MediaPlayerState.OFF:
-            info_name = await afsapi.get_play_name()
-            info_text = await afsapi.get_play_text()
+            try:
+                info_name = await afsapi.get_play_name()
+            except UnicodeDecodeError:
+                info_name = None
+            try:
+                info_text = await afsapi.get_play_text()
+            except UnicodeDecodeError:
+                info_text = None
 
             self._attr_media_title = " - ".join(filter(None, [info_name, info_text]))
-            self._attr_media_artist = await afsapi.get_play_artist()
-            self._attr_media_album_name = await afsapi.get_play_album()
+            try:
+                self._attr_media_artist = await afsapi.get_play_artist()
+            except UnicodeDecodeError:
+                self._attr_media_artist = None
+            try:
+                self._attr_media_album_name = await afsapi.get_play_album()
+            except UnicodeDecodeError:
+                self._attr_media_album_name = None
 
             radio_mode = await afsapi.get_mode()
             self._attr_source = radio_mode.label if radio_mode is not None else None
 
             self._attr_is_volume_muted = await afsapi.get_mute()
-            self._attr_media_image_url = await afsapi.get_play_graphic()
+            try:
+                self._attr_media_image_url = await afsapi.get_play_graphic()
+            except UnicodeDecodeError:
+                self._attr_media_image_url = None
 
             if self._supports_sound_mode:
                 try:

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -1,0 +1,99 @@
+"""Tests for the Frontier Silicon media player."""
+
+from unittest.mock import AsyncMock, patch
+
+from afsapi import PlayState
+import pytest
+
+from homeassistant.components.media_player import MediaPlayerState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_afsapi() -> AsyncMock:
+    """Create a mock AFSAPI device in playing state."""
+    mock = AsyncMock()
+    mock.get_power.return_value = True
+    mock.get_play_status.return_value = PlayState.PLAYING
+    mock.get_modes.return_value = []
+    mock.get_equalisers.return_value = []
+    mock.get_volume_steps.return_value = 41
+    mock.get_play_name.return_value = "Station Name"
+    mock.get_play_text.return_value = "Now Playing"
+    mock.get_play_artist.return_value = "Artist"
+    mock.get_play_album.return_value = "Album"
+    mock.get_mode.return_value = None
+    mock.get_mute.return_value = False
+    mock.get_play_graphic.return_value = "http://example.com/image.png"
+    mock.get_eq_preset.return_value = None
+    mock.get_volume.return_value = 20
+    return mock
+
+
+async def _setup_entity(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_afsapi: AsyncMock,
+) -> None:
+    """Set up the frontier_silicon integration with a mock AFSAPI."""
+    with patch(
+        "homeassistant.components.frontier_silicon.AFSAPI",
+        return_value=mock_afsapi,
+    ):
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_update_normal(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_afsapi: AsyncMock,
+) -> None:
+    """Test normal update with valid text metadata."""
+    await _setup_entity(hass, config_entry, mock_afsapi)
+
+    state = hass.states.get("media_player.mock_title")
+    assert state is not None
+    assert state.state == MediaPlayerState.PLAYING
+    assert state.attributes["media_title"] == "Station Name - Now Playing"
+    assert state.attributes["media_artist"] == "Artist"
+    assert state.attributes["media_album_name"] == "Album"
+    assert state.attributes["entity_picture"] is not None
+
+
+@pytest.mark.parametrize(
+    ("method", "attribute", "expected_value"),
+    [
+        ("get_play_name", "media_title", "Now Playing"),
+        ("get_play_text", "media_title", "Station Name"),
+        ("get_play_artist", "media_artist", None),
+        ("get_play_album", "media_album_name", None),
+        ("get_play_graphic", "entity_picture", None),
+    ],
+)
+async def test_update_unicode_decode_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_afsapi: AsyncMock,
+    method: str,
+    attribute: str,
+    expected_value: str | None,
+) -> None:
+    """Test that UnicodeDecodeError on a metadata call is handled gracefully."""
+    getattr(mock_afsapi, method).side_effect = UnicodeDecodeError(
+        "utf-8", b"\xc3", 0, 1, "invalid continuation byte"
+    )
+
+    await _setup_entity(hass, config_entry, mock_afsapi)
+
+    state = hass.states.get("media_player.mock_title")
+    assert state is not None
+    assert state.state == MediaPlayerState.PLAYING
+
+    if attribute == "media_title":
+        assert state.attributes["media_title"] == expected_value
+    else:
+        assert state.attributes.get(attribute) is expected_value


### PR DESCRIPTION
## Breaking change

N/A - this PR is not a breaking change.

## Proposed change

Some Frontier Silicon radios (e.g. Hama DIT2010) truncate text metadata at a fixed byte boundary, which can split a multi-byte UTF-8 character in half. The `afsapi` library then raises a `UnicodeDecodeError` when decoding the response, which crashes the entire entity update and makes the device unavailable.

This is common with radio stations broadcasting metadata in languages with diacritics (Czech, German, French, etc.). For example, a Czech station (Expres FM) returns the following raw response for `netRemote.play.info.text`:

```
00000120: 2074 7261 706e c3bd 206d 6f64 6572 c3a1   trapn.. moder..
00000130: 746f 7273 6bc3 bd20 7673 7475 7079 2061  torsk.. vstupy a
00000140: 2070 6f64 6f62 6ec3 3c2f 6338 5f61 7272   podobn.</c8_arr
```

The byte `0xc3` at the end is the start of a 2-byte UTF-8 sequence, but the continuation byte is missing - the radio firmware truncated the text mid-character right before the closing XML tag.

This fix catches `UnicodeDecodeError` on each text metadata API call individually (`get_play_name`, `get_play_text`, `get_play_artist`, `get_play_album`, `get_play_graphic`), setting only the affected field to `None` while keeping the rest of the entity functional.

The proper fix has also been submitted upstream to the `afsapi` library: https://github.com/zhelev/python-afsapi/pull/12 - that PR uses `errors="replace"` in the HTTP response decoding so that malformed bytes are replaced with the Unicode replacement character instead of raising an exception. Once that is merged and released, these try/except blocks can be removed.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/zhelev/python-afsapi/pull/12
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.