### PR TITLE
Fix Matter water heater off mode

### DIFF
--- a/homeassistant/components/matter/water_heater.py
+++ b/homeassistant/components/matter/water_heater.py
@@ -168,10 +168,15 @@ class MatterWaterHeater(MatterEntity, WaterHeaterEntity):
         self._attr_target_temperature = self._get_temperature_in_degrees(
             clusters.Thermostat.Attributes.OccupiedHeatingSetpoint
         )
+        system_mode = self.get_matter_attribute_value(
+            clusters.Thermostat.Attributes.SystemMode
+        )
         boost_state = self.get_matter_attribute_value(
             clusters.WaterHeaterManagement.Attributes.BoostState
         )
-        if boost_state == clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive:
+        if system_mode == clusters.Thermostat.Enums.SystemModeEnum.kOff:
+            self._attr_current_operation = STATE_OFF
+        elif boost_state == clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive:
             self._attr_current_operation = STATE_HIGH_DEMAND
         else:
             self._attr_current_operation = STATE_ECO
@@ -218,6 +223,7 @@ DISCOVERY_SCHEMAS = [
             clusters.Thermostat.Attributes.AbsMinHeatSetpointLimit,
             clusters.Thermostat.Attributes.AbsMaxHeatSetpointLimit,
             clusters.Thermostat.Attributes.LocalTemperature,
+            clusters.Thermostat.Attributes.SystemMode,
             clusters.WaterHeaterManagement.Attributes.FeatureMap,
         ),
         optional_attributes=(

--- a/tests/components/matter/test_water_heater.py
+++ b/tests/components/matter/test_water_heater.py
@@ -226,14 +226,14 @@ async def test_update_from_water_heater(
     assert state
     assert state.state == STATE_ECO
 
-    # confirm thermostat state is 'off' when SystemMode is set to 0 (kOff)
+    # confirm water heater state is 'off' when SystemMode is set to 0 (kOff)
     set_node_attribute(matter_node, 2, 513, 28, 0)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_OFF
 
-    # confirm thermostat state returns to 'eco' when SystemMode is set back to 4 (kHeat)
+    # confirm water heater state returns to 'eco' when SystemMode is set back to 4 (kHeat)
     set_node_attribute(matter_node, 2, 513, 28, 4)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)

--- a/tests/components/matter/test_water_heater.py
+++ b/tests/components/matter/test_water_heater.py
@@ -226,6 +226,20 @@ async def test_update_from_water_heater(
     assert state
     assert state.state == STATE_ECO
 
+    # confirm thermostat state is 'off' when SystemMode is set to 0 (kOff)
+    set_node_attribute(matter_node, 2, 513, 28, 0)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    # confirm thermostat state returns to 'eco' when SystemMode is set back to 4 (kHeat)
+    set_node_attribute(matter_node, 2, 513, 28, 4)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ECO
+
 
 @pytest.mark.parametrize("node_fixture", ["silabs_water_heater"])
 async def test_water_heater_turn_on_off(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Verify that setting `SystemMode` to `kOff (0)` on the device side correctly reflects `STATE_OFF` in the UI, and that returning to `kHeat (4)` restores `STATE_ECO`.


<details><summary>Details</summary>

https://github.com/user-attachments/assets/d4a00292-5a50-4f38-a9c2-df8ca140ae26

</details> 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166131
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
