### PR TITLE
Refactor None handling in renault diagnostics

### DIFF
--- a/homeassistant/components/renault/diagnostics.py
+++ b/homeassistant/components/renault/diagnostics.py
@@ -56,8 +56,12 @@ def _get_vehicle_diagnostics(vehicle: RenaultVehicleProxy) -> dict[str, Any]:
     return {
         "details": async_redact_data(vehicle.details.raw_data, TO_REDACT),
         "data": {
-            key: async_redact_data(
-                coordinator.data.raw_data if coordinator.data else None, TO_REDACT
+            key: (
+                async_redact_data(coordinator.data.raw_data, TO_REDACT)
+                # Renault coordinators override async_config_entry_first_refresh
+                # to not raise ConfigEntryNotReady, so coordinator data can be None
+                if coordinator.data
+                else None
             )
             for key, coordinator in vehicle.coordinators.items()
         },

--- a/tests/components/renault/test_diagnostics.py
+++ b/tests/components/renault/test_diagnostics.py
@@ -44,7 +44,7 @@ async def test_device_diagnostics(
     hass_client: ClientSessionGenerator,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test config entry diagnostics."""
+    """Test device diagnostics."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -59,14 +59,14 @@ async def test_device_diagnostics(
 
 @pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
-async def test_device_diagnostics_empty(
+async def test_device_diagnostics_invalid_upstream_exception(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     device_registry: dr.DeviceRegistry,
     hass_client: ClientSessionGenerator,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test for Renault sensors with empty data from Renault."""
+    """Test device diagnostics with invalid upstream exception."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/renault/test_diagnostics.py
+++ b/tests/components/renault/test_diagnostics.py
@@ -55,3 +55,30 @@ async def test_device_diagnostics(
         await get_diagnostics_for_device(hass, hass_client, config_entry, device)
         == snapshot
     )
+
+
+@pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
+@pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
+async def test_device_diagnostics_empty(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test for Renault sensors with empty data from Renault."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "VF1ZOE40VIN")})
+    assert device is not None
+
+    data = await get_diagnostics_for_device(hass, hass_client, config_entry, device)
+    assert data["data"] == {
+        "battery": None,
+        "battery_soc": None,
+        "charge_mode": None,
+        "charging_settings": None,
+        "cockpit": None,
+        "hvac_status": None,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactor `async_redact_data` call in renault diagnostics to avoid passing `None` as first argument. Move the `None` check outside the `async_redact_data` call for clarity.

Renault coordinators override `async_config_entry_first_refresh` to not raise `ConfigEntryNotReady`, so coordinator data can be `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr