### PR TITLE
Allow users to overwrite content type for AI task attachments

### DIFF
--- a/homeassistant/components/ai_task/task.py
+++ b/homeassistant/components/ai_task/task.py
@@ -74,7 +74,8 @@ async def _resolve_attachments(
             resolved_attachments.append(
                 conversation.Attachment(
                     media_content_id=media_content_id,
-                    mime_type=image_data.content_type,
+                    mime_type=attachment.get("media_content_type")
+                    or image_data.content_type,
                     path=temp_filename,
                 )
             )
@@ -89,7 +90,7 @@ async def _resolve_attachments(
             resolved_attachments.append(
                 conversation.Attachment(
                     media_content_id=media_content_id,
-                    mime_type=media.mime_type,
+                    mime_type=attachment.get("media_content_type") or media.mime_type,
                     path=media.path,
                 )
             )

--- a/tests/components/ai_task/test_task.py
+++ b/tests/components/ai_task/test_task.py
@@ -278,6 +278,108 @@ async def test_generate_data_mixed_attachments(
     assert media_attachment.path == Path("/media/test.mp4")
 
 
+async def test_generate_data_content_type(
+    hass: HomeAssistant,
+    init_components: None,
+    mock_ai_task_entity: MockAITaskEntity,
+) -> None:
+    """Test that user-provided content type of an attachment is respected."""
+    with (
+        patch(  # Intentionally broken content type
+            "homeassistant.components.camera.async_get_image",
+            return_value=Image(content_type="image/png", content=b"fake_camera_jpeg"),
+        ) as mock_get_camera_image,
+        patch(  # Same
+            "homeassistant.components.image.async_get_image",
+            return_value=Image(content_type="image/png", content=b"fake_image_jpeg"),
+        ) as mock_get_image_image,
+        patch(
+            "homeassistant.components.media_source.async_resolve_media",
+            return_value=media_source.PlayMedia(
+                url="http://example.com/test.png",  # jpeg image saved as png
+                mime_type="image/png",
+                path=Path("/media/test.png"),
+            ),
+        ) as mock_resolve_media,
+    ):
+        await async_generate_data(
+            hass,
+            task_name="Test Task",
+            entity_id=TEST_ENTITY_ID,
+            instructions="Describe these images",
+            attachments=[
+                {  # supply corrected content type from the user input
+                    "media_content_id": "media-source://camera/camera.front_door",
+                    "media_content_type": "image/jpeg",
+                },
+                {
+                    "media_content_id": "media-source://image/image.floorplan",
+                    "media_content_type": "image/jpeg",
+                },
+                {
+                    "media_content_id": "media-source://media_player/test.png",
+                    "media_content_type": "image/jpeg",
+                },
+            ],
+        )
+
+    # Verify both methods were called
+    mock_get_camera_image.assert_called_once_with(hass, "camera.front_door")
+    mock_get_image_image.assert_called_once_with(hass, "image.floorplan")
+    mock_resolve_media.assert_called_once_with(
+        hass, "media-source://media_player/test.png", None
+    )
+
+    # Check attachments
+    assert len(mock_ai_task_entity.mock_generate_data_tasks) == 1
+    task = mock_ai_task_entity.mock_generate_data_tasks[0]
+    assert task.attachments is not None
+    assert len(task.attachments) == 3
+
+    # Check camera attachment
+    camera_attachment = task.attachments[0]
+    assert (
+        camera_attachment.media_content_id == "media-source://camera/camera.front_door"
+    )
+    assert camera_attachment.mime_type == "image/jpeg"
+    assert isinstance(camera_attachment.path, Path)
+    assert camera_attachment.path.suffix == ".png"  # This is fine
+
+    # Verify camera snapshot content
+    assert camera_attachment.path.exists()
+    content = await hass.async_add_executor_job(camera_attachment.path.read_bytes)
+    assert content == b"fake_camera_jpeg"
+
+    # Check image attachment
+    image_attachment = task.attachments[1]
+    assert image_attachment.media_content_id == "media-source://image/image.floorplan"
+    assert image_attachment.mime_type == "image/jpeg"
+    assert isinstance(image_attachment.path, Path)
+    assert image_attachment.path.suffix == ".png"
+
+    # Verify image snapshot content
+    assert image_attachment.path.exists()
+    content = await hass.async_add_executor_job(image_attachment.path.read_bytes)
+    assert content == b"fake_image_jpeg"
+
+    # Trigger clean up
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + chat_session.CONVERSATION_TIMEOUT + timedelta(seconds=1),
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Verify the temporary file cleaned up
+    assert not camera_attachment.path.exists()
+    assert not image_attachment.path.exists()
+
+    # Check regular media attachment
+    media_attachment = task.attachments[2]
+    assert media_attachment.media_content_id == "media-source://media_player/test.png"
+    assert media_attachment.mime_type == "image/jpeg"
+    assert media_attachment.path == Path("/media/test.png")
+
+
 @pytest.mark.freeze_time("2025-06-14 22:59:00")
 async def test_generate_image(
     hass: HomeAssistant,

--- a/tests/components/ai_task/test_task.py
+++ b/tests/components/ai_task/test_task.py
@@ -312,9 +312,8 @@ async def test_generate_data_content_type(
                     "media_content_id": "media-source://camera/camera.front_door",
                     "media_content_type": "image/jpeg",
                 },
-                {
+                {  # User did not provide content type, fallback to the integration
                     "media_content_id": "media-source://image/image.floorplan",
-                    "media_content_type": "image/jpeg",
                 },
                 {
                     "media_content_id": "media-source://media_player/test.png",
@@ -353,7 +352,7 @@ async def test_generate_data_content_type(
     # Check image attachment
     image_attachment = task.attachments[1]
     assert image_attachment.media_content_id == "media-source://image/image.floorplan"
-    assert image_attachment.mime_type == "image/jpeg"
+    assert image_attachment.mime_type == "image/png"
     assert isinstance(image_attachment.path, Path)
     assert image_attachment.path.suffix == ".png"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a user adds attachments to `ai_task.generate_data` action using UI, the task input is the result of the media selector, for example:

```yaml
action: ai_task.generate_data
data:
  entity_id: ai_task.claude_ai_task
  task_name: test_png
  instructions: Please describe the image
  attachments:
    media_content_id: media-source://media_source/local/ai_task/bad_png.png
    media_content_type: image/jpeg
    metadata:
      title: bad_png.png
      thumbnail: null
      media_class: image
      children_media_class: null
      navigateIds:
        - {}
        - media_content_type: app
          media_content_id: media-source://media_source
        - media_content_type: ""
          media_content_id: media-source://media_source/local/ai_task
```
Currently we use only `media_content_id` and ignore all other information. However there are cases when the user may want to overwrite the media content type (for example, if the integration provides a wrong value). The field is already there.
This PR allows AI task action to respect the value provided by user.
If the value is not provided by the user, the value from the integration is used as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167208
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
