### PR TITLE
Fix fritzbox coordinator error handling: re-login on HTTPError, reload on ConnectionError

### DIFF
--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -183,9 +183,9 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             new_data = await self.hass.async_add_executor_job(
                 self._update_fritz_devices
             )
-        except (RequestConnectionError, HTTPError, LoginError) as ex:
+        except HTTPError as ex:
             LOGGER.debug(
-                "Error fetching %s data, attempting re-login: '%s'",
+                "Re-login %s due to HTTP error '%s'",
                 self.config_entry.title,
                 ex,
             )
@@ -193,14 +193,28 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
                 await self.hass.async_add_executor_job(self.fritz.login)
             except LoginError as login_ex:
                 raise ConfigEntryAuthFailed from login_ex
-            except (RequestConnectionError, HTTPError) as conn_ex:
-                raise UpdateFailed(conn_ex) from conn_ex
+            except RequestConnectionError as conn_ex:
+                self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id
+                )
+                raise UpdateFailed(str(conn_ex)) from conn_ex
             try:
                 new_data = await self.hass.async_add_executor_job(
                     self._update_fritz_devices
                 )
-            except (RequestConnectionError, HTTPError, LoginError) as retry_ex:
-                raise UpdateFailed(retry_ex) from retry_ex
+            except (HTTPError, RequestConnectionError) as retry_ex:
+                self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id
+                )
+                raise UpdateFailed(str(retry_ex)) from retry_ex
+        except RequestConnectionError as ex:
+            LOGGER.debug(
+                "Reload %s due to error '%s' to ensure proper re-login",
+                self.config_entry.title,
+                ex,
+            )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+            raise UpdateFailed(str(ex)) from ex
 
         for device in new_data.devices.values():
             # create device registry entry for new main devices

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -183,14 +183,24 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             new_data = await self.hass.async_add_executor_job(
                 self._update_fritz_devices
             )
-        except (RequestConnectionError, HTTPError) as ex:
+        except (RequestConnectionError, HTTPError, LoginError) as ex:
             LOGGER.debug(
-                "Reload %s due to error '%s' to ensure proper re-login",
+                "Error fetching %s data, attempting re-login: '%s'",
                 self.config_entry.title,
                 ex,
             )
-            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
-            raise UpdateFailed from ex
+            try:
+                await self.hass.async_add_executor_job(self.fritz.login)
+            except LoginError as login_ex:
+                raise ConfigEntryAuthFailed from login_ex
+            except (RequestConnectionError, HTTPError) as conn_ex:
+                raise UpdateFailed(conn_ex) from conn_ex
+            try:
+                new_data = await self.hass.async_add_executor_job(
+                    self._update_fritz_devices
+                )
+            except (RequestConnectionError, HTTPError, LoginError) as retry_ex:
+                raise UpdateFailed(retry_ex) from retry_ex
 
         for device in new_data.devices.values():
             # create device registry entry for new main devices

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -207,7 +207,7 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
                     self.config_entry.entry_id
                 )
                 raise UpdateFailed(str(retry_ex)) from retry_ex
-        except RequestConnectionError as ex:
+        except (RequestConnectionError, TimeoutError) as ex:
             LOGGER.debug(
                 "Reload %s due to error '%s' to ensure proper re-login",
                 self.config_entry.title,

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -33,7 +33,36 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_coordinator_update_after_reboot(
     hass: HomeAssistant, fritz: Mock
 ) -> None:
-    """Test coordinator after reboot."""
+    """Test coordinator re-login after a transient HTTP error during update.
+
+    When _update_fritz_devices raises HTTPError the coordinator attempts a
+    re-login and retries.  If both the re-login and the retry succeed the
+    entry stays loaded without triggering a full reload.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        unique_id="any",
+    )
+    entry.add_to_hass(hass)
+    # First update call succeeds; second raises HTTPError to simulate a reboot
+    fritz().update_devices.side_effect = ["", HTTPError(), ""]
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert fritz().login.call_count == 1
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Re-login was attempted once more (total 2: initial setup + re-login)
+    assert fritz().login.call_count == 2
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_coordinator_update_after_reboot_relogin_fails(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
+    """Test coordinator when re-login itself fails after an HTTP error."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
@@ -41,18 +70,14 @@ async def test_coordinator_update_after_reboot(
     )
     entry.add_to_hass(hass)
     fritz().update_devices.side_effect = ["", HTTPError()]
+    fritz().login.side_effect = [None, ConnectionError()]
 
     assert await hass.config_entries.async_setup(entry.entry_id)
-    assert fritz().update_devices.call_count == 1
-    assert fritz().update_templates.call_count == 1
-    assert fritz().get_devices.call_count == 1
-    assert fritz().get_templates.call_count == 1
-    assert fritz().login.call_count == 1
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_coordinator_update_after_password_change(
@@ -71,17 +96,41 @@ async def test_coordinator_update_after_password_change(
     assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_coordinator_update_when_unreachable(
+async def test_coordinator_update_relogin_detects_password_change(
     hass: HomeAssistant, fritz: Mock
 ) -> None:
-    """Test coordinator after reboot."""
+    """Test coordinator triggers reauth when re-login fails with LoginError."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
         unique_id="any",
     )
     entry.add_to_hass(hass)
+    fritz().update_devices.side_effect = ["", HTTPError()]
+    # Initial login succeeds; re-login fails with LoginError (password changed)
+    fritz().login.side_effect = [None, LoginError("some_user")]
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_coordinator_update_when_unreachable(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
+    """Test coordinator when device is unreachable during initial setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        unique_id="any",
+    )
+    entry.add_to_hass(hass)
+    # Both the initial update and the re-login attempt fail immediately
     fritz().update_devices.side_effect = [ConnectionError()]
+    fritz().login.side_effect = [None, ConnectionError()]
 
     assert not await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -62,7 +62,7 @@ async def test_coordinator_update_after_reboot(
 async def test_coordinator_update_after_reboot_relogin_fails(
     hass: HomeAssistant, fritz: Mock
 ) -> None:
-    """Test coordinator when re-login itself fails after an HTTP error."""
+    """Test coordinator schedules reload when re-login fails with ConnectionError."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
@@ -70,6 +70,7 @@ async def test_coordinator_update_after_reboot_relogin_fails(
     )
     entry.add_to_hass(hass)
     fritz().update_devices.side_effect = ["", HTTPError()]
+    # Initial login succeeds; re-login fails with ConnectionError (box went offline)
     fritz().login.side_effect = [None, ConnectionError()]
 
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -77,7 +78,7 @@ async def test_coordinator_update_after_reboot_relogin_fails(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entry.state is ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_coordinator_update_after_password_change(
@@ -126,16 +127,14 @@ async def test_coordinator_update_relogin_detects_password_change(
 async def test_coordinator_update_when_unreachable(
     hass: HomeAssistant, fritz: Mock
 ) -> None:
-    """Test coordinator when device is unreachable during initial setup."""
+    """Test coordinator schedules reload when device is unreachable during update."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
         unique_id="any",
     )
     entry.add_to_hass(hass)
-    # Both the initial update and the re-login attempt fail immediately
     fritz().update_devices.side_effect = [ConnectionError()]
-    fritz().login.side_effect = [None, ConnectionError()]
 
     assert not await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -11,7 +11,7 @@ from requests.exceptions import ConnectionError, HTTPError
 
 from homeassistant.components.fritzbox.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_DEVICES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -115,7 +115,12 @@ async def test_coordinator_update_relogin_detects_password_change(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.LOADED
+    flows = hass.config_entries.flow.async_progress()
+    assert any(
+        flow["handler"] == DOMAIN and flow["context"]["source"] == SOURCE_REAUTH
+        for flow in flows
+    )
 
 
 async def test_coordinator_update_when_unreachable(

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -141,6 +141,23 @@ async def test_coordinator_update_when_unreachable(
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_coordinator_update_when_timeout(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
+    """Test coordinator schedules reload when update times out."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        unique_id="any",
+    )
+    entry.add_to_hass(hass)
+    fritz().update_devices.side_effect = [TimeoutError()]
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
 async def test_coordinator_automatic_registry_cleanup(
     hass: HomeAssistant,
     fritz: Mock,

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -69,16 +69,17 @@ async def test_coordinator_update_after_reboot_relogin_fails(
         unique_id="any",
     )
     entry.add_to_hass(hass)
-    fritz().update_devices.side_effect = ["", HTTPError()]
-    # Initial login succeeds; re-login fails with ConnectionError (box went offline)
-    fritz().login.side_effect = [None, ConnectionError()]
+    fritz().update_devices.side_effect = ["", HTTPError(), ""]
+    # Initial login succeeds; re-login fails with ConnectionError (box went offline);
+    # login after schedule_reload succeeds
+    fritz().login.side_effect = [None, ConnectionError(), None]
 
     assert await hass.config_entries.async_setup(entry.entry_id)
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_coordinator_update_after_password_change(


### PR DESCRIPTION
## Summary

Two distinct error scenarios during `_async_update_data` are now handled separately:

**1. `HTTPError` (e.g. 403 Forbidden — expired session)**
The Fritz!Box is reachable but the session ID has expired. A full reload is unnecessary — the coordinator now re-logs in and retries the update immediately:
- If re-login succeeds and retry succeeds → no `UpdateFailed` raised, no ERROR log, entities stay available
- If re-login raises `LoginError` (password changed) → `ConfigEntryAuthFailed` to trigger reauth flow
- If re-login or retry raises `ConnectionError` → fall back to `schedule_reload`

**2. `RequestConnectionError` (e.g. nightly DSL forced reconnect)**
The Fritz!Box is temporarily unreachable. Re-login would also fail, so `schedule_reload` is triggered immediately for a clean recovery once the box is back online.

**`UpdateFailed` now includes the exception message** so the HA UI shows the actual error instead of an empty string.

## Changes

- `homeassistant/components/fritzbox/coordinator.py`: split error handling into `HTTPError` and `RequestConnectionError` branches
- `tests/components/fritzbox/test_coordinator.py`: updated tests to match new behavior

## Test plan

- [x] `test_coordinator_update_after_reboot` — HTTPError → re-login → retry succeeds → `LOADED`
- [x] `test_coordinator_update_after_reboot_relogin_fails` — HTTPError → re-login raises `ConnectionError` → `SETUP_RETRY`
- [x] `test_coordinator_update_relogin_detects_password_change` — HTTPError → re-login raises `LoginError` → reauth flow started
- [x] `test_coordinator_update_when_unreachable` — `ConnectionError` during update → `SETUP_RETRY`