### PR TITLE
Fix victron ble reauth flow title

### DIFF
--- a/homeassistant/components/victron_ble/config_flow.py
+++ b/homeassistant/components/victron_ble/config_flow.py
@@ -54,7 +54,7 @@ class VictronBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_devices_info[discovery_info.address] = discovery_info
         self._discovered_devices[discovery_info.address] = discovery_info.name
 
-        self.context["title_placeholders"] = {"title": discovery_info.name}
+        self.context["title_placeholders"] = {"name": discovery_info.name}
 
         return await self.async_step_access_token()
 

--- a/homeassistant/components/victron_ble/strings.json
+++ b/homeassistant/components/victron_ble/strings.json
@@ -18,7 +18,7 @@
       "invalid_access_token": "Invalid encryption key for instant readout",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     },
-    "flow_title": "{title}",
+    "flow_title": "{name}",
     "step": {
       "access_token": {
         "data": {

--- a/tests/components/victron_ble/test_config_flow.py
+++ b/tests/components/victron_ble/test_config_flow.py
@@ -307,3 +307,23 @@ async def test_async_step_reauth_device_not_found(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "reauth_confirm"
         assert result["errors"] == {"base": "no_devices_found"}
+
+
+async def test_reauth_flow_sets_title_placeholders(
+    hass: HomeAssistant,
+    mock_config_entry_added_to_hass: MockConfigEntry,
+    mock_discovered_service_info: AsyncMock,
+) -> None:
+    """Test that reauth flow has title_placeholders set for flow_title rendering.
+
+    Regression test for https://github.com/home-assistant/core/issues/167105 where
+    the flow_title used '{title}' but HA only automatically provides 'name' in
+    title_placeholders for reauth flows, causing a frontend MISSING_VALUE error.
+    """
+    await mock_config_entry_added_to_hass.start_reauth_flow(hass)
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["title_placeholders"]["name"] == (
+        mock_config_entry_added_to_hass.title
+    )


### PR DESCRIPTION
## Proposed change

The flow_title string in strings.json used {title} as its placeholder key, but Home Assistant automatically provides only name in title_placeholders for reauth (and reconfigure) flows. The bluetooth discovery flow manually set title_placeholders = {"title": ...}, so it worked fine — but the reauth flow (added in #165729) relied on HA's automatic behaviour which only provides name, so {title} was never resolved. This caused the frontend to throw a MISSING_VALUE error for flow_title during reauth.

Fix by aligning with the HA convention used by other integrations (esphome, shelly, etc.): use {name} in flow_title and set title_placeholders with the name key in async_step_bluetooth. Reauth then works automatically with no extra code, since HA core sets title_placeholders = {"name": entry.title} for all reauth flows.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: partially fixes https://github.com/home-assistant/core/issues/167105 (need to also address why the reauth flow is firing unnecessarily)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
