### PR TITLE
Extract serialization template functions into a serialization Jinja2 extension

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -10,14 +10,12 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from enum import Enum
 from functools import cache, lru_cache, partial, wraps
-import json
 import logging
 import math
 from operator import contains
 import pathlib
 import random
 import re
-from struct import error as StructError, pack, unpack_from
 import sys
 from types import CodeType
 from typing import TYPE_CHECKING, Any, Concatenate, Literal, NoReturn, Self, overload
@@ -30,7 +28,6 @@ from jinja2.runtime import AsyncLoopContext, LoopContext
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
 from lru import LRU
-import orjson
 from propcache.api import under_cached_property
 
 from homeassistant.const import (
@@ -142,10 +139,6 @@ MAX_TEMPLATE_OUTPUT = 256 * 1024  # 256KiB
 CACHED_TEMPLATE_LRU: LRU[State, TemplateState] = LRU(CACHED_TEMPLATE_STATES)
 CACHED_TEMPLATE_NO_COLLECT_LRU: LRU[State, TemplateState] = LRU(CACHED_TEMPLATE_STATES)
 ENTITY_COUNT_GROWTH_FACTOR = 1.2
-
-ORJSON_PASSTHROUGH_OPTIONS = (
-    orjson.OPT_PASSTHROUGH_DATACLASS | orjson.OPT_PASSTHROUGH_DATETIME
-)
 
 
 def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
@@ -1564,95 +1557,6 @@ def fail_when_undefined(value):
     return value
 
 
-def struct_pack(value: Any | None, format_string: str) -> bytes | None:
-    """Pack an object into a bytes object."""
-    try:
-        return pack(format_string, value)
-    except StructError:
-        _LOGGER.warning(
-            (
-                "Template warning: 'pack' unable to pack object '%s' with type '%s' and"
-                " format_string '%s' see https://docs.python.org/3/library/struct.html"
-                " for more information"
-            ),
-            str(value),
-            type(value).__name__,
-            format_string,
-        )
-        return None
-
-
-def struct_unpack(value: bytes, format_string: str, offset: int = 0) -> Any | None:
-    """Unpack an object from bytes an return the first native object."""
-    try:
-        return unpack_from(format_string, value, offset)[0]
-    except StructError:
-        _LOGGER.warning(
-            (
-                "Template warning: 'unpack' unable to unpack object '%s' with"
-                " format_string '%s' and offset %s see"
-                " https://docs.python.org/3/library/struct.html for more information"
-            ),
-            value,
-            format_string,
-            offset,
-        )
-        return None
-
-
-def from_hex(value: str) -> bytes:
-    """Perform hex string decode."""
-    return bytes.fromhex(value)
-
-
-def from_json(value, default=_SENTINEL):
-    """Convert a JSON string to an object."""
-    try:
-        return json_loads(value)
-    except JSON_DECODE_EXCEPTIONS:
-        if default is _SENTINEL:
-            raise_no_default("from_json", value)
-        return default
-
-
-def _to_json_default(obj: Any) -> None:
-    """Disable custom types in json serialization."""
-    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
-
-def to_json(
-    value: Any,
-    ensure_ascii: bool = False,
-    pretty_print: bool = False,
-    sort_keys: bool = False,
-) -> str:
-    """Convert an object to a JSON string."""
-    if ensure_ascii:
-        # For those who need ascii, we can't use orjson, so we fall back to the json library.
-        return json.dumps(
-            value,
-            ensure_ascii=ensure_ascii,
-            indent=2 if pretty_print else None,
-            sort_keys=sort_keys,
-        )
-
-    option = (
-        ORJSON_PASSTHROUGH_OPTIONS
-        # OPT_NON_STR_KEYS is added as a workaround to
-        # ensure subclasses of str are allowed as dict keys
-        # See: https://github.com/ijl/orjson/issues/445
-        | orjson.OPT_NON_STR_KEYS
-        | (orjson.OPT_INDENT_2 if pretty_print else 0)
-        | (orjson.OPT_SORT_KEYS if sort_keys else 0)
-    )
-
-    return orjson.dumps(
-        value,
-        option=option,
-        default=_to_json_default,
-    ).decode("utf-8")
-
-
 @pass_context
 def random_every_time(context, values):
     """Choose a random value.
@@ -1854,6 +1758,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.add_extension("homeassistant.helpers.template.extensions.LabelExtension")
         self.add_extension("homeassistant.helpers.template.extensions.MathExtension")
         self.add_extension("homeassistant.helpers.template.extensions.RegexExtension")
+        self.add_extension(
+            "homeassistant.helpers.template.extensions.SerializationExtension"
+        )
         self.add_extension("homeassistant.helpers.template.extensions.StringExtension")
         self.add_extension(
             "homeassistant.helpers.template.extensions.TypeCastExtension"
@@ -1864,9 +1771,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["combine"] = combine
         self.globals["iif"] = iif
         self.globals["merge_response"] = merge_response
-        self.globals["pack"] = struct_pack
         self.globals["typeof"] = typeof
-        self.globals["unpack"] = struct_unpack
         self.globals["version"] = version
         self.globals["zip"] = zip
 
@@ -1875,18 +1780,13 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["as_function"] = as_function
         self.filters["combine"] = combine
         self.filters["contains"] = contains
-        self.filters["from_json"] = from_json
-        self.filters["from_hex"] = from_hex
         self.filters["iif"] = iif
         self.filters["is_defined"] = fail_when_undefined
         self.filters["multiply"] = multiply
         self.filters["ord"] = ord
-        self.filters["pack"] = struct_pack
         self.filters["random"] = random_every_time
         self.filters["round"] = forgiving_round
-        self.filters["to_json"] = to_json
         self.filters["typeof"] = typeof
-        self.filters["unpack"] = struct_unpack
         self.filters["version"] = version
 
         self.tests["apply"] = apply

--- a/homeassistant/helpers/template/extensions/__init__.py
+++ b/homeassistant/helpers/template/extensions/__init__.py
@@ -11,6 +11,7 @@ from .issues import IssuesExtension
 from .labels import LabelExtension
 from .math import MathExtension
 from .regex import RegexExtension
+from .serialization import SerializationExtension
 from .string import StringExtension
 from .type_cast import TypeCastExtension
 
@@ -26,6 +27,7 @@ __all__ = [
     "LabelExtension",
     "MathExtension",
     "RegexExtension",
+    "SerializationExtension",
     "StringExtension",
     "TypeCastExtension",
 ]

--- a/homeassistant/helpers/template/extensions/serialization.py
+++ b/homeassistant/helpers/template/extensions/serialization.py
@@ -1,0 +1,157 @@
+"""Serialization functions for Home Assistant templates."""
+
+from __future__ import annotations
+
+import json
+import logging
+from struct import error as StructError, pack, unpack_from
+from typing import TYPE_CHECKING, Any
+
+import orjson
+
+from homeassistant.helpers.template.helpers import raise_no_default
+from homeassistant.util.json import JSON_DECODE_EXCEPTIONS, json_loads
+
+from .base import BaseTemplateExtension, TemplateFunction
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.template import TemplateEnvironment
+
+_LOGGER = logging.getLogger(__name__)
+
+_SENTINEL = object()
+
+_ORJSON_PASSTHROUGH_OPTIONS = (
+    orjson.OPT_PASSTHROUGH_DATACLASS | orjson.OPT_PASSTHROUGH_DATETIME
+)
+
+
+class SerializationExtension(BaseTemplateExtension):
+    """Jinja2 extension for serialization functions."""
+
+    def __init__(self, environment: TemplateEnvironment) -> None:
+        """Initialize the serialization extension."""
+        super().__init__(
+            environment,
+            functions=[
+                TemplateFunction(
+                    "pack",
+                    self.struct_pack,
+                    as_global=True,
+                    as_filter=True,
+                ),
+                TemplateFunction(
+                    "unpack",
+                    self.struct_unpack,
+                    as_global=True,
+                    as_filter=True,
+                ),
+                TemplateFunction(
+                    "from_json",
+                    self.from_json,
+                    as_filter=True,
+                ),
+                TemplateFunction(
+                    "to_json",
+                    self.to_json,
+                    as_filter=True,
+                ),
+                TemplateFunction(
+                    "from_hex",
+                    self.from_hex,
+                    as_filter=True,
+                ),
+            ],
+        )
+
+    @staticmethod
+    def struct_pack(value: Any | None, format_string: str) -> bytes | None:
+        """Pack an object into a bytes object."""
+        try:
+            return pack(format_string, value)
+        except StructError:
+            _LOGGER.warning(
+                (
+                    "Template warning: 'pack' unable to pack object '%s' with type '%s'"
+                    " and format_string '%s' see"
+                    " https://docs.python.org/3/library/struct.html"
+                    " for more information"
+                ),
+                str(value),
+                type(value).__name__,
+                format_string,
+            )
+            return None
+
+    @staticmethod
+    def struct_unpack(value: bytes, format_string: str, offset: int = 0) -> Any | None:
+        """Unpack an object from bytes and return the first native object."""
+        try:
+            return unpack_from(format_string, value, offset)[0]
+        except StructError:
+            _LOGGER.warning(
+                (
+                    "Template warning: 'unpack' unable to unpack object '%s' with"
+                    " format_string '%s' and offset %s see"
+                    " https://docs.python.org/3/library/struct.html"
+                    " for more information"
+                ),
+                value,
+                format_string,
+                offset,
+            )
+            return None
+
+    @staticmethod
+    def from_json(value: Any, default: Any = _SENTINEL) -> Any:
+        """Convert a JSON string to an object."""
+        try:
+            return json_loads(value)
+        except JSON_DECODE_EXCEPTIONS:
+            if default is _SENTINEL:
+                raise_no_default("from_json", value)
+            return default
+
+    @staticmethod
+    def to_json(
+        value: Any,
+        ensure_ascii: bool = False,
+        pretty_print: bool = False,
+        sort_keys: bool = False,
+    ) -> str:
+        """Convert an object to a JSON string."""
+        if ensure_ascii:
+            # For those who need ascii, we can't use orjson,
+            # so we fall back to the json library.
+            return json.dumps(
+                value,
+                ensure_ascii=ensure_ascii,
+                indent=2 if pretty_print else None,
+                sort_keys=sort_keys,
+            )
+
+        option = (
+            _ORJSON_PASSTHROUGH_OPTIONS
+            # OPT_NON_STR_KEYS is added as a workaround to
+            # ensure subclasses of str are allowed as dict keys
+            # See: https://github.com/ijl/orjson/issues/445
+            | orjson.OPT_NON_STR_KEYS
+            | (orjson.OPT_INDENT_2 if pretty_print else 0)
+            | (orjson.OPT_SORT_KEYS if sort_keys else 0)
+        )
+
+        return orjson.dumps(
+            value,
+            option=option,
+            default=_to_json_default,
+        ).decode("utf-8")
+
+    @staticmethod
+    def from_hex(value: str) -> bytes:
+        """Perform hex string decode."""
+        return bytes.fromhex(value)
+
+
+def _to_json_default(obj: Any) -> None:
+    """Disable custom types in json serialization."""
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")

--- a/tests/helpers/template/extensions/test_serialization.py
+++ b/tests/helpers/template/extensions/test_serialization.py
@@ -1,0 +1,178 @@
+"""Test serialization functions for Home Assistant templates."""
+
+from __future__ import annotations
+
+import json
+
+import orjson
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import TemplateError
+
+from tests.helpers.template.helpers import render, render_to_info
+
+
+def test_to_json(hass: HomeAssistant) -> None:
+    """Test the object to JSON string filter."""
+
+    # Note that we're not testing the actual json.loads and json.dumps methods,
+    # only the filters, so we don't need to be exhaustive with our sample JSON.
+    expected_result = {"Foo": "Bar"}
+    actual_result = render(hass, "{{ {'Foo': 'Bar'} | to_json }}")
+    assert actual_result == expected_result
+
+    expected_result = orjson.dumps({"Foo": "Bar"}, option=orjson.OPT_INDENT_2).decode()
+    actual_result = render(
+        hass, "{{ {'Foo': 'Bar'} | to_json(pretty_print=True) }}", parse_result=False
+    )
+    assert actual_result == expected_result
+
+    expected_result = orjson.dumps(
+        {"Z": 26, "A": 1, "M": 13}, option=orjson.OPT_SORT_KEYS
+    ).decode()
+    actual_result = render(
+        hass,
+        "{{ {'Z': 26, 'A': 1, 'M': 13} | to_json(sort_keys=True) }}",
+        parse_result=False,
+    )
+    assert actual_result == expected_result
+
+    with pytest.raises(TemplateError):
+        render(hass, "{{ {'Foo': now()} | to_json }}")
+
+    # Test special case where substring class cannot be rendered
+    # See: https://github.com/ijl/orjson/issues/445
+    class MyStr(str):
+        __slots__ = ()
+
+    expected_result = '{"mykey1":11.0,"mykey2":"myvalue2","mykey3":["opt3b","opt3a"]}'
+    test_dict = {
+        MyStr("mykey2"): "myvalue2",
+        MyStr("mykey1"): 11.0,
+        MyStr("mykey3"): ["opt3b", "opt3a"],
+    }
+    actual_result = render(
+        hass,
+        "{{ test_dict | to_json(sort_keys=True) }}",
+        {"test_dict": test_dict},
+        parse_result=False,
+    )
+    assert actual_result == expected_result
+
+
+def test_to_json_ensure_ascii(hass: HomeAssistant) -> None:
+    """Test the object to JSON string filter."""
+
+    # Note that we're not testing the actual json.loads and json.dumps methods,
+    # only the filters, so we don't need to be exhaustive with our sample JSON.
+    actual_value_ascii = render(hass, "{{ 'Bar ҝ éèà' | to_json(ensure_ascii=True) }}")
+    assert actual_value_ascii == '"Bar \\u049d \\u00e9\\u00e8\\u00e0"'
+    actual_value = render(hass, "{{ 'Bar ҝ éèà' | to_json(ensure_ascii=False) }}")
+    assert actual_value == '"Bar ҝ éèà"'
+
+    expected_result = json.dumps({"Foo": "Bar"}, indent=2)
+    actual_result = render(
+        hass,
+        "{{ {'Foo': 'Bar'} | to_json(pretty_print=True, ensure_ascii=True) }}",
+        parse_result=False,
+    )
+    assert actual_result == expected_result
+
+    expected_result = json.dumps({"Z": 26, "A": 1, "M": 13}, sort_keys=True)
+    actual_result = render(
+        hass,
+        "{{ {'Z': 26, 'A': 1, 'M': 13} | to_json(sort_keys=True, ensure_ascii=True) }}",
+        parse_result=False,
+    )
+    assert actual_result == expected_result
+
+
+def test_from_json(hass: HomeAssistant) -> None:
+    """Test the JSON string to object filter."""
+
+    # Note that we're not testing the actual json.loads and json.dumps methods,
+    # only the filters, so we don't need to be exhaustive with our sample JSON.
+    expected_result = "Bar"
+    actual_result = render(hass, '{{ (\'{"Foo": "Bar"}\' | from_json).Foo }}')
+    assert actual_result == expected_result
+
+    info = render_to_info(hass, "{{ 'garbage string' | from_json }}")
+    with pytest.raises(TemplateError, match="no default was specified"):
+        info.result()
+
+    actual_result = render(hass, "{{ 'garbage string' | from_json('Bar') }}")
+    assert actual_result == expected_result
+
+
+def test_from_hex(hass: HomeAssistant) -> None:
+    """Test the fromhex filter."""
+    assert render(hass, "{{ '0F010003' | from_hex }}") == b"\x0f\x01\x00\x03"
+
+
+def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+    """Test struct pack method."""
+
+    # render as filter
+    variables = {"value": 0xDEADBEEF}
+    assert render(hass, "{{ value | pack('>I') }}", variables) == b"\xde\xad\xbe\xef"
+
+    # render as function
+    assert render(hass, "{{ pack(value, '>I') }}", variables) == b"\xde\xad\xbe\xef"
+
+    # test with None value
+    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
+    assert render(hass, "{{ pack(value, '>I') }}", {"value": None}) is None
+    assert (
+        "Template warning: 'pack' unable to pack object 'None' with type 'NoneType' and"
+        " format_string '>I' see https://docs.python.org/3/library/struct.html for more"
+        " information" in caplog.text
+    )
+
+    # test with invalid filter
+    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
+    assert render(hass, "{{ pack(value, 'invalid filter') }}", variables) is None
+    assert (
+        "Template warning: 'pack' unable to pack object '3735928559' with type 'int'"
+        " and format_string 'invalid filter' see"
+        " https://docs.python.org/3/library/struct.html for more information"
+        in caplog.text
+    )
+
+
+def test_unpack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+    """Test struct unpack method."""
+
+    variables = {"value": b"\xde\xad\xbe\xef"}
+
+    # render as filter
+    result = render(hass, """{{ value | unpack('>I') }}""", variables)
+    assert result == 0xDEADBEEF
+
+    # render as function
+    result = render(hass, """{{ unpack(value, '>I') }}""", variables)
+    assert result == 0xDEADBEEF
+
+    # unpack with offset
+    result = render(hass, """{{ unpack(value, '>H', offset=2) }}""", variables)
+    assert result == 0xBEEF
+
+    # test with an empty bytes object
+    assert render(hass, """{{ unpack(value, '>I') }}""", {"value": b""}) is None
+    assert (
+        "Template warning: 'unpack' unable to unpack object 'b''' with format_string"
+        " '>I' and offset 0 see https://docs.python.org/3/library/struct.html for more"
+        " information" in caplog.text
+    )
+
+    # test with invalid filter
+    assert (
+        render(hass, """{{ unpack(value, 'invalid filter') }}""", {"value": b""})
+        is None
+    )
+    assert (
+        "Template warning: 'unpack' unable to unpack object 'b''' with format_string"
+        " 'invalid filter' and offset 0 see"
+        " https://docs.python.org/3/library/struct.html for more information"
+        in caplog.text
+    )

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -10,7 +10,6 @@ import random
 from unittest.mock import patch
 
 from freezegun import freeze_time
-import orjson
 import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
@@ -446,106 +445,9 @@ def test_as_function_no_arguments(hass: HomeAssistant) -> None:
     assert render(hass, tpl) == "Hello"
 
 
-def test_to_json(hass: HomeAssistant) -> None:
-    """Test the object to JSON string filter."""
-
-    # Note that we're not testing the actual json.loads and json.dumps methods,
-    # only the filters, so we don't need to be exhaustive with our sample JSON.
-    expected_result = {"Foo": "Bar"}
-    actual_result = render(hass, "{{ {'Foo': 'Bar'} | to_json }}")
-    assert actual_result == expected_result
-
-    expected_result = orjson.dumps({"Foo": "Bar"}, option=orjson.OPT_INDENT_2).decode()
-    actual_result = render(
-        hass, "{{ {'Foo': 'Bar'} | to_json(pretty_print=True) }}", parse_result=False
-    )
-    assert actual_result == expected_result
-
-    expected_result = orjson.dumps(
-        {"Z": 26, "A": 1, "M": 13}, option=orjson.OPT_SORT_KEYS
-    ).decode()
-    actual_result = render(
-        hass,
-        "{{ {'Z': 26, 'A': 1, 'M': 13} | to_json(sort_keys=True) }}",
-        parse_result=False,
-    )
-    assert actual_result == expected_result
-
-    with pytest.raises(TemplateError):
-        render(hass, "{{ {'Foo': now()} | to_json }}")
-
-    # Test special case where substring class cannot be rendered
-    # See: https://github.com/ijl/orjson/issues/445
-    class MyStr(str):
-        __slots__ = ()
-
-    expected_result = '{"mykey1":11.0,"mykey2":"myvalue2","mykey3":["opt3b","opt3a"]}'
-    test_dict = {
-        MyStr("mykey2"): "myvalue2",
-        MyStr("mykey1"): 11.0,
-        MyStr("mykey3"): ["opt3b", "opt3a"],
-    }
-    actual_result = render(
-        hass,
-        "{{ test_dict | to_json(sort_keys=True) }}",
-        {"test_dict": test_dict},
-        parse_result=False,
-    )
-    assert actual_result == expected_result
-
-
-def test_to_json_ensure_ascii(hass: HomeAssistant) -> None:
-    """Test the object to JSON string filter."""
-
-    # Note that we're not testing the actual json.loads and json.dumps methods,
-    # only the filters, so we don't need to be exhaustive with our sample JSON.
-    actual_value_ascii = render(hass, "{{ 'Bar ҝ éèà' | to_json(ensure_ascii=True) }}")
-    assert actual_value_ascii == '"Bar \\u049d \\u00e9\\u00e8\\u00e0"'
-    actual_value = render(hass, "{{ 'Bar ҝ éèà' | to_json(ensure_ascii=False) }}")
-    assert actual_value == '"Bar ҝ éèà"'
-
-    expected_result = json.dumps({"Foo": "Bar"}, indent=2)
-    actual_result = render(
-        hass,
-        "{{ {'Foo': 'Bar'} | to_json(pretty_print=True, ensure_ascii=True) }}",
-        parse_result=False,
-    )
-    assert actual_result == expected_result
-
-    expected_result = json.dumps({"Z": 26, "A": 1, "M": 13}, sort_keys=True)
-    actual_result = render(
-        hass,
-        "{{ {'Z': 26, 'A': 1, 'M': 13} | to_json(sort_keys=True, ensure_ascii=True) }}",
-        parse_result=False,
-    )
-    assert actual_result == expected_result
-
-
-def test_from_json(hass: HomeAssistant) -> None:
-    """Test the JSON string to object filter."""
-
-    # Note that we're not testing the actual json.loads and json.dumps methods,
-    # only the filters, so we don't need to be exhaustive with our sample JSON.
-    expected_result = "Bar"
-    actual_result = render(hass, '{{ (\'{"Foo": "Bar"}\' | from_json).Foo }}')
-    assert actual_result == expected_result
-
-    info = render_to_info(hass, "{{ 'garbage string' | from_json }}")
-    with pytest.raises(TemplateError, match="no default was specified"):
-        info.result()
-
-    actual_result = render(hass, "{{ 'garbage string' | from_json('Bar') }}")
-    assert actual_result == expected_result
-
-
 def test_ord(hass: HomeAssistant) -> None:
     """Test the ord filter."""
     assert render(hass, '{{ "d" | ord }}') == 100
-
-
-def test_from_hex(hass: HomeAssistant) -> None:
-    """Test the fromhex filter."""
-    assert render(hass, "{{ '0F010003' | from_hex }}") == b"\x0f\x01\x00\x03"
 
 
 @patch.object(random, "choice")
@@ -1179,74 +1081,6 @@ def test_version(hass: HomeAssistant) -> None:
 
     with pytest.raises(TemplateError):
         render(hass, "{{ version(None) < '2099.9.10' }}")
-
-
-def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
-    """Test struct pack method."""
-
-    # render as filter
-    variables = {"value": 0xDEADBEEF}
-    assert render(hass, "{{ value | pack('>I') }}", variables) == b"\xde\xad\xbe\xef"
-
-    # render as function
-    assert render(hass, "{{ pack(value, '>I') }}", variables) == b"\xde\xad\xbe\xef"
-
-    # test with None value
-    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
-    assert render(hass, "{{ pack(value, '>I') }}", {"value": None}) is None
-    assert (
-        "Template warning: 'pack' unable to pack object 'None' with type 'NoneType' and"
-        " format_string '>I' see https://docs.python.org/3/library/struct.html for more"
-        " information" in caplog.text
-    )
-
-    # test with invalid filter
-    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
-    assert render(hass, "{{ pack(value, 'invalid filter') }}", variables) is None
-    assert (
-        "Template warning: 'pack' unable to pack object '3735928559' with type 'int'"
-        " and format_string 'invalid filter' see"
-        " https://docs.python.org/3/library/struct.html for more information"
-        in caplog.text
-    )
-
-
-def test_unpack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
-    """Test struct unpack method."""
-
-    variables = {"value": b"\xde\xad\xbe\xef"}
-
-    # render as filter
-    result = render(hass, """{{ value | unpack('>I') }}""", variables)
-    assert result == 0xDEADBEEF
-
-    # render as function
-    result = render(hass, """{{ unpack(value, '>I') }}""", variables)
-    assert result == 0xDEADBEEF
-
-    # unpack with offset
-    result = render(hass, """{{ unpack(value, '>H', offset=2) }}""", variables)
-    assert result == 0xBEEF
-
-    # test with an empty bytes object
-    assert render(hass, """{{ unpack(value, '>I') }}""", {"value": b""}) is None
-    assert (
-        "Template warning: 'unpack' unable to unpack object 'b''' with format_string"
-        " '>I' and offset 0 see https://docs.python.org/3/library/struct.html for more"
-        " information" in caplog.text
-    )
-
-    # test with invalid filter
-    assert (
-        render(hass, """{{ unpack(value, 'invalid filter') }}""", {"value": b""})
-        is None
-    )
-    assert (
-        "Template warning: 'unpack' unable to unpack object 'b''' with format_string"
-        " 'invalid filter' and offset 0 see"
-        " https://docs.python.org/3/library/struct.html for more information"
-        in caplog.text
-    )
 
 
 def test_distance_function_with_1_state(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is part of the ongoing effort to refactor our huge single template monolith into something more maintainable. In previous PRs I've moved many categories of template methods out of the monolith template file into their own Jinja2 extension.

This PR moves the **serialization** template functions (`pack`, `unpack`, `from_json`, `to_json`, `from_hex`) into their own Jinja2 extension. Moves all tests as well.

There is no functional change in this PR, it is only moving these methods and tests into an extension.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
