### PR TITLE
Add native DHW service to Evohome

### DIFF
--- a/homeassistant/components/evohome/const.py
+++ b/homeassistant/components/evohome/const.py
@@ -37,4 +37,3 @@ class EvoService(StrEnum):
     SET_ZONE_OVERRIDE = "set_zone_override"
     CLEAR_ZONE_OVERRIDE = "clear_zone_override"
     SET_DHW_OVERRIDE = "set_dhw_override"
-    CLEAR_DHW_OVERRIDE = "clear_dhw_override"

--- a/homeassistant/components/evohome/const.py
+++ b/homeassistant/components/evohome/const.py
@@ -22,11 +22,9 @@ CONF_LOCATION_IDX: Final = "location_idx"
 SCAN_INTERVAL_DEFAULT: Final = timedelta(seconds=300)
 SCAN_INTERVAL_MINIMUM: Final = timedelta(seconds=60)
 
-ATTR_PERIOD: Final = "period"  # number of days
 ATTR_DURATION: Final = "duration"  # number of minutes, <24h
-
+ATTR_PERIOD: Final = "period"  # number of days
 ATTR_SETPOINT: Final = "setpoint"
-EVO_STATE: Final = "state"
 
 
 @unique

--- a/homeassistant/components/evohome/const.py
+++ b/homeassistant/components/evohome/const.py
@@ -26,6 +26,7 @@ ATTR_PERIOD: Final = "period"  # number of days
 ATTR_DURATION: Final = "duration"  # number of minutes, <24h
 
 ATTR_SETPOINT: Final = "setpoint"
+ATTR_STATE: Final = "state"
 
 
 @unique
@@ -37,3 +38,5 @@ class EvoService(StrEnum):
     RESET_SYSTEM = "reset_system"
     SET_ZONE_OVERRIDE = "set_zone_override"
     CLEAR_ZONE_OVERRIDE = "clear_zone_override"
+    SET_DHW_OVERRIDE = "set_dhw_override"
+    CLEAR_DHW_OVERRIDE = "clear_dhw_override"

--- a/homeassistant/components/evohome/const.py
+++ b/homeassistant/components/evohome/const.py
@@ -26,7 +26,7 @@ ATTR_PERIOD: Final = "period"  # number of days
 ATTR_DURATION: Final = "duration"  # number of minutes, <24h
 
 ATTR_SETPOINT: Final = "setpoint"
-ATTR_STATE: Final = "state"
+EVO_STATE: Final = "state"
 
 
 @unique

--- a/homeassistant/components/evohome/icons.json
+++ b/homeassistant/components/evohome/icons.json
@@ -13,6 +13,9 @@
     }
   },
   "services": {
+    "clear_dhw_override": {
+      "service": "mdi:water-heater-off"
+    },
     "clear_zone_override": {
       "service": "mdi:motion-sensor-off"
     },
@@ -21,6 +24,9 @@
     },
     "reset_system": {
       "service": "mdi:refresh"
+    },
+    "set_dhw_override": {
+      "service": "mdi:water-heater"
     },
     "set_system_mode": {
       "service": "mdi:pencil"

--- a/homeassistant/components/evohome/icons.json
+++ b/homeassistant/components/evohome/icons.json
@@ -13,9 +13,6 @@
     }
   },
   "services": {
-    "clear_dhw_override": {
-      "service": "mdi:water-heater-off"
-    },
     "clear_zone_override": {
       "service": "mdi:motion-sensor-off"
     },

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -88,14 +88,6 @@ def _register_dhw_entity_services(hass: HomeAssistant) -> None:
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
-        EvoService.CLEAR_DHW_OVERRIDE,
-        entity_domain=WATER_HEATER_DOMAIN,
-        schema=None,
-        func="async_clear_dhw_override",
-    )
-    service.async_register_platform_entity_service(
-        hass,
-        DOMAIN,
         EvoService.SET_DHW_OVERRIDE,
         entity_domain=WATER_HEATER_DOMAIN,
         schema=SET_DHW_OVERRIDE_SCHEMA,

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -60,7 +60,7 @@ SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
 
 # DHW service schemas (registered as entity services)
 SET_DHW_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required(EVO_STATE): vol.In(EvoDhwState),
+    vol.Required(EVO_STATE): vol.Coerce(EvoDhwState),
     vol.Optional(ATTR_DURATION): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(days=0), max=timedelta(days=1)),

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -16,21 +16,14 @@ import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
-from homeassistant.const import ATTR_MODE
+from homeassistant.const import ATTR_MODE, ATTR_STATE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import verify_domain_control
 
-from .const import (
-    ATTR_DURATION,
-    ATTR_PERIOD,
-    ATTR_SETPOINT,
-    DOMAIN,
-    EVO_STATE,
-    EvoService,
-)
+from .const import ATTR_DURATION, ATTR_PERIOD, ATTR_SETPOINT, DOMAIN, EvoService
 from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
@@ -60,7 +53,7 @@ SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
 
 # DHW service schemas (registered as entity services)
 SET_DHW_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required(EVO_STATE): vol.Coerce(EvoDhwState),
+    vol.Required(ATTR_STATE): vol.Coerce(EvoDhwState),
     vol.Optional(ATTR_DURATION): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(days=0), max=timedelta(days=1)),

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -14,7 +14,8 @@ from evohomeasync2.schemas.const import (
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.const import ATTR_MODE
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
+from homeassistant.const import ATTR_MODE, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
@@ -49,6 +50,15 @@ SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
     ),
 }
 
+# DHW service schemas (registered as entity services)
+SET_DHW_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
+    vol.Required("state"): vol.In([STATE_ON, STATE_OFF]),
+    vol.Optional(ATTR_DURATION): vol.All(
+        cv.time_period,
+        vol.Range(min=timedelta(days=0), max=timedelta(days=1)),
+    ),
+}
+
 
 def _register_zone_entity_services(hass: HomeAssistant) -> None:
     """Register entity-level services for zones."""
@@ -68,6 +78,27 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
         entity_domain=CLIMATE_DOMAIN,
         schema=SET_ZONE_OVERRIDE_SCHEMA,
         func="async_set_zone_override",
+    )
+
+
+def _register_dhw_entity_services(hass: HomeAssistant) -> None:
+    """Register entity-level services for DHW zones."""
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        EvoService.CLEAR_DHW_OVERRIDE,
+        entity_domain=WATER_HEATER_DOMAIN,
+        schema=None,
+        func="async_clear_dhw_override",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        EvoService.SET_DHW_OVERRIDE,
+        entity_domain=WATER_HEATER_DOMAIN,
+        schema=SET_DHW_OVERRIDE_SCHEMA,
+        func="async_set_dhw_override",
     )
 
 
@@ -156,3 +187,4 @@ def setup_service_functions(
     )
 
     _register_zone_entity_services(hass)
+    _register_dhw_entity_services(hass)

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -10,19 +10,27 @@ from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_M
 from evohomeasync2.schemas.const import (
     S2_DURATION as SZ_DURATION,
     S2_PERIOD as SZ_PERIOD,
+    DhwState as EvoDhwState,
 )
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
-from homeassistant.const import ATTR_MODE, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_MODE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import verify_domain_control
 
-from .const import ATTR_DURATION, ATTR_PERIOD, ATTR_SETPOINT, DOMAIN, EvoService
+from .const import (
+    ATTR_DURATION,
+    ATTR_PERIOD,
+    ATTR_SETPOINT,
+    DOMAIN,
+    EVO_STATE,
+    EvoService,
+)
 from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
@@ -52,7 +60,7 @@ SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
 
 # DHW service schemas (registered as entity services)
 SET_DHW_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required("state"): vol.In([STATE_ON, STATE_OFF]),
+    vol.Required(EVO_STATE): vol.In(EvoDhwState),
     vol.Optional(ATTR_DURATION): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(days=0), max=timedelta(days=1)),

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -10,7 +10,6 @@ from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_M
 from evohomeasync2.schemas.const import (
     S2_DURATION as SZ_DURATION,
     S2_PERIOD as SZ_PERIOD,
-    DhwState as EvoDhwState,
 )
 import voluptuous as vol
 
@@ -53,7 +52,7 @@ SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
 
 # DHW service schemas (registered as entity services)
 SET_DHW_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required(ATTR_STATE): vol.Coerce(EvoDhwState),
+    vol.Required(ATTR_STATE): cv.boolean,
     vol.Optional(ATTR_DURATION): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(days=0), max=timedelta(days=1)),

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -58,3 +58,19 @@ clear_zone_override:
       domain: climate
       supported_features:
         - climate.ClimateEntityFeature.TARGET_TEMPERATURE
+
+set_dhw_override:
+  target:
+    entity:
+      integration: evohome
+      domain: water_heater
+  fields:
+    state:
+      required: true
+      selector:
+        boolean:
+    duration:
+      example: "02:15"
+      selector:
+        duration:
+          enable_second: false

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -23,8 +23,7 @@ set_system_mode:
     duration:
       example: "18:00"
       selector:
-        duration:
-          enable_second: false
+        object:
 
 reset_system:
 
@@ -48,8 +47,7 @@ set_zone_override:
     duration:
       example: "02:15"
       selector:
-        duration:
-          enable_second: false
+        object:
 
 clear_zone_override:
   target:

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -23,7 +23,8 @@ set_system_mode:
     duration:
       example: "18:00"
       selector:
-        object:
+        duration:
+          enable_second: false
 
 reset_system:
 
@@ -47,7 +48,8 @@ set_zone_override:
     duration:
       example: "02:15"
       selector:
-        object:
+        duration:
+          enable_second: false
 
 clear_zone_override:
   target:

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -21,7 +21,7 @@
   },
   "services": {
     "clear_zone_override": {
-      "description": "Sets a zone to follow its schedule.",
+      "description": "Sets the zone to follow its schedule.",
       "name": "Clear zone override"
     },
     "refresh_system": {
@@ -29,11 +29,11 @@
       "name": "Refresh system"
     },
     "reset_system": {
-      "description": "Sets the system to `Auto` mode and resets all the zones to follow their schedules. Not all Evohome systems support this feature (i.e. `AutoWithReset` mode).",
+      "description": "Sets the system mode to `Auto` mode and resets all the zones to follow their schedules. Not all Evohome systems support this feature (i.e. `AutoWithReset` mode).",
       "name": "Reset system"
     },
     "set_dhw_override": {
-      "description": "Overrides a DHW state, either indefinitely or for a specified duration, after which it will revert to following its schedule.",
+      "description": "Overrides the DHW state, either indefinitely or for a specified duration, after which it will revert to following its schedule.",
       "fields": {
         "duration": {
           "description": "The DHW will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",
@@ -65,7 +65,7 @@
       "name": "Set system mode"
     },
     "set_zone_override": {
-      "description": "Overrides the zone's setpoint, either indefinitely or for a specified duration, after which it will revert to following its schedule.",
+      "description": "Overrides the zone setpoint, either indefinitely or for a specified duration, after which it will revert to following its schedule.",
       "fields": {
         "duration": {
           "description": "The zone will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -65,7 +65,7 @@
       "name": "Set system mode"
     },
     "set_zone_override": {
-      "description": "Overrides the zone's setpoint, either indefinitely or until for a specified duration, after which it will revert to following its schedule.",
+      "description": "Overrides the zone's setpoint, either indefinitely or for a specified duration, after which it will revert to following its schedule.",
       "fields": {
         "duration": {
           "description": "The zone will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -33,7 +33,7 @@
       "name": "Reset system"
     },
     "set_dhw_override": {
-      "description": "Overrides a DHW state, either indefinitely, or for a specified period of time, after which it will revert to following its schedule.",
+      "description": "Overrides a DHW state, either indefinitely or for a specified duration, after which it will revert to following its schedule.",
       "fields": {
         "duration": {
           "description": "The DHW will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",
@@ -47,7 +47,7 @@
       "name": "Set DHW override"
     },
     "set_system_mode": {
-      "description": "Sets the system mode, either indefinitely, or for a specified period of time, after which it will revert to `Auto`. Not all systems support all modes.",
+      "description": "Sets the system mode, either indefinitely or until a specified end time, after which it will revert to `Auto`. Not all systems support all modes.",
       "fields": {
         "duration": {
           "description": "The duration in hours; used only with `AutoWithEco` mode (up to 24 hours).",
@@ -65,7 +65,7 @@
       "name": "Set system mode"
     },
     "set_zone_override": {
-      "description": "Overrides the zone's setpoint, either indefinitely, or for a specified period of time, after which it will revert to following its schedule.",
+      "description": "Overrides the zone's setpoint, either indefinitely or until for a specified duration, after which it will revert to following its schedule.",
       "fields": {
         "duration": {
           "description": "The zone will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -40,7 +40,7 @@
           "name": "Duration"
         },
         "state": {
-          "description": "The DHW state: on or off.",
+          "description": "The DHW state: True (on: heat the water up to the setpoint) or False (off).",
           "name": "State"
         }
       },

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -20,6 +20,10 @@
     }
   },
   "services": {
+    "clear_dhw_override": {
+      "description": "Sets a DHW zone to follow its schedule.",
+      "name": "Clear DHW override"
+    },
     "clear_zone_override": {
       "description": "Sets a zone to follow its schedule.",
       "name": "Clear zone override"
@@ -31,6 +35,20 @@
     "reset_system": {
       "description": "Sets the system to `Auto` mode and resets all the zones to follow their schedules. Not all Evohome systems support this feature (i.e. `AutoWithReset` mode).",
       "name": "Reset system"
+    },
+    "set_dhw_override": {
+      "description": "Overrides a DHW state, either indefinitely, or for a specified period of time, after which it will revert to following its schedule.",
+      "fields": {
+        "duration": {
+          "description": "The DHW will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",
+          "name": "Duration"
+        },
+        "state": {
+          "description": "The DHW state: on or off.",
+          "name": "State"
+        }
+      },
+      "name": "Set DHW override"
     },
     "set_system_mode": {
       "description": "Sets the system mode, either indefinitely, or for a specified period of time, after which it will revert to `Auto`. Not all systems support all modes.",

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -20,10 +20,6 @@
     }
   },
   "services": {
-    "clear_dhw_override": {
-      "description": "Sets a DHW zone to follow its schedule.",
-      "name": "Clear DHW override"
-    },
     "clear_zone_override": {
       "description": "Sets a zone to follow its schedule.",
       "name": "Clear zone override"

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -99,9 +99,9 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
         )
 
     async def async_set_dhw_override(
-        self, state: EvoDhwState, duration: timedelta | None = None
+        self, state: bool, duration: timedelta | None = None
     ) -> None:
-        """Override the DHW zone's state, either permanently or for a duration."""
+        """Override the DHW zone's on/off state, either permanently or for a duration."""
 
         if duration is None:
             until = None  # indefinitely, aka permanent override

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -113,9 +113,9 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
 
         until = dt_util.as_utc(until) if until else None
 
-        if state == EvoDhwState.ON:
+        if state:
             await self.coordinator.call_client_api(self._evo_device.set_on(until=until))
-        else:  # EvoDhwState.OFF
+        else:
             await self.coordinator.call_client_api(
                 self._evo_device.set_off(until=until)
             )

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 from typing import Any
 
@@ -96,6 +97,33 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
         self._attr_precision = (
             PRECISION_TENTHS if coordinator.client_v1 else PRECISION_WHOLE
         )
+
+    async def async_clear_dhw_override(self) -> None:
+        """Clear the DHW override (if any) and return to following its schedule."""
+        await self.coordinator.call_client_api(self._evo_device.reset())
+
+    async def async_set_dhw_override(
+        self, state: str, duration: timedelta | None = None
+    ) -> None:
+        """Override the DHW zone's state, either permanently or for a duration."""
+
+        if duration is not None:
+            if duration.total_seconds() == 0:
+                await self._update_schedule()
+                until = self.setpoints.get("next_sp_from")
+            else:
+                until = dt_util.now() + duration
+        else:
+            until = None  # indefinitely
+
+        until = dt_util.as_utc(until) if until else None
+
+        if state == STATE_ON:
+            await self.coordinator.call_client_api(self._evo_device.set_on(until=until))
+        else:  # STATE_OFF
+            await self.coordinator.call_client_api(
+                self._evo_device.set_off(until=until)
+            )
 
     @property
     def current_operation(self) -> str | None:

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -103,7 +103,7 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
         await self.coordinator.call_client_api(self._evo_device.reset())
 
     async def async_set_dhw_override(
-        self, state: str, duration: timedelta | None = None
+        self, state: EvoDhwState, duration: timedelta | None = None
     ) -> None:
         """Override the DHW zone's state, either permanently or for a duration."""
 
@@ -118,9 +118,9 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
 
         until = dt_util.as_utc(until) if until else None
 
-        if state == STATE_ON:
+        if state == EvoDhwState.ON:
             await self.coordinator.call_client_api(self._evo_device.set_on(until=until))
-        else:  # STATE_OFF
+        else:  # EvoDhwState.OFF
             await self.coordinator.call_client_api(
                 self._evo_device.set_off(until=until)
             )

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -103,14 +103,13 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
     ) -> None:
         """Override the DHW zone's state, either permanently or for a duration."""
 
-        if duration is not None:
-            if duration.total_seconds() == 0:
-                await self._update_schedule()
-                until = self.setpoints.get("next_sp_from")
-            else:
-                until = dt_util.now() + duration
+        if duration is None:
+            until = None  # indefinitely, aka permanent override
+        elif duration.total_seconds() == 0:
+            await self._update_schedule()
+            until = self.setpoints.get("next_sp_from")
         else:
-            until = None  # indefinitely
+            until = dt_util.now() + duration
 
         until = dt_util.as_utc(until) if until else None
 

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -98,10 +98,6 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
             PRECISION_TENTHS if coordinator.client_v1 else PRECISION_WHOLE
         )
 
-    async def async_clear_dhw_override(self) -> None:
-        """Clear the DHW override (if any) and return to following its schedule."""
-        await self.coordinator.call_client_api(self._evo_device.reset())
-
     async def async_set_dhw_override(
         self, state: EvoDhwState, duration: timedelta | None = None
     ) -> None:

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -236,7 +236,6 @@ def dhw_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str
 
     evo: EvohomeClient = evohome.return_value
     dhw: HotWater | None = evo.tcs.hotwater
-
     assert dhw is not None, "Fixture has no DHW zone"
 
     return entity_id(Platform.WATER_HEATER, dhw.id)

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -236,6 +236,7 @@ def dhw_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str
 
     evo: EvohomeClient = evohome.return_value
     dhw: HotWater | None = evo.tcs.hotwater
+
     assert dhw is not None, "Fixture has no DHW zone"
 
     return entity_id(Platform.WATER_HEATER, dhw.id)

--- a/tests/components/evohome/snapshots/test_init.ambr
+++ b/tests/components/evohome/snapshots/test_init.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_setup[default]
-  dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override', 'clear_dhw_override', 'set_dhw_override'])
+  dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override', 'set_dhw_override'])
 # ---

--- a/tests/components/evohome/snapshots/test_init.ambr
+++ b/tests/components/evohome/snapshots/test_init.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_setup[default]
-  dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
+  dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override', 'clear_dhw_override', 'set_dhw_override'])
 # ---

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -209,7 +209,7 @@ async def test_set_zone_override_advance(
     zone_id: str,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test Evohome's set_zone_override service with no duration.
+    """Test Evohome's set_zone_override service with duration=0.
 
     The override is temporary until the next schedule change.
     """
@@ -413,7 +413,7 @@ async def test_set_dhw_override_advance(
     dhw_id: str,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test Evohome's set_dhw_override service with no duration.
+    """Test Evohome's set_dhw_override service with duration=0.
 
     The override is temporary until the next schedule change.
     """

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -16,12 +16,11 @@ from homeassistant.components.evohome.const import (
     ATTR_PERIOD,
     ATTR_SETPOINT,
     DOMAIN,
-    EVO_STATE,
     EvoService,
 )
 from homeassistant.components.evohome.water_heater import EvoDHW
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, ATTR_STATE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
@@ -402,7 +401,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                EVO_STATE: "Off",
+                ATTR_STATE: "Off",
             },
             target={ATTR_ENTITY_ID: dhw_id},
             blocking=True,
@@ -416,7 +415,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                EVO_STATE: "On",
+                ATTR_STATE: "On",
                 ATTR_DURATION: {"minutes": 135},
             },
             target={ATTR_ENTITY_ID: dhw_id},
@@ -458,7 +457,7 @@ async def test_set_dhw_override_advance(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                EVO_STATE: "On",
+                ATTR_STATE: "On",
                 ATTR_DURATION: {"minutes": 0},
             },
             target={ATTR_ENTITY_ID: dhw_id},

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -9,8 +9,6 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.evohome.climate import EvoZone
 from homeassistant.components.evohome.const import (
     ATTR_DURATION,
     ATTR_PERIOD,
@@ -201,48 +199,6 @@ async def test_set_zone_override(
         mock_fcn.assert_awaited_once_with(
             19.5, until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
         )
-
-
-@pytest.mark.parametrize("install", ["default"])
-async def test_set_zone_override_advance(
-    hass: HomeAssistant,
-    zone_id: str,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test Evohome's set_zone_override service with duration=0.
-
-    The override is temporary until the next schedule change.
-    """
-
-    freezer.move_to("2024-05-10T12:15:00+00:00")
-
-    expected_until = datetime(2024, 5, 10, 21, 10, tzinfo=UTC)
-
-    # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
-    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
-        (CLIMATE_DOMAIN, DOMAIN), {}
-    )
-
-    zone_entity: EvoZone = entities[zone_id]  # type: ignore[assignment]
-    zone_entity._schedule = None
-    zone_entity._setpoints = {}
-
-    # EvoZoneMode.TEMPORARY_OVERRIDE with duration 0 (i.e. until next schedule change)
-    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
-        await hass.services.async_call(
-            DOMAIN,
-            EvoService.SET_ZONE_OVERRIDE,
-            {
-                ATTR_SETPOINT: 19.5,
-                ATTR_DURATION: {"minutes": 0},
-            },
-            target={ATTR_ENTITY_ID: zone_id},
-            blocking=True,
-        )
-
-        mock_fcn.assert_awaited_once_with(19.5, until=expected_until)
-
-    assert zone_entity.setpoints["next_sp_from"] == expected_until
 
 
 @pytest.mark.parametrize("install", ["default"])

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
+from evohomeasync2.schemas.const import DhwState as EvoDhwState
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -15,13 +16,13 @@ from homeassistant.components.evohome.const import (
     ATTR_DURATION,
     ATTR_PERIOD,
     ATTR_SETPOINT,
-    ATTR_STATE,
     DOMAIN,
+    EVO_STATE,
     EvoService,
 )
 from homeassistant.components.evohome.water_heater import EvoDHW
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
@@ -405,7 +406,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                ATTR_STATE: STATE_OFF,
+                EVO_STATE: EvoDhwState.OFF,
             },
             target={ATTR_ENTITY_ID: dhw_id},
             blocking=True,
@@ -419,7 +420,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                ATTR_STATE: STATE_ON,
+                EVO_STATE: EvoDhwState.ON,
                 ATTR_DURATION: {"minutes": 135},
             },
             target={ATTR_ENTITY_ID: dhw_id},
@@ -462,7 +463,7 @@ async def test_set_dhw_override_advance(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                ATTR_STATE: STATE_ON,
+                EVO_STATE: EvoDhwState.ON,
                 ATTR_DURATION: {"minutes": 0},
             },
             target={ATTR_ENTITY_ID: dhw_id},

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -349,20 +349,6 @@ async def test_set_dhw_override(
 
     freezer.move_to("2024-07-10T12:00:00+00:00")
 
-    # EvoZoneMode.PERMANENT_OVERRIDE (on)
-    with patch("evohomeasync2.hotwater.HotWater.set_on") as mock_fcn:
-        await hass.services.async_call(
-            DOMAIN,
-            EvoService.SET_DHW_OVERRIDE,
-            {
-                ATTR_STATE: STATE_ON,
-            },
-            target={ATTR_ENTITY_ID: dhw_id},
-            blocking=True,
-        )
-
-        mock_fcn.assert_awaited_once_with(until=None)
-
     # EvoZoneMode.PERMANENT_OVERRIDE (off)
     with patch("evohomeasync2.hotwater.HotWater.set_off") as mock_fcn:
         await hass.services.async_call(
@@ -384,23 +370,6 @@ async def test_set_dhw_override(
             EvoService.SET_DHW_OVERRIDE,
             {
                 ATTR_STATE: STATE_ON,
-                ATTR_DURATION: {"minutes": 135},
-            },
-            target={ATTR_ENTITY_ID: dhw_id},
-            blocking=True,
-        )
-
-        mock_fcn.assert_awaited_once_with(
-            until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
-        )
-
-    # EvoZoneMode.TEMPORARY_OVERRIDE (off)
-    with patch("evohomeasync2.hotwater.HotWater.set_off") as mock_fcn:
-        await hass.services.async_call(
-            DOMAIN,
-            EvoService.SET_DHW_OVERRIDE,
-            {
-                ATTR_STATE: STATE_OFF,
                 ATTR_DURATION: {"minutes": 135},
             },
             target={ATTR_ENTITY_ID: dhw_id},

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -25,7 +25,6 @@ from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
-from homeassistant.util import dt as dt_util
 
 from .const import TEST_INSTALLS
 
@@ -219,7 +218,6 @@ async def test_set_zone_override_advance(
     freezer.move_to("2024-05-10T12:15:00+00:00")
 
     expected_until = datetime(2024, 5, 10, 21, 10, tzinfo=UTC)
-    expected_tzinfo = dt_util.get_time_zone("Europe/London")
 
     # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
     entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
@@ -246,7 +244,6 @@ async def test_set_zone_override_advance(
         mock_fcn.assert_awaited_once_with(19.5, until=expected_until)
 
     assert zone_entity.setpoints["next_sp_from"] == expected_until
-    assert zone_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo
 
 
 @pytest.mark.parametrize("install", ["default"])
@@ -445,7 +442,6 @@ async def test_set_dhw_override_advance(
     freezer.move_to("2024-05-10T12:15:00+00:00")
 
     expected_until = datetime(2024, 5, 10, 15, 30, tzinfo=UTC)
-    expected_tzinfo = dt_util.get_time_zone("Europe/London")
 
     # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
     entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
@@ -472,4 +468,3 @@ async def test_set_dhw_override_advance(
         mock_fcn.assert_awaited_once_with(until=expected_until)
 
     assert dhw_entity.setpoints["next_sp_from"] == expected_until
-    assert dhw_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -375,7 +375,6 @@ async def test_set_dhw_override_advance(
     """
 
     freezer.move_to("2024-05-10T12:15:00+00:00")
-
     expected_until = datetime(2024, 5, 10, 15, 30, tzinfo=UTC)
 
     # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -463,7 +463,7 @@ async def test_set_dhw_override_advance(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                EVO_STATE: EvoDhwState.ON,
+                EVO_STATE: "On",
                 ATTR_DURATION: {"minutes": 0},
             },
             target={ATTR_ENTITY_ID: dhw_id},

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -9,8 +9,6 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.evohome.climate import EvoZone
 from homeassistant.components.evohome.const import (
     ATTR_DURATION,
     ATTR_PERIOD,
@@ -19,17 +17,11 @@ from homeassistant.components.evohome.const import (
     DOMAIN,
     EvoService,
 )
-from homeassistant.components.evohome.water_heater import EvoDHW
-from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
-from homeassistant.util import dt as dt_util
 
 from .const import TEST_INSTALLS
-
-from tests.patch_time import HAFakeDatetime
 
 
 @pytest.mark.parametrize("install", ["default"])
@@ -205,50 +197,6 @@ async def test_set_zone_override(
         mock_fcn.assert_awaited_once_with(
             19.5, until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
         )
-
-
-@pytest.mark.parametrize("install", ["default"])
-async def test_set_zone_override_advance(
-    hass: HomeAssistant,
-    zone_id: str,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test Evohome's set_dhw_override service with no duration.
-
-    The override is temporary until the next schedule change.
-    """
-
-    freezer.move_to("2024-05-10T12:15:00+00:00")
-
-    expected_until = HAFakeDatetime(2024, 5, 10, 21, 10, tzinfo=UTC)
-    expected_tzinfo = dt_util.get_time_zone("Europe/London")
-
-    # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
-    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
-        (CLIMATE_DOMAIN, DOMAIN), {}
-    )
-
-    zone_entity: EvoZone = entities[zone_id]  # type: ignore[assignment]
-    zone_entity._schedule = None
-    zone_entity._setpoints = {}
-
-    # EvoZoneMode.TEMPORARY_OVERRIDE with duration 0 (i.e. until next schedule change)
-    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
-        await hass.services.async_call(
-            DOMAIN,
-            EvoService.SET_ZONE_OVERRIDE,
-            {
-                ATTR_SETPOINT: 19.5,
-                ATTR_DURATION: {"minutes": 0},
-            },
-            target={ATTR_ENTITY_ID: zone_id},
-            blocking=True,
-        )
-
-        mock_fcn.assert_awaited_once_with(19.5, until=expected_until)
-
-    assert zone_entity.setpoints["next_sp_from"] == expected_until
-    assert zone_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo
 
 
 @pytest.mark.parametrize("install", ["default"])
@@ -462,47 +410,3 @@ async def test_set_dhw_override(
         mock_fcn.assert_awaited_once_with(
             until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
         )
-
-
-@pytest.mark.parametrize("install", ["default"])
-async def test_set_dhw_override_advance(
-    hass: HomeAssistant,
-    dhw_id: str,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test Evohome's set_dhw_override service with no duration.
-
-    The override is temporary until the next schedule change.
-    """
-
-    freezer.move_to("2024-05-10T12:15:00+00:00")
-
-    expected_until = HAFakeDatetime(2024, 5, 10, 15, 30, tzinfo=UTC)
-    expected_tzinfo = dt_util.get_time_zone("Europe/London")
-
-    # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
-    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
-        (WATER_HEATER_DOMAIN, DOMAIN), {}
-    )
-
-    dhw_entity: EvoDHW = entities[dhw_id]  # type: ignore[assignment]
-    dhw_entity._schedule = None
-    dhw_entity._setpoints = {}
-
-    # EvoZoneMode.TEMPORARY_OVERRIDE with duration 0 (i.e. until next schedule change)
-    with patch("evohomeasync2.hotwater.HotWater.set_on") as mock_fcn:
-        await hass.services.async_call(
-            DOMAIN,
-            EvoService.SET_DHW_OVERRIDE,
-            {
-                ATTR_STATE: STATE_ON,
-                ATTR_DURATION: {"minutes": 0},
-            },
-            target={ATTR_ENTITY_ID: dhw_id},
-            blocking=True,
-        )
-
-        mock_fcn.assert_awaited_once_with(until=expected_until)
-
-    assert dhw_entity.setpoints["next_sp_from"] == expected_until
-    assert dhw_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -366,26 +366,6 @@ async def test_set_system_mode_validator(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_clear_dhw_override(
-    hass: HomeAssistant,
-    dhw_id: str,
-) -> None:
-    """Test Evohome's clear_dhw_override service (for a DHW zone)."""
-
-    # EvoZoneMode.FOLLOW_SCHEDULE
-    with patch("evohomeasync2.hotwater.HotWater.reset") as mock_fcn:
-        await hass.services.async_call(
-            DOMAIN,
-            EvoService.CLEAR_DHW_OVERRIDE,
-            {},
-            target={ATTR_ENTITY_ID: dhw_id},
-            blocking=True,
-        )
-
-        mock_fcn.assert_awaited_once_with()
-
-
-@pytest.mark.parametrize("install", ["default"])
 async def test_set_dhw_override(
     hass: HomeAssistant,
     dhw_id: str,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.evohome.climate import EvoZone
 from homeassistant.components.evohome.const import (
     ATTR_DURATION,
     ATTR_PERIOD,
@@ -17,9 +19,13 @@ from homeassistant.components.evohome.const import (
     DOMAIN,
     EvoService,
 )
+from homeassistant.components.evohome.water_heater import EvoDHW
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
+from homeassistant.util import dt as dt_util
 
 from .const import TEST_INSTALLS
 
@@ -197,6 +203,50 @@ async def test_set_zone_override(
         mock_fcn.assert_awaited_once_with(
             19.5, until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
         )
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_set_zone_override_advance(
+    hass: HomeAssistant,
+    zone_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test Evohome's set_zone_override service with no duration.
+
+    The override is temporary until the next schedule change.
+    """
+
+    freezer.move_to("2024-05-10T12:15:00+00:00")
+
+    expected_until = datetime(2024, 5, 10, 21, 10, tzinfo=UTC)
+    expected_tzinfo = dt_util.get_time_zone("Europe/London")
+
+    # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
+        (CLIMATE_DOMAIN, DOMAIN), {}
+    )
+
+    zone_entity: EvoZone = entities[zone_id]  # type: ignore[assignment]
+    zone_entity._schedule = None
+    zone_entity._setpoints = {}
+
+    # EvoZoneMode.TEMPORARY_OVERRIDE with duration 0 (i.e. until next schedule change)
+    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_ZONE_OVERRIDE,
+            {
+                ATTR_SETPOINT: 19.5,
+                ATTR_DURATION: {"minutes": 0},
+            },
+            target={ATTR_ENTITY_ID: zone_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(19.5, until=expected_until)
+
+    assert zone_entity.setpoints["next_sp_from"] == expected_until
+    assert zone_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo
 
 
 @pytest.mark.parametrize("install", ["default"])
@@ -379,3 +429,47 @@ async def test_set_dhw_override(
         mock_fcn.assert_awaited_once_with(
             until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
         )
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_set_dhw_override_advance(
+    hass: HomeAssistant,
+    dhw_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test Evohome's set_dhw_override service with no duration.
+
+    The override is temporary until the next schedule change.
+    """
+
+    freezer.move_to("2024-05-10T12:15:00+00:00")
+
+    expected_until = datetime(2024, 5, 10, 15, 30, tzinfo=UTC)
+    expected_tzinfo = dt_util.get_time_zone("Europe/London")
+
+    # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
+        (WATER_HEATER_DOMAIN, DOMAIN), {}
+    )
+
+    dhw_entity: EvoDHW = entities[dhw_id]  # type: ignore[assignment]
+    dhw_entity._schedule = None
+    dhw_entity._setpoints = {}
+
+    # EvoZoneMode.TEMPORARY_OVERRIDE with duration 0 (i.e. until next schedule change)
+    with patch("evohomeasync2.hotwater.HotWater.set_on") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_DHW_OVERRIDE,
+            {
+                ATTR_STATE: STATE_ON,
+                ATTR_DURATION: {"minutes": 0},
+            },
+            target={ATTR_ENTITY_ID: dhw_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(until=expected_until)
+
+    assert dhw_entity.setpoints["next_sp_from"] == expected_until
+    assert dhw_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
-from evohomeasync2.schemas.const import DhwState as EvoDhwState
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -406,7 +405,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                EVO_STATE: EvoDhwState.OFF,
+                EVO_STATE: "Off",
             },
             target={ATTR_ENTITY_ID: dhw_id},
             blocking=True,
@@ -420,7 +419,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                EVO_STATE: EvoDhwState.ON,
+                EVO_STATE: "On",
                 ATTR_DURATION: {"minutes": 135},
             },
             target={ATTR_ENTITY_ID: dhw_id},

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -9,18 +9,27 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.evohome.climate import EvoZone
 from homeassistant.components.evohome.const import (
     ATTR_DURATION,
     ATTR_PERIOD,
     ATTR_SETPOINT,
+    ATTR_STATE,
     DOMAIN,
     EvoService,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
+from homeassistant.components.evohome.water_heater import EvoDHW
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
+from homeassistant.util import dt as dt_util
 
 from .const import TEST_INSTALLS
+
+from tests.patch_time import HAFakeDatetime
 
 
 @pytest.mark.parametrize("install", ["default"])
@@ -199,6 +208,50 @@ async def test_set_zone_override(
 
 
 @pytest.mark.parametrize("install", ["default"])
+async def test_set_zone_override_advance(
+    hass: HomeAssistant,
+    zone_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test Evohome's set_dhw_override service with no duration.
+
+    The override is temporary until the next schedule change.
+    """
+
+    freezer.move_to("2024-05-10T12:15:00+00:00")
+
+    expected_until = HAFakeDatetime(2024, 5, 10, 21, 10, tzinfo=UTC)
+    expected_tzinfo = dt_util.get_time_zone("Europe/London")
+
+    # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
+        (CLIMATE_DOMAIN, DOMAIN), {}
+    )
+
+    zone_entity: EvoZone = entities[zone_id]  # type: ignore[assignment]
+    zone_entity._schedule = None
+    zone_entity._setpoints = {}
+
+    # EvoZoneMode.TEMPORARY_OVERRIDE with duration 0 (i.e. until next schedule change)
+    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_ZONE_OVERRIDE,
+            {
+                ATTR_SETPOINT: 19.5,
+                ATTR_DURATION: {"minutes": 0},
+            },
+            target={ATTR_ENTITY_ID: zone_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(19.5, until=expected_until)
+
+    assert zone_entity.setpoints["next_sp_from"] == expected_until
+    assert zone_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo
+
+
+@pytest.mark.parametrize("install", ["default"])
 async def test_set_zone_override_legacy(
     hass: HomeAssistant,
     zone_id: str,
@@ -316,3 +369,140 @@ async def test_set_system_mode_validator(
     assert exc_info.value.translation_placeholders == {
         ATTR_MODE: service_data[ATTR_MODE]
     }
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_clear_dhw_override(
+    hass: HomeAssistant,
+    dhw_id: str,
+) -> None:
+    """Test Evohome's clear_dhw_override service (for a DHW zone)."""
+
+    # EvoZoneMode.FOLLOW_SCHEDULE
+    with patch("evohomeasync2.hotwater.HotWater.reset") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.CLEAR_DHW_OVERRIDE,
+            {},
+            target={ATTR_ENTITY_ID: dhw_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_set_dhw_override(
+    hass: HomeAssistant,
+    dhw_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test Evohome's set_dhw_override service (for a DHW zone)."""
+
+    freezer.move_to("2024-07-10T12:00:00+00:00")
+
+    # EvoZoneMode.PERMANENT_OVERRIDE (on)
+    with patch("evohomeasync2.hotwater.HotWater.set_on") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_DHW_OVERRIDE,
+            {
+                ATTR_STATE: STATE_ON,
+            },
+            target={ATTR_ENTITY_ID: dhw_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(until=None)
+
+    # EvoZoneMode.PERMANENT_OVERRIDE (off)
+    with patch("evohomeasync2.hotwater.HotWater.set_off") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_DHW_OVERRIDE,
+            {
+                ATTR_STATE: STATE_OFF,
+            },
+            target={ATTR_ENTITY_ID: dhw_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(until=None)
+
+    # EvoZoneMode.TEMPORARY_OVERRIDE (on)
+    with patch("evohomeasync2.hotwater.HotWater.set_on") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_DHW_OVERRIDE,
+            {
+                ATTR_STATE: STATE_ON,
+                ATTR_DURATION: {"minutes": 135},
+            },
+            target={ATTR_ENTITY_ID: dhw_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(
+            until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
+        )
+
+    # EvoZoneMode.TEMPORARY_OVERRIDE (off)
+    with patch("evohomeasync2.hotwater.HotWater.set_off") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_DHW_OVERRIDE,
+            {
+                ATTR_STATE: STATE_OFF,
+                ATTR_DURATION: {"minutes": 135},
+            },
+            target={ATTR_ENTITY_ID: dhw_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(
+            until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
+        )
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_set_dhw_override_advance(
+    hass: HomeAssistant,
+    dhw_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test Evohome's set_dhw_override service with no duration.
+
+    The override is temporary until the next schedule change.
+    """
+
+    freezer.move_to("2024-05-10T12:15:00+00:00")
+
+    expected_until = HAFakeDatetime(2024, 5, 10, 15, 30, tzinfo=UTC)
+    expected_tzinfo = dt_util.get_time_zone("Europe/London")
+
+    # Simulate the schedule not yet having been fetched (e.g. HOMEASSISTANT_START)
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES].get(
+        (WATER_HEATER_DOMAIN, DOMAIN), {}
+    )
+
+    dhw_entity: EvoDHW = entities[dhw_id]  # type: ignore[assignment]
+    dhw_entity._schedule = None
+    dhw_entity._setpoints = {}
+
+    # EvoZoneMode.TEMPORARY_OVERRIDE with duration 0 (i.e. until next schedule change)
+    with patch("evohomeasync2.hotwater.HotWater.set_on") as mock_fcn:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_DHW_OVERRIDE,
+            {
+                ATTR_STATE: STATE_ON,
+                ATTR_DURATION: {"minutes": 0},
+            },
+            target={ATTR_ENTITY_ID: dhw_id},
+            blocking=True,
+        )
+
+        mock_fcn.assert_awaited_once_with(until=expected_until)
+
+    assert dhw_entity.setpoints["next_sp_from"] == expected_until
+    assert dhw_entity.setpoints["next_sp_from"].tzinfo == expected_tzinfo

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -337,7 +337,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                ATTR_STATE: "Off",
+                ATTR_STATE: False,
             },
             target={ATTR_ENTITY_ID: dhw_id},
             blocking=True,
@@ -351,7 +351,7 @@ async def test_set_dhw_override(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                ATTR_STATE: "On",
+                ATTR_STATE: True,
                 ATTR_DURATION: {"minutes": 135},
             },
             target={ATTR_ENTITY_ID: dhw_id},
@@ -392,7 +392,7 @@ async def test_set_dhw_override_advance(
             DOMAIN,
             EvoService.SET_DHW_OVERRIDE,
             {
-                ATTR_STATE: "On",
+                ATTR_STATE: True,
                 ATTR_DURATION: {"minutes": 0},
             },
             target={ATTR_ENTITY_ID: dhw_id},

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -42,7 +42,10 @@ async def test_setup_platform(
     async for _ in setup_evohome(hass, config, install=install):
         pass
 
-    for x in hass.states.async_all(WATER_HEATER_DOMAIN):
+    water_heater_states = hass.states.async_all(WATER_HEATER_DOMAIN)
+    assert water_heater_states
+
+    for x in water_heater_states:
         assert x == snapshot(name=f"{x.entity_id}-state")
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the native service call, `set_dhw_override`, to Evohome's HotWater (DHW) entity:
 - this mirrors the equivalent services for Evohome's Climate (zone) entity
 
It also adds corresponding tests, and hardens an existing test, `test_setup_platform`, to avoid an edge case when the test should fail but does not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io/pull/44641
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
