### PR TITLE
Handle access.logs.add events for UniFi Access G6 Pro Entry

### DIFF
--- a/homeassistant/components/unifi_access/coordinator.py
+++ b/homeassistant/components/unifi_access/coordinator.py
@@ -27,6 +27,7 @@ from unifi_access_api.models.websocket import (
     InsightsAdd,
     LocationUpdateState,
     LocationUpdateV2,
+    LogAdd,
     SettingUpdate,
     ThumbnailInfo,
     V2LocationState,
@@ -92,6 +93,7 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
         )
         self.client = client
         self._event_listeners: list[Callable[[DoorEvent], None]] = []
+        self._device_to_door: dict[str, str] = {}
 
     @callback
     def async_subscribe_door_events(
@@ -141,6 +143,7 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             "access.data.v2.location.update": self._handle_v2_location_update,
             "access.hw.door_bell": self._handle_doorbell,
             "access.logs.insights.add": self._handle_insights_add,
+            "access.logs.add": self._handle_logs_add,
             "access.data.setting.update": self._handle_setting_update,
         }
         self.client.start_websocket(
@@ -197,6 +200,13 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
 
         current_ids = {door.id for door in doors} | {self.config_entry.entry_id}
         self._remove_stale_devices(current_ids)
+
+        current_door_ids = {door.id for door in doors}
+        self._device_to_door = {
+            dev_id: door_id
+            for dev_id, door_id in self._device_to_door.items()
+            if door_id in current_door_ids
+        }
 
         return UnifiAccessData(
             doors={door.id: door for door in doors},
@@ -268,6 +278,8 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
     async def _handle_v2_location_update(self, msg: WebsocketMessage) -> None:
         """Handle V2 location update messages."""
         update = cast(V2LocationUpdate, msg)
+        for device_id in update.data.device_ids:
+            self._device_to_door[device_id] = update.data.id
         self._process_door_update(
             update.data.id, update.data.state, update.data.thumbnail
         )
@@ -395,6 +407,27 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
         for door in door_entries:
             if door.id:
                 self._dispatch_door_event(door.id, "access", event_type, attrs)
+
+    async def _handle_logs_add(self, msg: WebsocketMessage) -> None:
+        """Handle access log events (entry/exit via access.logs.add)."""
+        log = cast(LogAdd, msg)
+        source = log.data.source
+        if not source.event.result:
+            return
+        device_target = source.device_config
+        if device_target is None or device_target.id not in self._device_to_door:
+            return
+        door_id = self._device_to_door[device_target.id]
+        event_type = (
+            "access_granted" if source.event.result == "ACCESS" else "access_denied"
+        )
+        attrs: dict[str, Any] = {}
+        if source.actor.display_name:
+            attrs["actor"] = source.actor.display_name
+        if source.authentication.credential_provider:
+            attrs["authentication"] = source.authentication.credential_provider
+        attrs["result"] = source.event.result
+        self._dispatch_door_event(door_id, "access", event_type, attrs)
 
     def get_lock_rule_status(self, door_id: str) -> DoorLockRuleStatus | None:
         """Return the current lock rule status for a door."""

--- a/homeassistant/components/unifi_access/coordinator.py
+++ b/homeassistant/components/unifi_access/coordinator.py
@@ -278,11 +278,20 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
     async def _handle_v2_location_update(self, msg: WebsocketMessage) -> None:
         """Handle V2 location update messages."""
         update = cast(V2LocationUpdate, msg)
+        door_id = update.data.id
+
+        stale_device_ids = [
+            device_id
+            for device_id, mapped_door_id in self._device_to_door.items()
+            if mapped_door_id == door_id
+        ]
+        for device_id in stale_device_ids:
+            del self._device_to_door[device_id]
+
         for device_id in update.data.device_ids:
-            self._device_to_door[device_id] = update.data.id
-        self._process_door_update(
-            update.data.id, update.data.state, update.data.thumbnail
-        )
+            self._device_to_door[device_id] = door_id
+
+        self._process_door_update(door_id, update.data.state, update.data.thumbnail)
 
     def _process_door_update(
         self,
@@ -412,8 +421,6 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
         """Handle access log events (entry/exit via access.logs.add)."""
         log = cast(LogAdd, msg)
         source = log.data.source
-        if not source.event.result:
-            return
         device_target = source.device_config
         if device_target is None or device_target.id not in self._device_to_door:
             return
@@ -426,7 +433,8 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             attrs["actor"] = source.actor.display_name
         if source.authentication.credential_provider:
             attrs["authentication"] = source.authentication.credential_provider
-        attrs["result"] = source.event.result
+        if source.event.result:
+            attrs["result"] = source.event.result
         self._dispatch_door_event(door_id, "access", event_type, attrs)
 
     def get_lock_rule_status(self, door_id: str) -> DoorLockRuleStatus | None:

--- a/tests/components/unifi_access/test_event.py
+++ b/tests/components/unifi_access/test_event.py
@@ -560,12 +560,13 @@ async def test_logs_add_without_location_update_ignored(
     assert state.state == "unknown"
 
 
-async def test_logs_add_empty_result_ignored(
+@pytest.mark.freeze_time("2025-01-01 00:00:00+00:00")
+async def test_logs_add_empty_result_dispatches_access_denied(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_client: MagicMock,
 ) -> None:
-    """Test access.logs.add event with empty result is ignored."""
+    """Test access.logs.add event with empty result dispatches access_denied."""
     handlers = _get_ws_handlers(mock_client)
     await _populate_device_mapping(handlers)
 
@@ -590,7 +591,9 @@ async def test_logs_add_empty_result_ignored(
 
     state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
     assert state is not None
-    assert state.state == "unknown"
+    assert state.attributes["event_type"] == "access_denied"
+    assert "result" not in state.attributes
+    assert state.state == "2025-01-01T00:00:00.000+00:00"
 
 
 async def test_logs_add_no_device_config_target_ignored(
@@ -651,3 +654,126 @@ async def test_logs_add_empty_targets_ignored(
     state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
     assert state is not None
     assert state.state == "unknown"
+
+
+@pytest.mark.freeze_time("2025-01-01 00:00:00+00:00")
+async def test_logs_add_stale_device_mapping_cleared(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test stale device mappings are cleared when a door's devices change."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    # Reassign door-001 to only have camera-device-001 (hub-device-001 removed)
+    reassign_msg = V2LocationUpdate(
+        event="access.data.v2.location.update",
+        data=V2LocationUpdateData(
+            id="door-001",
+            location_type="door",
+            name="Front Door",
+            device_ids=["camera-device-001"],
+        ),
+    )
+    await handlers["access.data.v2.location.update"](reassign_msg)
+
+    # hub-device-001 should no longer resolve to door-001
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="hub-device-001",
+                        display_name="UA Hub Door",
+                    ),
+                ],
+                actor=LogActor(display_name="John Doe"),
+                event=LogEvent(result="ACCESS"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.state == "unknown"
+
+    # camera-device-001 should still resolve to door-001
+    camera_log = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="camera-device-001",
+                        display_name="Camera",
+                    ),
+                ],
+                actor=LogActor(display_name="Jane Doe"),
+                event=LogEvent(result="ACCESS"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](camera_log)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.attributes["event_type"] == "access_granted"
+    assert state.state == "2025-01-01T00:00:00.000+00:00"
+
+
+@pytest.mark.freeze_time("2025-01-01 00:00:00+00:00")
+async def test_logs_add_device_mapping_pruned_on_refresh(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test device-to-door mappings are pruned when a door is removed on refresh."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    # Simulate door-001 being removed from the hub
+    mock_client.get_doors.return_value = [
+        door for door in mock_client.get_doors.return_value if door.id != "door-001"
+    ]
+
+    # Trigger refresh via WebSocket reconnect
+    on_disconnect = mock_client.start_websocket.call_args[1]["on_disconnect"]
+    on_connect = mock_client.start_websocket.call_args[1]["on_connect"]
+    on_disconnect()
+    await hass.async_block_till_done()
+    on_connect()
+    await hass.async_block_till_done()
+
+    # hub-device-001 mapping should have been pruned;
+    # sending a log event for it must not raise an error
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="hub-device-001",
+                        display_name="UA Hub Door",
+                    ),
+                ],
+                actor=LogActor(display_name="John Doe"),
+                event=LogEvent(result="ACCESS"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    # door-001 entity was removed when the door disappeared
+    assert hass.states.get(FRONT_DOOR_ACCESS_ENTITY) is None

--- a/tests/components/unifi_access/test_event.py
+++ b/tests/components/unifi_access/test_event.py
@@ -14,6 +14,15 @@ from unifi_access_api.models.websocket import (
     InsightsAddData,
     InsightsMetadata,
     InsightsMetadataEntry,
+    LogActor,
+    LogAdd,
+    LogAddData,
+    LogAuthentication,
+    LogEvent,
+    LogSource,
+    LogTarget,
+    V2LocationUpdate,
+    V2LocationUpdateData,
     WebsocketMessage,
 )
 
@@ -391,3 +400,254 @@ async def test_unload_entry_removes_listeners(
     state = hass.states.get(FRONT_DOOR_DOORBELL_ENTITY)
     assert state is not None
     assert state.state == "unavailable"
+
+
+async def _populate_device_mapping(
+    handlers: dict[str, Callable[[WebsocketMessage], Awaitable[None]]],
+) -> None:
+    """Send a V2 location update to populate the device-to-door mapping."""
+    location_msg = V2LocationUpdate(
+        event="access.data.v2.location.update",
+        data=V2LocationUpdateData(
+            id="door-001",
+            location_type="door",
+            name="Front Door",
+            device_ids=["hub-device-001", "camera-device-001"],
+        ),
+    )
+    await handlers["access.data.v2.location.update"](location_msg)
+
+
+@pytest.mark.freeze_time("2025-01-01 00:00:00+00:00")
+async def test_logs_add_access_granted(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test access.logs.add event dispatches access_granted."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="hub-device-001",
+                        display_name="UA Hub Door",
+                    ),
+                ],
+                actor=LogActor(display_name="John Doe"),
+                event=LogEvent(result="ACCESS"),
+                authentication=LogAuthentication(credential_provider="NFC"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.attributes["event_type"] == "access_granted"
+    assert state.attributes["actor"] == "John Doe"
+    assert state.attributes["authentication"] == "NFC"
+    assert state.attributes["result"] == "ACCESS"
+    assert state.state == "2025-01-01T00:00:00.000+00:00"
+
+
+@pytest.mark.freeze_time("2025-01-01 00:00:00+00:00")
+async def test_logs_add_access_denied(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test access.logs.add event dispatches access_denied for non-ACCESS result."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="hub-device-001",
+                        display_name="UA Hub Door",
+                    ),
+                ],
+                event=LogEvent(result="BLOCKED"),
+                authentication=LogAuthentication(credential_provider="PIN_CODE"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.attributes["event_type"] == "access_denied"
+    assert state.attributes["result"] == "BLOCKED"
+    assert state.state == "2025-01-01T00:00:00.000+00:00"
+
+
+async def test_logs_add_unknown_device_ignored(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test access.logs.add event with unknown device ID is ignored."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="unknown-device",
+                        display_name="Unknown Hub",
+                    ),
+                ],
+                event=LogEvent(result="ACCESS"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_logs_add_without_location_update_ignored(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test access.logs.add event is ignored when no device mapping exists."""
+    handlers = _get_ws_handlers(mock_client)
+
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="hub-device-001",
+                        display_name="UA Hub Door",
+                    ),
+                ],
+                event=LogEvent(result="ACCESS"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_logs_add_empty_result_ignored(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test access.logs.add event with empty result is ignored."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="device_config",
+                        id="hub-device-001",
+                        display_name="UA Hub Door",
+                    ),
+                ],
+                event=LogEvent(result=""),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_logs_add_no_device_config_target_ignored(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test access.logs.add event without device_config target is ignored."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[
+                    LogTarget(
+                        type="user",
+                        id="some-user-id",
+                        display_name="Some User",
+                    ),
+                ],
+                event=LogEvent(result="ACCESS"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_logs_add_empty_targets_ignored(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test access.logs.add event with empty targets list is ignored."""
+    handlers = _get_ws_handlers(mock_client)
+    await _populate_device_mapping(handlers)
+
+    log_msg = LogAdd(
+        event="access.logs.add",
+        data=LogAddData(
+            source=LogSource(
+                target=[],
+                event=LogEvent(result="ACCESS"),
+            ),
+        ),
+    )
+
+    await handlers["access.logs.add"](log_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FRONT_DOOR_ACCESS_ENTITY)
+    assert state is not None
+    assert state.state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Some UniFi Access hubs (e.g. UA Hub Door paired with a G6 Pro Entry) emit access events via the `access.logs.add` WebSocket topic instead of `access.logs.insights.add`. Because no handler was registered for this topic, access events always remained `unknown` in Home Assistant.

This PR adds a handler for `access.logs.add` and builds a device-to-door mapping using `access.data.v2.location.update` events (which already carry `device_ids` for each door location). When a `access.logs.add` event arrives, the hub device ID is resolved to the door entity ID via this mapping before dispatching the access event.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167128
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
