### PR TITLE
Bump axis to v68 to improve MQTT event resiliance

### DIFF
--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -29,7 +29,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["axis"],
-  "requirements": ["axis==67"],
+  "requirements": ["axis==68"],
   "ssdp": [
     {
       "manufacturer": "AXIS"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -596,7 +596,7 @@ avea==1.6.1
 # avion==0.10
 
 # homeassistant.components.axis
-axis==67
+axis==68
 
 # homeassistant.components.fujitsu_fglair
 ayla-iot-unofficial==1.4.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -548,7 +548,7 @@ autoskope_client==1.4.1
 av==16.0.1
 
 # homeassistant.components.axis
-axis==67
+axis==68
 
 # homeassistant.components.fujitsu_fglair
 ayla-iot-unofficial==1.4.7

--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -68,8 +68,8 @@ class RtspEventMock(Protocol):
 
 
 class _RtspClientMock(Protocol):
-    async def __call__(
-        self, data: dict[str, Any] | None = None, state: str = ""
+    def __call__(
+        self, data: bytes | None = None, state: Signal | None = None
     ) -> None: ...
 
 
@@ -337,14 +337,16 @@ def fixture_axis_rtsp_client() -> Generator[_RtspClientMock]:
 
         rtsp_client_mock.return_value.stop = stop_stream
 
-        def make_rtsp_call(data: dict[str, Any] | None = None, state: str = "") -> None:
+        def make_rtsp_call(
+            data: bytes | None = None, state: Signal | None = None
+        ) -> None:
             """Generate a RTSP call."""
             axis_streammanager_session_callback = rtsp_client_mock.call_args[0][4]
 
-            if data:
+            if data is not None:
                 rtsp_client_mock.return_value.data = data
                 axis_streammanager_session_callback(signal=Signal.DATA)
-            elif state:
+            elif state is not None:
                 axis_streammanager_session_callback(signal=state)
             else:
                 raise NotImplementedError

--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -342,7 +342,7 @@ def fixture_axis_rtsp_client() -> Generator[_RtspClientMock]:
             axis_streammanager_session_callback = rtsp_client_mock.call_args[0][4]
 
             if data:
-                rtsp_client_mock.return_value.rtp.data = data
+                rtsp_client_mock.return_value.data = data
                 axis_streammanager_session_callback(signal=Signal.DATA)
             elif state:
                 axis_streammanager_session_callback(signal=state)

--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from ipaddress import ip_address
+import logging
 from types import MappingProxyType
 from typing import Any
 from unittest import mock
@@ -71,6 +72,33 @@ async def test_device_support_mqtt(
     pir = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.{NAME}_pir_0")
     assert pir.state == STATE_ON
     assert pir.name == f"{NAME} PIR 0"
+
+
+@pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_MQTT])
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_device_support_mqtt_without_required_event_keys(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ignore non-event MQTT payloads without raising callback exceptions."""
+    caplog.set_level(logging.ERROR, logger="homeassistant.components.mqtt.client")
+
+    mqtt_call = call(f"axis/{MAC}/#", mock.ANY, 0, "utf-8", ANY)
+    assert mqtt_call in mqtt_mock.async_subscribe.call_args_list
+
+    topic = f"axis/{MAC}/device"
+    message = (
+        b'{"timestamp": 1775115420, "time": "2026-04-02T09:37:00+0200", '
+        b'"zone": "CEST", "ip": "1.2.3.4", "host": "hostname", '
+        b'"temperature": {"temp_main": 23.5, "temp_cpu": 24.0}, '
+        b'"power": {"pwr": 4.76, "pwr-avg": 3.88, "pwr-max": 9.13}}'
+    )
+
+    async_fire_mqtt_message(hass, topic, message)
+    await hass.async_block_till_done()
+
+    assert "Exception in _mqtt_message" not in caplog.text
 
 
 @pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_MQTT])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/Kane610/axis/compare/v67...v68
Make MQTT events handling be more robust (https://github.com/Kane610/axis/pull/755)
Other changes are internal refactoring that does not affect running code (no test changes only extensions), except for the one data point move (to normalise classes with the newly added websocket, https://github.com/Kane610/axis/pull/731), which only affects tests as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167194
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
