### PR TITLE
Add manual and remaining watering time to Gardena Bluetooth for Aquaprecise

### DIFF
--- a/homeassistant/components/gardena_bluetooth/number.py
+++ b/homeassistant/components/gardena_bluetooth/number.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from gardena_bluetooth.const import DeviceConfiguration, Sensor, Spray, Valve
+from gardena_bluetooth.const import (
+    AquaContourWatering,
+    DeviceConfiguration,
+    Sensor,
+    Spray,
+    Valve,
+)
 from gardena_bluetooth.parse import (
     Characteristic,
     CharacteristicInt,
@@ -59,6 +65,18 @@ DESCRIPTIONS = (
         device_class=NumberDeviceClass.DURATION,
     ),
     GardenaBluetoothNumberEntityDescription(
+        key=AquaContourWatering.manual_watering_time.unique_id,
+        translation_key="manual_watering_time",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        mode=NumberMode.BOX,
+        native_min_value=0.0,
+        native_max_value=24 * 60 * 60,
+        native_step=60,
+        entity_category=EntityCategory.CONFIG,
+        char=AquaContourWatering.manual_watering_time,
+        device_class=NumberDeviceClass.DURATION,
+    ),
+    GardenaBluetoothNumberEntityDescription(
         key=Valve.remaining_open_time.unique_id,
         translation_key="remaining_open_time",
         native_unit_of_measurement=UnitOfTime.SECONDS,
@@ -67,6 +85,17 @@ DESCRIPTIONS = (
         native_step=60.0,
         entity_category=EntityCategory.DIAGNOSTIC,
         char=Valve.remaining_open_time,
+        device_class=NumberDeviceClass.DURATION,
+    ),
+    GardenaBluetoothNumberEntityDescription(
+        key=AquaContourWatering.remaining_watering_time.unique_id,
+        translation_key="remaining_watering_time",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        native_min_value=0.0,
+        native_max_value=24 * 60 * 60,
+        native_step=60.0,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        char=AquaContourWatering.remaining_watering_time,
         device_class=NumberDeviceClass.DURATION,
     ),
     GardenaBluetoothNumberEntityDescription(

--- a/homeassistant/components/gardena_bluetooth/strings.json
+++ b/homeassistant/components/gardena_bluetooth/strings.json
@@ -50,6 +50,9 @@
       "remaining_open_time": {
         "name": "Remaining open time"
       },
+      "remaining_watering_time": {
+        "name": "Remaining watering time"
+      },
       "seasonal_adjust": {
         "name": "Seasonal adjust"
       },

--- a/tests/components/gardena_bluetooth/snapshots/test_number.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_number.ambr
@@ -111,7 +111,45 @@
     'state': '45.0',
   })
 # ---
-# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time]
+# name: test_setup[service_info0-98bd0f14-0b0e-421a-84e5-ddbf75dc6de4-raw0-number.mock_title_manual_watering_time]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Mock Title Manual watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 60,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_manual_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_setup[service_info0-98bd0f14-0b0e-421a-84e5-ddbf75dc6de4-raw0-number.mock_title_manual_watering_time].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Mock Title Manual watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 60,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_manual_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.0',
+  })
+# ---
+# name: test_setup[service_info1-98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -130,7 +168,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].1
+# name: test_setup[service_info1-98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -149,7 +187,7 @@
     'state': '10.0',
   })
 # ---
-# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].2
+# name: test_setup[service_info1-98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -168,7 +206,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].3
+# name: test_setup[service_info1-98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -187,7 +225,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw2-number.mock_title_open_for]
+# name: test_setup[service_info2-98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw2-number.mock_title_open_for]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -206,7 +244,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_setup[98bd0f14-0b0e-421a-84e5-ddbf75dc6de4-raw0-number.mock_title_manual_watering_time]
+# name: test_setup[service_info3-98bd0d13-0b0e-421a-84e5-ddbf75dc6de4-raw3-number.mock_title_manual_watering_time]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -225,7 +263,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_setup[98bd0f14-0b0e-421a-84e5-ddbf75dc6de4-raw0-number.mock_title_manual_watering_time].1
+# name: test_setup[service_info3-98bd0d13-0b0e-421a-84e5-ddbf75dc6de4-raw3-number.mock_title_manual_watering_time].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -242,5 +280,81 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '10.0',
+  })
+# ---
+# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Mock Title Remaining watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Mock Title Remaining watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.0',
+  })
+# ---
+# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time].2
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Mock Title Remaining watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time].3
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Mock Title Remaining watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---

--- a/tests/components/gardena_bluetooth/test_number.py
+++ b/tests/components/gardena_bluetooth/test_number.py
@@ -4,12 +4,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import Mock, call
 
-from gardena_bluetooth.const import Sensor, Valve
+from gardena_bluetooth.const import AquaContourWatering, Sensor, Valve
 from gardena_bluetooth.exceptions import (
     CharacteristicNoAccess,
     GardenaBluetoothException,
 )
 from gardena_bluetooth.parse import Characteristic
+from habluetooth import BluetoothServiceInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -21,15 +22,16 @@ from homeassistant.components.number import (
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 
-from . import setup_entry
+from . import AQUA_CONTOUR_SERVICE_INFO, WATER_TIMER_SERVICE_INFO, setup_entry
 
 from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("uuid", "raw", "entity_id"),
+    ("service_info", "uuid", "raw", "entity_id"),
     [
         (
+            WATER_TIMER_SERVICE_INFO,
             Valve.manual_watering_time.uuid,
             [
                 Valve.manual_watering_time.encode(100),
@@ -38,6 +40,7 @@ from tests.common import MockConfigEntry
             "number.mock_title_manual_watering_time",
         ),
         (
+            WATER_TIMER_SERVICE_INFO,
             Valve.remaining_open_time.uuid,
             [
                 Valve.remaining_open_time.encode(100),
@@ -48,18 +51,39 @@ from tests.common import MockConfigEntry
             "number.mock_title_remaining_open_time",
         ),
         (
+            WATER_TIMER_SERVICE_INFO,
             Valve.remaining_open_time.uuid,
             [Valve.remaining_open_time.encode(100)],
             "number.mock_title_open_for",
+        ),
+        (
+            AQUA_CONTOUR_SERVICE_INFO,
+            AquaContourWatering.manual_watering_time.uuid,
+            [
+                AquaContourWatering.manual_watering_time.encode(100),
+                AquaContourWatering.manual_watering_time.encode(10),
+            ],
+            "number.mock_title_manual_watering_time",
+        ),
+        (
+            AQUA_CONTOUR_SERVICE_INFO,
+            AquaContourWatering.remaining_watering_time.uuid,
+            [
+                AquaContourWatering.remaining_watering_time.encode(100),
+                AquaContourWatering.remaining_watering_time.encode(10),
+                CharacteristicNoAccess("Test for no access"),
+                GardenaBluetoothException("Test for errors on bluetooth"),
+            ],
+            "number.mock_title_remaining_watering_time",
         ),
     ],
 )
 async def test_setup(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
-    mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
     scan_step: Callable[[], Awaitable[None]],
+    service_info: BluetoothServiceInfo,
     uuid: str,
     raw: list[bytes],
     entity_id: str,
@@ -67,7 +91,7 @@ async def test_setup(
     """Test setup creates expected entities."""
 
     mock_read_char_raw[uuid] = raw[0]
-    await setup_entry(hass, mock_entry, [Platform.NUMBER])
+    await setup_entry(hass, platforms=[Platform.NUMBER], service_info=service_info)
     assert hass.states.get(entity_id) == snapshot
 
     for char_raw in raw[1:]:
@@ -77,27 +101,43 @@ async def test_setup(
 
 
 @pytest.mark.parametrize(
-    ("char", "value", "expected", "entity_id"),
+    ("service_info", "char", "value", "expected", "entity_id"),
     [
         (
+            WATER_TIMER_SERVICE_INFO,
             Valve.manual_watering_time,
             100,
             100,
             "number.mock_title_manual_watering_time",
         ),
         (
+            WATER_TIMER_SERVICE_INFO,
             Valve.remaining_open_time,
             100,
             100 * 60,
             "number.mock_title_open_for",
         ),
+        (
+            AQUA_CONTOUR_SERVICE_INFO,
+            AquaContourWatering.manual_watering_time,
+            100,
+            100,
+            "number.mock_title_manual_watering_time",
+        ),
+        (
+            AQUA_CONTOUR_SERVICE_INFO,
+            AquaContourWatering.remaining_watering_time,
+            100,
+            100,
+            "number.mock_title_remaining_watering_time",
+        ),
     ],
 )
 async def test_config(
     hass: HomeAssistant,
-    mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
     mock_client: Mock,
+    service_info: BluetoothServiceInfo,
     char: Characteristic,
     value: Any,
     expected: Any,
@@ -106,7 +146,7 @@ async def test_config(
     """Test setup creates expected entities."""
 
     mock_read_char_raw[char.uuid] = char.encode(value)
-    await setup_entry(hass, mock_entry, [Platform.NUMBER])
+    await setup_entry(hass, platforms=[Platform.NUMBER], service_info=service_info)
     assert hass.states.get(entity_id)
 
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added manual watering time and the remaining watering time for contour devices. When manually starting watering it currently stops after 1 minute. With this change you can specify the watering time for the contour devices similar to the valve devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
