### PR TITLE
Improve Remote action naming consistency

### DIFF
--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -108,11 +108,11 @@
     },
     "toggle": {
       "description": "Sends the toggle command.",
-      "name": "Remote toggle"
+      "name": "Toggle via remote"
     },
     "turn_off": {
       "description": "Sends the turn off command.",
-      "name": "Remote turn off"
+      "name": "Turn off via remote"
     },
     "turn_on": {
       "description": "Sends the turn on command.",
@@ -122,7 +122,7 @@
           "name": "Activity"
         }
       },
-      "name": "Remote turn on"
+      "name": "Turn on via remote"
     }
   },
   "title": "Remote",

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -41,7 +41,7 @@
   },
   "services": {
     "delete_command": {
-      "description": "Deletes a command or a list of commands from the database.",
+      "description": "Deletes a command or a list of commands from a remote's database.",
       "fields": {
         "command": {
           "description": "The single command or the list of commands to be deleted.",
@@ -52,10 +52,10 @@
           "name": "Device"
         }
       },
-      "name": "Delete command"
+      "name": "Delete remote command"
     },
     "learn_command": {
-      "description": "Learns a command or a list of commands from a device.",
+      "description": "Teaches a remote a command or list of commands from a device.",
       "fields": {
         "alternative": {
           "description": "If code must be stored as an alternative. This is useful for discrete codes. Discrete codes are used for toggles that only perform one function. For example, a code to only turn a device on. If it is on already, sending the code won't change the state.",
@@ -78,7 +78,7 @@
           "name": "Timeout"
         }
       },
-      "name": "Learn command"
+      "name": "Learn remote command"
     },
     "send_command": {
       "description": "Sends a command or a list of commands to a device.",
@@ -104,15 +104,15 @@
           "name": "Repeats"
         }
       },
-      "name": "Send command"
+      "name": "Send remote command"
     },
     "toggle": {
       "description": "Sends the toggle command.",
-      "name": "[%key:common::action::toggle%]"
+      "name": "Remote toggle"
     },
     "turn_off": {
       "description": "Sends the turn off command.",
-      "name": "[%key:common::action::turn_off%]"
+      "name": "Remote turn off"
     },
     "turn_on": {
       "description": "Sends the turn on command.",
@@ -122,7 +122,7 @@
           "name": "Activity"
         }
       },
-      "name": "[%key:common::action::turn_on%]"
+      "name": "Remote turn on"
     }
   },
   "title": "Remote",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Aligns the Remote integration's action names and descriptions with the established naming patterns used across Home Assistant.

The action names did not include the integration name so "remote" has been added to all of them.

The descriptions are mostly unaltered, there might be a chance for further improvements here.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
