### PR TITLE
Add notify_on_use param to Schlage add_code service

### DIFF
--- a/homeassistant/components/schlage/__init__.py
+++ b/homeassistant/components/schlage/__init__.py
@@ -37,6 +37,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         schema={
             vol.Required("name"): cv.string,
             vol.Required("code"): cv.matches_regex(r"^\d{4,8}$"),
+            vol.Required("notify_on_use"): cv.boolean,
         },
         func=SERVICE_ADD_CODE,
     )

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -113,14 +113,14 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
             ) from ex
         return self._lock.access_codes
 
-    async def add_code(self, name: str, code: str) -> None:
+    async def add_code(self, name: str, code: str, notify_on_use: bool) -> None:
         """Add a lock code."""
 
         codes = await self._async_fetch_access_codes()
         self._validate_code_name(codes, name)
         self._validate_code_value(codes, code)
 
-        access_code = AccessCode(name=name, code=code)
+        access_code = AccessCode(name=name, code=code, notify_on_use=notify_on_use)
         try:
             await self.hass.async_add_executor_job(
                 self._lock.add_access_code, access_code

--- a/homeassistant/components/schlage/services.yaml
+++ b/homeassistant/components/schlage/services.yaml
@@ -23,6 +23,11 @@ add_code:
         text:
           multiline: false
           type: password
+    notify_on_use:
+      required: true
+      default: true
+      selector:
+        boolean:
 
 delete_code:
   target:

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -83,6 +83,10 @@
         "name": {
           "description": "Name for PIN code. Must be case insensitively unique to the lock.",
           "name": "PIN name"
+        },
+        "notify_on_use": {
+          "description": "Whether the native Schlage notification should be sent when this PIN is used.",
+          "name": "Notify when PIN is Used"
         }
       },
       "name": "Add PIN code"

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -86,7 +86,7 @@
         },
         "notify_on_use": {
           "description": "Whether the native Schlage notification should be sent when this PIN is used.",
-          "name": "Notify when PIN is Used"
+          "name": "Notify when PIN is used"
         }
       },
       "name": "Add PIN code"

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -108,7 +108,7 @@ async def test_add_code_service(
     hass: HomeAssistant,
     mock_lock: Mock,
     mock_added_config_entry: MockSchlageConfigEntry,
-    notify_on_use
+    notify_on_use: bool,
 ) -> None:
     """Test add_code service."""
     # Mock access_codes as empty initially

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -96,11 +96,19 @@ async def test_changed_by(
     assert lock_device is not None
     assert lock_device.attributes.get("changed_by") == "access code - foo"
 
-
+@pytest.mark.parametrize(
+    "notify_on_use",
+    [
+        True,
+        False,
+    ],
+    ids=["notify-true", "notify-false"],
+)
 async def test_add_code_service(
     hass: HomeAssistant,
     mock_lock: Mock,
     mock_added_config_entry: MockSchlageConfigEntry,
+    notify_on_use
 ) -> None:
     """Test add_code service."""
     # Mock access_codes as empty initially
@@ -114,6 +122,7 @@ async def test_add_code_service(
             "entity_id": "lock.vault_door",
             "name": "test_user",
             "code": "1234",
+            "notify_on_use": notify_on_use,
         },
         blocking=True,
     )
@@ -126,6 +135,7 @@ async def test_add_code_service(
     assert isinstance(call_args, AccessCode)
     assert call_args.name == "test_user"
     assert call_args.code == "1234"
+    assert call_args.notify_on_use == notify_on_use
 
 
 @pytest.mark.parametrize(
@@ -155,6 +165,7 @@ async def test_add_code_service_invalid_code(
                 "entity_id": "lock.vault_door",
                 "name": "test_user",
                 "code": code,
+                "notify_on_use": False,
             },
             blocking=True,
         )
@@ -184,6 +195,7 @@ async def test_add_code_service_duplicate_name(
                 "entity_id": "lock.vault_door",
                 "name": "test_user",
                 "code": "1234",
+                "notify_on_use": False,
             },
             blocking=True,
         )
@@ -215,6 +227,7 @@ async def test_add_code_service_duplicate_code(
                 "entity_id": "lock.vault_door",
                 "name": "test_user",
                 "code": "1234",
+                "notify_on_use": False,
             },
             blocking=True,
         )
@@ -438,6 +451,7 @@ async def test_add_code_service_refresh_error(
                 "entity_id": "lock.vault_door",
                 "name": "test_user",
                 "code": "1234",
+                "notify_on_use": False,
             },
             blocking=True,
         )
@@ -461,6 +475,7 @@ async def test_add_code_service_api_error(
                 "entity_id": "lock.vault_door",
                 "name": "test_user",
                 "code": "1234",
+                "notify_on_use": False,
             },
             blocking=True,
         )

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -96,6 +96,7 @@ async def test_changed_by(
     assert lock_device is not None
     assert lock_device.attributes.get("changed_by") == "access code - foo"
 
+
 @pytest.mark.parametrize(
     "notify_on_use",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change builds off of https://github.com/home-assistant/core/pull/151014 and adds in another configuration parameter available from pyschlage `notify_on_use`.
The behavior matches the native Schlage app, where when adding a new code, by default the value is true.

https://github.com/user-attachments/assets/9c1ce640-b7bc-4131-a305-3adf944f1103

https://github.com/user-attachments/assets/83e05a2f-9a37-44e9-8a7a-5ac55171b71c


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
