### PR TITLE
Add read-only MCP Assist context snapshot resource

### DIFF
--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -10,7 +10,7 @@ See https://modelcontextprotocol.io/docs/concepts/architecture#implementation-ex
 from collections.abc import Callable, Sequence
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 from mcp import types
 from mcp.server import Server
@@ -19,56 +19,23 @@ from pydantic import AnyUrl
 import voluptuous as vol
 from voluptuous_openapi import convert
 
-from homeassistant.components.calendar import DOMAIN as CALENDAR_DOMAIN
-from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
-from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import llm
-from homeassistant.util import yaml as yaml_util
 
 from .const import STATELESS_LLM_API
 
 _LOGGER = logging.getLogger(__name__)
 
-EXPOSED_ENTITIES_RESOURCE_URI = "homeassistant://assist/exposed-entities"
-EXPOSED_ENTITIES_RESOURCE_URL = AnyUrl(EXPOSED_ENTITIES_RESOURCE_URI)
-EXPOSED_ENTITIES_RESOURCE_MIME_TYPE = "text/yaml"
+LIVE_CONTEXT_RESOURCE_URI = "homeassistant://assist/live-context"
+LIVE_CONTEXT_RESOURCE_URL = AnyUrl(LIVE_CONTEXT_RESOURCE_URI)
+LIVE_CONTEXT_RESOURCE_MIME_TYPE = "text/plain"
+LIVE_CONTEXT_TOOL_NAME = "GetLiveContext"
 
 
-def _exposed_entities_resource_supported(
-    llm_api_id: str | list[str], assistant: str | None
-) -> bool:
-    """Return if the Assist exposed entities resource should be available."""
-    if assistant is None:
-        return False
-
-    if isinstance(llm_api_id, str):
-        llm_api_ids = [llm_api_id]
-    else:
-        llm_api_ids = llm_api_id
-
-    return llm.LLM_API_ASSIST in llm_api_ids
-
-
-def _get_exposed_entities_resource_contents(hass: HomeAssistant, assistant: str) -> str:
-    """Build model-friendly exposed entity context for the MCP resource."""
-    exposed_entities = llm.async_get_exposed_entities(
-        hass, assistant, include_state=True
-    )
-    entities = [
-        {"entity_id": entity_id, **entity_info}
-        for domain in (CALENDAR_DOMAIN, SCRIPT_DOMAIN, "entities")
-        for entity_id, entity_info in exposed_entities[domain].items()
-    ]
-    entities.sort(key=lambda item: (item["names"], item["entity_id"]))
-
-    return yaml_util.dump(
-        {
-            "assistant": assistant,
-            "entities": entities,
-        }
-    )
+def _has_live_context_tool(llm_api: llm.APIInstance) -> bool:
+    """Return if the selected API exposes the live context tool."""
+    return any(tool.name == LIVE_CONTEXT_TOOL_NAME for tool in llm_api.tools)
 
 
 def _format_tool(
@@ -98,9 +65,6 @@ async def create_server(
         llm_api_id = llm.LLM_API_ASSIST
 
     server = Server[Any]("home-assistant")
-    has_exposed_entities_resource = _exposed_entities_resource_supported(
-        llm_api_id, llm_context.assistant
-    )
 
     async def get_api_instance() -> llm.APIInstance:
         """Get the LLM API selected."""
@@ -140,36 +104,42 @@ async def create_server(
 
     @server.list_resources()  # type: ignore[no-untyped-call,untyped-decorator]
     async def handle_list_resources() -> list[types.Resource]:
-        if not has_exposed_entities_resource:
+        llm_api = await get_api_instance()
+        if not _has_live_context_tool(llm_api):
             return []
 
         return [
             types.Resource(
-                uri=EXPOSED_ENTITIES_RESOURCE_URL,
-                name="assist_exposed_entities",
-                title="Assist exposed entities",
+                uri=LIVE_CONTEXT_RESOURCE_URL,
+                name="assist_live_context",
+                title="Assist live context",
                 description=(
-                    "Entities exposed to Assist, including current state and"
-                    " a curated set of attributes."
+                    "A snapshot of the current Assist live context, matching"
+                    " the existing GetLiveContext tool output."
                 ),
-                mimeType=EXPOSED_ENTITIES_RESOURCE_MIME_TYPE,
+                mimeType=LIVE_CONTEXT_RESOURCE_MIME_TYPE,
             )
         ]
 
     @server.read_resource()  # type: ignore[no-untyped-call,untyped-decorator]
     async def handle_read_resource(uri: AnyUrl) -> Sequence[ReadResourceContents]:
-        if (
-            not has_exposed_entities_resource
-            or str(uri) != EXPOSED_ENTITIES_RESOURCE_URI
-        ):
+        if str(uri) != LIVE_CONTEXT_RESOURCE_URI:
             raise ValueError(f"Unknown resource: {uri}")
+
+        llm_api = await get_api_instance()
+        if not _has_live_context_tool(llm_api):
+            raise ValueError(f"Unknown resource: {uri}")
+
+        tool_response = await llm_api.async_call_tool(
+            llm.ToolInput(tool_name=LIVE_CONTEXT_TOOL_NAME, tool_args={})
+        )
+        if not tool_response.get("success"):
+            raise HomeAssistantError(cast(str, tool_response["error"]))
 
         return [
             ReadResourceContents(
-                content=_get_exposed_entities_resource_contents(
-                    hass, llm_context.assistant or CONVERSATION_DOMAIN
-                ),
-                mime_type=EXPOSED_ENTITIES_RESOURCE_MIME_TYPE,
+                content=cast(str, tool_response["result"]),
+                mime_type=LIVE_CONTEXT_RESOURCE_MIME_TYPE,
             )
         ]
 

--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -14,16 +14,61 @@ from typing import Any
 
 from mcp import types
 from mcp.server import Server
+from mcp.server.lowlevel.helper_types import ReadResourceContents
+from pydantic import AnyUrl
 import voluptuous as vol
 from voluptuous_openapi import convert
 
+from homeassistant.components.calendar import DOMAIN as CALENDAR_DOMAIN
+from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
+from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import llm
+from homeassistant.util import yaml as yaml_util
 
 from .const import STATELESS_LLM_API
 
 _LOGGER = logging.getLogger(__name__)
+
+EXPOSED_ENTITIES_RESOURCE_URI = "homeassistant://assist/exposed-entities"
+EXPOSED_ENTITIES_RESOURCE_URL = AnyUrl(EXPOSED_ENTITIES_RESOURCE_URI)
+EXPOSED_ENTITIES_RESOURCE_MIME_TYPE = "text/yaml"
+
+
+def _exposed_entities_resource_supported(
+    llm_api_id: str | list[str], assistant: str | None
+) -> bool:
+    """Return if the Assist exposed entities resource should be available."""
+    if assistant is None:
+        return False
+
+    if isinstance(llm_api_id, str):
+        llm_api_ids = [llm_api_id]
+    else:
+        llm_api_ids = llm_api_id
+
+    return llm.LLM_API_ASSIST in llm_api_ids
+
+
+def _get_exposed_entities_resource_contents(hass: HomeAssistant, assistant: str) -> str:
+    """Build model-friendly exposed entity context for the MCP resource."""
+    exposed_entities = llm.async_get_exposed_entities(
+        hass, assistant, include_state=True
+    )
+    entities = [
+        {"entity_id": entity_id, **entity_info}
+        for domain in (CALENDAR_DOMAIN, SCRIPT_DOMAIN, "entities")
+        for entity_id, entity_info in exposed_entities[domain].items()
+    ]
+    entities.sort(key=lambda item: (item["names"], item["entity_id"]))
+
+    return yaml_util.dump(
+        {
+            "assistant": assistant,
+            "entities": entities,
+        }
+    )
 
 
 def _format_tool(
@@ -53,6 +98,9 @@ async def create_server(
         llm_api_id = llm.LLM_API_ASSIST
 
     server = Server[Any]("home-assistant")
+    has_exposed_entities_resource = _exposed_entities_resource_supported(
+        llm_api_id, llm_context.assistant
+    )
 
     async def get_api_instance() -> llm.APIInstance:
         """Get the LLM API selected."""
@@ -89,6 +137,41 @@ async def create_server(
                 )
             ],
         )
+
+    @server.list_resources()  # type: ignore[no-untyped-call,untyped-decorator]
+    async def handle_list_resources() -> list[types.Resource]:
+        if not has_exposed_entities_resource:
+            return []
+
+        return [
+            types.Resource(
+                uri=EXPOSED_ENTITIES_RESOURCE_URL,
+                name="assist_exposed_entities",
+                title="Assist exposed entities",
+                description=(
+                    "Entities exposed to Assist, including current state and"
+                    " a curated set of attributes."
+                ),
+                mimeType=EXPOSED_ENTITIES_RESOURCE_MIME_TYPE,
+            )
+        ]
+
+    @server.read_resource()  # type: ignore[no-untyped-call,untyped-decorator]
+    async def handle_read_resource(uri: AnyUrl) -> Sequence[ReadResourceContents]:
+        if (
+            not has_exposed_entities_resource
+            or str(uri) != EXPOSED_ENTITIES_RESOURCE_URI
+        ):
+            raise ValueError(f"Unknown resource: {uri}")
+
+        return [
+            ReadResourceContents(
+                content=_get_exposed_entities_resource_contents(
+                    hass, llm_context.assistant or CONVERSATION_DOMAIN
+                ),
+                mime_type=EXPOSED_ENTITIES_RESOURCE_MIME_TYPE,
+            )
+        ]
 
     @server.list_tools()  # type: ignore[no-untyped-call,untyped-decorator]
     async def list_tools() -> list[types.Tool]:

--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -27,9 +27,9 @@ from .const import STATELESS_LLM_API
 
 _LOGGER = logging.getLogger(__name__)
 
-LIVE_CONTEXT_RESOURCE_URI = "homeassistant://assist/live-context"
-LIVE_CONTEXT_RESOURCE_URL = AnyUrl(LIVE_CONTEXT_RESOURCE_URI)
-LIVE_CONTEXT_RESOURCE_MIME_TYPE = "text/plain"
+SNAPSHOT_RESOURCE_URI = "homeassistant://assist/context-snapshot"
+SNAPSHOT_RESOURCE_URL = AnyUrl(SNAPSHOT_RESOURCE_URI)
+SNAPSHOT_RESOURCE_MIME_TYPE = "text/plain"
 LIVE_CONTEXT_TOOL_NAME = "GetLiveContext"
 
 
@@ -110,20 +110,20 @@ async def create_server(
 
         return [
             types.Resource(
-                uri=LIVE_CONTEXT_RESOURCE_URL,
-                name="assist_live_context",
-                title="Assist live context",
+                uri=SNAPSHOT_RESOURCE_URL,
+                name="assist_context_snapshot",
+                title="Assist context snapshot",
                 description=(
-                    "A snapshot of the current Assist live context, matching"
-                    " the existing GetLiveContext tool output."
+                    "A snapshot of the current Assist context, matching the"
+                    " existing GetLiveContext tool output."
                 ),
-                mimeType=LIVE_CONTEXT_RESOURCE_MIME_TYPE,
+                mimeType=SNAPSHOT_RESOURCE_MIME_TYPE,
             )
         ]
 
     @server.read_resource()  # type: ignore[no-untyped-call,untyped-decorator]
     async def handle_read_resource(uri: AnyUrl) -> Sequence[ReadResourceContents]:
-        if str(uri) != LIVE_CONTEXT_RESOURCE_URI:
+        if str(uri) != SNAPSHOT_RESOURCE_URI:
             raise ValueError(f"Unknown resource: {uri}")
 
         llm_api = await get_api_instance()
@@ -139,7 +139,7 @@ async def create_server(
         return [
             ReadResourceContents(
                 content=cast(str, tool_response["result"]),
-                mime_type=LIVE_CONTEXT_RESOURCE_MIME_TYPE,
+                mime_type=SNAPSHOT_RESOURCE_MIME_TYPE,
             )
         ]
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -620,6 +620,16 @@ class AssistAPI(API):
         return tools
 
 
+@callback
+def async_get_exposed_entities(
+    hass: HomeAssistant,
+    assistant: str,
+    include_state: bool = True,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Get exposed entities for an assistant."""
+    return _get_exposed_entities(hass, assistant, include_state)
+
+
 def _get_exposed_entities(
     hass: HomeAssistant,
     assistant: str,

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -620,16 +620,6 @@ class AssistAPI(API):
         return tools
 
 
-@callback
-def async_get_exposed_entities(
-    hass: HomeAssistant,
-    assistant: str,
-    include_state: bool = True,
-) -> dict[str, dict[str, dict[str, Any]]]:
-    """Get exposed entities for an assistant."""
-    return _get_exposed_entities(hass, assistant, include_state)
-
-
 def _get_exposed_entities(
     hass: HomeAssistant,
     assistant: str,

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -45,6 +45,7 @@ _LOGGER = logging.getLogger(__name__)
 
 TEST_ENTITY = "light.kitchen"
 SNAPSHOT_RESOURCE_URI = "homeassistant://assist/context-snapshot"
+TEST_LLM_API_ID = "test-api"
 INITIALIZE_MESSAGE = {
     "jsonrpc": "2.0",
     "id": "request-id-1",
@@ -65,6 +66,21 @@ EXPECTED_PROMPT_SUFFIX = """
   domain: light
   areas: Kitchen
 """
+
+
+class MockLLMAPI(llm.API):
+    """Test LLM API that does not expose any tools."""
+
+    async def async_get_api_instance(
+        self, llm_context: llm.LLMContext
+    ) -> llm.APIInstance:
+        """Return a test API instance."""
+        return llm.APIInstance(
+            api=self,
+            api_prompt="Test prompt",
+            llm_context=llm_context,
+            tools=[],
+        )
 
 
 @pytest.fixture
@@ -550,6 +566,34 @@ async def test_mcp_resource_read_unknown_resource(
     async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
         with pytest.raises(McpError, match="Unknown resource"):
             await session.read_resource(unknown_uri)
+
+
+@pytest.mark.parametrize("llm_hass_api", [TEST_LLM_API_ID])
+async def test_mcp_resources_unavailable_without_live_context_tool(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test resources are unavailable when the selected API exposes no live context."""
+
+    llm.async_register_api(
+        hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
+    )
+
+    resource_uri = mcp.types.Resource(
+        uri=SNAPSHOT_RESOURCE_URI,
+        name="assist_context_snapshot",
+    ).uri
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.list_resources()
+
+        assert result.resources == []
+
+        with pytest.raises(McpError, match="Unknown resource"):
+            await session.read_resource(resource_uri)
 
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST])

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -44,7 +44,7 @@ from tests.typing import ClientSessionGenerator
 _LOGGER = logging.getLogger(__name__)
 
 TEST_ENTITY = "light.kitchen"
-LIVE_CONTEXT_RESOURCE_URI = "homeassistant://assist/live-context"
+SNAPSHOT_RESOURCE_URI = "homeassistant://assist/context-snapshot"
 INITIALIZE_MESSAGE = {
     "jsonrpc": "2.0",
     "id": "request-id-1",
@@ -497,9 +497,9 @@ async def test_mcp_resources_list(
 
     assert len(result.resources) == 1
     resource = result.resources[0]
-    assert str(resource.uri) == LIVE_CONTEXT_RESOURCE_URI
-    assert resource.name == "assist_live_context"
-    assert resource.title == "Assist live context"
+    assert str(resource.uri) == SNAPSHOT_RESOURCE_URI
+    assert resource.name == "assist_context_snapshot"
+    assert resource.title == "Assist context snapshot"
     assert resource.description is not None
     assert resource.mimeType == "text/plain"
 
@@ -530,7 +530,6 @@ async def test_mcp_resource_read(
         "  state: 'off'\n"
         "  areas: Kitchen\n"
     )
-    assert "entity_id:" not in content.text
 
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -36,6 +36,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.setup import async_setup_component
+from homeassistant.util.yaml.loader import parse_yaml
 
 from tests.common import MockConfigEntry, setup_test_component_platform
 from tests.components.light.common import MockLight
@@ -44,6 +45,44 @@ from tests.typing import ClientSessionGenerator
 _LOGGER = logging.getLogger(__name__)
 
 TEST_ENTITY = "light.kitchen"
+EXPOSED_ENTITIES_RESOURCE_URI = "homeassistant://assist/exposed-entities"
+
+
+class MockLLMAPI(llm.API):
+    """Test LLM API."""
+
+    async def async_get_api_instance(
+        self, llm_context: llm.LLMContext
+    ) -> llm.APIInstance:
+        """Return a test API instance."""
+        return llm.APIInstance(
+            api=self,
+            api_prompt="Test prompt",
+            llm_context=llm_context,
+            tools=[],
+        )
+
+
+@pytest.fixture(name="llm_hass_api")
+def llm_hass_api_fixture(
+    hass: HomeAssistant, request: pytest.FixtureRequest
+) -> str | list[str]:
+    """Fixture for the config entry llm_hass_api."""
+    llm_hass_api: str | list[str] = getattr(request, "param", [llm.LLM_API_ASSIST])
+
+    if isinstance(llm_hass_api, str):
+        llm_api_ids = [llm_hass_api]
+    else:
+        llm_api_ids = llm_hass_api
+
+    if "test-api" in llm_api_ids:
+        llm.async_register_api(
+            hass, MockLLMAPI(hass=hass, id="test-api", name="Test API")
+        )
+
+    return llm_hass_api
+
+
 INITIALIZE_MESSAGE = {
     "jsonrpc": "2.0",
     "id": "request-id-1",
@@ -479,6 +518,199 @@ async def test_get_unknown_prompt(
     async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
         with pytest.raises(McpError):
             await session.get_prompt(name="Unknown")
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_resources_list(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test the resource list endpoint."""
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.list_resources()
+
+    assert len(result.resources) == 1
+    resource = result.resources[0]
+    assert str(resource.uri) == EXPOSED_ENTITIES_RESOURCE_URI
+    assert resource.name == "assist_exposed_entities"
+    assert resource.title == "Assist exposed entities"
+    assert resource.description is not None
+    assert resource.mimeType == "text/yaml"
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_resource_read(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test reading an MCP resource."""
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        resources = await session.list_resources()
+        resource = resources.resources[0]
+        result = await session.read_resource(resource.uri)
+
+    assert len(result.contents) == 1
+    content = result.contents[0]
+    assert content.uri == resource.uri
+    assert content.mimeType == "text/yaml"
+    parsed = parse_yaml(content.text)
+    assert parsed["assistant"] == "conversation"
+    assert parsed["entities"] == [
+        {
+            "entity_id": "light.kitchen",
+            "names": "Kitchen Light",
+            "domain": "light",
+            "state": "off",
+            "areas": "Kitchen",
+        }
+    ]
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_resource_read_includes_attributes_and_local_timestamps(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test resource payload reuses the Assist exposed entity context."""
+
+    await hass.config.async_set_time_zone("America/New_York")
+    hass.states.async_set(
+        "climate.hallway",
+        "heat",
+        {
+            "friendly_name": "Hallway Thermostat",
+            "current_temperature": 21,
+            "temperature": 22,
+        },
+    )
+    async_expose_entity(hass, CONVERSATION_DOMAIN, "climate.hallway", True)
+
+    hass.states.async_set(
+        "sensor.next_alarm",
+        "2024-01-15T10:30:00+00:00",
+        {
+            "device_class": "timestamp",
+            "friendly_name": "Next Alarm",
+        },
+    )
+    async_expose_entity(hass, CONVERSATION_DOMAIN, "sensor.next_alarm", True)
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        resources = await session.list_resources()
+        resource = resources.resources[0]
+        result = await session.read_resource(resource.uri)
+
+    parsed = parse_yaml(result.contents[0].text)
+    entities = {entity["entity_id"]: entity for entity in parsed["entities"]}
+
+    assert entities["climate.hallway"]["attributes"] == {
+        "current_temperature": "21",
+        "temperature": "22",
+    }
+    assert entities["sensor.next_alarm"]["state"] == "2024-01-15T05:30:00-05:00"
+    assert entities["sensor.next_alarm"]["attributes"] == {
+        "device_class": "timestamp",
+    }
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_resource_read_includes_scripts_and_calendars(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test resource payload includes all exposed Assist objects."""
+
+    hass.states.async_set(
+        "calendar.household", "on", {"friendly_name": "Household Calendar"}
+    )
+    async_expose_entity(hass, CONVERSATION_DOMAIN, "calendar.household", True)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "bedtime": {
+                    "alias": "Bedtime",
+                    "description": "Prepare the house for bed",
+                    "sequence": [],
+                }
+            }
+        },
+    )
+    async_expose_entity(hass, CONVERSATION_DOMAIN, "script.bedtime", True)
+    await hass.async_block_till_done()
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        resources = await session.list_resources()
+        resource = resources.resources[0]
+        result = await session.read_resource(resource.uri)
+
+    entities = {
+        entity["entity_id"]: entity
+        for entity in parse_yaml(result.contents[0].text)["entities"]
+    }
+    assert entities["calendar.household"]["domain"] == "calendar"
+    assert entities["calendar.household"]["names"] == "Household Calendar"
+    assert entities["script.bedtime"]["domain"] == "script"
+    assert entities["script.bedtime"]["names"] == "Bedtime"
+
+
+@pytest.mark.parametrize(
+    ("llm_hass_api", "expected_count"),
+    [
+        ("test-api", 0),
+        ([llm.LLM_API_ASSIST, "test-api"], 1),
+    ],
+)
+async def test_mcp_resources_respect_selected_llm_api(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+    expected_count: int,
+) -> None:
+    """Test resources are only exposed when Assist is selected."""
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.list_resources()
+
+    assert len(result.resources) == expected_count
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_resource_read_unknown_resource(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test reading an unknown MCP resource."""
+
+    unknown_uri = mcp.types.Resource(
+        uri="homeassistant://assist/missing",
+        name="missing",
+    ).uri
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        with pytest.raises(McpError, match="Unknown resource"):
+            await session.read_resource(unknown_uri)
 
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST])

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -36,7 +36,6 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.setup import async_setup_component
-from homeassistant.util.yaml.loader import parse_yaml
 
 from tests.common import MockConfigEntry, setup_test_component_platform
 from tests.components.light.common import MockLight
@@ -45,44 +44,7 @@ from tests.typing import ClientSessionGenerator
 _LOGGER = logging.getLogger(__name__)
 
 TEST_ENTITY = "light.kitchen"
-EXPOSED_ENTITIES_RESOURCE_URI = "homeassistant://assist/exposed-entities"
-
-
-class MockLLMAPI(llm.API):
-    """Test LLM API."""
-
-    async def async_get_api_instance(
-        self, llm_context: llm.LLMContext
-    ) -> llm.APIInstance:
-        """Return a test API instance."""
-        return llm.APIInstance(
-            api=self,
-            api_prompt="Test prompt",
-            llm_context=llm_context,
-            tools=[],
-        )
-
-
-@pytest.fixture(name="llm_hass_api")
-def llm_hass_api_fixture(
-    hass: HomeAssistant, request: pytest.FixtureRequest
-) -> str | list[str]:
-    """Fixture for the config entry llm_hass_api."""
-    llm_hass_api: str | list[str] = getattr(request, "param", [llm.LLM_API_ASSIST])
-
-    if isinstance(llm_hass_api, str):
-        llm_api_ids = [llm_hass_api]
-    else:
-        llm_api_ids = llm_hass_api
-
-    if "test-api" in llm_api_ids:
-        llm.async_register_api(
-            hass, MockLLMAPI(hass=hass, id="test-api", name="Test API")
-        )
-
-    return llm_hass_api
-
-
+LIVE_CONTEXT_RESOURCE_URI = "homeassistant://assist/live-context"
 INITIALIZE_MESSAGE = {
     "jsonrpc": "2.0",
     "id": "request-id-1",
@@ -535,11 +497,11 @@ async def test_mcp_resources_list(
 
     assert len(result.resources) == 1
     resource = result.resources[0]
-    assert str(resource.uri) == EXPOSED_ENTITIES_RESOURCE_URI
-    assert resource.name == "assist_exposed_entities"
-    assert resource.title == "Assist exposed entities"
+    assert str(resource.uri) == LIVE_CONTEXT_RESOURCE_URI
+    assert resource.name == "assist_live_context"
+    assert resource.title == "Assist live context"
     assert resource.description is not None
-    assert resource.mimeType == "text/yaml"
+    assert resource.mimeType == "text/plain"
 
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
@@ -560,137 +522,15 @@ async def test_mcp_resource_read(
     assert len(result.contents) == 1
     content = result.contents[0]
     assert content.uri == resource.uri
-    assert content.mimeType == "text/yaml"
-    parsed = parse_yaml(content.text)
-    assert parsed["assistant"] == "conversation"
-    assert parsed["entities"] == [
-        {
-            "entity_id": "light.kitchen",
-            "names": "Kitchen Light",
-            "domain": "light",
-            "state": "off",
-            "areas": "Kitchen",
-        }
-    ]
-
-
-@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
-async def test_mcp_resource_read_includes_attributes_and_local_timestamps(
-    hass: HomeAssistant,
-    setup_integration: None,
-    mcp_url: str,
-    mcp_client: Any,
-    hass_supervisor_access_token: str,
-) -> None:
-    """Test resource payload reuses the Assist exposed entity context."""
-
-    await hass.config.async_set_time_zone("America/New_York")
-    hass.states.async_set(
-        "climate.hallway",
-        "heat",
-        {
-            "friendly_name": "Hallway Thermostat",
-            "current_temperature": 21,
-            "temperature": 22,
-        },
+    assert content.mimeType == "text/plain"
+    assert content.text == (
+        "Live Context: An overview of the areas and the devices in this smart home:\n"
+        "- names: Kitchen Light\n"
+        "  domain: light\n"
+        "  state: 'off'\n"
+        "  areas: Kitchen\n"
     )
-    async_expose_entity(hass, CONVERSATION_DOMAIN, "climate.hallway", True)
-
-    hass.states.async_set(
-        "sensor.next_alarm",
-        "2024-01-15T10:30:00+00:00",
-        {
-            "device_class": "timestamp",
-            "friendly_name": "Next Alarm",
-        },
-    )
-    async_expose_entity(hass, CONVERSATION_DOMAIN, "sensor.next_alarm", True)
-
-    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
-        resources = await session.list_resources()
-        resource = resources.resources[0]
-        result = await session.read_resource(resource.uri)
-
-    parsed = parse_yaml(result.contents[0].text)
-    entities = {entity["entity_id"]: entity for entity in parsed["entities"]}
-
-    assert entities["climate.hallway"]["attributes"] == {
-        "current_temperature": "21",
-        "temperature": "22",
-    }
-    assert entities["sensor.next_alarm"]["state"] == "2024-01-15T05:30:00-05:00"
-    assert entities["sensor.next_alarm"]["attributes"] == {
-        "device_class": "timestamp",
-    }
-
-
-@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
-async def test_mcp_resource_read_includes_scripts_and_calendars(
-    hass: HomeAssistant,
-    setup_integration: None,
-    mcp_url: str,
-    mcp_client: Any,
-    hass_supervisor_access_token: str,
-) -> None:
-    """Test resource payload includes all exposed Assist objects."""
-
-    hass.states.async_set(
-        "calendar.household", "on", {"friendly_name": "Household Calendar"}
-    )
-    async_expose_entity(hass, CONVERSATION_DOMAIN, "calendar.household", True)
-
-    assert await async_setup_component(
-        hass,
-        "script",
-        {
-            "script": {
-                "bedtime": {
-                    "alias": "Bedtime",
-                    "description": "Prepare the house for bed",
-                    "sequence": [],
-                }
-            }
-        },
-    )
-    async_expose_entity(hass, CONVERSATION_DOMAIN, "script.bedtime", True)
-    await hass.async_block_till_done()
-
-    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
-        resources = await session.list_resources()
-        resource = resources.resources[0]
-        result = await session.read_resource(resource.uri)
-
-    entities = {
-        entity["entity_id"]: entity
-        for entity in parse_yaml(result.contents[0].text)["entities"]
-    }
-    assert entities["calendar.household"]["domain"] == "calendar"
-    assert entities["calendar.household"]["names"] == "Household Calendar"
-    assert entities["script.bedtime"]["domain"] == "script"
-    assert entities["script.bedtime"]["names"] == "Bedtime"
-
-
-@pytest.mark.parametrize(
-    ("llm_hass_api", "expected_count"),
-    [
-        ("test-api", 0),
-        ([llm.LLM_API_ASSIST, "test-api"], 1),
-    ],
-)
-async def test_mcp_resources_respect_selected_llm_api(
-    hass: HomeAssistant,
-    setup_integration: None,
-    mcp_url: str,
-    mcp_client: Any,
-    hass_supervisor_access_token: str,
-    expected_count: int,
-) -> None:
-    """Test resources are only exposed when Assist is selected."""
-
-    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
-        result = await session.list_resources()
-
-    assert len(result.resources) == expected_count
+    assert "entity_id:" not in content.text
 
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])


### PR DESCRIPTION
## Proposed change

Motivation: expose an explicit, on-demand snapshot of Assist-visible context for inspection, debugging, and explanation workflows. This is not intended to replace the existing `GetLiveContext` tool for action flows or up-to-date operational context.

Add the first minimal read-only MCP Resources support to the `mcp_server` integration.

This PR exposes a single concrete resource, `homeassistant://assist/context-snapshot`, and returns the existing `GetLiveContext` output through `resources/read` as a static snapshot.

To keep the change small and reviewable, this PR only adds:

- `resources/list` support for a single read-only resource
- `resources/read` support for that resource
- MCP session/API tests in the existing `test_http.py` style

This intentionally does not add resource templates, completion, subscriptions, notifications, or transport/session redesign.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44501
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [[development checklist](https://developers.home-assistant.io/docs/development_checklist/)][dev-checklist]
- [x] I have followed the [[perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [[www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [[manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/)][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [[open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure)][prs] in this repository.

## Testing

- `python -m pytest --timeout=10 tests/components/mcp_server`
- `prek run --show-diff-on-failure --files homeassistant/components/mcp_server/server.py tests/components/mcp_server/test_http.py`

Note: the file-scoped `prek` invocation reaches unrelated pre-existing `mypy` failures in other repo files (`matter`, `stream`, `frontend`) while the touched files pass the change-specific lint/format checks.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr