### PR TITLE
Fix polling pause in Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -185,9 +185,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
 
     def _should_poll(self) -> bool:
         """Return True if at least one mower is connected and at least one is not OFF."""
-        return any(mower.metadata.connected for mower in self.data.values()) and any(
-            mower.mower.state != MowerStates.OFF for mower in self.data.values()
-        )
+        return any(mower.mower.state != MowerStates.OFF for mower in self.data.values())
 
     async def _pong_watchdog(self) -> None:
         """Watchdog to check for pong messages."""

--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -184,7 +184,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
             )
 
     def _should_poll(self) -> bool:
-        """Return True if at least one mower is connected and at least one is not OFF."""
+        """Return True if at least one mower is not OFF."""
         return any(mower.mower.state != MowerStates.OFF for mower in self.data.values())
 
     async def _pong_watchdog(self) -> None:

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -516,27 +516,12 @@ async def test_add_and_remove_work_area(
     )
 
 
-@pytest.mark.parametrize(
-    ("mower1_connected", "mower1_state", "mower2_connected", "mower2_state"),
-    [
-        (True, MowerStates.OFF, False, MowerStates.OFF),  # False
-        (False, MowerStates.PAUSED, False, MowerStates.OFF),  # False
-        (False, MowerStates.OFF, True, MowerStates.OFF),  # False
-        (False, MowerStates.OFF, False, MowerStates.PAUSED),  # False
-        (True, MowerStates.OFF, True, MowerStates.OFF),  # False
-        (False, MowerStates.OFF, False, MowerStates.OFF),  # False
-    ],
-)
 async def test_dynamic_polling(
     hass: HomeAssistant,
     mock_automower_client,
     mock_config_entry,
     freezer: FrozenDateTimeFactory,
     values: dict[str, MowerAttributes],
-    mower1_connected: bool,
-    mower1_state: MowerStates,
-    mower2_connected: bool,
-    mower2_state: MowerStates,
 ) -> None:
     """Test that the ws_ready_callback triggers an attempt to start the Watchdog task.
 
@@ -579,10 +564,8 @@ async def test_dynamic_polling(
     assert mock_automower_client.get_status.call_count == 2
 
     # websocket is still active, but mowers are inactive -> no polling required
-    poll_values[TEST_MOWER_ID].metadata.connected = mower1_connected
-    poll_values[TEST_MOWER_ID].mower.state = mower1_state
-    poll_values["1234"].metadata.connected = mower2_connected
-    poll_values["1234"].mower.state = mower2_state
+    poll_values[TEST_MOWER_ID].mower.state = MowerStates.OFF
+    poll_values["1234"].mower.state = MowerStates.OFF
 
     mock_automower_client.get_status.return_value = poll_values
     freezer.tick(SCAN_INTERVAL)
@@ -608,9 +591,7 @@ async def test_dynamic_polling(
     # websocket is still active, and mowers are active -> polling required
     mock_automower_client.get_status.reset_mock()
     assert mock_automower_client.get_status.call_count == 0
-    poll_values[TEST_MOWER_ID].metadata.connected = True
     poll_values[TEST_MOWER_ID].mower.state = MowerStates.PAUSED
-    poll_values["1234"].metadata.connected = False
     poll_values["1234"].mower.state = MowerStates.OFF
     websocket_values = deepcopy(poll_values)
     callback_holder["data_cb"](websocket_values)
@@ -623,17 +604,6 @@ async def test_dynamic_polling(
     assert mock_automower_client.get_status.call_count == 2
 
 
-@pytest.mark.parametrize(
-    ("mower1_connected", "mower1_state", "mower2_connected", "mower2_state"),
-    [
-        (True, MowerStates.OFF, False, MowerStates.OFF),  # False
-        (False, MowerStates.PAUSED, False, MowerStates.OFF),  # False
-        (False, MowerStates.OFF, True, MowerStates.OFF),  # False
-        (False, MowerStates.OFF, False, MowerStates.PAUSED),  # False
-        (True, MowerStates.OFF, True, MowerStates.OFF),  # False
-        (False, MowerStates.OFF, False, MowerStates.OFF),  # False
-    ],
-)
 async def test_websocket_watchdog(
     hass: HomeAssistant,
     mock_automower_client,
@@ -641,10 +611,6 @@ async def test_websocket_watchdog(
     freezer: FrozenDateTimeFactory,
     entity_registry: er.EntityRegistry,
     values: dict[str, MowerAttributes],
-    mower1_connected: bool,
-    mower1_state: MowerStates,
-    mower2_connected: bool,
-    mower2_state: MowerStates,
 ) -> None:
     """Test that the ws_ready_callback triggers an attempt to start the Watchdog task.
 
@@ -686,10 +652,8 @@ async def test_websocket_watchdog(
     assert mock_automower_client.get_status.call_count == 2
 
     # websocket is still active, but mowers are inactive -> no polling required
-    poll_values[TEST_MOWER_ID].metadata.connected = mower1_connected
-    poll_values[TEST_MOWER_ID].mower.state = mower1_state
-    poll_values["1234"].metadata.connected = mower2_connected
-    poll_values["1234"].mower.state = mower2_state
+    poll_values[TEST_MOWER_ID].mower.state = MowerStates.OFF
+    poll_values["1234"].mower.state = MowerStates.OFF
 
     mock_automower_client.get_status.return_value = poll_values
     freezer.tick(SCAN_INTERVAL)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently polling pauses, when all devices are off or disconnected. This works good, if the device gets on again, because there is a websocket message for the new state. But it's not working when the device is disconnected, because the websocket doesn't change the `connected` state. This only works with polling. With this change we only pause polling, when all devices are off.

Please include in next patch release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
