### PR TITLE
Fix flaky fire_callbacks tests in casper_glow

### DIFF
--- a/tests/components/casper_glow/conftest.py
+++ b/tests/components/casper_glow/conftest.py
@@ -1,6 +1,6 @@
 """Casper Glow session fixtures."""
 
-from collections.abc import Callable, Generator
+from collections.abc import Awaitable, Callable, Generator
 from unittest.mock import MagicMock, patch
 
 from pycasperglow import GlowState
@@ -53,15 +53,17 @@ def mock_casper_glow() -> Generator[MagicMock]:
 
 @pytest.fixture
 def fire_callbacks(
+    hass: HomeAssistant,
     mock_casper_glow: MagicMock,
-) -> Callable[[GlowState], None]:
+) -> Callable[[GlowState], Awaitable[None]]:
     """Return a helper that fires all registered device callbacks with a given state."""
 
-    def _fire(state: GlowState) -> None:
+    async def _fire(state: GlowState) -> None:
         for cb in (
             call[0][0] for call in mock_casper_glow.register_callback.call_args_list
         ):
             cb(state)
+        await hass.async_block_till_done()
 
     return _fire
 

--- a/tests/components/casper_glow/test_binary_sensor.py
+++ b/tests/components/casper_glow/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Test the Casper Glow binary sensor platform."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
 from pycasperglow import GlowState
@@ -43,7 +43,7 @@ async def test_paused_state_update(
     hass: HomeAssistant,
     mock_casper_glow: MagicMock,
     mock_config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
     is_paused: bool,
     expected_state: str,
 ) -> None:
@@ -53,7 +53,7 @@ async def test_paused_state_update(
     ):
         await setup_integration(hass, mock_config_entry)
 
-    fire_callbacks(GlowState(is_paused=is_paused))
+    await fire_callbacks(GlowState(is_paused=is_paused))
     state = hass.states.get(PAUSED_ENTITY_ID)
     assert state is not None
     assert state.state == expected_state
@@ -63,7 +63,7 @@ async def test_paused_ignores_none_state(
     hass: HomeAssistant,
     mock_casper_glow: MagicMock,
     mock_config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that a callback with is_paused=None does not overwrite the state."""
     with patch(
@@ -72,13 +72,13 @@ async def test_paused_ignores_none_state(
         await setup_integration(hass, mock_config_entry)
 
     # Set a known value first
-    fire_callbacks(GlowState(is_paused=True))
+    await fire_callbacks(GlowState(is_paused=True))
     state = hass.states.get(PAUSED_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
 
     # Callback with no is_paused data — state should remain unchanged
-    fire_callbacks(GlowState(is_on=True))
+    await fire_callbacks(GlowState(is_on=True))
     state = hass.states.get(PAUSED_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
@@ -93,7 +93,7 @@ async def test_charging_state_update(
     hass: HomeAssistant,
     mock_casper_glow: MagicMock,
     mock_config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
     is_charging: bool,
     expected_state: str,
 ) -> None:
@@ -103,7 +103,7 @@ async def test_charging_state_update(
     ):
         await setup_integration(hass, mock_config_entry)
 
-    fire_callbacks(GlowState(is_charging=is_charging))
+    await fire_callbacks(GlowState(is_charging=is_charging))
     state = hass.states.get(CHARGING_ENTITY_ID)
     assert state is not None
     assert state.state == expected_state
@@ -113,7 +113,7 @@ async def test_charging_ignores_none_state(
     hass: HomeAssistant,
     mock_casper_glow: MagicMock,
     mock_config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that a callback with is_charging=None does not overwrite the state."""
     with patch(
@@ -122,13 +122,13 @@ async def test_charging_ignores_none_state(
         await setup_integration(hass, mock_config_entry)
 
     # Set a known value first
-    fire_callbacks(GlowState(is_charging=True))
+    await fire_callbacks(GlowState(is_charging=True))
     state = hass.states.get(CHARGING_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
 
     # Callback with no is_charging data — state should remain unchanged
-    fire_callbacks(GlowState(is_on=True))
+    await fire_callbacks(GlowState(is_on=True))
     state = hass.states.get(CHARGING_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON

--- a/tests/components/casper_glow/test_light.py
+++ b/tests/components/casper_glow/test_light.py
@@ -1,6 +1,6 @@
 """Test the Casper Glow light platform."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
 from pycasperglow import CasperGlowError, GlowState
@@ -83,19 +83,19 @@ async def test_turn_off(
 async def test_state_update_via_callback(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that the entity updates state when the device fires a callback."""
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
-    fire_callbacks(GlowState(is_on=True))
+    await fire_callbacks(GlowState(is_on=True))
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
 
-    fire_callbacks(GlowState(is_on=False))
+    await fire_callbacks(GlowState(is_on=False))
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_OFF
@@ -149,10 +149,10 @@ async def test_brightness_snap_to_nearest(
 async def test_brightness_update_via_callback(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that brightness updates via device callback."""
-    fire_callbacks(GlowState(is_on=True, brightness_level=80))
+    await fire_callbacks(GlowState(is_on=True, brightness_level=80))
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
@@ -196,7 +196,7 @@ async def test_state_update_via_callback_after_command_failure(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_casper_glow: MagicMock,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that device callbacks correctly update state even after a command failure."""
     mock_casper_glow.turn_on.side_effect = CasperGlowError("Connection failed")
@@ -215,7 +215,7 @@ async def test_state_update_via_callback_after_command_failure(
     assert state.state == STATE_UNKNOWN
 
     # Device sends a push state update — entity reflects true device state
-    fire_callbacks(GlowState(is_on=True))
+    await fire_callbacks(GlowState(is_on=True))
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None

--- a/tests/components/casper_glow/test_select.py
+++ b/tests/components/casper_glow/test_select.py
@@ -1,6 +1,6 @@
 """Test the Casper Glow select platform."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
 from pycasperglow import CasperGlowError, GlowState
@@ -44,14 +44,14 @@ async def test_entities(
 async def test_select_state_from_callback(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that the select entity shows dimming time reported by device callback."""
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
-    fire_callbacks(
+    await fire_callbacks(
         GlowState(configured_dimming_time_minutes=int(DIMMING_TIME_OPTIONS[2]))
     )
 
@@ -64,7 +64,7 @@ async def test_select_option(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_casper_glow: MagicMock,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test selecting a dimming time option."""
     await hass.services.async_call(
@@ -82,7 +82,7 @@ async def test_select_option(
     assert state.state == DIMMING_TIME_OPTIONS[1]
 
     # A subsequent device callback must not overwrite the user's selection.
-    fire_callbacks(
+    await fire_callbacks(
         GlowState(configured_dimming_time_minutes=int(DIMMING_TIME_OPTIONS[0]))
     )
 
@@ -118,7 +118,7 @@ async def test_select_state_update_via_callback_after_command_failure(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_casper_glow: MagicMock,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that device callbacks correctly update state even after a command failure."""
     mock_casper_glow.set_brightness_and_dimming_time.side_effect = CasperGlowError(
@@ -138,7 +138,7 @@ async def test_select_state_update_via_callback_after_command_failure(
     assert state.state == STATE_UNKNOWN
 
     # Device sends a push state update — entity reflects true state
-    fire_callbacks(
+    await fire_callbacks(
         GlowState(configured_dimming_time_minutes=int(DIMMING_TIME_OPTIONS[1]))
     )
 
@@ -150,10 +150,10 @@ async def test_select_state_update_via_callback_after_command_failure(
 async def test_select_ignores_remaining_time_updates(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test that callbacks with only remaining time do not change the select state."""
-    fire_callbacks(GlowState(dimming_time_remaining_ms=2_640_000))
+    await fire_callbacks(GlowState(dimming_time_remaining_ms=2_640_000))
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None

--- a/tests/components/casper_glow/test_sensor.py
+++ b/tests/components/casper_glow/test_sensor.py
@@ -1,6 +1,6 @@
 """Test the Casper Glow sensor platform."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
 from pycasperglow import BatteryLevel, GlowState
@@ -59,13 +59,13 @@ async def test_battery_state_updated_via_callback(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_casper_glow: MagicMock,
-    fire_callbacks: Callable[[GlowState], None],
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
 ) -> None:
     """Test battery sensor updates when a device callback fires."""
     with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
-    fire_callbacks(GlowState(battery_level=BatteryLevel.PCT_50))
+    await fire_callbacks(GlowState(battery_level=BatteryLevel.PCT_50))
 
     state = hass.states.get(BATTERY_ENTITY_ID)
     assert state is not None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make the fire_callbacks test fixture async and await hass.async_block_till_done() after firing device callbacks so assertions observe the resulting state write on slower hardware.

Fixes #167417

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #167417
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
