### PR TITLE
Fix blocking SSL context creation in unifi_access integration

### DIFF
--- a/homeassistant/components/unifi_access/__init__.py
+++ b/homeassistant/components/unifi_access/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_VERIFY_SSL, Plat
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import create_no_verify_ssl_context
 
 from .coordinator import UnifiAccessConfigEntry, UnifiAccessCoordinator
 
@@ -26,11 +27,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnifiAccessConfigEntry) 
     """Set up UniFi Access from a config entry."""
     session = async_get_clientsession(hass, verify_ssl=entry.data[CONF_VERIFY_SSL])
 
+    ssl_context = (
+        None if entry.data[CONF_VERIFY_SSL] else create_no_verify_ssl_context()
+    )
     client = UnifiAccessApiClient(
         host=entry.data[CONF_HOST],
         api_token=entry.data[CONF_API_TOKEN],
         session=session,
         verify_ssl=entry.data[CONF_VERIFY_SSL],
+        ssl_context=ssl_context,
     )
 
     try:

--- a/homeassistant/components/unifi_access/config_flow.py
+++ b/homeassistant/components/unifi_access/config_flow.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_VERIFY_SSL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import create_no_verify_ssl_context
 
 from .const import DOMAIN
 
@@ -30,11 +31,15 @@ class UnifiAccessConfigFlow(ConfigFlow, domain=DOMAIN):
         session = async_get_clientsession(
             self.hass, verify_ssl=user_input[CONF_VERIFY_SSL]
         )
+        ssl_context = (
+            None if user_input[CONF_VERIFY_SSL] else create_no_verify_ssl_context()
+        )
         client = UnifiAccessApiClient(
             host=user_input[CONF_HOST],
             api_token=user_input[CONF_API_TOKEN],
             session=session,
             verify_ssl=user_input[CONF_VERIFY_SSL],
+            ssl_context=ssl_context,
         )
         try:
             await client.authenticate()

--- a/tests/components/unifi_access/test_config_flow.py
+++ b/tests/components/unifi_access/test_config_flow.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from unifi_access_api import ApiAuthError, ApiConnectionError
@@ -361,3 +362,42 @@ async def test_reconfigure_flow_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.parametrize(
+    ("verify_ssl", "expect_ssl_context"),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+async def test_user_flow_ssl_context(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+    verify_ssl: bool,
+    expect_ssl_context: bool,
+) -> None:
+    """Test that a pre-warmed no-verify SSL context is passed when verify_ssl is False."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.unifi_access.config_flow.UnifiAccessApiClient",
+        wraps=lambda **kwargs: mock_client,
+    ) as patched_client:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: MOCK_HOST,
+                CONF_API_TOKEN: MOCK_API_TOKEN,
+                CONF_VERIFY_SSL: verify_ssl,
+            },
+        )
+
+    _, call_kwargs = patched_client.call_args
+    if expect_ssl_context:
+        assert isinstance(call_kwargs["ssl_context"], ssl.SSLContext)
+    else:
+        assert call_kwargs["ssl_context"] is None

--- a/tests/components/unifi_access/test_config_flow.py
+++ b/tests/components/unifi_access/test_config_flow.py
@@ -365,10 +365,10 @@ async def test_reconfigure_flow_errors(
 
 
 @pytest.mark.parametrize(
-    ("verify_ssl", "expect_ssl_context"),
+    ("verify_ssl", "expected_ssl_context_type"),
     [
-        (False, True),
-        (True, False),
+        (False, ssl.SSLContext),
+        (True, type(None)),
     ],
 )
 async def test_user_flow_ssl_context(
@@ -376,7 +376,7 @@ async def test_user_flow_ssl_context(
     mock_setup_entry: AsyncMock,
     mock_client: MagicMock,
     verify_ssl: bool,
-    expect_ssl_context: bool,
+    expected_ssl_context_type: type,
 ) -> None:
     """Test that a pre-warmed no-verify SSL context is passed when verify_ssl is False."""
     result = await hass.config_entries.flow.async_init(
@@ -397,7 +397,4 @@ async def test_user_flow_ssl_context(
         )
 
     _, call_kwargs = patched_client.call_args
-    if expect_ssl_context:
-        assert isinstance(call_kwargs["ssl_context"], ssl.SSLContext)
-    else:
-        assert call_kwargs["ssl_context"] is None
+    assert isinstance(call_kwargs["ssl_context"], expected_ssl_context_type)

--- a/tests/components/unifi_access/test_init.py
+++ b/tests/components/unifi_access/test_init.py
@@ -63,17 +63,17 @@ async def test_setup_entry(
 
 
 @pytest.mark.parametrize(
-    ("verify_ssl", "expect_ssl_context"),
+    ("verify_ssl", "expected_ssl_context_type"),
     [
-        (False, True),
-        (True, False),
+        (False, ssl.SSLContext),
+        (True, type(None)),
     ],
 )
 async def test_setup_entry_ssl_context(
     hass: HomeAssistant,
     mock_client: MagicMock,
     verify_ssl: bool,
-    expect_ssl_context: bool,
+    expected_ssl_context_type: type,
 ) -> None:
     """Test that a pre-warmed no-verify SSL context is passed when verify_ssl is False."""
     entry = MockConfigEntry(
@@ -97,10 +97,7 @@ async def test_setup_entry_ssl_context(
         await hass.async_block_till_done()
 
     _, call_kwargs = patched_client.call_args
-    if expect_ssl_context:
-        assert isinstance(call_kwargs["ssl_context"], ssl.SSLContext)
-    else:
-        assert call_kwargs["ssl_context"] is None
+    assert isinstance(call_kwargs["ssl_context"], expected_ssl_context_type)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/unifi_access/test_init.py
+++ b/tests/components/unifi_access/test_init.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from unittest.mock import MagicMock
+import ssl
+from unittest.mock import MagicMock, patch
 
 import pytest
 from unifi_access_api import (
@@ -25,6 +26,7 @@ from unifi_access_api.models.websocket import (
 
 from homeassistant.components.unifi_access.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -58,6 +60,47 @@ async def test_setup_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     mock_client.authenticate.assert_awaited_once()
     mock_client.get_doors.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("verify_ssl", "expect_ssl_context"),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+async def test_setup_entry_ssl_context(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    verify_ssl: bool,
+    expect_ssl_context: bool,
+) -> None:
+    """Test that a pre-warmed no-verify SSL context is passed when verify_ssl is False."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="UniFi Access",
+        data={
+            "host": "192.168.1.1",
+            "api_token": "test-token",
+            CONF_VERIFY_SSL: verify_ssl,
+        },
+        version=1,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.unifi_access.UnifiAccessApiClient",
+        wraps=lambda **kwargs: mock_client,
+    ) as patched_client:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    _, call_kwargs = patched_client.call_args
+    if expect_ssl_context:
+        assert isinstance(call_kwargs["ssl_context"], ssl.SSLContext)
+    else:
+        assert call_kwargs["ssl_context"] is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

The `unifi_access` integration triggered two blocking call warnings on every Home Assistant startup:

- `Detected blocking call to load_default_certs`
- `Detected blocking call to set_default_verify_paths`

Both warnings point to `__init__.py` line 28 where `UnifiAccessApiClient` is instantiated. When `verify_ssl=False`, the library internally calls `ssl.create_default_context()` in its constructor, which performs blocking I/O (loading system certificates) inside the async event loop.

The fix passes Home Assistant's pre-warmed, cached SSL context (from `create_no_verify_ssl_context()` in `homeassistant.util.ssl`) via the library's `ssl_context` parameter. These contexts are eagerly created at module load time — outside the event loop — so no blocking I/O occurs during integration setup. The same fix is applied in `config_flow.py`.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167409
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
