### PR TITLE
Fix setup without dhw

### DIFF
--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -131,6 +131,9 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
         try:
             dhw = await self.client.hot_water_state(include=DHW_STATE_INCLUDE)
         except BSBLANError:
+            # Preserve last known DHW state if available (entity may depend on it)
+            if self.data:
+                dhw = self.data.dhw
             LOGGER.debug(
                 "DHW (Domestic Hot Water) state not available on device at %s",
                 self.config_entry.data[CONF_HOST],

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -10,6 +10,7 @@ from bsblan import (
     BSBLAN,
     BSBLANAuthError,
     BSBLANConnectionError,
+    BSBLANError,
     HotWaterConfig,
     HotWaterSchedule,
     HotWaterState,
@@ -50,7 +51,7 @@ class BSBLanFastData:
 
     state: State
     sensor: Sensor
-    dhw: HotWaterState
+    dhw: HotWaterState | None = None
 
 
 @dataclass
@@ -111,7 +112,6 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
             # This reduces response time significantly (~0.2s per parameter)
             state = await self.client.state(include=STATE_INCLUDE)
             sensor = await self.client.sensor(include=SENSOR_INCLUDE)
-            dhw = await self.client.hot_water_state(include=DHW_STATE_INCLUDE)
 
         except BSBLANAuthError as err:
             raise ConfigEntryAuthFailed(
@@ -125,6 +125,16 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
                 translation_key="coordinator_connection_error",
                 translation_placeholders={"host": host},
             ) from err
+
+        # Fetch DHW state separately - device may not support hot water
+        dhw: HotWaterState | None = None
+        try:
+            dhw = await self.client.hot_water_state(include=DHW_STATE_INCLUDE)
+        except BSBLANError:
+            LOGGER.debug(
+                "DHW (Domestic Hot Water) state not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
 
         return BSBLanFastData(
             state=state,
@@ -159,13 +169,6 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
             dhw_config = await self.client.hot_water_config(include=DHW_CONFIG_INCLUDE)
             dhw_schedule = await self.client.hot_water_schedule()
 
-        except AttributeError:
-            # Device does not support DHW functionality
-            LOGGER.debug(
-                "DHW (Domestic Hot Water) not available on device at %s",
-                self.config_entry.data[CONF_HOST],
-            )
-            return BSBLanSlowData()
         except (BSBLANConnectionError, BSBLANAuthError) as err:
             # If config update fails, keep existing data
             LOGGER.debug(
@@ -176,6 +179,13 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
             if self.data:
                 return self.data
             # First fetch failed, return empty data
+            return BSBLanSlowData()
+        except BSBLANError, AttributeError:
+            # Device does not support DHW functionality
+            LOGGER.debug(
+                "DHW (Domestic Hot Water) not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
             return BSBLanSlowData()
 
         return BSBLanSlowData(

--- a/homeassistant/components/bsblan/diagnostics.py
+++ b/homeassistant/components/bsblan/diagnostics.py
@@ -22,7 +22,9 @@ async def async_get_config_entry_diagnostics(
         "fast_coordinator_data": {
             "state": data.fast_coordinator.data.state.model_dump(),
             "sensor": data.fast_coordinator.data.sensor.model_dump(),
-            "dhw": data.fast_coordinator.data.dhw.model_dump(),
+            "dhw": data.fast_coordinator.data.dhw.model_dump()
+            if data.fast_coordinator.data.dhw
+            else None,
         },
         "static": data.static.model_dump() if data.static is not None else None,
     }

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from bsblan import BSBLANError, SetHotWaterParam
+from bsblan import BSBLANError, HotWaterState, SetHotWaterParam
 
 from homeassistant.components.water_heater import (
     STATE_ECO,
@@ -46,8 +46,10 @@ async def async_setup_entry(
     data = entry.runtime_data
 
     # Only create water heater entity if DHW (Domestic Hot Water) is available
-    # Check if we have any DHW-related data indicating water heater support
     dhw_data = data.fast_coordinator.data.dhw
+    if dhw_data is None:
+        # Device does not support DHW, skip water heater setup
+        return
     if (
         dhw_data.operating_mode is None
         and dhw_data.nominal_setpoint is None
@@ -108,10 +110,20 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
             self._attr_max_temp = 65.0  # Default maximum
 
     @property
+    def _dhw(self) -> HotWaterState:
+        """Return DHW state data.
+
+        This entity is only created when DHW data is available.
+        """
+        dhw = self.coordinator.data.dhw
+        assert dhw is not None
+        return dhw
+
+    @property
     def current_operation(self) -> str | None:
         """Return current operation."""
         if (
-            operating_mode := self.coordinator.data.dhw.operating_mode
+            operating_mode := self._dhw.operating_mode
         ) is None or operating_mode.value is None:
             return None
         return BSBLAN_TO_HA_OPERATION_MODE.get(operating_mode.value)
@@ -119,16 +131,14 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if (
-            current_temp := self.coordinator.data.dhw.dhw_actual_value_top_temperature
-        ) is None:
+        if (current_temp := self._dhw.dhw_actual_value_top_temperature) is None:
             return None
         return current_temp.value
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if (target_temp := self.coordinator.data.dhw.nominal_setpoint) is None:
+        if (target_temp := self._dhw.nominal_setpoint) is None:
             return None
         return target_temp.value
 

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -222,7 +222,7 @@ async def test_coordinator_fast_no_dhw_support(
     assert mock_config_entry.runtime_data.fast_coordinator.data.dhw is None
 
     # Water heater entity should not be created
-    assert hass.states.get("water_heater.bsblan") is None
+    assert hass.states.get("water_heater.bsb_lan") is None
 
 
 async def test_coordinator_slow_no_dhw_support(

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -201,6 +201,30 @@ async def test_config_entry_timeout_error(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_coordinator_fast_no_dhw_support(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test fast coordinator when device does not support DHW."""
+    mock_bsblan.hot_water_state.side_effect = BSBLANError(
+        "None of the requested parameters are valid for this section"
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Integration should still load even if DHW is not supported
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    # DHW data should be None in the fast coordinator
+    assert mock_config_entry.runtime_data.fast_coordinator.data.dhw is None
+
+    # Water heater entity should not be created
+    assert hass.states.get("water_heater.bsblan") is None
+
+
 async def test_coordinator_slow_no_dhw_support(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If this bug fix could be in the next patch release.

This pull request improves the BSBLan integration's handling of devices that do not support Domestic Hot Water (DHW) functionality. It ensures that the integration gracefully handles the absence of DHW support, avoids errors, and prevents the creation of water heater entities when DHW is unavailable. The diagnostics output is also updated to reflect the possible absence of DHW data, and new tests are added to verify this behavior.

**Improvements to DHW Support Detection and Handling:**

* The `BSBLanFastData` dataclass now allows the `dhw` attribute to be `None`, and the coordinator fetches DHW state separately, handling devices that do not support DHW without raising errors. [[1]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL53-R54) [[2]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL114) [[3]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cR129-R138)
* In the slow coordinator, the code now catches both `BSBLANError` and `AttributeError` to detect lack of DHW support and logs an appropriate debug message, returning empty data when DHW is not available. [[1]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL162-L168) [[2]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cR183-R189)

**Water Heater Entity Setup Adjustments:**

* The water heater platform now checks if DHW data is present before setting up entities, preventing water heater entity creation when DHW is not supported by the device.
* Access to DHW state in the entity is now centralized through a `_dhw` property, ensuring safe and clear access only when DHW data is available.

**Diagnostics and Testing Updates:**

* The diagnostics output now properly handles the case where DHW data may be `None`, avoiding errors in the diagnostics view.
* A new test verifies that the integration loads correctly and does not create a water heater entity when DHW is not supported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165319
- This PR is related to issue: #165319
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
