### PR TITLE
Fix handling of missing period statistics in Anglian Water coordinator

### DIFF
--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -137,12 +137,7 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                         usage_statistic_id,
                     )
                     allow_update_last_stored_hour = True
-                    if not (last_records := last_stat.get(usage_statistic_id)):
-                        _LOGGER.debug(
-                            "No stored statistics found for %s, skipping update",
-                            usage_statistic_id,
-                        )
-                        continue
+                    last_records = last_stat[usage_statistic_id]
                     usage_sum = float(last_records[0].get("sum") or 0.0)
                     last_stats_time = last_records[0]["start"]
                 else:

--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -137,12 +137,13 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                         usage_statistic_id,
                     )
                     allow_update_last_stored_hour = True
-                    if not (last_records := last_stat.get(usage_statistic_id)):
+                    if not last_stat:
                         _LOGGER.debug(
                             "No stored statistics found for %s, skipping update",
                             usage_statistic_id,
                         )
                         continue
+                    last_records = last_stat[usage_statistic_id]
                     usage_sum = float(last_records[0].get("sum") or 0.0)
                     last_stats_time = last_records[0]["start"]
                 else:

--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -107,6 +107,7 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                     continue
                 start = dt_util.as_local(parsed_read_at) - timedelta(hours=1)
                 _LOGGER.debug("Getting statistics at %s", start)
+                stats: dict[str, list[Any]] = {}
                 for end in (start + timedelta(seconds=1), None):
                     stats = await get_instance(self.hass).async_add_executor_job(
                         statistics_during_period,
@@ -127,15 +128,31 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                             "Not found, trying to find oldest statistic after %s",
                             start,
                         )
-                assert stats
 
-                def _safe_get_sum(records: list[Any]) -> float:
-                    if records and "sum" in records[0]:
-                        return float(records[0]["sum"])
-                    return 0.0
+                if not stats or not stats.get(usage_statistic_id):
+                    _LOGGER.debug(
+                        "Could not find existing statistics during period lookup for %s, "
+                        "falling back to last stored statistic",
+                        usage_statistic_id,
+                    )
+                    if not (last_records := last_stat.get(usage_statistic_id)):
+                        _LOGGER.debug(
+                            "No stored statistics found for %s, skipping update",
+                            usage_statistic_id,
+                        )
+                        continue
+                    usage_sum = float(last_records[0].get("sum") or 0.0)
+                    last_stats_time = last_records[0]["start"]
+                else:
+                    records = stats[usage_statistic_id]
 
-                usage_sum = _safe_get_sum(stats.get(usage_statistic_id, []))
-                last_stats_time = stats[usage_statistic_id][0]["start"]
+                    def _safe_get_sum(records: list[Any]) -> float:
+                        if records and "sum" in records[0]:
+                            return float(records[0]["sum"])
+                        return 0.0
+
+                    usage_sum = _safe_get_sum(records)
+                    last_stats_time = records[0]["start"]
 
             usage_statistics = []
 

--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -137,13 +137,12 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                         usage_statistic_id,
                     )
                     allow_update_last_stored_hour = True
-                    if not last_stat:
+                    if not (last_records := last_stat.get(usage_statistic_id)):
                         _LOGGER.debug(
                             "No stored statistics found for %s, skipping update",
                             usage_statistic_id,
                         )
                         continue
-                    last_records = last_stat[usage_statistic_id]
                     usage_sum = float(last_records[0].get("sum") or 0.0)
                     last_stats_time = last_records[0]["start"]
                 else:

--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -92,6 +92,7 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                 _LOGGER.debug("Updating statistics for the first time")
                 usage_sum = 0.0
                 last_stats_time = None
+                allow_update_last_stored_hour = False
             else:
                 if not meter.readings or len(meter.readings) == 0:
                     _LOGGER.debug("No recent usage statistics found, skipping update")
@@ -135,6 +136,7 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                         "falling back to last stored statistic",
                         usage_statistic_id,
                     )
+                    allow_update_last_stored_hour = True
                     if not (last_records := last_stat.get(usage_statistic_id)):
                         _LOGGER.debug(
                             "No stored statistics found for %s, skipping update",
@@ -144,6 +146,7 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                     usage_sum = float(last_records[0].get("sum") or 0.0)
                     last_stats_time = last_records[0]["start"]
                 else:
+                    allow_update_last_stored_hour = False
                     records = stats[usage_statistic_id]
 
                     def _safe_get_sum(records: list[Any]) -> float:
@@ -165,7 +168,13 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                     )
                     continue
                 start = dt_util.as_local(parsed_read_at) - timedelta(hours=1)
-                if last_stats_time is not None and start.timestamp() <= last_stats_time:
+                if last_stats_time is not None and (
+                    start.timestamp() < last_stats_time
+                    or (
+                        start.timestamp() == last_stats_time
+                        and not allow_update_last_stored_hour
+                    )
+                ):
                     continue
                 usage_state = max(0, read["consumption"] / 1000)
                 usage_sum = max(0, read["read"])

--- a/tests/components/anglian_water/test_coordinator.py
+++ b/tests/components/anglian_water/test_coordinator.py
@@ -227,39 +227,6 @@ async def test_coordinator_subsequent_run_missing_period_statistics(
     assert corrected_stats[statistic_id][0]["sum"] == 70
 
 
-async def test_coordinator_missing_period_statistics_without_last_record(
-    recorder_mock: Recorder,
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_anglian_water_client: AsyncMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test fallback handles missing record for the expected statistic id."""
-    coordinator = AnglianWaterUpdateCoordinator(
-        hass, mock_anglian_water_client, mock_config_entry
-    )
-
-    with (
-        patch(
-            "homeassistant.components.anglian_water.coordinator.get_last_statistics",
-            return_value={"unexpected_stat_id": [{"start": 1234.0, "sum": 1.0}]},
-        ),
-        patch(
-            "homeassistant.components.anglian_water.coordinator.statistics_during_period",
-            return_value={},
-        ),
-    ):
-        await coordinator._async_update_data()
-
-    assert "No stored statistics found for" in caplog.text
-
-    statistic_id = f"anglian_water:{ACCOUNT_NUMBER}_testsn_usage"
-    stats = await hass.async_add_executor_job(
-        get_last_statistics, hass, 1, statistic_id, True, {"sum"}
-    )
-    assert stats == {}
-
-
 async def test_coordinator_period_statistics_without_sum(
     recorder_mock: Recorder,
     hass: HomeAssistant,

--- a/tests/components/anglian_water/test_coordinator.py
+++ b/tests/components/anglian_water/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for the Anglian Water coordinator."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 from pyanglianwater.meter import SmartMeter
@@ -179,6 +180,15 @@ async def test_coordinator_subsequent_run_missing_period_statistics(
     await coordinator._async_update_data()
     await async_wait_recording_done(hass)
 
+    # Correct the latest already-stored reading. Fallback should still update
+    # this hour instead of skipping it.
+    mock_smart_meter.readings[-1] = {
+        "read_at": "2024-06-01T14:00:00",
+        "consumption": 35,
+        "read": 70,
+    }
+
+    # Add a new later reading to ensure fallback also accepts newer entries.
     mock_smart_meter.readings.append(
         {"read_at": "2024-06-01T15:00:00Z", "consumption": 20, "read": 90}
     )
@@ -196,4 +206,22 @@ async def test_coordinator_subsequent_run_missing_period_statistics(
     stats = await hass.async_add_executor_job(
         get_last_statistics, hass, 1, statistic_id, True, {"sum"}
     )
-    assert stats[statistic_id][0]["sum"] >= 50
+    assert stats[statistic_id][0]["sum"] >= 70
+
+    parsed_read_at = dt_util.parse_datetime("2024-06-01T14:00:00")
+    assert parsed_read_at is not None
+    corrected_start = dt_util.as_local(parsed_read_at) - timedelta(hours=1)
+
+    corrected_stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        corrected_start,
+        corrected_start + timedelta(seconds=1),
+        {
+            statistic_id,
+        },
+        "hour",
+        None,
+        {"sum"},
+    )
+    assert corrected_stats[statistic_id][0]["sum"] == 70

--- a/tests/components/anglian_water/test_coordinator.py
+++ b/tests/components/anglian_water/test_coordinator.py
@@ -1,6 +1,6 @@
 """Tests for the Anglian Water coordinator."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from pyanglianwater.meter import SmartMeter
 import pytest
@@ -162,3 +162,38 @@ async def test_coordinator_invalid_readings(
         "Could not parse read_at time also-invalid-date, skipping reading"
         in caplog.text
     )
+
+
+async def test_coordinator_subsequent_run_missing_period_statistics(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smart_meter: SmartMeter,
+    mock_anglian_water_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the coordinator handles missing period lookup statistics."""
+    coordinator = AnglianWaterUpdateCoordinator(
+        hass, mock_anglian_water_client, mock_config_entry
+    )
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    mock_smart_meter.readings.append(
+        {"read_at": "2024-06-01T15:00:00Z", "consumption": 20, "read": 90}
+    )
+
+    with patch(
+        "homeassistant.components.anglian_water.coordinator.statistics_during_period",
+        return_value={},
+    ):
+        await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    assert "Could not find existing statistics during period lookup" in caplog.text
+
+    statistic_id = f"anglian_water:{ACCOUNT_NUMBER}_testsn_usage"
+    stats = await hass.async_add_executor_job(
+        get_last_statistics, hass, 1, statistic_id, True, {"sum"}
+    )
+    assert stats[statistic_id][0]["sum"] >= 50

--- a/tests/components/anglian_water/test_coordinator.py
+++ b/tests/components/anglian_water/test_coordinator.py
@@ -225,3 +225,36 @@ async def test_coordinator_subsequent_run_missing_period_statistics(
         {"sum"},
     )
     assert corrected_stats[statistic_id][0]["sum"] == 70
+
+
+async def test_coordinator_missing_period_statistics_without_last_record(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test fallback handles missing record for the expected statistic id."""
+    coordinator = AnglianWaterUpdateCoordinator(
+        hass, mock_anglian_water_client, mock_config_entry
+    )
+
+    with (
+        patch(
+            "homeassistant.components.anglian_water.coordinator.get_last_statistics",
+            return_value={"unexpected_stat_id": [{"start": 1234.0, "sum": 1.0}]},
+        ),
+        patch(
+            "homeassistant.components.anglian_water.coordinator.statistics_during_period",
+            return_value={},
+        ),
+    ):
+        await coordinator._async_update_data()
+
+    assert "No stored statistics found for" in caplog.text
+
+    statistic_id = f"anglian_water:{ACCOUNT_NUMBER}_testsn_usage"
+    stats = await hass.async_add_executor_job(
+        get_last_statistics, hass, 1, statistic_id, True, {"sum"}
+    )
+    assert stats == {}

--- a/tests/components/anglian_water/test_coordinator.py
+++ b/tests/components/anglian_water/test_coordinator.py
@@ -258,3 +258,30 @@ async def test_coordinator_missing_period_statistics_without_last_record(
         get_last_statistics, hass, 1, statistic_id, True, {"sum"}
     )
     assert stats == {}
+
+
+async def test_coordinator_period_statistics_without_sum(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test period lookup records without sum are handled safely."""
+    coordinator = AnglianWaterUpdateCoordinator(
+        hass, mock_anglian_water_client, mock_config_entry
+    )
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    statistic_id = f"anglian_water:{ACCOUNT_NUMBER}_testsn_usage"
+    with patch(
+        "homeassistant.components.anglian_water.coordinator.statistics_during_period",
+        return_value={statistic_id: [{"start": 0.0}]},
+    ):
+        await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    stats = await hass.async_add_executor_job(
+        get_last_statistics, hass, 1, statistic_id, True, {"sum"}
+    )
+    assert stats[statistic_id]

--- a/tests/components/anglian_water/test_coordinator.py
+++ b/tests/components/anglian_water/test_coordinator.py
@@ -190,7 +190,7 @@ async def test_coordinator_subsequent_run_missing_period_statistics(
 
     # Add a new later reading to ensure fallback also accepts newer entries.
     mock_smart_meter.readings.append(
-        {"read_at": "2024-06-01T15:00:00Z", "consumption": 20, "read": 90}
+        {"read_at": "2024-06-01T15:00:00", "consumption": 20, "read": 90}
     )
 
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There appears to be a race condition where statistics cannot be loaded into the database inside the Anglian Water coordiantor, a number of reasons can cause this, such as either API failures, or meter problems.

```
2026-04-04 15:05:18.594 ERROR (MainThread) [homeassistant.components.anglian_water.coordinator] Unexpected error fetching anglian_water data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 426, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/anglian_water/coordinator.py", line 63, in _async_update_data
    await self._insert_statistics()
  File "/usr/src/homeassistant/homeassistant/components/anglian_water/coordinator.py", line 130, in _insert_statistics
    assert stats
           ^^^^^
AssertionError
```

However, I am unable to replicate this scenario at all apart from with a test case. So I am unfortunately purely relying on the written test case to help.

I wonder, could we tag this for 2026.4.2?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
