### PR TITLE
Fix missing color_mode initialization in MQTT JSON light schema

### DIFF
--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -146,7 +146,6 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
     _entity_id_format = ENTITY_ID_FORMAT
     _attributes_extra_blocked = MQTT_LIGHT_ATTRIBUTES_BLOCKED
 
-    _fixed_color_mode: ColorMode | str | None = None
     _flash_times: dict[str, int | None]
     _topic: dict[str, str | None]
     _optimistic: bool
@@ -190,6 +189,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
         self._attr_supported_features |= (
             config[CONF_TRANSITION] and LightEntityFeature.TRANSITION
         )
+        self._attr_color_mode = ColorMode.UNKNOWN
         if supported_color_modes := self._config.get(CONF_SUPPORTED_COLOR_MODES):
             self._attr_supported_color_modes = supported_color_modes
             if self.supported_color_modes and len(self.supported_color_modes) == 1:

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -521,6 +521,58 @@ async def test_brightness_only(
                 light.DOMAIN: {
                     "schema": "json",
                     "name": "test",
+                    "state_topic": "test_light",
+                    "command_topic": "test_light/set",
+                    "supported_color_modes": ["brightness"],
+                }
+            }
+        },
+        {
+            mqtt.DOMAIN: {
+                light.DOMAIN: {
+                    "schema": "json",
+                    "name": "test",
+                    "state_topic": "test_light",
+                    "command_topic": "test_light/set",
+                    "supported_color_modes": ["color_temp"],
+                }
+            }
+        },
+    ],
+)
+async def test_single_color_mode_turn_on(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test turning on a single color mode light does not raise.
+
+    Regression test: PR #162715 changed _attr_color_mode default to None
+    and added a strict check. The JSON schema must initialize color_mode
+    during setup so that turn_on does not raise "does not report a color mode".
+    """
+    mqtt_mock = await mqtt_mock_entry()
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_UNKNOWN
+
+    # This should not raise "does not report a color mode"
+    await common.async_turn_on(hass, "light.test")
+    mqtt_mock.async_publish.assert_called_once_with(
+        "test_light/set", '{"state":"ON"}', 0, False
+    )
+
+    async_fire_mqtt_message(hass, "test_light", '{"state":"ON", "brightness": 50}')
+    state = hass.states.get("light.test")
+    assert state.state == STATE_ON
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                light.DOMAIN: {
+                    "schema": "json",
+                    "name": "test",
                     "state_topic": "test_light_rgb",
                     "command_topic": "test_light_rgb/set",
                     "supported_color_modes": ["color_temp"],


### PR DESCRIPTION
## Proposed change

PR #162715 changed `_attr_color_mode` default from `ColorMode.UNKNOWN` to `None` and added a strict check that raises `HomeAssistantError` when a light is on but `color_mode is None`. The template schema (`schema_template.py`) was updated to initialize `_attr_color_mode = ColorMode.UNKNOWN` before the color mode branching logic, but the JSON schema (`schema_json.py`) was not.

This causes MQTT JSON schema lights to fail with:
> `does not report a color mode`

This PR initializes `_attr_color_mode = ColorMode.UNKNOWN` before the color mode branching in `_setup_from_config`, and removes the unused `_fixed_color_mode` class variable.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: #162715 (Raise on missing color mode)
- The template schema received the safety net in #162715, the JSON schema did not

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr