### PR TITLE
Bump python-roborock from 5.0.0 to 5.3.0

### DIFF
--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==5.0.0",
+    "python-roborock==5.3.0",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2663,7 +2663,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==5.0.0
+python-roborock==5.3.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2262,7 +2262,7 @@ python-qube-heatpump==1.8.0
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==5.0.0
+python-roborock==5.3.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `python-roborock` from 5.0.0 to 5.3.0.

**Full diff:** https://github.com/Python-roborock/python-roborock/compare/v5.0.0...v5.3.0

**Changelog:**
- [5.1.0](https://github.com/Python-roborock/python-roborock/releases/tag/v5.1.0) — protobuf stub improvements, typing migrations, Q7 map content support
- [5.2.0](https://github.com/Python-roborock/python-roborock/releases/tag/v5.2.0) — bug fixes for device serial number/product model handling and map-related commands for B01/Q7 devices
- [5.3.0](https://github.com/Python-roborock/python-roborock/releases/tag/v5.3.0) — adds `ConsumableAttribute.STRAINER_WORK_TIME` and `ConsumableAttribute.CLEANING_BRUSH_WORK_TIME`, required by #167395 to wire up dock consumable reset buttons

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: #160121
- This PR is related to pull request: #167395
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
