### PR TITLE
Fix nzbget positional argument mismatch in NZBGetAPI calls

### DIFF
--- a/homeassistant/components/nzbget/config_flow.py
+++ b/homeassistant/components/nzbget/config_flow.py
@@ -30,12 +30,12 @@ def _validate_input(data: dict[str, Any]) -> None:
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
     nzbget_api = NZBGetAPI(
-        data[CONF_HOST],
-        data.get(CONF_USERNAME),
-        data.get(CONF_PASSWORD),
-        data[CONF_SSL],
-        data[CONF_VERIFY_SSL],
-        data[CONF_PORT],
+        host=data[CONF_HOST],
+        username=data.get(CONF_USERNAME),
+        password=data.get(CONF_PASSWORD),
+        secure=data[CONF_SSL],
+        verify_certificate=data[CONF_VERIFY_SSL],
+        port=data[CONF_PORT],
     )
 
     nzbget_api.version()

--- a/homeassistant/components/nzbget/coordinator.py
+++ b/homeassistant/components/nzbget/coordinator.py
@@ -38,12 +38,12 @@ class NZBGetDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Initialize global NZBGet data updater."""
         self.nzbget = NZBGetAPI(
-            config_entry.data[CONF_HOST],
-            config_entry.data.get(CONF_USERNAME),
-            config_entry.data.get(CONF_PASSWORD),
-            config_entry.data[CONF_SSL],
-            config_entry.data[CONF_VERIFY_SSL],
-            config_entry.data[CONF_PORT],
+            host=config_entry.data[CONF_HOST],
+            username=config_entry.data.get(CONF_USERNAME),
+            password=config_entry.data.get(CONF_PASSWORD),
+            secure=config_entry.data[CONF_SSL],
+            verify_certificate=config_entry.data[CONF_VERIFY_SSL],
+            port=config_entry.data[CONF_PORT],
         )
 
         self._completed_downloads_init = False


### PR DESCRIPTION
## Proposed change

Both `coordinator.py` and `config_flow.py` call `NZBGetAPI()` with positional arguments but skip the `urlbase` parameter (which is the second positional arg). This shifts every subsequent argument by one position, so `CONF_SSL` (a boolean) gets passed as `password`, and `quote(False)` raises a `TypeError` on Python 3.14.

Switched both call sites to use keyword arguments.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
