### PR TITLE
Fix modem_callerid test_setup_entry mock

### DIFF
--- a/tests/components/modem_callerid/test_init.py
+++ b/tests/components/modem_callerid/test_init.py
@@ -1,7 +1,5 @@
 """Test Modem Caller ID integration."""
 
-from unittest.mock import patch
-
 from phone_modem import exceptions
 
 from homeassistant.components.modem_callerid.const import DOMAIN
@@ -21,14 +19,7 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
         data={CONF_DEVICE: com_port().device},
     )
     entry.add_to_hass(hass)
-    with (
-        patch("aioserial.AioSerial", autospec=True),
-        patch(
-            "homeassistant.components.modem_callerid.PhoneModem._get_response",
-            return_value="OK",
-        ),
-        patch("phone_modem.PhoneModem._modem_sm"),
-    ):
+    with patch_init_modem():
         await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.LOADED
 


### PR DESCRIPTION
## Proposed change

`test_setup_entry` patched `aioserial.AioSerial` and internal `PhoneModem` methods but missed `PhoneModem.initialize()`, which is the call that actually opens the serial port. The test has been broken since the refactor in #59691 (Feb 2022). The other two tests in the same file already use the `patch_init_modem()` helper correctly, so this just switches `test_setup_entry` to use it too.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
