### PR TITLE
Add descriptions for sensor statistics repair issues

### DIFF
--- a/homeassistant/components/sensor/strings.json
+++ b/homeassistant/components/sensor/strings.json
@@ -330,15 +330,15 @@
   },
   "issues": {
     "mean_type_changed": {
-      "description": "",
+      "description": "The mean type of {statistic_id} has changed. Existing long-term statistics may no longer be valid.",
       "title": "The mean type of {statistic_id} has changed"
     },
     "state_class_removed": {
-      "description": "",
+      "description": "The state class of {statistic_id} is no longer set. Long-term statistics may no longer be recorded for this entity.",
       "title": "{statistic_id} no longer has a state class"
     },
     "units_changed": {
-      "description": "",
+      "description": "The unit of {statistic_id} changed from \"{metadata_unit}\" to \"{state_unit}\". Supported units are: {supported_unit}.",
       "title": "The unit of {statistic_id} has changed"
     }
   },


### PR DESCRIPTION
## Proposed change

Three sensor repair issues (`units_changed`, `state_class_removed`, `mean_type_changed`) have empty `description` fields in `strings.json`. All three are created with `is_fixable=False`, which requires a description translation. Empty strings get stripped during translation compilation, so the keys are missing and the translation validation fails.

Added descriptions for each using the placeholders already passed by `recorder.py`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
