### PR TITLE
Use offline command for non-UTF-8 stdout test

### DIFF
--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
+import shlex
+import sys
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -184,12 +187,16 @@ async def test_non_text_stdout_capture(
     mock_output, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test handling of non-text output."""
+    non_utf8_cmd = (
+        f"{shlex.quote(sys.executable)} -c"
+        ' "import sys; sys.stdout.buffer.write(bytes([0x80, 0x81, 0x82]))"'
+    )
     assert await async_setup_component(
         hass,
         shell_command.DOMAIN,
         {
             shell_command.DOMAIN: {
-                "output_image": "curl -o - https://raw.githubusercontent.com/home-assistant/assets/master/misc/loading-screen.gif"
+                "output_image": non_utf8_cmd,
             }
         },
     )
@@ -205,7 +212,9 @@ async def test_non_text_stdout_capture(
     # Non-text output throws with 'return_response'
     with pytest.raises(
         HomeAssistantError,
-        match="Unable to handle non-utf8 output of command: `curl -o - https://raw.githubusercontent.com/home-assistant/assets/master/misc/loading-screen.gif`",
+        match=re.escape(
+            f"Unable to handle non-utf8 output of command: `{non_utf8_cmd}`"
+        ),
     ):
         response = await hass.services.async_call(
             "shell_command", "output_image", blocking=True, return_response=True


### PR DESCRIPTION
## Proposed change

`test_non_text_stdout_capture` used `curl` to download a GIF from GitHub to produce binary output. This requires network access, which shouldn't be required for a unit test.

Replaced it with a `python3` one-liner that writes raw non-UTF-8 bytes to stdout. Same code path, no network needed.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
