### PR TITLE
Use mark.usefixtures for unreferenced fixtures in Evohome

### DIFF
--- a/tests/components/evohome/test_coordinator.py
+++ b/tests/components/evohome/test_coordinator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
-from evohomeasync2 import EvohomeClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -19,10 +18,9 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.parametrize("install", ["minimal"])
+@pytest.mark.usefixtures("evohome")
 async def test_setup_platform(
     hass: HomeAssistant,
-    config: dict[str, str],
-    evohome: EvohomeClient,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test entities and their states after setup of evohome."""

--- a/tests/components/evohome/test_init.py
+++ b/tests/components/evohome/test_init.py
@@ -7,7 +7,7 @@ import logging
 from unittest.mock import Mock, patch
 
 import aiohttp
-from evohomeasync2 import EvohomeClient, exceptions as evo_exc
+from evohomeasync2 import exceptions as evo_exc
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -172,11 +172,8 @@ async def test_client_request_failure_v2(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_setup(
-    hass: HomeAssistant,
-    evohome: EvohomeClient,
-    snapshot: SnapshotAssertion,
-) -> None:
+@pytest.mark.usefixtures("evohome")
+async def test_setup(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
     """Test services after setup of evohome.
 
     Registered services vary by the type of system.

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
-from evohomeasync2 import EvohomeClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -25,10 +24,8 @@ from .const import TEST_INSTALLS
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_refresh_system(
-    hass: HomeAssistant,
-    evohome: EvohomeClient,
-) -> None:
+@pytest.mark.usefixtures("evohome")
+async def test_refresh_system(hass: HomeAssistant) -> None:
     """Test Evohome's refresh_system service (for all temperature control systems)."""
 
     # EvoService.REFRESH_SYSTEM
@@ -63,9 +60,9 @@ async def test_reset_system(
 
 
 @pytest.mark.parametrize("install", ["default"])
+@pytest.mark.usefixtures("ctl_id")
 async def test_set_system_mode(
     hass: HomeAssistant,
-    ctl_id: str,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test Evohome's set_system_mode service (for a temperature control system)."""
@@ -293,6 +290,7 @@ _SET_SYSTEM_MODE_VALIDATOR_PARAMS = [
 
 
 @pytest.mark.parametrize("install", ["default"])
+@pytest.mark.usefixtures("evohome")
 @pytest.mark.parametrize(
     ("service_data", "expected_translation_key"),
     _SET_SYSTEM_MODE_VALIDATOR_PARAMS,
@@ -300,7 +298,6 @@ _SET_SYSTEM_MODE_VALIDATOR_PARAMS = [
 )
 async def test_set_system_mode_validator(
     hass: HomeAssistant,
-    evohome: EvohomeClient,
     service_data: dict[str, Any],
     expected_translation_key: str,
 ) -> None:

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from evohomeasync2 import EvohomeClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -50,9 +49,9 @@ async def test_setup_platform(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
+@pytest.mark.usefixtures("evohome")
 async def test_set_operation_mode(
     hass: HomeAssistant,
-    evohome: EvohomeClient,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -119,7 +118,8 @@ async def test_set_operation_mode(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_set_away_mode(hass: HomeAssistant, evohome: EvohomeClient) -> None:
+@pytest.mark.usefixtures("evohome")
+async def test_set_away_mode(hass: HomeAssistant) -> None:
     """Test SERVICE_SET_AWAY_MODE of an evohome DHW zone."""
 
     # set_away_mode: off
@@ -152,7 +152,8 @@ async def test_set_away_mode(hass: HomeAssistant, evohome: EvohomeClient) -> Non
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_off(hass: HomeAssistant, evohome: EvohomeClient) -> None:
+@pytest.mark.usefixtures("evohome")
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test SERVICE_TURN_OFF of an evohome DHW zone."""
 
     # turn_off
@@ -170,7 +171,8 @@ async def test_turn_off(hass: HomeAssistant, evohome: EvohomeClient) -> None:
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_on(hass: HomeAssistant, evohome: EvohomeClient) -> None:
+@pytest.mark.usefixtures("evohome")
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test SERVICE_TURN_ON of an evohome DHW zone."""
 
     # turn_on


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In Evohome tests, use `@pytest.mark.usefixtures()` instead of passing the fixture in as an unused arg.

No breaking changes, no end-user visibility.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
