### PR TITLE
Update roborock services to raise ServiceNotSupported for new devices that don't yet support it

### DIFF
--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -19,7 +19,11 @@ from homeassistant.components.vacuum import (
     VacuumEntityFeature,
 )
 from homeassistant.core import HomeAssistant, ServiceResponse, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceNotSupported,
+    ServiceValidationError,
+)
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
@@ -484,6 +488,18 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
                 },
             ) from err
 
+    async def get_maps(self) -> ServiceResponse:
+        """Get map information such as map id and room ids."""
+        raise ServiceNotSupported(DOMAIN, "get_maps", self.entity_id)
+
+    async def get_vacuum_current_position(self) -> ServiceResponse:
+        """Get the current position of the vacuum from the map."""
+        raise ServiceNotSupported(DOMAIN, "get_vacuum_current_position", self.entity_id)
+
+    async def async_set_vacuum_goto_position(self, x: int, y: int) -> None:
+        """Set the vacuum to go to a specific position."""
+        raise ServiceNotSupported(DOMAIN, "set_vacuum_goto_position", self.entity_id)
+
 
 class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
     """Representation of a Roborock Q10 vacuum."""
@@ -654,3 +670,15 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
                     "command": command,
                 },
             ) from err
+
+    async def get_maps(self) -> ServiceResponse:
+        """Get map information such as map id and room ids."""
+        raise ServiceNotSupported(DOMAIN, "get_maps", self.entity_id)
+
+    async def get_vacuum_current_position(self) -> ServiceResponse:
+        """Get the current position of the vacuum from the map."""
+        raise ServiceNotSupported(DOMAIN, "get_vacuum_current_position", self.entity_id)
+
+    async def async_set_vacuum_goto_position(self, x: int, y: int) -> None:
+        """Set the vacuum to go to a specific position."""
+        raise ServiceNotSupported(DOMAIN, "set_vacuum_goto_position", self.entity_id)

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -34,7 +34,11 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceNotSupported,
+    ServiceValidationError,
+)
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -217,6 +221,32 @@ async def test_get_maps(
     assert response == snapshot
 
 
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        Q7_ENTITY_ID,
+        Q10_ENTITY_ID,
+    ],
+)
+async def test_get_maps_not_supported(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_id: str,
+) -> None:
+    """Test that the service for maps correctly outputs rooms with the right name."""
+    with pytest.raises(
+        ServiceNotSupported, match="does not support action roborock.get_maps"
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            GET_MAPS_SERVICE_NAME,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+            return_response=True,
+        )
+
+
 async def test_goto(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
@@ -237,6 +267,32 @@ async def test_goto(
     assert vacuum_command.send.call_args == (
         call(RoborockCommand.APP_GOTO_TARGET, params=[25500, 25500])
     )
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        Q7_ENTITY_ID,
+        Q10_ENTITY_ID,
+    ],
+)
+async def test_goto_not_supported(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_id: str,
+) -> None:
+    """Test that the service for maps correctly outputs rooms with the right name."""
+    with pytest.raises(
+        ServiceNotSupported,
+        match="does not support action roborock.set_vacuum_goto_position",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SET_VACUUM_GOTO_POSITION_SERVICE_NAME,
+            {ATTR_ENTITY_ID: entity_id, "x": 25500, "y": 25500},
+            blocking=True,
+        )
 
 
 async def test_get_current_position(
@@ -300,6 +356,33 @@ async def test_get_current_position_no_robot_position(
             DOMAIN,
             GET_VACUUM_CURRENT_POSITION_SERVICE_NAME,
             {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+            return_response=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        Q7_ENTITY_ID,
+        Q10_ENTITY_ID,
+    ],
+)
+async def test_get_current_position_not_supported(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_id: str,
+) -> None:
+    """Test that the service for maps correctly outputs rooms with the right name."""
+    with pytest.raises(
+        ServiceNotSupported,
+        match="does not support action roborock.get_vacuum_current_position",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            GET_VACUUM_CURRENT_POSITION_SERVICE_NAME,
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
             return_response=True,
         )

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -231,10 +231,9 @@ async def test_get_maps(
 async def test_get_maps_not_supported(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
-    snapshot: SnapshotAssertion,
     entity_id: str,
 ) -> None:
-    """Test that the service for maps correctly outputs rooms with the right name."""
+    """Test that unsupported vacuums raise ServiceNotSupported for get_maps."""
     with pytest.raises(
         ServiceNotSupported, match="does not support action roborock.get_maps"
     ):
@@ -279,10 +278,9 @@ async def test_goto(
 async def test_goto_not_supported(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
-    snapshot: SnapshotAssertion,
     entity_id: str,
 ) -> None:
-    """Test that the service for maps correctly outputs rooms with the right name."""
+    """Test that unsupported vacuums raise ServiceNotSupported for goto."""
     with pytest.raises(
         ServiceNotSupported,
         match="does not support action roborock.set_vacuum_goto_position",
@@ -371,10 +369,9 @@ async def test_get_current_position_no_robot_position(
 async def test_get_current_position_not_supported(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
-    snapshot: SnapshotAssertion,
     entity_id: str,
 ) -> None:
-    """Test that the service for maps correctly outputs rooms with the right name."""
+    """Test that the current-position service raises ServiceNotSupported."""
     with pytest.raises(
         ServiceNotSupported,
         match="does not support action roborock.get_vacuum_current_position",


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update roborock `get_maps` to raise `ServiceNotSupported` for new devices that don't yet support it. This can be removed in the future and replaced with a real implementation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162746
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
