### PR TITLE
Add Powerline hint to username field description

### DIFF
--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -5,7 +5,7 @@
     "data_description_password": "Password for the FRITZ!Box.",
     "data_description_port": "Leave empty to use the default port.",
     "data_description_ssl": "Use SSL to connect to the FRITZ!Box.",
-    "data_description_username": "Username for the FRITZ!Box.",
+    "data_description_username": "Username for the FRITZ!Box. For FRITZ!Powerline devices without username, enter any value.",
     "data_feature_device_tracking": "Enable network device tracking"
   },
   "config": {

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -5,7 +5,7 @@
     "data_description_password": "Password for the FRITZ!Box.",
     "data_description_port": "Leave empty to use the default port.",
     "data_description_ssl": "Use SSL to connect to the FRITZ!Box.",
-    "data_description_username": "Username for the FRITZ!Box. FRITZ!Powerline devices do not require a username; enter any value.",
+    "data_description_username": "Username for the FRITZ!Box. FRITZ!Powerline devices ignore this information and accept any value.",
     "data_feature_device_tracking": "Enable network device tracking"
   },
   "config": {

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -5,7 +5,7 @@
     "data_description_password": "Password for the FRITZ!Box.",
     "data_description_port": "Leave empty to use the default port.",
     "data_description_ssl": "Use SSL to connect to the FRITZ!Box.",
-    "data_description_username": "Username for the FRITZ!Box. For FRITZ!Powerline devices without username, enter any value.",
+    "data_description_username": "Username for the FRITZ!Box. FRITZ!Powerline devices do not require a username; enter any value.",
     "data_feature_device_tracking": "Enable network device tracking"
   },
   "config": {


### PR DESCRIPTION
## What it does

Adds a note to the username field description in the Fritz integration config flow, mentioning that FRITZ!Powerline devices don't have a username and any value can be entered.

## Why

FRITZ!Powerline devices (e.g. 1240E) only support password-based authentication — they have no username concept and accept any value in the username field. When these devices appear via SSDP auto-discovery, users see the config form with a required username field and don't know what to enter.

As discussed with @chemelli74 and @mib1185, a documentation update + a short hint in the `data_description` is the right approach.

## Changes

- **strings.json**: Update `data_description_username` to mention Powerline devices

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally
- [x] There is no commented out code in this PR

Related to #79343