### PR TITLE
Use fixtures for all entity IDs in Evohome tests

### DIFF
--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -239,8 +239,7 @@ def dhw_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str
     evo: EvohomeClient = evohome.return_value
     dhw: HotWater | None = evo.tcs.hotwater
 
-    if dhw is None:
-        pytest.skip("Fixture has no DHW zone")
+    assert dhw is not None, "Fixture has no DHW zone"
 
     return entity_id(Platform.WATER_HEATER, dhw.id)
 

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -245,7 +245,10 @@ def dhw_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str
 
 
 @pytest.fixture
-def entity_id(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> Callable[[Platform, str], str]:
+def entity_id(
+    hass: HomeAssistant,
+    entity registry: er.EntityRegistry,
+) -> Callable[[Platform, str], str]:
     """Return a helper to lookup an entity_id from platform and unique_id."""
 
     def get_entity_id(platform: Platform, unique_id: str) -> str:

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -8,7 +8,7 @@ from http import HTTPMethod
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from evohomeasync2 import EvohomeClient
+from evohomeasync2 import EvohomeClient, HotWater
 from evohomeasync2.auth import AbstractTokenManager, Auth
 from evohomeasync2.control_system import ControlSystem
 from evohomeasync2.zone import Zone
@@ -18,8 +18,9 @@ import pytest
 from homeassistant.components.evohome.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonArrayType, JsonObjectType
 
 from .const import ACCESS_TOKEN, REFRESH_TOKEN, SESSION_ID, USERNAME
@@ -210,20 +211,53 @@ async def evohome(
 
 
 @pytest.fixture
-def ctl_id(evohome: MagicMock) -> str:
-    """Return the entity_id of the evohome integration's controller."""
+def ctl_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str:
+    """Return the entity_id of evohome's controller (a Climate entity)."""
+
+    evo: EvohomeClient = evohome.return_value
+    tcs: ControlSystem = evo.tcs
+
+    return entity_id(Platform.CLIMATE, tcs.id)
+
+
+@pytest.fixture
+def zone_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str:
+    """Return the entity_id of evohome's first zone (a Climate entity)."""
 
     evo: EvohomeClient = evohome.return_value
     ctl: ControlSystem = evo.tcs
 
-    return f"{Platform.CLIMATE}.{slugify(ctl.location.name)}"
+    zone: Zone = evo.tcs.zones[0]
+
+    return entity_id(Platform.CLIMATE, f"{zone.id}z" if zone.id == ctl.id else zone.id)
 
 
 @pytest.fixture
-def zone_id(evohome: MagicMock) -> str:
-    """Return the entity_id of the evohome integration's first zone."""
+def dhw_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str:
+    """Return the entity_id of Evohome's DHW controller (a WaterHeater entity)."""
 
     evo: EvohomeClient = evohome.return_value
-    zone: Zone = evo.tcs.zones[0]
+    dhw: HotWater | None = evo.tcs.hotwater
 
-    return f"{Platform.CLIMATE}.{slugify(zone.name)}"
+    if dhw is None:
+        pytest.skip("Fixture has no DHW zone")
+
+    return entity_id(Platform.WATER_HEATER, dhw.id)
+
+
+@pytest.fixture
+def entity_id(hass: HomeAssistant) -> Callable[[Platform, str], str]:
+    """Return a helper to lookup an entity_id from platform and unique_id."""
+
+    entity_registry = er.async_get(hass)
+
+    def get_entity_id(platform: Platform, unique_id: str) -> str:
+        """Return an entity_id from the entity registry."""
+
+        entity = entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
+        assert entity is not None, (
+            f"Entity not found for platform={platform}: {unique_id}"
+        )
+        return entity
+
+    return get_entity_id

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -246,8 +246,7 @@ def dhw_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str
 
 @pytest.fixture
 def entity_id(
-    hass: HomeAssistant,
-    entity registry: er.EntityRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> Callable[[Platform, str], str]:
     """Return a helper to lookup an entity_id from platform and unique_id."""
 

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -246,10 +246,8 @@ def dhw_id(evohome: MagicMock, entity_id: Callable[[Platform, str], str]) -> str
 
 
 @pytest.fixture
-def entity_id(hass: HomeAssistant) -> Callable[[Platform, str], str]:
+def entity_id(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> Callable[[Platform, str], str]:
     """Return a helper to lookup an entity_id from platform and unique_id."""
-
-    entity_registry = er.async_get(hass)
 
     def get_entity_id(platform: Platform, unique_id: str) -> str:
         """Return an entity_id from the entity registry."""

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -24,8 +24,6 @@ from homeassistant.core import HomeAssistant
 from .conftest import setup_evohome
 from .const import TEST_INSTALLS_WITH_DHW
 
-DHW_ENTITY_ID = "water_heater.domestic_hot_water"
-
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_setup_platform(
@@ -49,9 +47,9 @@ async def test_setup_platform(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-@pytest.mark.usefixtures("evohome")
 async def test_set_operation_mode(
     hass: HomeAssistant,
+    dhw_id: str,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -66,7 +64,7 @@ async def test_set_operation_mode(
             WATER_HEATER_DOMAIN,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ENTITY_ID,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_OPERATION_MODE: "auto",
             },
             blocking=True,
@@ -80,7 +78,7 @@ async def test_set_operation_mode(
             WATER_HEATER_DOMAIN,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ENTITY_ID,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_OPERATION_MODE: "off",
             },
             blocking=True,
@@ -100,7 +98,7 @@ async def test_set_operation_mode(
             WATER_HEATER_DOMAIN,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ENTITY_ID,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_OPERATION_MODE: "on",
             },
             blocking=True,
@@ -118,8 +116,7 @@ async def test_set_operation_mode(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-@pytest.mark.usefixtures("evohome")
-async def test_set_away_mode(hass: HomeAssistant) -> None:
+async def test_set_away_mode(hass: HomeAssistant, dhw_id: str) -> None:
     """Test SERVICE_SET_AWAY_MODE of an evohome DHW zone."""
 
     # set_away_mode: off
@@ -128,7 +125,7 @@ async def test_set_away_mode(hass: HomeAssistant) -> None:
             WATER_HEATER_DOMAIN,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ENTITY_ID,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_AWAY_MODE: "off",
             },
             blocking=True,
@@ -142,7 +139,7 @@ async def test_set_away_mode(hass: HomeAssistant) -> None:
             WATER_HEATER_DOMAIN,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ENTITY_ID,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_AWAY_MODE: "on",
             },
             blocking=True,
@@ -152,8 +149,7 @@ async def test_set_away_mode(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-@pytest.mark.usefixtures("evohome")
-async def test_turn_off(hass: HomeAssistant) -> None:
+async def test_turn_off(hass: HomeAssistant, dhw_id: str) -> None:
     """Test SERVICE_TURN_OFF of an evohome DHW zone."""
 
     # turn_off
@@ -162,7 +158,7 @@ async def test_turn_off(hass: HomeAssistant) -> None:
             WATER_HEATER_DOMAIN,
             SERVICE_TURN_OFF,
             {
-                ATTR_ENTITY_ID: DHW_ENTITY_ID,
+                ATTR_ENTITY_ID: dhw_id,
             },
             blocking=True,
         )
@@ -171,8 +167,7 @@ async def test_turn_off(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-@pytest.mark.usefixtures("evohome")
-async def test_turn_on(hass: HomeAssistant) -> None:
+async def test_turn_on(hass: HomeAssistant, dhw_id: str) -> None:
     """Test SERVICE_TURN_ON of an evohome DHW zone."""
 
     # turn_on
@@ -181,7 +176,7 @@ async def test_turn_on(hass: HomeAssistant) -> None:
             WATER_HEATER_DOMAIN,
             SERVICE_TURN_ON,
             {
-                ATTR_ENTITY_ID: DHW_ENTITY_ID,
+                ATTR_ENTITY_ID: dhw_id,
             },
             blocking=True,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA.

This prepares Evohome for upcoming changes where it may be possible to have more than one HotWater entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
