### PR TITLE
Fix llm tool results mutation

### DIFF
--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -1440,7 +1440,7 @@ class IntentResponse:
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of an intent response."""
         response_dict: dict[str, Any] = {
-            "speech": self.speech,
+            "speech": self.speech.copy(),
             "card": self.card,
             "language": self.language,
             "response_type": self.response_type.value,

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -1440,16 +1440,16 @@ class IntentResponse:
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of an intent response."""
         response_dict: dict[str, Any] = {
-            "speech": self.speech.copy(),
-            "card": self.card,
+            "speech": {k: dict(v) for k, v in self.speech.items()},
+            "card": {k: dict(v) for k, v in self.card.items()},
             "language": self.language,
             "response_type": self.response_type.value,
         }
 
         if self.reprompt:
-            response_dict["reprompt"] = self.reprompt
+            response_dict["reprompt"] = {k: dict(v) for k, v in self.reprompt.items()}
         if self.speech_slots:
-            response_dict["speech_slots"] = self.speech_slots
+            response_dict["speech_slots"] = self.speech_slots.copy()
 
         response_data: dict[str, Any] = {}
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -331,7 +331,6 @@ class IntentResponseDict(dict):
         result = intent_response.as_dict()
         del result["language"]
         del result["card"]
-        result["speech"] = result["speech"].copy()
         super().__init__(result)
         self.original = intent_response
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -331,6 +331,7 @@ class IntentResponseDict(dict):
         result = intent_response.as_dict()
         del result["language"]
         del result["card"]
+        result["speech"] = result["speech"].copy()
         super().__init__(result)
         self.original = intent_response
 

--- a/tests/components/conversation/test_util.py
+++ b/tests/components/conversation/test_util.py
@@ -11,6 +11,7 @@ async def test_async_get_result_from_chat_log(
 ) -> None:
     """Test getting result from chat log."""
     intent_response = intent.IntentResponse(language="en")
+    tool_result = llm.IntentResponseDict(intent_response)
     with (
         chat_session.async_get_chat_session(hass) as session,
         conversation.async_get_chat_log(
@@ -23,7 +24,7 @@ async def test_async_get_result_from_chat_log(
                     agent_id="mock-agent-id",
                     tool_call_id="mock-tool-call-id",
                     tool_name="mock-tool-name",
-                    tool_result=llm.IntentResponseDict(intent_response),
+                    tool_result=tool_result,
                 ),
                 conversation.AssistantContent(
                     agent_id="mock-agent-id",
@@ -37,3 +38,4 @@ async def test_async_get_result_from_chat_log(
     # Original intent response is returned with speech set
     assert result.response is intent_response
     assert result.response.speech["plain"]["speech"] == "This is a response."
+    assert tool_result["speech"] != result.response.speech

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -963,7 +963,7 @@ async def test_get_all_entity_aliases(
 
 
 async def test_intent_response_dict() -> None:
-    """Test that IntentResponse.to_dict copies mutable objects."""
+    """Test that IntentResponse.as_dict() copies mutable objects."""
     response = intent.IntentResponse(
         language="en",
         intent=None,

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -1,6 +1,7 @@
 """Tests for the intent helpers."""
 
 import asyncio
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -959,3 +960,76 @@ async def test_get_all_entity_aliases(
 
     state = State("light.test", "on", {"friendly_name": friendly_name})
     assert intent.async_get_entity_aliases(hass, entry, state=state) == expected
+
+
+async def test_intent_response_dict() -> None:
+    """Test that IntentResponse.to_dict copies mutable objects."""
+    response = intent.IntentResponse(
+        language="en",
+        intent=None,
+    )
+    # Prepare the intent response initial state
+    response.async_set_speech(
+        speech="Hello", speech_type="plain", extra_data={"key": "value"}
+    )
+    response.async_set_reprompt(
+        speech="Hi", speech_type="plain", extra_data={"key2": "value2"}
+    )
+    response.async_set_card(title="Title", content="Content", card_type="simple")
+    response.async_set_results(
+        success_results=[
+            intent.IntentResponseTarget(
+                type=intent.IntentResponseTargetType.FLOOR,
+                name="first floor",
+                id="floor-1",
+            )
+        ],
+        failed_results=[
+            intent.IntentResponseTarget(
+                type=intent.IntentResponseTargetType.ENTITY,
+                name="kitchen light",
+                id="light.kitchen",
+            )
+        ],
+    )
+    response.async_set_states(
+        matched_states=[State("light.kitchen", "on")],
+        unmatched_states=[State("light.bedroom", "off")],
+    )
+    response.async_set_speech_slots({"name": {"value": "kitchen"}})
+
+    response_dict1 = response.as_dict()
+    response_dict2 = deepcopy(response_dict1)
+
+    # Mutate the dict
+    response.async_set_speech(
+        speech="Changed", speech_type="plain", extra_data={"key": "changed"}
+    )
+    response.async_set_reprompt(
+        speech="Changed", speech_type="plain", extra_data={"key2": "changed2"}
+    )
+    response.async_set_card(title="Changed", content="Changed", card_type="simple")
+    response.async_set_results(
+        success_results=[
+            intent.IntentResponseTarget(
+                type=intent.IntentResponseTargetType.FLOOR,
+                name="changed floor",
+                id="floor-changed",
+            )
+        ],
+        failed_results=[
+            intent.IntentResponseTarget(
+                type=intent.IntentResponseTargetType.ENTITY,
+                name="changed light",
+                id="light.changed",
+            )
+        ],
+    )
+    response.async_set_states(
+        matched_states=[State("light.changed", "on")],
+        unmatched_states=[State("light.changed_bedroom", "off")],
+    )
+    response.async_set_speech_slots({"name": {"value": "changed"}})
+
+    # The original dict should not be affected by the mutations
+    assert response_dict1 == response_dict2

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -1001,7 +1001,7 @@ async def test_intent_response_dict() -> None:
     response_dict1 = response.as_dict()
     response_dict2 = deepcopy(response_dict1)
 
-    # Mutate the dict
+    # Mutate the original object
     response.async_set_speech(
         speech="Changed", speech_type="plain", extra_data={"key": "changed"}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When we set speech for the conversation response in https://github.com/home-assistant/core/blob/a084e850281bec1328f4484421d4c36e9f7b3c6c/homeassistant/components/conversation/util.py#L41
we accidentally change the speech for the tool result stored in the chat log. This speech itself is not so important, but may invalidate the cache.

In this PR we will make a copy of the speech to avoid mutating of the original tool results in chat_log.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
