### PR TITLE
Bump pyrainbird to 6.3.0

### DIFF
--- a/homeassistant/components/rainbird/manifest.json
+++ b/homeassistant/components/rainbird/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pyrainbird"],
-  "requirements": ["pyrainbird==6.1.1"]
+  "requirements": ["pyrainbird==6.3.0"]
 }


### PR DESCRIPTION
Bumps pyrainbird to 6.3.0 to fix regressions and add support for new controllers.