### PR TITLE
Add contour and position names to gardena

### DIFF
--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -38,6 +38,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TEXT,
     Platform.VALVE,
 ]
 LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/gardena_bluetooth/icons.json
+++ b/homeassistant/components/gardena_bluetooth/icons.json
@@ -1,0 +1,12 @@
+{
+  "entity": {
+    "text": {
+      "contour_name": {
+        "default": "mdi:vector-polygon"
+      },
+      "position_name": {
+        "default": "mdi:map-marker-radius"
+      }
+    }
+  }
+}

--- a/homeassistant/components/gardena_bluetooth/strings.json
+++ b/homeassistant/components/gardena_bluetooth/strings.json
@@ -151,6 +151,14 @@
       "state": {
         "name": "[%key:common::state::open%]"
       }
+    },
+    "text": {
+      "contour_name": {
+        "name": "Contour {number}"
+      },
+      "position_name": {
+        "name": "Position {number}"
+      }
     }
   }
 }

--- a/homeassistant/components/gardena_bluetooth/text.py
+++ b/homeassistant/components/gardena_bluetooth/text.py
@@ -38,7 +38,6 @@ DESCRIPTIONS = (
             char=getattr(AquaContourPosition, f"position_name_{i}"),
             native_max=20,
             entity_category=EntityCategory.CONFIG,
-            icon="mdi:map-marker-radius",
         )
         for i in range(1, 6)
     ),
@@ -51,7 +50,6 @@ DESCRIPTIONS = (
             char=getattr(AquaContourContours, f"contour_name_{i}"),
             native_max=20,
             entity_category=EntityCategory.CONFIG,
-            icon="mdi:vector-polygon",
         )
         for i in range(1, 6)
     ),

--- a/homeassistant/components/gardena_bluetooth/text.py
+++ b/homeassistant/components/gardena_bluetooth/text.py
@@ -1,0 +1,91 @@
+"""Support for text entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gardena_bluetooth.const import AquaContourContours, AquaContourPosition
+from gardena_bluetooth.parse import CharacteristicNullString
+
+from homeassistant.components.text import TextEntity, TextEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import GardenaBluetoothConfigEntry
+from .entity import GardenaBluetoothDescriptorEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class GardenaBluetoothTextEntityDescription(TextEntityDescription):
+    """Description of entity."""
+
+    char: CharacteristicNullString
+
+    @property
+    def context(self) -> set[str]:
+        """Context needed for update coordinator."""
+        return {self.char.uuid}
+
+
+DESCRIPTIONS = (
+    *(
+        GardenaBluetoothTextEntityDescription(
+            key=f"position_{i}_name",
+            translation_key="position_name",
+            translation_placeholders={"number": str(i)},
+            has_entity_name=True,
+            char=getattr(AquaContourPosition, f"position_name_{i}"),
+            native_max=20,
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:map-marker-radius",
+        )
+        for i in range(1, 6)
+    ),
+    *(
+        GardenaBluetoothTextEntityDescription(
+            key=f"contour_{i}_name",
+            translation_key="contour_name",
+            translation_placeholders={"number": str(i)},
+            has_entity_name=True,
+            char=getattr(AquaContourContours, f"contour_name_{i}"),
+            native_max=20,
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:vector-polygon",
+        )
+        for i in range(1, 6)
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: GardenaBluetoothConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up text based on a config entry."""
+    coordinator = entry.runtime_data
+    entities = [
+        GardenaBluetoothTextEntity(coordinator, description, description.context)
+        for description in DESCRIPTIONS
+        if description.char.unique_id in coordinator.characteristics
+    ]
+    async_add_entities(entities)
+
+
+class GardenaBluetoothTextEntity(GardenaBluetoothDescriptorEntity, TextEntity):
+    """Representation of a text entity."""
+
+    entity_description: GardenaBluetoothTextEntityDescription
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the value reported by the text."""
+        char = self.entity_description.char
+        return self.coordinator.get_cached(char)
+
+    async def async_set_value(self, value: str) -> None:
+        """Change the text."""
+        char = self.entity_description.char
+        await self.coordinator.write(char, value)
+        self.async_write_ha_state()

--- a/homeassistant/components/gardena_bluetooth/text.py
+++ b/homeassistant/components/gardena_bluetooth/text.py
@@ -86,4 +86,3 @@ class GardenaBluetoothTextEntity(GardenaBluetoothDescriptorEntity, TextEntity):
         """Change the text."""
         char = self.entity_description.char
         await self.coordinator.write(char, value)
-        self.async_write_ha_state()

--- a/tests/components/gardena_bluetooth/snapshots/test_text.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_text.ambr
@@ -1,0 +1,601 @@
+# serializer version: 1
+# name: test_setup[aqua_contour][text.mock_title_contour_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_contour_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 1',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:vector-polygon',
+    'original_name': 'Contour 1',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-contour_1_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Contour 1',
+      'icon': 'mdi:vector-polygon',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_contour_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Contour 1',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_contour_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 2',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:vector-polygon',
+    'original_name': 'Contour 2',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-contour_2_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Contour 2',
+      'icon': 'mdi:vector-polygon',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_contour_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Contour 2',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_contour_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 3',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:vector-polygon',
+    'original_name': 'Contour 3',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-contour_3_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Contour 3',
+      'icon': 'mdi:vector-polygon',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_contour_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Contour 3',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_contour_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 4',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:vector-polygon',
+    'original_name': 'Contour 4',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-contour_4_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Contour 4',
+      'icon': 'mdi:vector-polygon',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_contour_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Contour 4',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_contour_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contour 5',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:vector-polygon',
+    'original_name': 'Contour 5',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'contour_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-contour_5_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_contour_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Contour 5',
+      'icon': 'mdi:vector-polygon',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_contour_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Contour 5',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_position_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Position 1',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:map-marker-radius',
+    'original_name': 'Position 1',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'position_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-position_1_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Position 1',
+      'icon': 'mdi:map-marker-radius',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_position_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Position 1',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_position_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Position 2',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:map-marker-radius',
+    'original_name': 'Position 2',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'position_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-position_2_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Position 2',
+      'icon': 'mdi:map-marker-radius',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_position_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Position 2',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_position_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Position 3',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:map-marker-radius',
+    'original_name': 'Position 3',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'position_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-position_3_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Position 3',
+      'icon': 'mdi:map-marker-radius',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_position_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Position 3',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_position_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Position 4',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:map-marker-radius',
+    'original_name': 'Position 4',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'position_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-position_4_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Position 4',
+      'icon': 'mdi:map-marker-radius',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_position_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Position 4',
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.mock_title_position_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Position 5',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:map-marker-radius',
+    'original_name': 'Position 5',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'position_name',
+    'unique_id': '00000000-0000-0000-0000-000000000003-position_5_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[aqua_contour][text.mock_title_position_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Position 5',
+      'icon': 'mdi:map-marker-radius',
+      'max': 20,
+      'min': 0,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.mock_title_position_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Position 5',
+  })
+# ---

--- a/tests/components/gardena_bluetooth/snapshots/test_text.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_text.ambr
@@ -30,7 +30,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:vector-polygon',
+    'original_icon': None,
     'original_name': 'Contour 1',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -45,7 +45,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Contour 1',
-      'icon': 'mdi:vector-polygon',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -90,7 +89,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:vector-polygon',
+    'original_icon': None,
     'original_name': 'Contour 2',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -105,7 +104,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Contour 2',
-      'icon': 'mdi:vector-polygon',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -150,7 +148,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:vector-polygon',
+    'original_icon': None,
     'original_name': 'Contour 3',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -165,7 +163,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Contour 3',
-      'icon': 'mdi:vector-polygon',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -210,7 +207,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:vector-polygon',
+    'original_icon': None,
     'original_name': 'Contour 4',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -225,7 +222,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Contour 4',
-      'icon': 'mdi:vector-polygon',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -270,7 +266,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:vector-polygon',
+    'original_icon': None,
     'original_name': 'Contour 5',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -285,7 +281,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Contour 5',
-      'icon': 'mdi:vector-polygon',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -330,7 +325,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:map-marker-radius',
+    'original_icon': None,
     'original_name': 'Position 1',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -345,7 +340,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Position 1',
-      'icon': 'mdi:map-marker-radius',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -390,7 +384,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:map-marker-radius',
+    'original_icon': None,
     'original_name': 'Position 2',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -405,7 +399,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Position 2',
-      'icon': 'mdi:map-marker-radius',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -450,7 +443,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:map-marker-radius',
+    'original_icon': None,
     'original_name': 'Position 3',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -465,7 +458,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Position 3',
-      'icon': 'mdi:map-marker-radius',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -510,7 +502,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:map-marker-radius',
+    'original_icon': None,
     'original_name': 'Position 4',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -525,7 +517,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Position 4',
-      'icon': 'mdi:map-marker-radius',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,
@@ -570,7 +561,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:map-marker-radius',
+    'original_icon': None,
     'original_name': 'Position 5',
     'platform': 'gardena_bluetooth',
     'previous_unique_id': None,
@@ -585,7 +576,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Position 5',
-      'icon': 'mdi:map-marker-radius',
       'max': 20,
       'min': 0,
       'mode': <TextMode.TEXT: 'text'>,

--- a/tests/components/gardena_bluetooth/test_text.py
+++ b/tests/components/gardena_bluetooth/test_text.py
@@ -1,0 +1,87 @@
+"""Test Gardena Bluetooth text entities."""
+
+from unittest.mock import Mock
+
+from gardena_bluetooth.const import AquaContourContours, AquaContourPosition
+from habluetooth import BluetoothServiceInfo
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.text import (
+    ATTR_VALUE,
+    DOMAIN as TEXT_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import AQUA_CONTOUR_SERVICE_INFO, setup_entry
+
+from tests.common import snapshot_platform
+
+
+@pytest.mark.parametrize(
+    ("service_info", "raw"),
+    [
+        pytest.param(
+            AQUA_CONTOUR_SERVICE_INFO,
+            {
+                AquaContourPosition.position_name_1.uuid: b"Position 1\x00",
+                AquaContourPosition.position_name_2.uuid: b"Position 2\x00",
+                AquaContourPosition.position_name_3.uuid: b"Position 3\x00",
+                AquaContourPosition.position_name_4.uuid: b"Position 4\x00",
+                AquaContourPosition.position_name_5.uuid: b"Position 5\x00",
+                AquaContourContours.contour_name_1.uuid: b"Contour 1\x00",
+                AquaContourContours.contour_name_2.uuid: b"Contour 2\x00",
+                AquaContourContours.contour_name_3.uuid: b"Contour 3\x00",
+                AquaContourContours.contour_name_4.uuid: b"Contour 4\x00",
+                AquaContourContours.contour_name_5.uuid: b"Contour 5\x00",
+            },
+            id="aqua_contour",
+        ),
+    ],
+)
+async def test_setup(
+    hass: HomeAssistant,
+    mock_read_char_raw: dict[str, bytes],
+    service_info: BluetoothServiceInfo,
+    raw: dict[str, bytes],
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test text entities."""
+    mock_read_char_raw.update(raw)
+
+    entry = await setup_entry(
+        hass, platforms=[Platform.TEXT], service_info=service_info
+    )
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+async def test_text_set_value(
+    hass: HomeAssistant,
+    mock_read_char_raw: dict[str, bytes],
+    mock_client: Mock,
+) -> None:
+    """Test setting text value."""
+    mock_read_char_raw[AquaContourPosition.position_name_1.uuid] = b"Position 1\x00"
+
+    await setup_entry(
+        hass, platforms=[Platform.TEXT], service_info=AQUA_CONTOUR_SERVICE_INFO
+    )
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "text.mock_title_position_1",
+            ATTR_VALUE: "New Position Name",
+        },
+        blocking=True,
+    )
+
+    assert len(mock_client.write_char.mock_calls) == 1
+    args = mock_client.write_char.mock_calls[0].args
+    assert args[0] == AquaContourPosition.position_name_1
+    assert args[1] == "New Position Name"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add ability to configure position and contour names on aqua contours. The device allow each position and contour to have a user defined name. This allow us to set these names for each position and contour.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44533
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
