### PR TITLE
fix(tibber): await set_access_token coroutine in async_get_client

### DIFF
--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -55,7 +55,7 @@ class TibberRuntimeData:
                 time_zone=dt_util.get_default_time_zone(),
                 ssl=ssl_util.get_default_context(),
             )
-        self._client.set_access_token(access_token)
+        await self._client.set_access_token(access_token)
         return self._client
 
 


### PR DESCRIPTION
## Proposed change
`set_access_token()` is a coroutine in pyTibber but was called without
`await` in `async_get_client()`. This means the OAuth2 access token is
never actually updated after expiry, causing the realtime watchdog to
fail reconnection with `"exp" claim timestamp check failed`.

This regression was introduced in #156690 which refactored the Tibber
integration to use OAuth2 but missed the `await` on the coroutine call.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
- This PR fixes or closes issue: fixes #166228
- This PR is related to issue: Regression introduced in #156690

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass** - no tests needed for this single-line fix
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`) — no formatting changes needed for this single-line fix
- [ ] Tests have been added to verify that the new code works. — no new tests needed for adding a missing `await` keyword

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr