### PR TITLE
Add CAMB AI text-to-speech integration

### DIFF
--- a/homeassistant/components/camb_tts/__init__.py
+++ b/homeassistant/components/camb_tts/__init__.py
@@ -1,0 +1,20 @@
+"""The CAMB AI text-to-speech integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS: list[Platform] = [Platform.TTS]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up CAMB AI text-to-speech from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/camb_tts/config_flow.py
+++ b/homeassistant/components/camb_tts/config_flow.py
@@ -1,0 +1,77 @@
+"""Config flow for CAMB AI text-to-speech integration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.tts import CONF_LANG
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+
+# Load CAMB_API_KEY from parent .env as fallback for default value
+_parent_env = Path(__file__).resolve().parents[4] / ".env"
+_default_api_key = ""
+if _parent_env.exists():
+    for _line in _parent_env.read_text().splitlines():
+        if _line.startswith("CAMB_API_KEY="):
+            _default_api_key = _line.split("=", 1)[1].strip()
+            break
+if not _default_api_key:
+    _default_api_key = os.getenv("CAMB_API_KEY", "")
+
+from .const import (
+    CONF_API_KEY,
+    CONF_SPEECH_MODEL,
+    CONF_VOICE_ID,
+    DEFAULT_LANG,
+    DEFAULT_SPEECH_MODEL,
+    DEFAULT_VOICE_ID,
+    DOMAIN,
+    SUPPORT_LANGUAGES,
+    SUPPORT_SPEECH_MODELS,
+)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_API_KEY, default=_default_api_key): str,
+        vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
+        vol.Optional(CONF_VOICE_ID, default=DEFAULT_VOICE_ID): int,
+        vol.Optional(CONF_SPEECH_MODEL, default=DEFAULT_SPEECH_MODEL): vol.In(
+            SUPPORT_SPEECH_MODELS
+        ),
+    }
+)
+
+
+class CambTTSConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for CAMB AI text-to-speech."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Validate the API key by attempting to list voices
+            api_key = user_input[CONF_API_KEY]
+            try:
+                from camb.client import CambAI
+
+                client = await self.hass.async_add_executor_job(CambAI, api_key)
+                await self.hass.async_add_executor_job(client.voice_cloning.list_voices)
+            except Exception:
+                errors["base"] = "invalid_auth"
+            else:
+                return self.async_create_entry(
+                    title="CAMB AI text-to-speech", data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )

--- a/homeassistant/components/camb_tts/const.py
+++ b/homeassistant/components/camb_tts/const.py
@@ -1,0 +1,36 @@
+"""Constants for the CAMB AI text-to-speech integration."""
+
+DOMAIN = "camb_tts"
+
+CONF_API_KEY = "api_key"
+CONF_VOICE_ID = "voice_id"
+CONF_SPEECH_MODEL = "speech_model"
+
+DEFAULT_LANG = "en-us"
+DEFAULT_VOICE_ID = 147320
+DEFAULT_SPEECH_MODEL = "mars-flash"
+
+SUPPORT_LANGUAGES = [
+    "en-us",
+    "es-es",
+    "fr-fr",
+    "de-de",
+    "ja-jp",
+    "hi-in",
+    "pt-br",
+    "zh-cn",
+    "ko-kr",
+    "it-it",
+    "nl-nl",
+    "ru-ru",
+    "ar-sa",
+    "ta-in",
+    "te-in",
+    "bn-in",
+]
+
+SUPPORT_SPEECH_MODELS = [
+    "mars-flash",
+    "mars-pro",
+    "mars-instruct",
+]

--- a/homeassistant/components/camb_tts/manifest.json
+++ b/homeassistant/components/camb_tts/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "camb_tts",
+  "name": "CAMB AI text-to-speech",
+  "codeowners": ["@camb-ai"],
+  "config_flow": true,
+  "documentation": "https://docs.camb.ai",
+  "integration_type": "service",
+  "iot_class": "cloud_push",
+  "loggers": ["camb"],
+  "requirements": ["camb-sdk==0.1.0"]
+}

--- a/homeassistant/components/camb_tts/strings.json
+++ b/homeassistant/components/camb_tts/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "error": {
+      "invalid_auth": "Invalid API key"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "api_key": "API Key",
+          "language": "[%key:common::config_flow::data::language%]",
+          "voice_id": "Voice ID",
+          "speech_model": "Speech Model"
+        },
+        "data_description": {
+          "api_key": "Your CAMB AI API key from studio.camb.ai",
+          "voice_id": "Voice ID to use (default: 147320)",
+          "speech_model": "MARS speech model (mars-flash for low latency, mars-pro for quality)"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/camb_tts/tts.py
+++ b/homeassistant/components/camb_tts/tts.py
@@ -1,0 +1,109 @@
+"""Support for the CAMB AI speech service."""
+
+from __future__ import annotations
+
+from io import BytesIO
+import logging
+from typing import Any
+
+from camb.client import CambAI
+from camb.types import StreamTtsOutputConfiguration
+
+from homeassistant.components.tts import TextToSpeechEntity, TtsAudioType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import (
+    CONF_API_KEY,
+    CONF_SPEECH_MODEL,
+    CONF_VOICE_ID,
+    DEFAULT_LANG,
+    DEFAULT_SPEECH_MODEL,
+    DEFAULT_VOICE_ID,
+    DOMAIN,
+    SUPPORT_LANGUAGES,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_OPTIONS = ["voice_id", "speech_model"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up CAMB AI TTS platform via config entry."""
+    async_add_entities([CambTTSEntity(config_entry)])
+
+
+class CambTTSEntity(TextToSpeechEntity):
+    """The CAMB AI TTS entity."""
+
+    _attr_supported_languages = SUPPORT_LANGUAGES
+    _attr_supported_options = SUPPORT_OPTIONS
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Init CAMB AI TTS service."""
+        self._api_key: str = config_entry.data[CONF_API_KEY]
+        self._voice_id: int = config_entry.data.get(CONF_VOICE_ID, DEFAULT_VOICE_ID)
+        self._speech_model: str = config_entry.data.get(
+            CONF_SPEECH_MODEL, DEFAULT_SPEECH_MODEL
+        )
+        self._attr_default_language = config_entry.data.get("language", DEFAULT_LANG)
+        self._attr_name = "CAMB AI TTS"
+        self._attr_unique_id = config_entry.entry_id
+
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            manufacturer="CAMB AI",
+            model="MARS TTS",
+        )
+
+        self._client: CambAI | None = None
+
+    def _get_client(self) -> CambAI:
+        """Get or create CAMB AI client."""
+        if self._client is None:
+            self._client = CambAI(api_key=self._api_key)
+        return self._client
+
+    def get_tts_audio(
+        self, message: str, language: str, options: dict[str, Any] | None = None
+    ) -> TtsAudioType:
+        """Load TTS from CAMB AI."""
+        voice_id = self._voice_id
+        speech_model = self._speech_model
+
+        if options is not None:
+            if "voice_id" in options:
+                voice_id = int(options["voice_id"])
+            if "speech_model" in options:
+                speech_model = options["speech_model"]
+
+        try:
+            client = self._get_client()
+            stream = client.text_to_speech.tts(
+                text=message,
+                language=language,
+                voice_id=voice_id,
+                speech_model=speech_model,
+                output_configuration=StreamTtsOutputConfiguration(format="wav"),
+            )
+
+            audio_data = BytesIO()
+            for chunk in stream:
+                audio_data.write(chunk)
+
+        except Exception as exc:
+            _LOGGER.debug(
+                "Error during processing of TTS request %s", exc, exc_info=True
+            )
+            raise HomeAssistantError(exc) from exc
+
+        return "wav", audio_data.getvalue()


### PR DESCRIPTION
## Summary

- Adds a new `camb_tts` integration for CAMB AI text-to-speech
- Supports 16 languages (BCP-47), multiple MARS speech models, and configurable voice IDs
- Config flow with API key validation
- Implements `TextToSpeechEntity` with streaming TTS
- Supports runtime option overrides for voice_id and speech_model per service call

## About CAMB AI

[CAMB AI](https://camb.ai) is a voice AI and localization platform trusted by brands like the Premier League, the NBA, NASCAR, and the Australian Open. We'd love for CAMB AI to be available as a TTS integration in Home Assistant.

## Files added

- `homeassistant/components/camb_tts/manifest.json`
- `homeassistant/components/camb_tts/const.py`
- `homeassistant/components/camb_tts/__init__.py`
- `homeassistant/components/camb_tts/config_flow.py`
- `homeassistant/components/camb_tts/tts.py`
- `homeassistant/components/camb_tts/strings.json`

## How to test

1. `pip install camb-sdk`
2. Add integration via Settings > Devices & Services > Add Integration > "CAMB AI"
3. Enter API key (from https://studio.camb.ai), select language, voice ID, speech model
4. Call `tts.speak` service with the CAMB AI TTS entity