### PR TITLE
Bump victron-mqtt to 2026.4.1

### DIFF
--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["victron-mqtt==2026.4.0"],
+  "requirements": ["victron-mqtt==2026.4.1"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -47,6 +47,128 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "alternator_mode": {
+        "name": "Mode"
+      },
+      "dcdc_mode": {
+        "name": "Mode"
+      },
+      "digitalinput_settings_invert_translation": {
+        "name": "Invert digital input"
+      },
+      "evcharger_charge": {
+        "name": "EV charging"
+      },
+      "evcharger_connected": {
+        "name": "Connected"
+      },
+      "generator_autorun": {
+        "name": "Auto-start enabled"
+      },
+      "generator_gen_id_quiet_hours_enabled": {
+        "name": "Generator quiet hours enabled"
+      },
+      "generator_gen_id_start_on_soc_enabled": {
+        "name": "Generator start on SOC enabled"
+      },
+      "generator_gen_id_start_on_temp_enabled": {
+        "name": "Generator start on high temp enabled"
+      },
+      "generator_gen_id_start_on_voltage_enabled": {
+        "name": "Generator start on voltage enabled"
+      },
+      "generator_manual_start": {
+        "name": "Manual start"
+      },
+      "gps_connected": {
+        "name": "Connected"
+      },
+      "gps_fix": {
+        "name": "Fix"
+      },
+      "inverter_alarm_high_temperature": {
+        "name": "High temperature alarm"
+      },
+      "inverter_alarm_high_voltage": {
+        "name": "High voltage alarm"
+      },
+      "inverter_alarm_high_voltage_ac_out": {
+        "name": "High voltage AC-out alarm"
+      },
+      "inverter_alarm_low_temperature": {
+        "name": "Low temperature alarm"
+      },
+      "inverter_alarm_low_voltage": {
+        "name": "Low voltage alarm"
+      },
+      "inverter_alarm_low_voltage_ac_out": {
+        "name": "Low voltage AC-out alarm"
+      },
+      "inverter_alarm_overload": {
+        "name": "Overload alarm"
+      },
+      "inverter_alarm_ripple": {
+        "name": "Ripple alarm"
+      },
+      "multi_disable_charge": {
+        "name": "ESS disable charge"
+      },
+      "multi_disable_feed_in": {
+        "name": "ESS disable feed-in"
+      },
+      "multi_relay0_state": {
+        "name": "Relay on Multi RS state"
+      },
+      "solarcharger_load_state": {
+        "name": "Load state"
+      },
+      "solarcharger_mode": {
+        "name": "Mode"
+      },
+      "solarcharger_relay_state": {
+        "name": "Relay state"
+      },
+      "switch_output_state": {
+        "name": "Switch {output} state"
+      },
+      "switchable_output_output_state": {
+        "name": "Switchable output {output} state"
+      },
+      "system_dynamicess_active": {
+        "name": "Dynamic ESS active"
+      },
+      "system_dynamicess_allow_gridfeedin": {
+        "name": "Dynamic ESS allow grid feed-in"
+      },
+      "system_dynamicess_available": {
+        "name": "Dynamic ESS available"
+      },
+      "system_ess_battery_use": {
+        "name": "ESS only critical loads from battery"
+      },
+      "system_ess_schedule_charge_slot_enabled": {
+        "name": "ESS BatteryLife schedule charge {slot} enabled"
+      },
+      "system_relay_relay": {
+        "name": "Relay {relay} state"
+      },
+      "system_settings_overvoltage_feedin": {
+        "name": "PV DC overvoltage feed-in"
+      },
+      "vebus_device_device_number_power_assist_enabled": {
+        "name": "{device_number} PowerAssist enabled"
+      },
+      "vebus_inverter_connected": {
+        "name": "Connected"
+      },
+      "vebus_inverter_ignoreacin1_onoff_control": {
+        "name": "Control ignore AC-in-1"
+      },
+      "vebus_inverter_setting_alarm_grid_lost": {
+        "name": "Grid lost alarm setting"
+      }
+    },
     "sensor": {
       "acload_current": {
         "name": "Load current"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3237,7 +3237,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.0
+victron-mqtt==2026.4.1
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2740,7 +2740,7 @@ venstarcolortouch==0.21
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.0
+victron-mqtt==2026.4.1
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.4.0` to `2026.4.1` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json`, `requirements_all.txt`, and `requirements_test_all.txt`
- Update entity translations (`strings.json`) from latest topic definitions

Changelog: https://github.com/tomer-w/victron_mqtt/releases/tag/v2026.4.1

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40m+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr