### PR TITLE
Add delay_on and delay_off support to binary_sensor template config flow

### DIFF
--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -57,7 +57,11 @@ from .alarm_control_panel import (
     TemplateCodeFormat,
     async_create_preview_alarm_control_panel,
 )
-from .binary_sensor import async_create_preview_binary_sensor
+from .binary_sensor import (
+    CONF_DELAY_OFF,
+    CONF_DELAY_ON,
+    async_create_preview_binary_sensor,
+)
 from .const import (
     CONF_ADVANCED_OPTIONS,
     CONF_AVAILABILITY,
@@ -420,14 +424,19 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             vol.Optional(CONF_FORECAST_HOURLY): selector.TemplateSelector(),
         }
 
+    advanced_options_schema = {
+        vol.Optional(CONF_AVAILABILITY): selector.TemplateSelector(),
+    }
+    if domain == Platform.BINARY_SENSOR:
+        advanced_options_schema |= {
+            vol.Optional(CONF_DELAY_ON): selector.DurationSelector(),
+            vol.Optional(CONF_DELAY_OFF): selector.DurationSelector(),
+        }
+
     schema |= {
         vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
         vol.Optional(CONF_ADVANCED_OPTIONS): section(
-            vol.Schema(
-                {
-                    vol.Optional(CONF_AVAILABILITY): selector.TemplateSelector(),
-                }
-            ),
+            vol.Schema(advanced_options_schema),
             {"collapsed": True},
         ),
     }

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -78,8 +78,8 @@ BINARY_SENSOR_OPTIONS = {
             "on",
             {"one": "on", "two": "off"},
             {},
-            {},
-            {},
+            {"advanced_options": {"delay_on": {"seconds": 5}, "delay_off": {"seconds": 10}}},
+            {"advanced_options": {"delay_on": {"seconds": 5}, "delay_off": {"seconds": 10}}},
             {},
         ),
         (
@@ -317,6 +317,12 @@ async def test_config_flow(
     assert result["step_id"] == template_type
 
     availability = {"advanced_options": {"availability": "{{ True }}"}}
+    # Merge advanced_options from extra_input if present
+    if "advanced_options" in extra_input:
+        availability["advanced_options"].update(extra_input.pop("advanced_options"))
+        if "advanced_options" in extra_options:
+            extra_options = extra_options.copy()
+            extra_options.pop("advanced_options")
 
     with patch(
         "homeassistant.components.template.async_setup_entry", wraps=async_setup_entry
@@ -372,8 +378,8 @@ async def test_config_flow(
         (
             "binary_sensor",
             {"state": "{{ false }}"},
-            {},
-            {},
+            {"advanced_options": {"delay_on": {"seconds": 5}, "delay_off": {"seconds": 10}}},
+            {"advanced_options": {"delay_on": {"seconds": 5}, "delay_off": {"seconds": 10}}},
         ),
         (
             "switch",
@@ -576,8 +582,8 @@ async def test_config_flow_device(
             },
             ["on", "off"],
             {"one": "on", "two": "off"},
-            {},
-            {},
+            {"advanced_options": {"delay_on": {"seconds": 5}}},
+            {"advanced_options": {"delay_on": {"seconds": 10}, "delay_off": {"seconds": 10}}},
             "state",
         ),
         (


### PR DESCRIPTION
This PR adds support for taking `delay_on` and `delay_off` in the advanced options of a binary_sensor template config flow. Test coverage is extended to ensure backward compatibility and new functionality work seamlessly.