### PR TITLE
Add media year attribute to Kaleidescape media player

### DIFF
--- a/homeassistant/components/kaleidescape/media_player.py
+++ b/homeassistant/components/kaleidescape/media_player.py
@@ -138,6 +138,11 @@ class KaleidescapeMediaPlayer(KaleidescapeEntity, MediaPlayerEntity):
         return self._device.movie.cover
 
     @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        """Return entity specific state attributes."""
+        return {"media_year": self._device.movie.year}
+
+    @property
     def media_title(self) -> str:
         """Title of current playing media."""
         return self._device.movie.title

--- a/tests/components/kaleidescape/test_media_player.py
+++ b/tests/components/kaleidescape/test_media_player.py
@@ -88,6 +88,7 @@ async def test_update_state(hass: HomeAssistant, mock_device: MagicMock) -> None
     entity = hass.states.get(ENTITY_ID)
     assert entity is not None
     assert entity.state == STATE_PLAYING
+    assert entity.attributes["media_year"] == "year"
 
     # Devices pauses playing
     mock_device.movie.play_status = kaleidescape_const.PLAY_STATUS_PAUSED


### PR DESCRIPTION
## Summary

Add `media_year` extra state attribute to the Kaleidescape media player entity, exposing the release year of the currently playing media. The data is already available via `device.movie.year` in pykaleidescape but was not surfaced in Home Assistant.

Related: https://github.com/SteveEasley/pykaleidescape/issues/6