### PR TITLE
Fail more gracefully when the thermostat is "busy"

### DIFF
--- a/homeassistant/components/radiotherm/coordinator.py
+++ b/homeassistant/components/radiotherm/coordinator.py
@@ -46,11 +46,15 @@ class RadioThermUpdateCoordinator(DataUpdateCoordinator[RadioThermUpdate]):
         try:
             return await async_get_data(self.hass, self.init_data.tstat)
         except RadiothermTstatError as ex:
-            msg = f"{self._description} was busy (invalid value returned): {ex}"
-            raise UpdateFailed(msg) from ex
+            _LOGGER.warning(
+                "%s was busy (invalid value returned): %s", self._description, ex
+            )
         except TimeoutError as ex:
-            msg = f"{self._description}) timed out waiting for a response: {ex}"
-            raise UpdateFailed(msg) from ex
+            _LOGGER.warning(
+                "%s timed out waiting for a response: %s", self._description, ex
+            )
         except (OSError, URLError) as ex:
-            msg = f"{self._description} connection error: {ex}"
-            raise UpdateFailed(msg) from ex
+            _LOGGER.error("%s connection error: %s", self._description, ex)
+
+        # If an error was raised, then pass the current state back.
+        return self.data

--- a/homeassistant/components/radiotherm/coordinator.py
+++ b/homeassistant/components/radiotherm/coordinator.py
@@ -10,7 +10,7 @@ from radiotherm.validate import RadiothermTstatError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .data import RadioThermInitData, RadioThermUpdate, async_get_data
 


### PR DESCRIPTION
## Proposed change
These thermostats (CT30, CT50, CT80) have a very slow WiFi module. Although it can sometimes respond pretty quickly, it will often take seconds or more to respond to the most common GET request (`/tstat`). Instead of raising an error each time it is busy, just return the previous state and send a warning to the logger.

To give an idea of how often this occurs, with the default 15 sec UPDATE_INTERVAL, I will see about 20-30 "was busy" errors per day in my logs for the CT80.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
None.

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
