### PR TITLE
Mark Govee local devices unavailable when they stop responding

### DIFF
--- a/homeassistant/components/govee_light_local/const.py
+++ b/homeassistant/components/govee_light_local/const.py
@@ -11,4 +11,8 @@ CONF_LISTENING_PORT_DEFAULT = 4002
 CONF_DISCOVERY_INTERVAL_DEFAULT = 60
 
 SCAN_INTERVAL = timedelta(seconds=30)
+# A device is considered unavailable if we have not heard a status response
+# from it for three consecutive poll cycles. This tolerates a single dropped
+# UDP response plus some jitter before flapping the entity state.
+DEVICE_TIMEOUT = SCAN_INTERVAL * 3
 DISCOVERY_TIMEOUT = 5

--- a/homeassistant/components/govee_light_local/light.py
+++ b/homeassistant/components/govee_light_local/light.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -22,7 +23,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MANUFACTURER
+from .const import DEVICE_TIMEOUT, DOMAIN, MANUFACTURER
 from .coordinator import GoveeLocalApiCoordinator, GoveeLocalConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,6 +120,19 @@ class GoveeLight(CoordinatorEntity[GoveeLocalApiCoordinator], LightEntity):
         )
 
     @property
+    def available(self) -> bool:
+        """Return if the device is reachable.
+
+        The underlying library updates ``lastseen`` whenever the device
+        replies to a status request. The coordinator polls every
+        ``SCAN_INTERVAL``, so if we have not heard back within
+        ``DEVICE_TIMEOUT`` we consider the device offline.
+        """
+        if not super().available:
+            return False
+        return datetime.now() - self._device.lastseen < DEVICE_TIMEOUT
+
+    @property
     def is_on(self) -> bool:
         """Return true if device is on (brightness above 0)."""
         return self._device.on
@@ -205,8 +219,8 @@ class GoveeLight(CoordinatorEntity[GoveeLocalApiCoordinator], LightEntity):
 
     @callback
     def _update_callback(self, device: GoveeDevice) -> None:
-        if self.hass:
-            self.async_write_ha_state()
+        """Handle device state updates pushed by the library."""
+        self.async_write_ha_state()
 
     def _save_last_color_state(self) -> None:
         color_mode = self.color_mode

--- a/tests/components/govee_light_local/test_light.py
+++ b/tests/components/govee_light_local/test_light.py
@@ -3,10 +3,16 @@
 from errno import EADDRINUSE, ENETDOWN
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from freezegun.api import FrozenDateTimeFactory
 from govee_local_api import GoveeDevice
+from govee_local_api.message import DevStatusResponse
 import pytest
 
-from homeassistant.components.govee_light_local.const import DOMAIN
+from homeassistant.components.govee_light_local.const import (
+    DEVICE_TIMEOUT,
+    DOMAIN,
+    SCAN_INTERVAL,
+)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
@@ -18,12 +24,18 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import (
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .conftest import DEFAULT_CAPABILITIES, SCENE_CAPABILITIES
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_light_known_device(
@@ -755,3 +767,148 @@ async def test_scene_none(hass: HomeAssistant, mock_govee_api: MagicMock) -> Non
     assert light.state == "on"
     assert light.attributes[ATTR_EFFECT] is None
     mock_govee_api.set_scene.assert_not_called()
+
+
+def _status_response(
+    *,
+    is_on: bool = False,
+    brightness: int = 0,
+    r: int = 0,
+    g: int = 0,
+    b: int = 0,
+    color_temp: int = 0,
+) -> DevStatusResponse:
+    """Build a DevStatusResponse matching the library's wire format.
+
+    Driving availability tests through the library's public ``device.update``
+    keeps the test honest about the contract we depend on: ``lastseen`` is
+    refreshed whenever a status response is applied.
+    """
+    return DevStatusResponse(
+        {
+            "onOff": 1 if is_on else 0,
+            "brightness": brightness,
+            "color": {"r": r, "g": g, "b": b},
+            "colorTemInKelvin": color_temp,
+        }
+    )
+
+
+async def test_device_becomes_unavailable_after_timeout(
+    hass: HomeAssistant,
+    mock_govee_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a device goes unavailable when no status response arrives."""
+    device = GoveeDevice(
+        controller=mock_govee_api,
+        ip="192.168.1.100",
+        fingerprint="asdawdqwdqwd",
+        sku="H615A",
+        capabilities=DEFAULT_CAPABILITIES,
+    )
+    mock_govee_api.devices = [device]
+
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.H615A")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    # Advance past DEVICE_TIMEOUT without firing any status responses, and
+    # tick the coordinator forward so a state write occurs.
+    freezer.tick(DEVICE_TIMEOUT + SCAN_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.H615A")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_device_recovers_after_status_response(
+    hass: HomeAssistant,
+    mock_govee_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that an unavailable device recovers when it responds again."""
+    device = GoveeDevice(
+        controller=mock_govee_api,
+        ip="192.168.1.100",
+        fingerprint="asdawdqwdqwd",
+        sku="H615A",
+        capabilities=DEFAULT_CAPABILITIES,
+    )
+    mock_govee_api.devices = [device]
+
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Drive it unavailable first.
+    freezer.tick(DEVICE_TIMEOUT + SCAN_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.H615A")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    # A status response refreshes lastseen and fires the entity callback.
+    device.update(_status_response())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.H615A")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_one_silent_device_does_not_affect_others(
+    hass: HomeAssistant,
+    mock_govee_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that one silent device does not pull the others unavailable."""
+    silent = GoveeDevice(
+        controller=mock_govee_api,
+        ip="192.168.1.100",
+        fingerprint="silent_device",
+        sku="H615A",
+        capabilities=DEFAULT_CAPABILITIES,
+    )
+    chatty = GoveeDevice(
+        controller=mock_govee_api,
+        ip="192.168.1.101",
+        fingerprint="chatty_device",
+        sku="H615B",
+        capabilities=DEFAULT_CAPABILITIES,
+    )
+    mock_govee_api.devices = [silent, chatty]
+
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Tick past the timeout, but have the chatty device reply along the way.
+    freezer.tick(SCAN_INTERVAL)
+    chatty.update(_status_response())
+    freezer.tick(DEVICE_TIMEOUT)
+    chatty.update(_status_response())
+
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done()
+
+    silent_state = hass.states.get("light.H615A")
+    chatty_state = hass.states.get("light.H615B")
+    assert silent_state is not None
+    assert chatty_state is not None
+    assert silent_state.state == STATE_UNAVAILABLE
+    assert chatty_state.state == STATE_OFF


### PR DESCRIPTION
Ran into some instances where my lights didn't show as unavailable but weren't responsive. I *think* I tracked it down to this. Thank you all for the great integration!

## Proposed change

Tha coordinator's `_async_update_data` fires UDP status requests and returns immediately without waiting for responses, so `last_update_success` was always True and entities never went unavailable when devices dropped off the network. Use the library's per-device `lastseen` timestamp to mark individual entities unavailable after three missed poll cycles, preserving per-device isolation when only some devices are silent.

Also drop the dead `if self.hass:` guard in `_update_callback`, which was unreachable given the entity lifecycle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
