### PR TITLE
Add support for `geo` field to CalDAV, Calendar

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -224,6 +224,8 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
             item_data["description"] = description
         if location := kwargs.get("location"):
             item_data["location"] = location
+        if geo := kwargs.get("geo"):
+            item_data["geo"] = geo
         if rrule := kwargs.get("rrule"):
             item_data["rrule"] = rrule
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -225,7 +225,8 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
         if location := kwargs.get("location"):
             item_data["location"] = location
         if geo := kwargs.get("geo"):
-            item_data["geo"] = geo
+            # The caldav package expects a tuple of (latitude, longitude)
+            item_data["geo"] = (geo["latitude"], geo["longitude"])
         if rrule := kwargs.get("rrule"):
             item_data["rrule"] = rrule
 

--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -80,7 +80,7 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
                     start=self.to_local(vevent.dtstart.value),
                     end=self.to_local(self.get_end_date(vevent)),
                     location=get_attr_value(vevent, "location"),
-                    geo=get_attr_value(vevent, "geo"),
+                    geo=self.to_structured_geolocation(get_attr_value(vevent, "geo")),
                     description=get_attr_value(vevent, "description"),
                 )
             )
@@ -176,7 +176,7 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
             start=self.to_local(vevent.dtstart.value),
             end=self.to_local(self.get_end_date(vevent)),
             location=get_attr_value(vevent, "location"),
-            geo=get_attr_value(vevent, "geo"),
+            geo=self.to_structured_geolocation(get_attr_value(vevent, "geo")),
             description=get_attr_value(vevent, "description"),
         )
 
@@ -246,3 +246,23 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
             enddate += timedelta(days=1)
 
         return enddate
+
+    @staticmethod
+    def to_structured_geolocation(obj: str | None) -> CalendarEvent.Geolocation | None:
+        """Return the structured `Geolocation` object for the string.
+
+        Per RFC 5545, the geolocation must be specified as a semicolon separated string,
+        with float coordinates given in the order `<latitude>;<longitude>`.
+        """
+
+        if not obj:
+            return None
+
+        values = obj.split(sep=";")
+        if len(values) != 2:
+            return None
+
+        return CalendarEvent.Geolocation(
+            latitude=values[0],
+            longitude=values[1],
+        )

--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -80,6 +80,7 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
                     start=self.to_local(vevent.dtstart.value),
                     end=self.to_local(self.get_end_date(vevent)),
                     location=get_attr_value(vevent, "location"),
+                    geo=get_attr_value(vevent, "geo"),
                     description=get_attr_value(vevent, "description"),
                 )
             )
@@ -175,6 +176,7 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
             start=self.to_local(vevent.dtstart.value),
             end=self.to_local(self.get_end_date(vevent)),
             location=get_attr_value(vevent, "location"),
+            geo=get_attr_value(vevent, "geo"),
             description=get_attr_value(vevent, "description"),
         )
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -585,7 +585,7 @@ class CalendarEntity(Entity):
             "start_time": event.start_datetime_local.strftime(DATE_STR_FORMAT),
             "end_time": event.end_datetime_local.strftime(DATE_STR_FORMAT),
             "location": event.location or "",
-            "geo": event.geo.state_attributes if event.geo is not None else "",
+            "geo": event.geo.state_attributes if event.geo is not None else {},
             "description": event.description or "",
         }
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -50,6 +50,9 @@ from .const import (
     EVENT_END,
     EVENT_END_DATE,
     EVENT_END_DATETIME,
+    EVENT_GEO,
+    EVENT_GEO_LAT,
+    EVENT_GEO_LONG,
     EVENT_IN,
     EVENT_IN_DAYS,
     EVENT_IN_WEEKS,
@@ -225,6 +228,12 @@ CREATE_EVENT_SCHEMA = vol.All(
             vol.Required(EVENT_SUMMARY): cv.string,
             vol.Optional(EVENT_DESCRIPTION, default=""): cv.string,
             vol.Optional(EVENT_LOCATION): cv.string,
+            vol.Optional(EVENT_GEO): vol.All(
+                {
+                    vol.Required(EVENT_GEO_LAT): cv.latitude,
+                    vol.Required(EVENT_GEO_LONG): cv.longitude,
+                }
+            ),
             vol.Inclusive(
                 EVENT_START_DATE, "dates", "Start and end dates must both be specified"
             ): cv.date,
@@ -364,12 +373,27 @@ def get_date(date: dict[str, Any]) -> datetime.datetime:
 class CalendarEvent:
     """An event on a calendar."""
 
+    @dataclasses.dataclass
+    class Geolocation:
+        """The geolocation associated with a calendar event."""
+
+        latitude: str
+        longitude: str
+
+        @property
+        def state_attributes(self) -> dict[str, Any]:
+            """Return the nested entity state attributes."""
+            return {
+                "latitude": self.latitude,
+                "longitude": self.longitude,
+            }
+
     start: datetime.date | datetime.datetime
     end: datetime.date | datetime.datetime
     summary: str
     description: str | None = None
     location: str | None = None
-    geo: str | None = None
+    geo: Geolocation | None = None
 
     uid: str | None = None
     recurrence_id: str | None = None
@@ -421,14 +445,14 @@ class CalendarEvent:
             self.end = self.start + datetime.timedelta(days=1)
 
 
-def _event_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, str]:
+def _event_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, JsonValueType]:
     """Convert CalendarEvent dataclass items to dictionary of attributes."""
-    result: dict[str, str] = {}
+    result: dict[str, JsonValueType] = {}
     for name, value in obj:
         if isinstance(value, (datetime.datetime, datetime.date)):
             result[name] = value.isoformat()
         elif value is not None:
-            result[name] = str(value)
+            result[name] = value
     return result
 
 
@@ -561,7 +585,7 @@ class CalendarEntity(Entity):
             "start_time": event.start_datetime_local.strftime(DATE_STR_FORMAT),
             "end_time": event.end_datetime_local.strftime(DATE_STR_FORMAT),
             "location": event.location or "",
-            "geo": event.geo or "",
+            "geo": event.geo.state_attributes if event.geo is not None else "",
             "description": event.description or "",
         }
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -369,6 +369,7 @@ class CalendarEvent:
     summary: str
     description: str | None = None
     location: str | None = None
+    geo: str | None = None
 
     uid: str | None = None
     recurrence_id: str | None = None
@@ -560,6 +561,7 @@ class CalendarEntity(Entity):
             "start_time": event.start_datetime_local.strftime(DATE_STR_FORMAT),
             "end_time": event.end_datetime_local.strftime(DATE_STR_FORMAT),
             "location": event.location or "",
+            "geo": event.geo or "",
             "description": event.description or "",
         }
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -579,15 +579,18 @@ class CalendarEntity(Entity):
         if (event := self.event) is None:
             return None
 
-        return {
+        attributes = {
             "message": event.summary,
             "all_day": event.all_day,
             "start_time": event.start_datetime_local.strftime(DATE_STR_FORMAT),
             "end_time": event.end_datetime_local.strftime(DATE_STR_FORMAT),
             "location": event.location or "",
-            "geo": event.geo.state_attributes if event.geo is not None else {},
             "description": event.description or "",
         }
+        if event.geo:
+            attributes["geo"] = event.geo.state_attributes
+
+        return attributes
 
     @final
     @property

--- a/homeassistant/components/calendar/const.py
+++ b/homeassistant/components/calendar/const.py
@@ -33,6 +33,7 @@ EVENT_END = "dtend"
 EVENT_SUMMARY = "summary"
 EVENT_DESCRIPTION = "description"
 EVENT_LOCATION = "location"
+EVENT_GEO = "geo"
 EVENT_RECURRENCE_ID = "recurrence_id"
 EVENT_RECURRENCE_RANGE = "recurrence_range"
 EVENT_RRULE = "rrule"
@@ -62,4 +63,5 @@ LIST_EVENT_FIELDS = {
     EVENT_SUMMARY,
     EVENT_DESCRIPTION,
     EVENT_LOCATION,
+    EVENT_GEO,
 }

--- a/homeassistant/components/calendar/const.py
+++ b/homeassistant/components/calendar/const.py
@@ -34,6 +34,8 @@ EVENT_SUMMARY = "summary"
 EVENT_DESCRIPTION = "description"
 EVENT_LOCATION = "location"
 EVENT_GEO = "geo"
+EVENT_GEO_LAT = "latitude"
+EVENT_GEO_LONG = "longitude"
 EVENT_RECURRENCE_ID = "recurrence_id"
 EVENT_RECURRENCE_RANGE = "recurrence_range"
 EVENT_RRULE = "rrule"
@@ -64,4 +66,6 @@ LIST_EVENT_FIELDS = {
     EVENT_DESCRIPTION,
     EVENT_LOCATION,
     EVENT_GEO,
+    EVENT_GEO_LAT,
+    EVENT_GEO_LONG,
 }

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -37,9 +37,9 @@ create_event:
       selector:
         text:
     geo:
-      example: "50.1;30.2"
+      example: '{"latitude": "50.1", "longitude": "30.2"}'
       selector:
-        text:
+        location:
 get_events:
   target:
     entity:

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -36,6 +36,10 @@ create_event:
       example: "Conference Room - F123, Bldg. 002"
       selector:
         text:
+    geo:
+      example: "50.1;30.2"
+      selector:
+        text:
 get_events:
   target:
     entity:

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -93,15 +93,15 @@
           "name": "End time"
         },
         "geo": {
-          "description": "The geolocation coordinates of the event, separated by a semicolon.",
-          "name": "Geo"
+          "description": "The geographic coordinates of the event.",
+          "name": "Geographic position"
         },
         "in": {
           "description": "Days or weeks that you want to create the event in.",
           "name": "In"
         },
         "location": {
-          "description": "The location of the event.",
+          "description": "Friendly name for the location of the event.",
           "name": "Location"
         },
         "start_date": {

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -34,6 +34,9 @@
         "end_time": {
           "name": "End time"
         },
+        "geo": {
+          "name": "Geo"
+        },
         "location": {
           "name": "Location"
         },
@@ -88,6 +91,10 @@
         "end_date_time": {
           "description": "The date and time the event should end.",
           "name": "End time"
+        },
+        "geo": {
+          "description": "The geolocation coordinates of the event, separated by a semicolon.",
+          "name": "Geo"
         },
         "in": {
           "description": "Days or weeks that you want to create the event in.",

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -30,6 +30,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171127T170000Z
 DTEND:20171127T180000Z
 SUMMARY:This is a normal event
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:Surprisingly rainy
 END:VEVENT
@@ -44,6 +45,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171127T100000Z
 DTEND:20171127T110000Z
 SUMMARY:This is an offset event !!-02:00
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:Surprisingly shiny
 END:VEVENT
@@ -58,6 +60,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171127
 DTEND:20171128
 SUMMARY:This is an all day event
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:What a beautiful day
 END:VEVENT
@@ -71,6 +74,7 @@ UID:4
 DTSTAMP:20171125T000000Z
 DTSTART:20171127
 SUMMARY:This is an event without dtend or duration
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:What an endless day
 END:VEVENT
@@ -85,6 +89,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171127
 DURATION:PT1H
 SUMMARY:This is an event with duration
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:What a day
 END:VEVENT
@@ -99,6 +104,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171127T100000Z
 DURATION:PT1H
 SUMMARY:This is an event with duration
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:What a day
 END:VEVENT
@@ -113,6 +119,7 @@ DTSTART;TZID=America/Los_Angeles:20171127T083000
 DTSTAMP:20180301T020053Z
 DTEND;TZID=America/Los_Angeles:20171127T093000
 SUMMARY:Enjoy the sun
+GEO:37.735817;-122.453273
 LOCATION:San Francisco
 DESCRIPTION:Sunny day
 END:VEVENT
@@ -126,6 +133,7 @@ UID:8
 DTSTART:20171127T190000
 DTEND:20171127T200000
 SUMMARY:This is a floating Event
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:What a day
 END:VEVENT
@@ -140,6 +148,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171027T220000Z
 DTEND:20171027T223000Z
 SUMMARY:This is a recurring event
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:Every day for a while
 RRULE:FREQ=DAILY;UNTIL=20171227T215959
@@ -155,6 +164,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171027T230000Z
 DURATION:PT30M
 SUMMARY:This is a recurring event with a duration
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:Every day for a while as well
 RRULE:FREQ=DAILY;UNTIL=20171227T215959
@@ -170,6 +180,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171027T233000Z
 DTEND:20171027T235959Z
 SUMMARY:This is a recurring event that has ended
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:Every day for a while
 RRULE:FREQ=DAILY;UNTIL=20171127T225959
@@ -185,6 +196,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171027T234500Z
 DTEND:20171027T235959Z
 SUMMARY:This is a recurring event that never ends
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:Every day forever
 RRULE:FREQ=DAILY
@@ -200,6 +212,7 @@ DTSTAMP:20161125T000000Z
 DTSTART:20161127
 DTEND:20161128
 SUMMARY:This is a recurring all day event
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:Groundhog Day
 RRULE:FREQ=DAILY;COUNT=100
@@ -215,6 +228,7 @@ DTSTAMP:20151125T000000Z
 DTSTART:20151127T000000Z
 DTEND:20151127T003000Z
 SUMMARY:This is an hourly recurring event
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 DESCRIPTION:The bell tolls for thee
 RRULE:FREQ=HOURLY;INTERVAL=1;COUNT=12
@@ -271,6 +285,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171127
 DTEND:20171128
 SUMMARY:All day event with same start and end
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 END:VEVENT
 END:VCALENDAR
@@ -284,6 +299,7 @@ DTSTAMP:20171125T000000Z
 DTSTART:20171127T010000
 DTEND:20171127T010000
 SUMMARY:Event with no duration
+GEO:53.537999;9.989934
 LOCATION:Hamburg
 END:VEVENT
 END:VCALENDAR
@@ -455,6 +471,7 @@ async def test_ongoing_event(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -480,6 +497,7 @@ async def test_just_ended_event(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -505,6 +523,7 @@ async def test_ongoing_event_different_tz(
         "start_time": "2017-11-27 16:30:00",
         "description": "Sunny day",
         "end_time": "2017-11-27 17:30:00",
+        "geo": "37.735817;-122.453273",
         "location": "San Francisco",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -530,6 +549,7 @@ async def test_ongoing_floating_event_returned(
         "start_time": "2017-11-27 19:00:00",
         "end_time": "2017-11-27 20:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "What a day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -555,6 +575,7 @@ async def test_ongoing_event_with_offset(
         "start_time": "2017-11-27 10:00:00",
         "end_time": "2017-11-27 11:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Surprisingly shiny",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -596,6 +617,7 @@ async def test_matching_filter(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -638,6 +660,7 @@ async def test_matching_filter_real_regexp(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -758,6 +781,7 @@ async def test_all_day_event(
         "start_time": "2017-11-27 00:00:00",
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "What a beautiful day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -783,6 +807,7 @@ async def test_event_rrule(
         "start_time": "2017-11-27 22:00:00",
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Every day for a while",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -808,6 +833,7 @@ async def test_event_rrule_ongoing(
         "start_time": "2017-11-27 22:00:00",
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Every day for a while",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -833,6 +859,7 @@ async def test_event_rrule_duration(
         "start_time": "2017-11-27 23:00:00",
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Every day for a while as well",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -858,6 +885,7 @@ async def test_event_rrule_duration_ongoing(
         "start_time": "2017-11-27 23:00:00",
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Every day for a while as well",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -883,6 +911,7 @@ async def test_event_rrule_endless(
         "start_time": "2017-11-27 23:45:00",
         "end_time": "2017-11-27 23:59:59",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Every day forever",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -940,6 +969,7 @@ async def test_event_rrule_all_day_early(
         "start_time": "2016-12-01 00:00:00",
         "end_time": "2016-12-02 00:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "Groundhog Day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -965,6 +995,7 @@ async def test_event_rrule_hourly_on_first(
         "start_time": "2015-11-27 00:00:00",
         "end_time": "2015-11-27 00:30:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "The bell tolls for thee",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -990,6 +1021,7 @@ async def test_event_rrule_hourly_on_last(
         "start_time": "2015-11-27 11:00:00",
         "end_time": "2015-11-27 11:30:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "The bell tolls for thee",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -1062,6 +1094,7 @@ async def test_get_events_custom_calendars(
             "start": {"dateTime": "2017-11-27T09:00:00-08:00"},
             "summary": "This is a normal event",
             "location": "Hamburg",
+            "geo": "53.537999;9.989934",
             "description": "Surprisingly rainy",
             "uid": None,
             "recurrence_id": None,
@@ -1123,6 +1156,7 @@ async def test_setup_config_entry(
         "start_time": "2017-11-27 00:00:00",
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
+        "geo": "53.537999;9.989934",
         "description": "What a beautiful day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -10,6 +10,7 @@ import zoneinfo
 from caldav.objects import Event
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.calendar import CalendarEntityFeature
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
@@ -471,7 +472,10 @@ async def test_ongoing_event(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -497,7 +501,10 @@ async def test_just_ended_event(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -523,7 +530,10 @@ async def test_ongoing_event_different_tz(
         "start_time": "2017-11-27 16:30:00",
         "description": "Sunny day",
         "end_time": "2017-11-27 17:30:00",
-        "geo": "37.735817;-122.453273",
+        "geo": {
+            "latitude": "37.735817",
+            "longitude": "-122.453273",
+        },
         "location": "San Francisco",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -549,7 +559,10 @@ async def test_ongoing_floating_event_returned(
         "start_time": "2017-11-27 19:00:00",
         "end_time": "2017-11-27 20:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "What a day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -575,7 +588,10 @@ async def test_ongoing_event_with_offset(
         "start_time": "2017-11-27 10:00:00",
         "end_time": "2017-11-27 11:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Surprisingly shiny",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -617,7 +633,10 @@ async def test_matching_filter(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -660,7 +679,10 @@ async def test_matching_filter_real_regexp(
         "start_time": "2017-11-27 17:00:00",
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Surprisingly rainy",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -781,7 +803,10 @@ async def test_all_day_event(
         "start_time": "2017-11-27 00:00:00",
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "What a beautiful day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -807,7 +832,10 @@ async def test_event_rrule(
         "start_time": "2017-11-27 22:00:00",
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Every day for a while",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -833,7 +861,10 @@ async def test_event_rrule_ongoing(
         "start_time": "2017-11-27 22:00:00",
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Every day for a while",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -859,7 +890,10 @@ async def test_event_rrule_duration(
         "start_time": "2017-11-27 23:00:00",
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Every day for a while as well",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -885,7 +919,10 @@ async def test_event_rrule_duration_ongoing(
         "start_time": "2017-11-27 23:00:00",
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Every day for a while as well",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -911,7 +948,10 @@ async def test_event_rrule_endless(
         "start_time": "2017-11-27 23:45:00",
         "end_time": "2017-11-27 23:59:59",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Every day forever",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -969,7 +1009,10 @@ async def test_event_rrule_all_day_early(
         "start_time": "2016-12-01 00:00:00",
         "end_time": "2016-12-02 00:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "Groundhog Day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -995,7 +1038,10 @@ async def test_event_rrule_hourly_on_first(
         "start_time": "2015-11-27 00:00:00",
         "end_time": "2015-11-27 00:30:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "The bell tolls for thee",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -1021,7 +1067,10 @@ async def test_event_rrule_hourly_on_last(
         "start_time": "2015-11-27 11:00:00",
         "end_time": "2015-11-27 11:30:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "The bell tolls for thee",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -1094,7 +1143,10 @@ async def test_get_events_custom_calendars(
             "start": {"dateTime": "2017-11-27T09:00:00-08:00"},
             "summary": "This is a normal event",
             "location": "Hamburg",
-            "geo": "53.537999;9.989934",
+            "geo": {
+                "latitude": "53.537999",
+                "longitude": "9.989934",
+            },
             "description": "Surprisingly rainy",
             "uid": None,
             "recurrence_id": None,
@@ -1156,7 +1208,10 @@ async def test_setup_config_entry(
         "start_time": "2017-11-27 00:00:00",
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
-        "geo": "53.537999;9.989934",
+        "geo": {
+            "latitude": "53.537999",
+            "longitude": "9.989934",
+        },
         "description": "What a beautiful day",
         "supported_features": CalendarEntityFeature.CREATE_EVENT,
     }
@@ -1268,6 +1323,27 @@ async def test_config_entry_supported_components(
                 ),
             },
         ),
+        # Event with geo field
+        (
+            {
+                "summary": "Geo Event",
+                "start_date_time": "2025-08-06T10:00:00+00:00",
+                "end_date_time": "2025-08-06T11:00:00+00:00",
+                "location": "Hamburg",
+                "geo": {"latitude": 53.537999, "longitude": 9.989934},
+            },
+            {
+                "summary": "Geo Event",
+                "dtstart": datetime.datetime(
+                    2025, 8, 6, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")
+                ),
+                "dtend": datetime.datetime(
+                    2025, 8, 6, 11, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")
+                ),
+                "location": "Hamburg",
+                "geo": (53.537999, 9.989934),
+            },
+        ),
         # Rrule is not supported in API (async_call) calls.
     ],
 )
@@ -1294,3 +1370,37 @@ async def test_add_vevent(
     calendars[0].add_event.assert_called_once()
     assert calendars[0].add_event.call_args
     assert calendars[0].add_event.call_args[1] == expected_ics_fields
+
+
+@pytest.mark.parametrize("tz", [UTC])
+@pytest.mark.parametrize(
+    "geo",
+    [
+        {"latitude": 91.0, "longitude": 9.0},
+        {"latitude": -91.0, "longitude": 9.0},
+        {"latitude": 53.0, "longitude": 181.0},
+        {"latitude": 53.0, "longitude": -181.0},
+    ],
+)
+async def test_add_vevent_invalid_geo(
+    hass: HomeAssistant,
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    geo: dict[str, float],
+) -> None:
+    """Test that invalid geo coordinates are rejected."""
+    await setup_platform_cb()
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            "calendar",
+            "create_event",
+            {
+                "summary": "Invalid Geo",
+                "start_date_time": "2025-08-06T10:00:00+00:00",
+                "end_date_time": "2025-08-06T11:00:00+00:00",
+                "geo": geo,
+            },
+            target={"entity_id": TEST_ENTITY},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Adds support for the `geo` field specified in RFC5545 to the CalDAV/Calendar components. Location is currently supported, but this only provides a friendly name for the location, rather than the lat/long coordinates.

This change:
- Adds the ability to set geopositional coordinates via a location selector when running the `create_event` action
- Ensures that geopositional coordinates are returned when fetching events


Example of new field when creating an event:
<img width="1199" height="620" alt="image" src="https://github.com/user-attachments/assets/08a72e63-c6ea-49b8-85a7-7ded486fd1cb" />


Example of new field when fetching an event:
<img width="1201" height="375" alt="image" src="https://github.com/user-attachments/assets/9ea8d712-9009-4687-86bb-2ceddb7cf824" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`. 
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description. N/A

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
