### PR TITLE
Add Infrared platform to SMLIGHT

### DIFF
--- a/homeassistant/components/smlight/__init__.py
+++ b/homeassistant/components/smlight/__init__.py
@@ -18,6 +18,7 @@ from .coordinator import (
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.INFRARED,
     Platform.LIGHT,
     Platform.REMOTE,
     Platform.SENSOR,

--- a/homeassistant/components/smlight/infrared.py
+++ b/homeassistant/components/smlight/infrared.py
@@ -32,12 +32,12 @@ async def async_setup_entry(
 class SmInfraredEntity(SmEntity, InfraredEntity):
     """Representation of a SLZB-Ultima infrared."""
 
-    _attr_translation_key = "infrared"
+    _attr_translation_key = "infrared_emitter"
 
     def __init__(self, coordinator: SmDataUpdateCoordinator) -> None:
         """Initialize the SLZB-Ultima infrared."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.unique_id}-infrared"
+        self._attr_unique_id = f"{coordinator.unique_id}-infrared-emitter"
 
     async def async_send_command(self, command: InfraredCommand) -> None:
         """Send an IR command."""

--- a/homeassistant/components/smlight/infrared.py
+++ b/homeassistant/components/smlight/infrared.py
@@ -1,0 +1,62 @@
+"""Infrared platform for SLZB-Ultima."""
+
+from __future__ import annotations
+
+from pysmlight.exceptions import SmlightError
+from pysmlight.models import IRPayload
+
+from homeassistant.components.infrared import InfraredCommand, InfraredEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SmConfigEntry, SmDataUpdateCoordinator
+from .entity import SmEntity
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SmConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Initialize infrared for SLZB-Ultima device."""
+    coordinator = entry.runtime_data.data
+
+    if coordinator.data.info.has_peripherals:
+        async_add_entities([SmInfraredEntity(coordinator)])
+
+
+class SmInfraredEntity(SmEntity, InfraredEntity):
+    """Representation of a SLZB-Ultima infrared."""
+
+    _attr_translation_key = "infrared"
+
+    def __init__(self, coordinator: SmDataUpdateCoordinator) -> None:
+        """Initialize the SLZB-Ultima infrared."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.unique_id}-infrared"
+
+    async def async_send_command(self, command: InfraredCommand) -> None:
+        """Send an IR command."""
+        timings = [
+            interval
+            for timing in command.get_raw_timings()
+            for interval in (timing.high_us, timing.low_us)
+        ]
+
+        freq = command.modulation
+
+        try:
+            await self.coordinator.async_execute_command(
+                self.coordinator.client.actions.send_ir_code,
+                IRPayload.from_raw_timings(timings, freq=freq),
+            )
+        except (SmlightError, ValueError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_ir_code_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -79,6 +79,11 @@
         "name": "Zigbee restart"
       }
     },
+    "infrared": {
+      "infrared": {
+        "name": "IR Remote"
+      }
+    },
     "light": {
       "ambilight": {
         "name": "Ambilight"

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -80,8 +80,8 @@
       }
     },
     "infrared": {
-      "infrared": {
-        "name": "IR Remote"
+      "infrared_emitter": {
+        "name": "IR Emitter"
       }
     },
     "light": {

--- a/tests/components/smlight/test_infrared.py
+++ b/tests/components/smlight/test_infrared.py
@@ -52,7 +52,7 @@ async def test_infrared_setup_ultima(
     mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("infrared.mock_title_ir_remote")
+    state = hass.states.get("infrared.mock_title_ir_emitter")
     assert state is not None
 
 
@@ -69,7 +69,7 @@ async def test_infrared_not_created_non_ultima(
     )
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("infrared.mock_title_ir_remote")
+    state = hass.states.get("infrared.mock_title_ir_emitter")
     assert state is None
 
 
@@ -83,7 +83,7 @@ async def test_infrared_send_command(
     mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "infrared.mock_title_ir_remote"
+    entity_id = "infrared.mock_title_ir_emitter"
     state = hass.states.get(entity_id)
     assert state is not None
 
@@ -108,7 +108,7 @@ async def test_infrared_send_command_error(
     mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "infrared.mock_title_ir_remote"
+    entity_id = "infrared.mock_title_ir_emitter"
     state = hass.states.get(entity_id)
     assert state is not None
 
@@ -133,7 +133,7 @@ async def test_infrared_send_empty_command_error(
     mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "infrared.mock_title_ir_remote"
+    entity_id = "infrared.mock_title_ir_emitter"
     state = hass.states.get(entity_id)
     assert state is not None
 
@@ -159,7 +159,7 @@ async def test_infrared_state_updated_after_send(
     mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "infrared.mock_title_ir_remote"
+    entity_id = "infrared.mock_title_ir_emitter"
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/smlight/test_infrared.py
+++ b/tests/components/smlight/test_infrared.py
@@ -1,0 +1,170 @@
+"""Tests for SLZB-Ultima infrared entity."""
+
+from unittest.mock import MagicMock
+
+from infrared_protocols import Command, Timing
+from pysmlight import Info
+from pysmlight.exceptions import SmlightError
+from pysmlight.models import IRPayload
+import pytest
+
+from homeassistant.components.infrared import async_send_command
+from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .conftest import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+class MockCommand(Command):
+    """Mock InfraredCommand."""
+
+    def __init__(self) -> None:
+        """Initialize with fixed 38kHz modulation."""
+        super().__init__(modulation=38000)
+
+    def get_raw_timings(self) -> list[Timing]:
+        """Return some fake timings."""
+        return [Timing(high_us=9000, low_us=4500), Timing(high_us=560, low_us=1690)]
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Platforms, which should be loaded during the test."""
+    return [Platform.INFRARED]
+
+
+MOCK_ULTIMA = Info(
+    MAC="AA:BB:CC:DD:EE:FF",
+    model="SLZB-Ultima3",
+)
+
+
+async def test_infrared_setup_ultima(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test infrared entity is created for Ultima devices."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("infrared.mock_title_ir_remote")
+    assert state is not None
+
+
+async def test_infrared_not_created_non_ultima(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test infrared entity is not created for non-Ultima devices."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = Info(
+        MAC="AA:BB:CC:DD:EE:FF",
+        model="SLZB-MR1",
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("infrared.mock_title_ir_remote")
+    assert state is None
+
+
+async def test_infrared_send_command(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test sending IR command."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "infrared.mock_title_ir_remote"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    await async_send_command(
+        hass,
+        entity_id,
+        MockCommand(),
+    )
+
+    mock_smlight_client.actions.send_ir_code.assert_called_once_with(
+        IRPayload.from_raw_timings([9000, 4500, 560, 1690], freq=38000)
+    )
+
+
+async def test_infrared_send_command_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test connection error handling."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "infrared.mock_title_ir_remote"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    mock_smlight_client.actions.send_ir_code.side_effect = SmlightError("Failed")
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await async_send_command(
+            hass,
+            entity_id,
+            MockCommand(),
+        )
+    assert exc_info.value.translation_key == "send_ir_code_failed"
+
+
+async def test_infrared_send_empty_command_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test ValueError from pysmlight is surfaced as HomeAssistantError."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "infrared.mock_title_ir_remote"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    mock_smlight_client.actions.send_ir_code.side_effect = ValueError("empty payload")
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await async_send_command(
+            hass,
+            entity_id,
+            MockCommand(),
+        )
+    assert exc_info.value.translation_key == "send_ir_code_failed"
+
+
+@pytest.mark.freeze_time("2025-09-03T22:00:00+00:00")
+async def test_infrared_state_updated_after_send(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test that entity state is updated with a timestamp after a successful send."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "infrared.mock_title_ir_remote"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    await async_send_command(hass, entity_id, MockCommand())
+
+    state = hass.states.get(entity_id)
+    assert state.state == "2025-09-03T22:00:00.000+00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the infrared platform to the SMLIGHT integration, exposing the IR blaster on SLZB-Ultima devices as an InfraredEntity. This allows other integrations (e.g. LG Infrared) that support IR control to use the Ultima's hardware emitter via the infrared component's async_send_command API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44546
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
