### PR TITLE
Replace pyopnsense with aiopnsense in OPNsense integration

### DIFF
--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -2,23 +2,17 @@
 
 import logging
 
-from pyopnsense import diagnostics
-from pyopnsense.exceptions import APIException
+from aiopnsense import OPNsenseClient, OPNsenseError
 import voluptuous as vol
 
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_API_SECRET,
-    CONF_INTERFACE_CLIENT,
-    CONF_TRACKER_INTERFACES,
-    DOMAIN,
-    OPNSENSE_DATA,
-)
+from .const import CONF_API_SECRET, CONF_TRACKER_INTERFACES, DOMAIN, OPNSENSE_DATA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +34,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass: HomeAssistant, config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the opnsense component."""
 
     conf = config[DOMAIN]
@@ -50,32 +44,49 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     verify_ssl = conf[CONF_VERIFY_SSL]
     tracker_interfaces = conf[CONF_TRACKER_INTERFACES]
 
-    interfaces_client = diagnostics.InterfaceClient(
-        api_key, api_secret, url, verify_ssl, timeout=20
+    session = async_get_clientsession(hass, verify_ssl=verify_ssl)
+    client = OPNsenseClient(
+        url,
+        api_key,
+        api_secret,
+        session,
+        opts={"verify_ssl": verify_ssl},
+        throw_errors=True,
     )
+
     try:
-        interfaces_client.get_arp()
-    except APIException:
+        await client.get_arp_table()
+    except OPNsenseError:
         _LOGGER.exception("Failure while connecting to OPNsense API endpoint")
         return False
 
+    interface_map: dict[str, str] = {}
     if tracker_interfaces:
-        # Verify that specified tracker interfaces are valid
-        netinsight_client = diagnostics.NetworkInsightClient(
-            api_key, api_secret, url, verify_ssl, timeout=20
-        )
-        interfaces = list(netinsight_client.get_interfaces().values())
+        try:
+            interfaces = await client.get_interfaces()
+        except OPNsenseError:
+            _LOGGER.exception("Failure while retrieving OPNsense network interfaces")
+            return False
+        interface_map = {
+            iface_id: iface_data.get("name", "")
+            for iface_id, iface_data in interfaces.items()
+        }
+        interface_names = list(interface_map.values())
         for interface in tracker_interfaces:
-            if interface not in interfaces:
+            if interface not in interface_names:
                 _LOGGER.error(
-                    "Specified OPNsense tracker interface %s is not found", interface
+                    "Specified OPNsense tracker interface %s is not found",
+                    interface,
                 )
                 return False
 
     hass.data[OPNSENSE_DATA] = {
-        CONF_INTERFACE_CLIENT: interfaces_client,
+        "client": client,
+        "interface_map": interface_map,
         CONF_TRACKER_INTERFACES: tracker_interfaces,
     }
 
-    load_platform(hass, Platform.DEVICE_TRACKER, DOMAIN, tracker_interfaces, config)
+    await async_load_platform(
+        hass, Platform.DEVICE_TRACKER, DOMAIN, tracker_interfaces, config
+    )
     return True

--- a/homeassistant/components/opnsense/const.py
+++ b/homeassistant/components/opnsense/const.py
@@ -4,5 +4,4 @@ DOMAIN = "opnsense"
 OPNSENSE_DATA = DOMAIN
 
 CONF_API_SECRET = "api_secret"
-CONF_INTERFACE_CLIENT = "interface_client"
 CONF_TRACKER_INTERFACES = "tracker_interfaces"

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -2,13 +2,13 @@
 
 from typing import Any, NewType
 
-from pyopnsense import diagnostics
+from aiopnsense import OPNsenseClient
 
 from homeassistant.components.device_tracker import DeviceScanner
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_INTERFACE_CLIENT, CONF_TRACKER_INTERFACES, OPNSENSE_DATA
+from .const import CONF_TRACKER_INTERFACES, OPNSENSE_DATA
 
 DeviceDetails = NewType("DeviceDetails", dict[str, Any])
 DeviceDetailsByMAC = NewType("DeviceDetailsByMAC", dict[str, DeviceDetails])
@@ -19,8 +19,9 @@ async def async_get_scanner(
 ) -> DeviceScanner | None:
     """Configure the OPNsense device_tracker."""
     return OPNsenseDeviceScanner(
-        hass.data[OPNSENSE_DATA][CONF_INTERFACE_CLIENT],
+        hass.data[OPNSENSE_DATA]["client"],
         hass.data[OPNSENSE_DATA][CONF_TRACKER_INTERFACES],
+        hass.data[OPNSENSE_DATA]["interface_map"],
     )
 
 
@@ -28,38 +29,51 @@ class OPNsenseDeviceScanner(DeviceScanner):
     """This class queries a router running OPNsense."""
 
     def __init__(
-        self, client: diagnostics.InterfaceClient, interfaces: list[str]
+        self,
+        client: OPNsenseClient,
+        interfaces: list[str],
+        interface_map: dict[str, str],
     ) -> None:
         """Initialize the scanner."""
         self.last_results: dict[str, Any] = {}
         self.client = client
         self.interfaces = interfaces
+        self.interface_map = interface_map
 
     def _get_mac_addrs(self, devices: list[DeviceDetails]) -> DeviceDetailsByMAC | dict:
         """Create dict with mac address keys from list of devices."""
         out_devices = {}
         for device in devices:
-            if not self.interfaces or device["intf_description"] in self.interfaces:
-                out_devices[device["mac"]] = device
+            if not self.interfaces:
+                out_devices[device["mac-address"]] = device
+            else:
+                intf_description = self.interface_map.get(
+                    device.get("interface", ""), ""
+                )
+                if intf_description in self.interfaces:
+                    out_devices[device["mac-address"]] = device
         return out_devices
 
-    def scan_devices(self) -> list[str]:
+    async def async_scan_devices(self) -> list[str]:
         """Scan for new devices and return a list with found device IDs."""
-        self.update_info()
+        await self.async_update_info()
         return list(self.last_results)
 
     def get_device_name(self, device: str) -> str | None:
         """Return the name of the given device or None if we don't know."""
         if device not in self.last_results:
             return None
-        return self.last_results[device].get("hostname") or None
+        hostname = self.last_results[device].get("hostname")
+        if not hostname or hostname == "?":
+            return None
+        return hostname
 
-    def update_info(self) -> bool:
+    async def async_update_info(self) -> bool:
         """Ensure the information from the OPNsense router is up to date.
 
         Return boolean if scanning successful.
         """
-        devices = self.client.get_arp()
+        devices = await self.client.get_arp_table()
         self.last_results = self._get_mac_addrs(devices)
         return True
 

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -63,7 +63,7 @@ class OPNsenseDeviceScanner(DeviceScanner):
         """Return the name of the given device or None if we don't know."""
         if device not in self.last_results:
             return None
-        hostname = self.last_results[device].get("hostname")
+        hostname: str | None = self.last_results[device].get("hostname")
         if not hostname or hostname == "?":
             return None
         return hostname

--- a/homeassistant/components/opnsense/manifest.json
+++ b/homeassistant/components/opnsense/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/opnsense",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": ["pbr", "pyopnsense"],
+  "loggers": ["aiopnsense"],
   "quality_scale": "legacy",
-  "requirements": ["pyopnsense==0.4.0"]
+  "requirements": ["aiopnsense==1.0.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -356,6 +356,9 @@ aiooui==0.1.9
 # homeassistant.components.pegel_online
 aiopegelonline==0.1.1
 
+# homeassistant.components.opnsense
+aiopnsense==1.0.8
+
 # homeassistant.components.acmeda
 aiopulse==0.4.6
 
@@ -2351,9 +2354,6 @@ pyopenuv==2023.02.0
 
 # homeassistant.components.openweathermap
 pyopenweathermap==0.2.2
-
-# homeassistant.components.opnsense
-pyopnsense==0.4.0
 
 # homeassistant.components.opple
 pyoppleio-legacy==1.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -341,6 +341,9 @@ aiooui==0.1.9
 # homeassistant.components.pegel_online
 aiopegelonline==0.1.1
 
+# homeassistant.components.opnsense
+aiopnsense==1.0.8
+
 # homeassistant.components.acmeda
 aiopulse==0.4.6
 
@@ -2013,9 +2016,6 @@ pyopenuv==2023.02.0
 
 # homeassistant.components.openweathermap
 pyopenweathermap==0.2.2
-
-# homeassistant.components.opnsense
-pyopnsense==0.4.0
 
 # homeassistant.components.osoenergy
 pyosoenergyapi==1.2.4

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -189,11 +189,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     "norway_air": {"pymetno": {"async-timeout"}},
     "opengarage": {"open-garage": {"async-timeout"}},
     "opensensemap": {"opensensemap-api": {"async-timeout"}},
-    "opnsense": {
-        # https://github.com/mtreinish/pyopnsense/issues/27
-        # pyopnsense > pbr > setuptools
-        "pbr": {"setuptools"}
-    },
     "pvpc_hourly_pricing": {"aiopvpc": {"async-timeout"}},
     "remote_rpi_gpio": {
         # https://github.com/waveform80/colorzero/issues/9
@@ -298,10 +293,6 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
     },
     # https://github.com/ejpenney/pyobihai
     "obihai": {"homeassistant": {"pyobihai"}},
-    "opnsense": {
-        # Setuptools - distutils-precedence.pth
-        "pbr": {"setuptools"}
-    },
     # https://github.com/iamkubi/pydactyl
     "pterodactyl": {"homeassistant": {"py-dactyl"}},
     "remote_rpi_gpio": {

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -1,52 +1,58 @@
 """The tests for the opnsense device tracker platform."""
 
-from unittest import mock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components import opnsense
 from homeassistant.components.device_tracker import legacy
-from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN
+from homeassistant.components.opnsense.const import CONF_API_SECRET, DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+ARP_RESPONSE = [
+    {
+        "hostname": "?",
+        "ip-address": "192.168.0.123",
+        "mac-address": "ff:ff:ff:ff:ff:ff",
+        "interface": "igb1",
+        "expires": 1199,
+        "type": "ethernet",
+    },
+    {
+        "hostname": "Desktop",
+        "ip-address": "192.168.0.167",
+        "mac-address": "ff:ff:ff:ff:ff:fe",
+        "interface": "igb1",
+        "expires": 1199,
+        "type": "ethernet",
+    },
+]
 
-@pytest.fixture(name="mocked_opnsense")
-def mocked_opnsense():
-    """Mock for pyopnense.diagnostics."""
-    with mock.patch.object(opnsense, "diagnostics") as mocked_opn:
-        yield mocked_opn
+INTERFACES_RESPONSE = {
+    "igb0": {"name": "WAN", "interface": "igb0"},
+    "igb1": {"name": "LAN", "interface": "igb1"},
+}
+
+
+@pytest.fixture(name="mock_opnsense_client")
+def mock_opnsense_client_fixture() -> AsyncMock:
+    """Mock for aiopnsense.OPNsenseClient."""
+    with patch(
+        "homeassistant.components.opnsense.OPNsenseClient",
+    ) as mock_cls:
+        client = mock_cls.return_value
+        client.get_arp_table = AsyncMock(return_value=ARP_RESPONSE)
+        client.get_interfaces = AsyncMock(return_value=INTERFACES_RESPONSE)
+        yield client
 
 
 async def test_get_scanner(
-    hass: HomeAssistant, mocked_opnsense, mock_device_tracker_conf: list[legacy.Device]
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+    mock_device_tracker_conf: list[legacy.Device],
 ) -> None:
     """Test creating an opnsense scanner."""
-    interface_client = mock.MagicMock()
-    mocked_opnsense.InterfaceClient.return_value = interface_client
-    interface_client.get_arp.return_value = [
-        {
-            "hostname": "",
-            "intf": "igb1",
-            "intf_description": "LAN",
-            "ip": "192.168.0.123",
-            "mac": "ff:ff:ff:ff:ff:ff",
-            "manufacturer": "",
-        },
-        {
-            "hostname": "Desktop",
-            "intf": "igb1",
-            "intf_description": "LAN",
-            "ip": "192.168.0.167",
-            "mac": "ff:ff:ff:ff:ff:fe",
-            "manufacturer": "OEM",
-        },
-    ]
-    network_insight_client = mock.MagicMock()
-    mocked_opnsense.NetworkInsightClient.return_value = network_insight_client
-    network_insight_client.get_interfaces.return_value = {"igb0": "WAN", "igb1": "LAN"}
-
     result = await async_setup_component(
         hass,
         DOMAIN,

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+from aiopnsense import OPNsenseError
 import pytest
 
 from homeassistant.components.device_tracker import legacy
@@ -72,3 +73,126 @@ async def test_get_scanner(
     assert device_1.state == "home"
     device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
     assert device_2.state == "home"
+
+
+async def test_get_scanner_with_interfaces(
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+    mock_device_tracker_conf: list[legacy.Device],
+) -> None:
+    """Test creating an opnsense scanner with tracker interfaces."""
+    result = await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_URL: "https://fake_host_fun/api",
+                CONF_API_KEY: "fake_key",
+                CONF_API_SECRET: "fake_secret",
+                CONF_VERIFY_SSL: False,
+                "tracker_interfaces": ["LAN"],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert result
+    # Both devices are on igb1 (LAN), so both should be tracked
+    device_1 = hass.states.get("device_tracker.desktop")
+    assert device_1 is not None
+    assert device_1.state == "home"
+    device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+    assert device_2.state == "home"
+
+
+async def test_get_scanner_with_interfaces_filters(
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+    mock_device_tracker_conf: list[legacy.Device],
+) -> None:
+    """Test that scanner filters devices by interface."""
+    result = await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_URL: "https://fake_host_fun/api",
+                CONF_API_KEY: "fake_key",
+                CONF_API_SECRET: "fake_secret",
+                CONF_VERIFY_SSL: False,
+                "tracker_interfaces": ["WAN"],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert result
+    # Both devices are on igb1 (LAN), not WAN, so neither should be tracked
+    device_1 = hass.states.get("device_tracker.desktop")
+    assert device_1 is None
+    device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+    assert device_2 is None
+
+
+async def test_setup_fails_on_connection_error(
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+) -> None:
+    """Test setup fails gracefully on connection error."""
+    mock_opnsense_client.get_arp_table = AsyncMock(side_effect=OPNsenseError)
+
+    result = await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_URL: "https://fake_host_fun/api",
+                CONF_API_KEY: "fake_key",
+                CONF_API_SECRET: "fake_secret",
+                CONF_VERIFY_SSL: False,
+            }
+        },
+    )
+    assert not result
+
+
+async def test_setup_fails_on_interface_error(
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+) -> None:
+    """Test setup fails when interface retrieval fails."""
+    mock_opnsense_client.get_interfaces = AsyncMock(side_effect=OPNsenseError)
+
+    result = await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_URL: "https://fake_host_fun/api",
+                CONF_API_KEY: "fake_key",
+                CONF_API_SECRET: "fake_secret",
+                CONF_VERIFY_SSL: False,
+                "tracker_interfaces": ["LAN"],
+            }
+        },
+    )
+    assert not result
+
+
+async def test_setup_fails_on_invalid_interface(
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+) -> None:
+    """Test setup fails when a configured interface doesn't exist."""
+    result = await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_URL: "https://fake_host_fun/api",
+                CONF_API_KEY: "fake_key",
+                CONF_API_SECRET: "fake_secret",
+                CONF_VERIFY_SSL: False,
+                "tracker_interfaces": ["NONEXISTENT"],
+            }
+        },
+    )
+    assert not result


### PR DESCRIPTION
## Proposed change

Replace the unmaintained `pyopnsense` library with [`aiopnsense`](https://pypi.org/project/aiopnsense/) ([GitHub](https://github.com/Snuffy2/aiopnsense)).

OPNsense 25.7 changed all API endpoints from camelCase to snake_case. `pyopnsense` is unmaintained and still uses the old endpoints, causing 403 errors for all OPNsense 25.7+ users. `aiopnsense` supports both old camelCase and new snake_case endpoints automatically based on firmware detection.

This is a standalone dependency swap per [the review process guidelines (section 7)](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr). No new features are added — the integration keeps its YAML-only setup and legacy `DeviceScanner` pattern.

### What changed

- Drop `pyopnsense==0.4.0`, add `aiopnsense==1.0.8`
- Convert sync `setup()` → `async_setup()` (new library is async)
- Convert sync `scan_devices()`/`update_info()` → async equivalents
- Adapt to `aiopnsense` ARP field names (`mac-address`, `interface` instead of `mac`, `intf_description`)
- Build interface device-to-name mapping for tracker interface filtering
- Update tests for new library API

### What did NOT change

- No config flow (planned for follow-up PR)
- No `ScannerEntity` migration (planned for follow-up PR)
- No new features

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #149414
- This PR is related to issue:
- Link to documentation pull request:

Part of a planned 3-PR series:
1. **This PR** — Dependency swap (`pyopnsense` → `aiopnsense`)
2. Add config flow + YAML import (follow-up)
3. Migrate device tracker to `ScannerEntity` (follow-up)

Related PRs: #166798 (will be superseded), #151121 (@HarlemSquirrel's config flow), #166821 (@Snuffy2's aiopnsense integration)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io