### PR TITLE
Fix Tractive switch availability

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -246,6 +246,7 @@ class TractiveClient:
                     ):
                         self._last_hw_time = event["hardware"]["time"]
                         self._send_hardware_update(event)
+                        self._send_switch_update(event)
                     if (
                         "position" in event
                         and self._last_pos_time != event["position"]["time"]
@@ -302,7 +303,10 @@ class TractiveClient:
         for switch, key in SWITCH_KEY_MAP.items():
             if switch_data := event.get(key):
                 payload[switch] = switch_data["active"]
-        payload[ATTR_POWER_SAVING] = event.get("tracker_state_reason") == "POWER_SAVING"
+        if hardware := event.get("hardware", {}):
+            payload[ATTR_POWER_SAVING] = (
+                hardware.get("power_saving_zone_id") is not None
+            )
         self._dispatch_tracker_event(
             TRACKER_SWITCH_STATUS_UPDATED, event["tracker_id"], payload
         )

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -100,13 +100,11 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
-        if self.entity_description.key not in event:
-            return
+        if ATTR_POWER_SAVING in event:
+            self._attr_available = not event[ATTR_POWER_SAVING]
 
-        # We received an event, so the service is online and the switch entities should
-        #  be available.
-        self._attr_available = not event[ATTR_POWER_SAVING]
-        self._attr_is_on = event[self.entity_description.key]
+        if self.entity_description.key in event:
+            self._attr_is_on = event[self.entity_description.key]
 
         self.async_write_ha_state()
 

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -248,10 +248,7 @@ async def test_switch_unavailable(
 
     event = {
         "tracker_id": "device_id_123",
-        "buzzer_control": {"active": True},
-        "led_control": {"active": False},
-        "live_tracking": {"active": True},
-        "tracker_state_reason": "POWER_SAVING",
+        "hardware": {"power_saving_zone_id": "zone_id_123"},
     }
     mock_tractive_client.send_switch_event(mock_config_entry, event)
     await hass.async_block_till_done()
@@ -260,7 +257,9 @@ async def test_switch_unavailable(
     assert state
     assert state.state == STATE_UNAVAILABLE
 
-    mock_tractive_client.send_switch_event(mock_config_entry)
+    event["hardware"]["power_saving_zone_id"] = None
+
+    mock_tractive_client.send_switch_event(mock_config_entry, event)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It appears that Tractive changed the payload for switch events causing them to be permanently unavailable.
This PR changes the way switch availability is determined – it checks whether the tracker reports the power saving zone ID (switches should be unavailable in the power saving zone because the API doesn't support changing their state when the tracker is in these zones).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167215
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
