### PR TITLE
Fix/openrgb stable device key

### DIFF
--- a/homeassistant/components/openrgb/coordinator.py
+++ b/homeassistant/components/openrgb/coordinator.py
@@ -107,14 +107,28 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
         Note: the OpenRGB device.id is intentionally not used because it is just
         a positional index that can change when devices are added or removed.
+
+        For HID devices without a serial number, the location string is excluded
+        because it contains a platform-specific path (e.g. DevSrvsID on macOS)
+        that changes every time the device is reconnected. For devices with a
+        serial number, location is not needed since serial is already unique.
+        For non-HID devices (e.g. I2C), location is more stable and is included.
         """
+        location = device.metadata.location or "none"
+        serial = device.metadata.serial or "none"
+
+        # HID location paths change on reconnect, so only include location
+        # for non-HID devices without a serial number
+        if location.startswith("HID:") or serial != "none":
+            location = "none"
+
         parts = (
             self.entry_id,
             device.type.name,
             device.metadata.vendor or "none",
             device.metadata.description or "none",
-            device.metadata.serial or "none",
-            device.metadata.location or "none",
+            serial,
+            location,
         )
         # Double pipe is readable and is unlikely to appear in metadata
         return UID_SEPARATOR.join(parts)

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -349,3 +349,76 @@ async def test_normal_update_without_errors(
     state = hass.states.get("light.ene_dram")
     assert state
     assert state.state == STATE_ON
+
+
+async def test_device_key_stable_across_hid_reconnect(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test that device key does not change when HID location changes on reconnect."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Set HID location (like a USB keyboard)
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:4295213270"
+    mock_openrgb_device.metadata.serial = ""
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    key_before = coordinator._get_device_key(mock_openrgb_device)
+
+    # Simulate reconnect with changed location
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:4295217216"
+    key_after = coordinator._get_device_key(mock_openrgb_device)
+
+    assert key_before == key_after
+
+
+async def test_device_key_uses_serial_ignores_location(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test that device key uses serial and ignores location when serial is present."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_openrgb_device.metadata.serial = "ABC123"
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:111"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    key1 = coordinator._get_device_key(mock_openrgb_device)
+
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:222"
+    key2 = coordinator._get_device_key(mock_openrgb_device)
+
+    assert key1 == key2
+    assert "ABC123" in key1
+    assert "DevSrvsID" not in key1
+
+
+async def test_device_key_includes_location_for_i2c(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test that device key includes location for non-HID devices without serial."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_openrgb_device.metadata.serial = ""
+    mock_openrgb_device.metadata.location = "I2C: PIIX4, address 0x70"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    key = coordinator._get_device_key(mock_openrgb_device)
+
+    assert "I2C: PIIX4, address 0x70" in key


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This change may cause a **one-time entity ID change** for HID devices (keyboards, mice, headsets, etc.) that have no serial number. After updating, users may see a new entity replacing the old one. The old entity can be safely removed. This only happens once — subsequent reconnections will reuse the same stable entity.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The OpenRGB integration builds a device key from metadata fields including `location`. For HID devices, this field contains a platform-specific path (e.g. `HID: DevSrvsID:XXXXXXX` on macOS) that changes every time the USB device is physically disconnected and reconnected. This causes Home Assistant to create duplicate entities on each reconnect.

This is especially problematic with OpenRGB's new USB hotplug detection support, which automatically removes and re-adds devices when they are unplugged and replugged — triggering the unstable key on every cycle.

The fix excludes `location` from the device key for HID devices, since it is not stable across reconnections. For devices with a serial number, `location` is also excluded since serial already provides uniqueness. For non-HID devices (e.g. I2C), `location` remains in the key as it is more stable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
