### PR TITLE
Add extra state attributes for the Renault charging mode sensor

### DIFF
--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -158,9 +158,11 @@ def _get_charging_settings_attributes(
     """Return the charging_settings attributes."""
     data = entity.coordinator.data
     return {
-        "schedules": tuple(schedule.for_json() for schedule in schedules)
-        if (schedules := data.schedules)
-        else None,
+        "schedules": (
+            [schedule.for_json() for schedule in schedules]
+            if (schedules := data.schedules)
+            else None
+        ),
         "dateTime": data.dateTime,
         "startDateTime": data.startDateTime,
         "delay": data.delay,

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -56,6 +56,7 @@ class RenaultSensorEntityDescription[T: KamereonVehicleDataAttributes](
     condition_lambda: Callable[[RenaultVehicleProxy], bool] | None = None
     requires_fuel: bool = False
     value_lambda: Callable[[RenaultSensor[T]], StateType | datetime]
+    attributes_lambda: Callable[[RenaultSensor[T]], Mapping[str, Any]] | None = None
 
 
 async def async_setup_entry(
@@ -81,11 +82,27 @@ class RenaultSensor[T: KamereonVehicleDataAttributes](
     """Mixin for sensor specific attributes."""
 
     entity_description: RenaultSensorEntityDescription[T]
+    # Do not store these attributes in the HA DB
+    _unrecorded_attributes = frozenset(
+        {
+            "schedules",
+            "startDateTime",
+            "dateTime",
+            "delay",
+        }
+    )
 
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state of this entity."""
         return self.entity_description.value_lambda(self)
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the attributes of this entity."""
+        if self.entity_description.attributes_lambda:
+            return self.entity_description.attributes_lambda(self)
+        return None
 
 
 def _get_charging_power(
@@ -133,6 +150,21 @@ def _get_charging_settings_mode_formatted(
     """Return the charging_settings mode of this entity."""
     charging_mode = entity.coordinator.data.mode
     return charging_mode.lower() if charging_mode else None
+
+
+def _get_charging_settings_attributes(
+    entity: RenaultSensor[KamereonVehicleChargingSettingsData],
+) -> Mapping[str, Any]:
+    """Return the charging_settings attributes."""
+    data = entity.coordinator.data
+    return {
+        "schedules": [schedule.for_json() for schedule in schedules]
+        if (schedules := data.schedules)
+        else None,
+        "dateTime": data.dateTime,
+        "startDateTime": data.startDateTime,
+        "delay": data.delay,
+    }
 
 
 SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
@@ -329,6 +361,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
             "scheduled",
         ],
         value_lambda=_get_charging_settings_mode_formatted,
+        attributes_lambda=_get_charging_settings_attributes,
     ),
     RenaultSensorEntityDescription[KamereonVehicleTyrePressureData](
         key="front_left_pressure",

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -86,8 +86,8 @@ class RenaultSensor[T: KamereonVehicleDataAttributes](
     _unrecorded_attributes = frozenset(
         {
             "schedules",
-            "startDateTime",
-            "dateTime",
+            "start_date_time",
+            "last_update",
             "delay",
         }
     )

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -163,8 +163,8 @@ def _get_charging_settings_attributes(
             if (schedules := data.schedules)
             else None
         ),
-        "dateTime": data.dateTime,
-        "startDateTime": data.startDateTime,
+        "last_update": data.dateTime,
+        "start_date_time": data.startDateTime,
         "delay": data.delay,
     }
 

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -160,7 +160,7 @@ def _get_charging_settings_attributes(
     return {
         "schedules": (
             [schedule.for_json() for schedule in schedules]
-            if (schedules := data.schedules)
+            if (schedules := data.schedules) is not None
             else None
         ),
         "last_update": data.dateTime,

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -158,7 +158,7 @@ def _get_charging_settings_attributes(
     """Return the charging_settings attributes."""
     data = entity.coordinator.data
     return {
-        "schedules": [schedule.for_json() for schedule in schedules]
+        "schedules": tuple(schedule.for_json() for schedule in schedules)
         if (schedules := data.schedules)
         else None,
         "dateTime": data.dateTime,

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -154,6 +154,20 @@
           "always": "Always",
           "delayed": "Delayed",
           "scheduled": "Scheduled"
+        },
+        "state_attributes": {
+          "delay": {
+            "name": "Minutes to next start"
+          },
+          "last_update": {
+            "name": "Last mode update"
+          },
+          "schedules": {
+            "name": "Current schedules"
+          },
+          "start_date_time": {
+            "name": "Delayed start time"
+          }
         }
       },
       "front_left_pressure": {

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -5971,7 +5971,7 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': tuple(
+      'schedules': list([
         dict({
           'activated': True,
           'friday': dict({
@@ -6069,7 +6069,7 @@
           'tuesday': None,
           'wednesday': None,
         }),
-      ),
+      ]),
       'startDateTime': None,
     }),
     'context': <ANY>,

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -346,6 +346,8 @@
 # name: test_sensor_empty[zoe_40][sensor.reg_zoe_40_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'dateTime': None,
+      'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-ZOE-40 Charging mode',
       'options': list([
@@ -353,6 +355,11 @@
         'delayed',
         'scheduled',
       ]),
+      'schedules': tuple(
+        list([
+        ]),
+      ),
+      'startDateTime': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_zoe_40_charging_mode',
@@ -2417,6 +2424,8 @@
 # name: test_sensors[captur_phev][sensor.reg_captur_phev_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'dateTime': None,
+      'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-CAPTUR_PHEV Charging mode',
       'options': list([
@@ -2424,6 +2433,11 @@
         'delayed',
         'scheduled',
       ]),
+      'schedules': tuple(
+        list([
+        ]),
+      ),
+      'startDateTime': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_captur_phev_charging_mode',
@@ -3398,6 +3412,8 @@
 # name: test_sensors[megane_e_tech][sensor.reg_meg_0_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'dateTime': None,
+      'delay': 300,
       'device_class': 'enum',
       'friendly_name': 'REG-MEG-0 Charging mode',
       'options': list([
@@ -3405,6 +3421,11 @@
         'delayed',
         'scheduled',
       ]),
+      'schedules': tuple(
+        list([
+        ]),
+      ),
+      'startDateTime': '2025-12-29T10:20:30Z',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_meg_0_charging_mode',
@@ -4263,6 +4284,8 @@
 # name: test_sensors[twingo_3_electric][sensor.reg_twingo_iii_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'dateTime': None,
+      'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-TWINGO-III Charging mode',
       'options': list([
@@ -4270,6 +4293,11 @@
         'delayed',
         'scheduled',
       ]),
+      'schedules': tuple(
+        list([
+        ]),
+      ),
+      'startDateTime': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_twingo_iii_charging_mode',
@@ -5070,6 +5098,8 @@
 # name: test_sensors[zoe_40][sensor.reg_zoe_40_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'dateTime': None,
+      'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-ZOE-40 Charging mode',
       'options': list([
@@ -5077,6 +5107,11 @@
         'delayed',
         'scheduled',
       ]),
+      'schedules': tuple(
+        list([
+        ]),
+      ),
+      'startDateTime': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_zoe_40_charging_mode',
@@ -5942,6 +5977,8 @@
 # name: test_sensors[zoe_50][sensor.reg_zoe_50_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'dateTime': None,
+      'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-ZOE-50 Charging mode',
       'options': list([
@@ -5949,6 +5986,108 @@
         'delayed',
         'scheduled',
       ]),
+      'schedules': tuple(
+        list([
+          dict({
+            'activated': True,
+            'friday': dict({
+              'duration': 450,
+              'startTime': 'T00:00Z',
+            }),
+            'id': 1,
+            'monday': dict({
+              'duration': 450,
+              'startTime': 'T00:00Z',
+            }),
+            'saturday': dict({
+              'duration': 450,
+              'startTime': 'T00:00Z',
+            }),
+            'sunday': dict({
+              'duration': 450,
+              'startTime': 'T00:00Z',
+            }),
+            'thursday': dict({
+              'duration': 450,
+              'startTime': 'T00:00Z',
+            }),
+            'tuesday': dict({
+              'duration': 450,
+              'startTime': 'T00:00Z',
+            }),
+            'wednesday': dict({
+              'duration': 450,
+              'startTime': 'T00:00Z',
+            }),
+          }),
+          dict({
+            'activated': True,
+            'friday': dict({
+              'duration': 15,
+              'startTime': 'T23:30Z',
+            }),
+            'id': 2,
+            'monday': dict({
+              'duration': 15,
+              'startTime': 'T23:30Z',
+            }),
+            'saturday': dict({
+              'duration': 15,
+              'startTime': 'T23:30Z',
+            }),
+            'sunday': dict({
+              'duration': 15,
+              'startTime': 'T23:30Z',
+            }),
+            'thursday': dict({
+              'duration': 15,
+              'startTime': 'T23:30Z',
+            }),
+            'tuesday': dict({
+              'duration': 15,
+              'startTime': 'T23:30Z',
+            }),
+            'wednesday': dict({
+              'duration': 15,
+              'startTime': 'T23:30Z',
+            }),
+          }),
+          dict({
+            'activated': False,
+            'friday': None,
+            'id': 3,
+            'monday': None,
+            'saturday': None,
+            'sunday': None,
+            'thursday': None,
+            'tuesday': None,
+            'wednesday': None,
+          }),
+          dict({
+            'activated': False,
+            'friday': None,
+            'id': 4,
+            'monday': None,
+            'saturday': None,
+            'sunday': None,
+            'thursday': None,
+            'tuesday': None,
+            'wednesday': None,
+          }),
+          dict({
+            'activated': False,
+            'friday': None,
+            'id': 5,
+            'monday': None,
+            'saturday': None,
+            'sunday': None,
+            'thursday': None,
+            'tuesday': None,
+            'wednesday': None,
+          }),
+        ]),
+      ),
+      'startDateTime': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_zoe_50_charging_mode',

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -355,10 +355,7 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': tuple(
-        list([
-        ]),
-      ),
+      'schedules': None,
       'startDateTime': None,
     }),
     'context': <ANY>,
@@ -2433,10 +2430,7 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': tuple(
-        list([
-        ]),
-      ),
+      'schedules': None,
       'startDateTime': None,
     }),
     'context': <ANY>,
@@ -3421,10 +3415,7 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': tuple(
-        list([
-        ]),
-      ),
+      'schedules': None,
       'startDateTime': '2025-12-29T10:20:30Z',
     }),
     'context': <ANY>,
@@ -4293,10 +4284,7 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': tuple(
-        list([
-        ]),
-      ),
+      'schedules': None,
       'startDateTime': None,
     }),
     'context': <ANY>,
@@ -5107,10 +5095,7 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': tuple(
-        list([
-        ]),
-      ),
+      'schedules': None,
       'startDateTime': None,
     }),
     'context': <ANY>,
@@ -5986,107 +5971,105 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': tuple(
-        list([
-          dict({
-            'activated': True,
-            'friday': dict({
-              'duration': 450,
-              'startTime': 'T00:00Z',
-            }),
-            'id': 1,
-            'monday': dict({
-              'duration': 450,
-              'startTime': 'T00:00Z',
-            }),
-            'saturday': dict({
-              'duration': 450,
-              'startTime': 'T00:00Z',
-            }),
-            'sunday': dict({
-              'duration': 450,
-              'startTime': 'T00:00Z',
-            }),
-            'thursday': dict({
-              'duration': 450,
-              'startTime': 'T00:00Z',
-            }),
-            'tuesday': dict({
-              'duration': 450,
-              'startTime': 'T00:00Z',
-            }),
-            'wednesday': dict({
-              'duration': 450,
-              'startTime': 'T00:00Z',
-            }),
+      'schedules': list([
+        dict({
+          'activated': True,
+          'friday': dict({
+            'duration': 450,
+            'startTime': 'T00:00Z',
           }),
-          dict({
-            'activated': True,
-            'friday': dict({
-              'duration': 15,
-              'startTime': 'T23:30Z',
-            }),
-            'id': 2,
-            'monday': dict({
-              'duration': 15,
-              'startTime': 'T23:30Z',
-            }),
-            'saturday': dict({
-              'duration': 15,
-              'startTime': 'T23:30Z',
-            }),
-            'sunday': dict({
-              'duration': 15,
-              'startTime': 'T23:30Z',
-            }),
-            'thursday': dict({
-              'duration': 15,
-              'startTime': 'T23:30Z',
-            }),
-            'tuesday': dict({
-              'duration': 15,
-              'startTime': 'T23:30Z',
-            }),
-            'wednesday': dict({
-              'duration': 15,
-              'startTime': 'T23:30Z',
-            }),
+          'id': 1,
+          'monday': dict({
+            'duration': 450,
+            'startTime': 'T00:00Z',
           }),
-          dict({
-            'activated': False,
-            'friday': None,
-            'id': 3,
-            'monday': None,
-            'saturday': None,
-            'sunday': None,
-            'thursday': None,
-            'tuesday': None,
-            'wednesday': None,
+          'saturday': dict({
+            'duration': 450,
+            'startTime': 'T00:00Z',
           }),
-          dict({
-            'activated': False,
-            'friday': None,
-            'id': 4,
-            'monday': None,
-            'saturday': None,
-            'sunday': None,
-            'thursday': None,
-            'tuesday': None,
-            'wednesday': None,
+          'sunday': dict({
+            'duration': 450,
+            'startTime': 'T00:00Z',
           }),
-          dict({
-            'activated': False,
-            'friday': None,
-            'id': 5,
-            'monday': None,
-            'saturday': None,
-            'sunday': None,
-            'thursday': None,
-            'tuesday': None,
-            'wednesday': None,
+          'thursday': dict({
+            'duration': 450,
+            'startTime': 'T00:00Z',
           }),
-        ]),
-      ),
+          'tuesday': dict({
+            'duration': 450,
+            'startTime': 'T00:00Z',
+          }),
+          'wednesday': dict({
+            'duration': 450,
+            'startTime': 'T00:00Z',
+          }),
+        }),
+        dict({
+          'activated': True,
+          'friday': dict({
+            'duration': 15,
+            'startTime': 'T23:30Z',
+          }),
+          'id': 2,
+          'monday': dict({
+            'duration': 15,
+            'startTime': 'T23:30Z',
+          }),
+          'saturday': dict({
+            'duration': 15,
+            'startTime': 'T23:30Z',
+          }),
+          'sunday': dict({
+            'duration': 15,
+            'startTime': 'T23:30Z',
+          }),
+          'thursday': dict({
+            'duration': 15,
+            'startTime': 'T23:30Z',
+          }),
+          'tuesday': dict({
+            'duration': 15,
+            'startTime': 'T23:30Z',
+          }),
+          'wednesday': dict({
+            'duration': 15,
+            'startTime': 'T23:30Z',
+          }),
+        }),
+        dict({
+          'activated': False,
+          'friday': None,
+          'id': 3,
+          'monday': None,
+          'saturday': None,
+          'sunday': None,
+          'thursday': None,
+          'tuesday': None,
+          'wednesday': None,
+        }),
+        dict({
+          'activated': False,
+          'friday': None,
+          'id': 4,
+          'monday': None,
+          'saturday': None,
+          'sunday': None,
+          'thursday': None,
+          'tuesday': None,
+          'wednesday': None,
+        }),
+        dict({
+          'activated': False,
+          'friday': None,
+          'id': 5,
+          'monday': None,
+          'saturday': None,
+          'sunday': None,
+          'thursday': None,
+          'tuesday': None,
+          'wednesday': None,
+        }),
+      ]),
       'startDateTime': None,
     }),
     'context': <ANY>,

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -2430,7 +2430,8 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': None,
+      'schedules': list([
+      ]),
       'start_date_time': None,
     }),
     'context': <ANY>,
@@ -3415,7 +3416,8 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': None,
+      'schedules': list([
+      ]),
       'start_date_time': '2025-12-29T10:20:30Z',
     }),
     'context': <ANY>,
@@ -4284,7 +4286,8 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': None,
+      'schedules': list([
+      ]),
       'start_date_time': None,
     }),
     'context': <ANY>,

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -5971,7 +5971,7 @@
         'delayed',
         'scheduled',
       ]),
-      'schedules': list([
+      'schedules': tuple(
         dict({
           'activated': True,
           'friday': dict({
@@ -6069,7 +6069,7 @@
           'tuesday': None,
           'wednesday': None,
         }),
-      ]),
+      ),
       'startDateTime': None,
     }),
     'context': <ANY>,

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -346,17 +346,17 @@
 # name: test_sensor_empty[zoe_40][sensor.reg_zoe_40_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'dateTime': None,
       'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-ZOE-40 Charging mode',
+      'last_update': None,
       'options': list([
         'always',
         'delayed',
         'scheduled',
       ]),
       'schedules': None,
-      'startDateTime': None,
+      'start_date_time': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_zoe_40_charging_mode',
@@ -2421,17 +2421,17 @@
 # name: test_sensors[captur_phev][sensor.reg_captur_phev_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'dateTime': None,
       'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-CAPTUR_PHEV Charging mode',
+      'last_update': None,
       'options': list([
         'always',
         'delayed',
         'scheduled',
       ]),
       'schedules': None,
-      'startDateTime': None,
+      'start_date_time': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_captur_phev_charging_mode',
@@ -3406,17 +3406,17 @@
 # name: test_sensors[megane_e_tech][sensor.reg_meg_0_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'dateTime': None,
       'delay': 300,
       'device_class': 'enum',
       'friendly_name': 'REG-MEG-0 Charging mode',
+      'last_update': None,
       'options': list([
         'always',
         'delayed',
         'scheduled',
       ]),
       'schedules': None,
-      'startDateTime': '2025-12-29T10:20:30Z',
+      'start_date_time': '2025-12-29T10:20:30Z',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_meg_0_charging_mode',
@@ -4275,17 +4275,17 @@
 # name: test_sensors[twingo_3_electric][sensor.reg_twingo_iii_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'dateTime': None,
       'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-TWINGO-III Charging mode',
+      'last_update': None,
       'options': list([
         'always',
         'delayed',
         'scheduled',
       ]),
       'schedules': None,
-      'startDateTime': None,
+      'start_date_time': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_twingo_iii_charging_mode',
@@ -5086,17 +5086,17 @@
 # name: test_sensors[zoe_40][sensor.reg_zoe_40_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'dateTime': None,
       'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-ZOE-40 Charging mode',
+      'last_update': None,
       'options': list([
         'always',
         'delayed',
         'scheduled',
       ]),
       'schedules': None,
-      'startDateTime': None,
+      'start_date_time': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_zoe_40_charging_mode',
@@ -5962,10 +5962,10 @@
 # name: test_sensors[zoe_50][sensor.reg_zoe_50_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'dateTime': None,
       'delay': None,
       'device_class': 'enum',
       'friendly_name': 'REG-ZOE-50 Charging mode',
+      'last_update': None,
       'options': list([
         'always',
         'delayed',
@@ -6070,7 +6070,7 @@
           'wednesday': None,
         }),
       ]),
-      'startDateTime': None,
+      'start_date_time': None,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.reg_zoe_50_charging_mode',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add extra state attributes for the Renault charging mode sensor showing the details of the active charging mode.

Notes for approver:
The dateTime attribute is left in because even is you make a separate sensor for it I deem it useful to have the attribute with the Charging mode sensor so you do not loose the latest value if the separate sensor is disabled. I see this as a disadvantage with the current timestamp sensors.

The extra curly brackets for the "schedules" attribute add an extra hyphen to the result and this is not correct.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44466
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
