### PR TITLE
Fix ProxmoxVE migration causing reauthentication

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -190,10 +190,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) ->
     if entry.version < 3:
         data = dict(entry.data)
         # If CONF_REALM wasn't there yet, extract from username
-        if CONF_REALM not in data and "@" in data.get(CONF_USERNAME, ""):
-            username, realm = data[CONF_USERNAME].split("@", 1)
-            data[CONF_USERNAME] = username
-            data[CONF_REALM] = realm.lower()
+        if CONF_REALM not in data:
+            data[CONF_REALM] = DEFAULT_REALM
+            if "@" in data.get(CONF_USERNAME, ""):
+                username, realm = data[CONF_USERNAME].split("@", 1)
+                data[CONF_USERNAME] = username
+                data[CONF_REALM] = realm.lower()
 
         realm = data[CONF_REALM].lower()
 

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -189,6 +189,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) ->
     # Migration for additional configuration options added to support API tokens
     if entry.version < 3:
         data = dict(entry.data)
+        # If CONF_REALM wasn't there yet, extract from username
+        if CONF_REALM not in data and "@" in data.get(CONF_USERNAME, ""):
+            username, realm = data[CONF_USERNAME].split("@", 1)
+            data[CONF_USERNAME] = username
+            data[CONF_REALM] = realm.lower()
+
         realm = data[CONF_REALM].lower()
 
         # If the realm is one of the base providers, set the provider to match the realm.

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -281,6 +281,33 @@ async def test_migration_v2_to_v3(
     assert entry.data[CONF_REALM] == AUTH_PAM
 
 
+async def test_migration_v2_to_v3_without_realm(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration from version 2 to 3."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        unique_id="1",
+        data={
+            CONF_HOST: "http://test_host",
+            CONF_PORT: 8006,
+            CONF_USERNAME: "test_user@pam",
+            CONF_PASSWORD: "test_password",
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert entry.version == 2
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 3
+    assert entry.data[CONF_AUTH_METHOD] == AUTH_PAM
+    assert entry.data[CONF_REALM] == AUTH_PAM
+
+
 async def test_new_vm_creates_entity(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Old realm (as part of the username) was not correctly migrating to the new auth method selector

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/167618
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
