### PR TITLE
Update template fan tests to use new framework

### DIFF
--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -67,14 +67,15 @@ def assert_action(
     calls: list[ServiceCall],
     expected_calls: int,
     expected_action: str,
+    index: int = -1,
     **kwargs,
 ) -> None:
     """Validate the action was properly called."""
     assert len(calls) == expected_calls
-    assert calls[-1].data["action"] == expected_action
-    assert calls[-1].data["caller"] == platform_setup.entity_id
+    assert calls[index].data["action"] == expected_action
+    assert calls[index].data["caller"] == platform_setup.entity_id
     for key, value in kwargs.items():
-        assert calls[-1].data[key] == value
+        assert calls[index].data[key] == value
 
 
 async def async_trigger(

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -20,86 +20,57 @@ from homeassistant.components.fan import (
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import entity_registry as er
-from homeassistant.setup import async_setup_component
+from homeassistant.helpers.typing import ConfigType
 
-from .conftest import ConfigurationStyle, async_get_flow_preview_state
+from .conftest import (
+    ConfigurationStyle,
+    TemplatePlatformSetup,
+    assert_action,
+    async_get_flow_preview_state,
+    async_trigger,
+    make_test_action,
+    make_test_trigger,
+    setup_and_test_nested_unique_id,
+    setup_and_test_unique_id,
+    setup_entity,
+)
 
-from tests.common import MockConfigEntry, assert_setup_component
+from tests.common import MockConfigEntry
 from tests.components.fan import common
 from tests.typing import WebSocketGenerator
 
-TEST_OBJECT_ID = "test_fan"
-TEST_ENTITY_ID = f"fan.{TEST_OBJECT_ID}"
+TEST_INPUT_BOOLEAN = "input_boolean.state"
+TEST_STATE_ENTITY_ID = "sensor.test_sensor"
+TEST_AVAILABILITY_ENTITY = "binary_sensor.availability"
 
-# Represent for fan's state
-_STATE_INPUT_BOOLEAN = "input_boolean.state"
-# Represent for fan's percent
-_STATE_TEST_SENSOR = "sensor.test_sensor"
-# Represent for fan's availability
-_STATE_AVAILABILITY_BOOLEAN = "availability_boolean.state"
+TEST_FAN = TemplatePlatformSetup(
+    fan.DOMAIN,
+    "fans",
+    "test_fan",
+    make_test_trigger(
+        TEST_INPUT_BOOLEAN, TEST_STATE_ENTITY_ID, TEST_AVAILABILITY_ENTITY
+    ),
+)
 
-TEST_STATE_TRIGGER = {
-    "trigger": {
-        "trigger": "state",
-        "entity_id": [
-            TEST_ENTITY_ID,
-            _STATE_INPUT_BOOLEAN,
-            _STATE_AVAILABILITY_BOOLEAN,
-            _STATE_TEST_SENSOR,
-        ],
-    },
-    "variables": {"triggering_entity": "{{ trigger.entity_id }}"},
-    "action": [
-        {"event": "action_event", "event_data": {"what": "{{ triggering_entity }}"}}
-    ],
-}
+ON_ACTION = make_test_action("turn_on")
+OFF_ACTION = make_test_action("turn_off")
 
 OPTIMISTIC_ON_OFF_ACTIONS = {
-    "turn_on": {
-        "service": "test.automation",
-        "data": {
-            "action": "turn_on",
-            "caller": "{{ this.entity_id }}",
-        },
-    },
-    "turn_off": {
-        "service": "test.automation",
-        "data": {
-            "action": "turn_off",
-            "caller": "{{ this.entity_id }}",
-        },
-    },
-}
-NAMED_ON_OFF_ACTIONS = {
-    **OPTIMISTIC_ON_OFF_ACTIONS,
-    "name": TEST_OBJECT_ID,
+    **ON_ACTION,
+    **OFF_ACTION,
 }
 
-PERCENTAGE_ACTION = {
-    "set_percentage": {
-        "action": "test.automation",
-        "data": {
-            "action": "set_percentage",
-            "percentage": "{{ percentage }}",
-            "caller": "{{ this.entity_id }}",
-        },
-    },
-}
+PERCENTAGE_ACTION = make_test_action(
+    "set_percentage", {"percentage": "{{ percentage }}"}
+)
 OPTIMISTIC_PERCENTAGE_CONFIG = {
     **OPTIMISTIC_ON_OFF_ACTIONS,
     **PERCENTAGE_ACTION,
 }
 
-PRESET_MODE_ACTION = {
-    "set_preset_mode": {
-        "action": "test.automation",
-        "data": {
-            "action": "set_preset_mode",
-            "preset_mode": "{{ preset_mode }}",
-            "caller": "{{ this.entity_id }}",
-        },
-    },
-}
+PRESET_MODE_ACTION = make_test_action(
+    "set_preset_mode", {"preset_mode": "{{ preset_mode }}"}
+)
 OPTIMISTIC_PRESET_MODE_CONFIG = {
     **OPTIMISTIC_ON_OFF_ACTIONS,
     **PRESET_MODE_ACTION,
@@ -109,38 +80,18 @@ OPTIMISTIC_PRESET_MODE_CONFIG2 = {
     "preset_modes": ["auto", "low", "medium", "high"],
 }
 
-OSCILLATE_ACTION = {
-    "set_oscillating": {
-        "action": "test.automation",
-        "data": {
-            "action": "set_oscillating",
-            "oscillating": "{{ oscillating }}",
-            "caller": "{{ this.entity_id }}",
-        },
-    },
-}
+OSCILLATE_ACTION = make_test_action(
+    "set_oscillating", {"oscillating": "{{ oscillating }}"}
+)
 OPTIMISTIC_OSCILLATE_CONFIG = {
     **OPTIMISTIC_ON_OFF_ACTIONS,
     **OSCILLATE_ACTION,
 }
 
-DIRECTION_ACTION = {
-    "set_direction": {
-        "action": "test.automation",
-        "data": {
-            "action": "set_direction",
-            "direction": "{{ direction }}",
-            "caller": "{{ this.entity_id }}",
-        },
-    },
-}
+DIRECTION_ACTION = make_test_action("set_direction", {"direction": "{{ direction }}"})
 OPTIMISTIC_DIRECTION_CONFIG = {
     **OPTIMISTIC_ON_OFF_ACTIONS,
     **DIRECTION_ACTION,
-}
-UNIQUE_ID_CONFIG = {
-    **OPTIMISTIC_ON_OFF_ACTIONS,
-    "unique_id": "not-so-unique-anymore",
 }
 
 
@@ -153,7 +104,7 @@ def _verify(
     expected_preset_mode: str | None = None,
 ) -> None:
     """Verify fan's state, speed and osc."""
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     attributes = state.attributes
     assert state.state == str(expected_state)
     assert attributes.get(ATTR_PERCENTAGE) == expected_percentage
@@ -162,94 +113,16 @@ def _verify(
     assert attributes.get(ATTR_PRESET_MODE) == expected_preset_mode
 
 
-async def async_setup_legacy_format(
-    hass: HomeAssistant, count: int, fan_config: dict[str, Any]
-) -> None:
-    """Do setup of fan integration via legacy format."""
-    config = {"fan": {"platform": "template", "fans": fan_config}}
-
-    with assert_setup_component(count, fan.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            fan.DOMAIN,
-            config,
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-
-async def async_setup_modern_format(
-    hass: HomeAssistant, count: int, fan_config: dict[str, Any]
-) -> None:
-    """Do setup of fan integration via modern format."""
-    config = {"template": {"fan": fan_config}}
-
-    with assert_setup_component(count, template.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            template.DOMAIN,
-            config,
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-
-async def async_setup_trigger_format(
-    hass: HomeAssistant, count: int, fan_config: dict[str, Any]
-) -> None:
-    """Do setup of fan integration via trigger format."""
-    config = {"template": {"fan": fan_config, **TEST_STATE_TRIGGER}}
-
-    with assert_setup_component(count, template.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            template.DOMAIN,
-            config,
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-
 @pytest.fixture
 async def setup_fan(
     hass: HomeAssistant,
     count: int,
     style: ConfigurationStyle,
-    fan_config: dict[str, Any],
+    config: ConfigType,
+    extra_config: ConfigType,
 ) -> None:
     """Do setup of fan integration."""
-    if style == ConfigurationStyle.LEGACY:
-        await async_setup_legacy_format(hass, count, fan_config)
-    elif style == ConfigurationStyle.MODERN:
-        await async_setup_modern_format(hass, count, fan_config)
-    elif style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(hass, count, fan_config)
-
-
-@pytest.fixture
-async def setup_named_fan(
-    hass: HomeAssistant,
-    count: int,
-    style: ConfigurationStyle,
-    fan_config: dict[str, Any],
-) -> None:
-    """Do setup of fan integration."""
-    if style == ConfigurationStyle.LEGACY:
-        await async_setup_legacy_format(hass, count, {TEST_OBJECT_ID: fan_config})
-    elif style == ConfigurationStyle.MODERN:
-        await async_setup_modern_format(
-            hass, count, {"name": TEST_OBJECT_ID, **fan_config}
-        )
-    elif style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(
-            hass, count, {"name": TEST_OBJECT_ID, **fan_config}
-        )
+    await setup_entity(hass, TEST_FAN, style, count, config, extra_config=extra_config)
 
 
 @pytest.fixture
@@ -258,60 +131,10 @@ async def setup_state_fan(
     count: int,
     style: ConfigurationStyle,
     state_template: str,
+    extra_config: ConfigType,
 ):
     """Do setup of fan integration using a state template."""
-    if style == ConfigurationStyle.LEGACY:
-        await async_setup_legacy_format(
-            hass,
-            count,
-            {
-                TEST_OBJECT_ID: {
-                    **OPTIMISTIC_ON_OFF_ACTIONS,
-                    "value_template": state_template,
-                }
-            },
-        )
-    elif style == ConfigurationStyle.MODERN:
-        await async_setup_modern_format(
-            hass,
-            count,
-            {
-                **NAMED_ON_OFF_ACTIONS,
-                "state": state_template,
-            },
-        )
-    elif style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(
-            hass,
-            count,
-            {
-                **NAMED_ON_OFF_ACTIONS,
-                "state": state_template,
-            },
-        )
-
-
-@pytest.fixture
-async def setup_test_fan_with_extra_config(
-    hass: HomeAssistant,
-    count: int,
-    style: ConfigurationStyle,
-    fan_config: dict[str, Any],
-    extra_config: dict[str, Any],
-) -> None:
-    """Do setup of fan integration."""
-    if style == ConfigurationStyle.LEGACY:
-        await async_setup_legacy_format(
-            hass, count, {TEST_OBJECT_ID: {**fan_config, **extra_config}}
-        )
-    elif style == ConfigurationStyle.MODERN:
-        await async_setup_modern_format(
-            hass, count, {"name": TEST_OBJECT_ID, **fan_config, **extra_config}
-        )
-    elif style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(
-            hass, count, {"name": TEST_OBJECT_ID, **fan_config, **extra_config}
-        )
+    await setup_entity(hass, TEST_FAN, style, count, extra_config, state_template)
 
 
 @pytest.fixture
@@ -322,37 +145,9 @@ async def setup_optimistic_fan_attribute(
     extra_config: dict,
 ) -> None:
     """Do setup of a non-optimistic fan with an optimistic attribute."""
-    if style == ConfigurationStyle.LEGACY:
-        await async_setup_legacy_format(
-            hass,
-            count,
-            {
-                TEST_OBJECT_ID: {
-                    **extra_config,
-                    "value_template": "{{ 1 == 1 }}",
-                }
-            },
-        )
-    elif style == ConfigurationStyle.MODERN:
-        await async_setup_modern_format(
-            hass,
-            count,
-            {
-                "name": TEST_OBJECT_ID,
-                **extra_config,
-                "state": "{{ 1 == 1 }}",
-            },
-        )
-    elif style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(
-            hass,
-            count,
-            {
-                "name": TEST_OBJECT_ID,
-                **extra_config,
-                "state": "{{ 1 == 1 }}",
-            },
-        )
+    await setup_entity(
+        hass, TEST_FAN, style, count, {}, "{{ 1==1 }}", extra_config=extra_config
+    )
 
 
 @pytest.fixture
@@ -366,45 +161,21 @@ async def setup_single_attribute_state_fan(
     extra_config: dict,
 ) -> None:
     """Do setup of fan integration testing a single attribute."""
-    extra = {attribute: attribute_template} if attribute and attribute_template else {}
-    if style == ConfigurationStyle.LEGACY:
-        await async_setup_legacy_format(
-            hass,
-            count,
-            {
-                TEST_OBJECT_ID: {
-                    **OPTIMISTIC_ON_OFF_ACTIONS,
-                    "value_template": state_template,
-                    **extra,
-                    **extra_config,
-                }
-            },
-        )
-    elif style == ConfigurationStyle.MODERN:
-        await async_setup_modern_format(
-            hass,
-            count,
-            {
-                **NAMED_ON_OFF_ACTIONS,
-                "state": state_template,
-                **extra,
-                **extra_config,
-            },
-        )
-    elif style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(
-            hass,
-            count,
-            {
-                **NAMED_ON_OFF_ACTIONS,
-                "state": state_template,
-                **extra,
-                **extra_config,
-            },
-        )
+    await setup_entity(
+        hass,
+        TEST_FAN,
+        style,
+        count,
+        {attribute: attribute_template} if attribute and attribute_template else {},
+        state_template,
+        {**OPTIMISTIC_ON_OFF_ACTIONS, **extra_config},
+    )
 
 
-@pytest.mark.parametrize(("count", "state_template"), [(1, "{{ 'on' }}")])
+@pytest.mark.parametrize(
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", OPTIMISTIC_ON_OFF_ACTIONS)],
+)
 @pytest.mark.parametrize(
     "style",
     [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
@@ -412,6 +183,7 @@ async def setup_single_attribute_state_fan(
 @pytest.mark.usefixtures("setup_state_fan")
 async def test_missing_optional_config(hass: HomeAssistant) -> None:
     """Test: missing optional template is ok."""
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
     _verify(hass, STATE_ON, None, None, None, None)
 
 
@@ -421,26 +193,18 @@ async def test_missing_optional_config(hass: HomeAssistant) -> None:
     [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
 @pytest.mark.parametrize(
-    "fan_config",
-    [
-        {
-            "value_template": "{{ 'on' }}",
-            "turn_off": {"service": "script.fan_off"},
-        },
-        {
-            "value_template": "{{ 'on' }}",
-            "turn_on": {"service": "script.fan_on"},
-        },
-    ],
+    "extra_config",
+    [OFF_ACTION, ON_ACTION],
 )
-@pytest.mark.usefixtures("setup_fan")
+@pytest.mark.usefixtures("setup_optimistic_fan_attribute")
 async def test_wrong_template_config(hass: HomeAssistant) -> None:
     """Test: missing 'turn_on' or 'turn_off' will fail."""
     assert hass.states.async_all("fan") == []
 
 
 @pytest.mark.parametrize(
-    ("count", "state_template"), [(1, "{{ is_state('input_boolean.state', 'on') }}")]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ is_state('input_boolean.state', 'on') }}", OPTIMISTIC_ON_OFF_ACTIONS)],
 )
 @pytest.mark.parametrize(
     "style",
@@ -449,20 +213,17 @@ async def test_wrong_template_config(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_state_fan")
 async def test_state_template(hass: HomeAssistant) -> None:
     """Test state template."""
+    await async_trigger(hass, TEST_INPUT_BOOLEAN, STATE_OFF)
     _verify(hass, STATE_OFF, None, None, None, None)
 
-    hass.states.async_set(_STATE_INPUT_BOOLEAN, STATE_ON)
-    await hass.async_block_till_done()
-
+    await async_trigger(hass, TEST_INPUT_BOOLEAN, STATE_ON)
     _verify(hass, STATE_ON, None, None, None, None)
 
-    hass.states.async_set(_STATE_INPUT_BOOLEAN, STATE_OFF)
-    await hass.async_block_till_done()
-
+    await async_trigger(hass, TEST_INPUT_BOOLEAN, STATE_OFF)
     _verify(hass, STATE_OFF, None, None, None, None)
 
 
-@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(("count", "extra_config"), [(1, OPTIMISTIC_ON_OFF_ACTIONS)])
 @pytest.mark.parametrize(
     ("state_template", "expected"),
     [
@@ -489,6 +250,7 @@ async def test_state_template(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_state_fan")
 async def test_state_template_states(hass: HomeAssistant, expected: str) -> None:
     """Test state template."""
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
     _verify(hass, expected, None, None, None, None)
 
 
@@ -511,13 +273,14 @@ async def test_state_template_states(hass: HomeAssistant, expected: str) -> None
 @pytest.mark.usefixtures("setup_single_attribute_state_fan")
 async def test_picture_template(hass: HomeAssistant) -> None:
     """Test picture template."""
-    state = hass.states.get(TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.attributes.get("entity_picture") == ""
 
-    hass.states.async_set(_STATE_TEST_SENSOR, STATE_ON)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, STATE_ON)
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.attributes["entity_picture"] == "/local/switch.png"
 
 
@@ -540,13 +303,14 @@ async def test_picture_template(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_single_attribute_state_fan")
 async def test_icon_template(hass: HomeAssistant) -> None:
     """Test icon template."""
-    state = hass.states.get(TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.attributes.get("icon") == ""
 
-    hass.states.async_set(_STATE_INPUT_BOOLEAN, STATE_ON)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_INPUT_BOOLEAN, STATE_ON)
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.attributes["icon"] == "mdi:eye"
 
 
@@ -581,11 +345,10 @@ async def test_icon_template(hass: HomeAssistant) -> None:
 )
 @pytest.mark.usefixtures("setup_single_attribute_state_fan")
 async def test_percentage_template(
-    hass: HomeAssistant, percent: str, expected: int, calls: list[ServiceCall]
+    hass: HomeAssistant, percent: str, expected: int
 ) -> None:
     """Test templates with fan percentages from other entities."""
-    hass.states.async_set(_STATE_TEST_SENSOR, percent)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, percent)
     _verify(hass, STATE_ON, expected, None, None, None)
 
 
@@ -622,8 +385,7 @@ async def test_preset_mode_template(
     hass: HomeAssistant, preset_mode: str, expected: int
 ) -> None:
     """Test preset_mode template."""
-    hass.states.async_set(_STATE_TEST_SENSOR, preset_mode)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, preset_mode)
     _verify(hass, STATE_ON, None, None, None, expected)
 
 
@@ -658,8 +420,7 @@ async def test_oscillating_template(
     hass: HomeAssistant, oscillating: str, expected: bool | None
 ) -> None:
     """Test oscillating template."""
-    hass.states.async_set(_STATE_TEST_SENSOR, oscillating)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, oscillating)
     _verify(hass, STATE_ON, None, expected, None, None)
 
 
@@ -694,20 +455,19 @@ async def test_direction_template(
     hass: HomeAssistant, direction: str, expected: bool | None
 ) -> None:
     """Test direction template."""
-    hass.states.async_set(_STATE_TEST_SENSOR, direction)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, direction)
     _verify(hass, STATE_ON, None, None, expected, None)
 
 
-@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(("count", "extra_config"), [(1, {})])
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
+    ("style", "config"),
     [
         (
             ConfigurationStyle.LEGACY,
             {
                 "availability_template": (
-                    "{{ is_state('availability_boolean.state', 'on') }}"
+                    "{{ is_state('binary_sensor.availability', 'on') }}"
                 ),
                 "value_template": "{{ 'on' }}",
                 "oscillating_template": "{{ 1 == 1 }}",
@@ -719,7 +479,7 @@ async def test_direction_template(
         (
             ConfigurationStyle.MODERN,
             {
-                "availability": ("{{ is_state('availability_boolean.state', 'on') }}"),
+                "availability": ("{{ is_state('binary_sensor.availability', 'on') }}"),
                 "state": "{{ 'on' }}",
                 "oscillating": "{{ 1 == 1 }}",
                 "direction": "{{ 'forward' }}",
@@ -730,7 +490,7 @@ async def test_direction_template(
         (
             ConfigurationStyle.TRIGGER,
             {
-                "availability": ("{{ is_state('availability_boolean.state', 'on') }}"),
+                "availability": ("{{ is_state('binary_sensor.availability', 'on') }}"),
                 "state": "{{ 'on' }}",
                 "oscillating": "{{ 1 == 1 }}",
                 "direction": "{{ 'forward' }}",
@@ -740,20 +500,19 @@ async def test_direction_template(
         ),
     ],
 )
-@pytest.mark.usefixtures("setup_named_fan")
+@pytest.mark.usefixtures("setup_fan")
 async def test_availability_template_with_entities(hass: HomeAssistant) -> None:
     """Test availability tempalates with values from other entities."""
     for state, test_assert in ((STATE_ON, True), (STATE_OFF, False)):
-        hass.states.async_set(_STATE_AVAILABILITY_BOOLEAN, state)
-        await hass.async_block_till_done()
+        await async_trigger(hass, TEST_AVAILABILITY_ENTITY, state)
         assert (
-            hass.states.get(TEST_ENTITY_ID).state != STATE_UNAVAILABLE
+            hass.states.get(TEST_FAN.entity_id).state != STATE_UNAVAILABLE
         ) == test_assert
 
 
-@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(("count", "extra_config"), [(1, {})])
 @pytest.mark.parametrize(
-    ("style", "fan_config", "states"),
+    ("style", "config", "states"),
     [
         (
             ConfigurationStyle.LEGACY,
@@ -898,15 +657,16 @@ async def test_availability_template_with_entities(hass: HomeAssistant) -> None:
         ),
     ],
 )
-@pytest.mark.usefixtures("setup_named_fan")
+@pytest.mark.usefixtures("setup_fan")
 async def test_template_with_unavailable_entities(hass: HomeAssistant, states) -> None:
     """Test unavailability with value_template."""
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
     _verify(hass, states[0], states[1], states[2], states[3], None)
 
 
-@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(("count", "extra_config"), [(1, {})])
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
+    ("style", "config"),
     [
         (
             ConfigurationStyle.LEGACY,
@@ -946,50 +706,35 @@ async def test_template_with_unavailable_entities(hass: HomeAssistant, states) -
         ),
     ],
 )
-@pytest.mark.usefixtures("setup_named_fan")
+@pytest.mark.usefixtures("setup_fan")
 async def test_invalid_availability_template_keeps_component_available(
     hass: HomeAssistant, caplog_setup_text, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that an invalid availability keeps the device available."""
     # Ensure trigger entities update.
-    hass.states.async_set(_STATE_INPUT_BOOLEAN, STATE_ON)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_INPUT_BOOLEAN, STATE_ON)
 
-    assert hass.states.get(TEST_ENTITY_ID).state != STATE_UNAVAILABLE
+    assert hass.states.get(TEST_FAN.entity_id).state != STATE_UNAVAILABLE
 
     err = "'x' is undefined"
     assert err in caplog_setup_text or err in caplog.text
 
 
-@pytest.mark.parametrize(("count", "extra_config"), [(1, OPTIMISTIC_ON_OFF_ACTIONS)])
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'off' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'off' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'off' }}",
-            },
-        ),
-    ],
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'off' }}", OPTIMISTIC_ON_OFF_ACTIONS)],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_on_off(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test turn on and turn off."""
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.state == STATE_OFF
 
     for expected_calls, (func, action) in enumerate(
@@ -998,15 +743,13 @@ async def test_on_off(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
             (common.async_turn_off, "turn_off"),
         ]
     ):
-        await func(hass, TEST_ENTITY_ID)
+        await func(hass, TEST_FAN.entity_id)
 
-        assert len(calls) == expected_calls + 1
-        assert calls[-1].data["action"] == action
-        assert calls[-1].data["caller"] == TEST_ENTITY_ID
+        assert_action(TEST_FAN, calls, expected_calls + 1, action)
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"),
+    ("count", "extra_config", "state_template"),
     [
         (
             1,
@@ -1015,380 +758,236 @@ async def test_on_off(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
                 **OPTIMISTIC_PRESET_MODE_CONFIG2,
                 **OPTIMISTIC_PERCENTAGE_CONFIG,
             },
+            "{{ 'off' }}",
         )
     ],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'off' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'off' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'off' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_on_with_extra_attributes(
     hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test turn on and turn off."""
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.state == STATE_OFF
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID, 100)
+    await common.async_turn_on(hass, TEST_FAN.entity_id, 100)
 
-    assert len(calls) == 2
-    assert calls[-2].data["action"] == "turn_on"
-    assert calls[-2].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 2, "turn_on", index=-2)
+    assert_action(TEST_FAN, calls, 2, "set_percentage", percentage=100)
 
-    assert calls[-1].data["action"] == "set_percentage"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
-    assert calls[-1].data["percentage"] == 100
+    await common.async_turn_off(hass, TEST_FAN.entity_id)
 
-    await common.async_turn_off(hass, TEST_ENTITY_ID)
+    assert_action(TEST_FAN, calls, 3, "turn_off")
 
-    assert len(calls) == 3
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    await common.async_turn_on(hass, TEST_FAN.entity_id, None, "auto")
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID, None, "auto")
+    assert_action(TEST_FAN, calls, 5, "turn_on", index=-2)
+    assert_action(TEST_FAN, calls, 5, "set_preset_mode", preset_mode="auto")
 
-    assert len(calls) == 5
-    assert calls[-2].data["action"] == "turn_on"
-    assert calls[-2].data["caller"] == TEST_ENTITY_ID
+    await common.async_turn_off(hass, TEST_FAN.entity_id)
 
-    assert calls[-1].data["action"] == "set_preset_mode"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
-    assert calls[-1].data["preset_mode"] == "auto"
+    assert_action(TEST_FAN, calls, 6, "turn_off")
 
-    await common.async_turn_off(hass, TEST_ENTITY_ID)
+    await common.async_turn_on(hass, TEST_FAN.entity_id, 50, "high")
 
-    assert len(calls) == 6
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 9, "turn_on", index=-3)
+    assert_action(TEST_FAN, calls, 9, "set_preset_mode", index=-2, preset_mode="high")
+    assert_action(TEST_FAN, calls, 9, "set_percentage", percentage=50)
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID, 50, "high")
+    await common.async_turn_off(hass, TEST_FAN.entity_id)
 
-    assert len(calls) == 9
-    assert calls[-3].data["action"] == "turn_on"
-    assert calls[-3].data["caller"] == TEST_ENTITY_ID
-
-    assert calls[-2].data["action"] == "set_preset_mode"
-    assert calls[-2].data["caller"] == TEST_ENTITY_ID
-    assert calls[-2].data["preset_mode"] == "high"
-
-    assert calls[-1].data["action"] == "set_percentage"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
-    assert calls[-1].data["percentage"] == 50
-
-    await common.async_turn_off(hass, TEST_ENTITY_ID)
-
-    assert len(calls) == 10
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 10, "turn_off")
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, {**OPTIMISTIC_ON_OFF_ACTIONS, **DIRECTION_ACTION})]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", {**OPTIMISTIC_ON_OFF_ACTIONS, **DIRECTION_ACTION})],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_set_invalid_direction_from_initial_stage(hass: HomeAssistant) -> None:
     """Test set invalid direction when fan is in initial state."""
-    await common.async_set_direction(hass, TEST_ENTITY_ID, "invalid")
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    await common.async_set_direction(hass, TEST_FAN.entity_id, "invalid")
     _verify(hass, STATE_ON, None, None, None, None)
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, {**OPTIMISTIC_ON_OFF_ACTIONS, **OSCILLATE_ACTION})]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", {**OPTIMISTIC_ON_OFF_ACTIONS, **OSCILLATE_ACTION})],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_set_osc(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set oscillating."""
     expected_calls = 0
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
     expected_calls += 1
     for state in (True, False):
-        await common.async_oscillate(hass, TEST_ENTITY_ID, state)
+        await common.async_oscillate(hass, TEST_FAN.entity_id, state)
         _verify(hass, STATE_ON, None, state, None, None)
         expected_calls += 1
-        assert len(calls) == expected_calls
-        assert calls[-1].data["action"] == "set_oscillating"
-        assert calls[-1].data["caller"] == TEST_ENTITY_ID
-        assert calls[-1].data["oscillating"] == state
+        assert_action(
+            TEST_FAN, calls, expected_calls, "set_oscillating", oscillating=state
+        )
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, {**OPTIMISTIC_ON_OFF_ACTIONS, **DIRECTION_ACTION})]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", {**OPTIMISTIC_ON_OFF_ACTIONS, **DIRECTION_ACTION})],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_set_direction(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set valid direction."""
     expected_calls = 0
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
     expected_calls += 1
     for direction in (DIRECTION_FORWARD, DIRECTION_REVERSE):
-        await common.async_set_direction(hass, TEST_ENTITY_ID, direction)
+        await common.async_set_direction(hass, TEST_FAN.entity_id, direction)
         _verify(hass, STATE_ON, None, None, direction, None)
         expected_calls += 1
-        assert len(calls) == expected_calls
-        assert calls[-1].data["action"] == "set_direction"
-        assert calls[-1].data["caller"] == TEST_ENTITY_ID
-        assert calls[-1].data["direction"] == direction
+        assert_action(
+            TEST_FAN, calls, expected_calls, "set_direction", direction=direction
+        )
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, {**OPTIMISTIC_ON_OFF_ACTIONS, **DIRECTION_ACTION})]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", {**OPTIMISTIC_ON_OFF_ACTIONS, **DIRECTION_ACTION})],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_set_invalid_direction(
     hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test set invalid direction when fan has valid direction."""
+
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
     expected_calls = 1
     for direction in (DIRECTION_FORWARD, "invalid"):
-        await common.async_set_direction(hass, TEST_ENTITY_ID, direction)
+        await common.async_set_direction(hass, TEST_FAN.entity_id, direction)
         _verify(hass, STATE_ON, None, None, DIRECTION_FORWARD, None)
-        assert len(calls) == expected_calls
-        assert calls[-1].data["action"] == "set_direction"
-        assert calls[-1].data["caller"] == TEST_ENTITY_ID
-        assert calls[-1].data["direction"] == DIRECTION_FORWARD
+        assert_action(
+            TEST_FAN,
+            calls,
+            expected_calls,
+            "set_direction",
+            direction=DIRECTION_FORWARD,
+        )
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, OPTIMISTIC_PRESET_MODE_CONFIG2)]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", OPTIMISTIC_PRESET_MODE_CONFIG2)],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_preset_modes(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test preset_modes."""
-    expected_calls = 0
-    valid_modes = OPTIMISTIC_PRESET_MODE_CONFIG2["preset_modes"]
-    for mode in ("auto", "low", "medium", "high", "invalid", "smart"):
-        if mode not in valid_modes:
-            with pytest.raises(NotValidPresetModeError):
-                await common.async_set_preset_mode(hass, TEST_ENTITY_ID, mode)
-        else:
-            await common.async_set_preset_mode(hass, TEST_ENTITY_ID, mode)
-            expected_calls += 1
-
-            assert len(calls) == expected_calls
-            assert calls[-1].data["action"] == "set_preset_mode"
-            assert calls[-1].data["caller"] == TEST_ENTITY_ID
-            assert calls[-1].data["preset_mode"] == mode
+    for cnt, mode in enumerate(("auto", "low", "medium", "high")):
+        await common.async_set_preset_mode(hass, TEST_FAN.entity_id, mode)
+        assert_action(TEST_FAN, calls, cnt + 1, "set_preset_mode", preset_mode=mode)
 
 
-@pytest.mark.parametrize(("count", "extra_config"), [(1, OPTIMISTIC_PERCENTAGE_CONFIG)])
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", OPTIMISTIC_PRESET_MODE_CONFIG2)],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_state_fan")
+async def test_invalid_preset_modes(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test invalid preset_modes."""
+    for mode in ("invalid", "smart"):
+        with pytest.raises(NotValidPresetModeError):
+            await common.async_set_preset_mode(hass, TEST_FAN.entity_id, mode)
+
+
+@pytest.mark.parametrize(
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", OPTIMISTIC_PERCENTAGE_CONFIG)],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_set_percentage(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set valid speed percentage."""
     expected_calls = 0
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
     expected_calls += 1
     for state, value in (
         (STATE_ON, 100),
         (STATE_ON, 66),
         (STATE_ON, 0),
     ):
-        await common.async_set_percentage(hass, TEST_ENTITY_ID, value)
+        await common.async_set_percentage(hass, TEST_FAN.entity_id, value)
         _verify(hass, state, value, None, None, None)
         expected_calls += 1
-        assert len(calls) == expected_calls
-        assert calls[-1].data["action"] == "set_percentage"
-        assert calls[-1].data["caller"] == TEST_ENTITY_ID
-        assert calls[-1].data["percentage"] == value
+        assert_action(
+            TEST_FAN, calls, expected_calls, "set_percentage", percentage=value
+        )
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID, percentage=50)
+    await common.async_turn_on(hass, TEST_FAN.entity_id, percentage=50)
     _verify(hass, STATE_ON, 50, None, None, None)
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, {"speed_count": 3, **OPTIMISTIC_PERCENTAGE_CONFIG})]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", {"speed_count": 3, **OPTIMISTIC_PERCENTAGE_CONFIG})],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_increase_decrease_speed(
     hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test set valid increase and decrease speed."""
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
     for func, extra, state, value in (
         (common.async_set_percentage, 100, STATE_ON, 100),
         (common.async_decrease_speed, None, STATE_ON, 66),
@@ -1396,12 +995,12 @@ async def test_increase_decrease_speed(
         (common.async_decrease_speed, None, STATE_ON, 0),
         (common.async_increase_speed, None, STATE_ON, 33),
     ):
-        await func(hass, TEST_ENTITY_ID, extra)
+        await func(hass, TEST_FAN.entity_id, extra)
         _verify(hass, state, value, None, None, None)
 
 
 @pytest.mark.parametrize(
-    ("count", "fan_config"),
+    ("count", "config", "extra_config"),
     [
         (
             1,
@@ -1413,6 +1012,7 @@ async def test_increase_decrease_speed(
                 **OSCILLATE_ACTION,
                 **DIRECTION_ACTION,
             },
+            {},
         )
     ],
 )
@@ -1420,71 +1020,51 @@ async def test_increase_decrease_speed(
     "style",
     [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_named_fan")
+@pytest.mark.usefixtures("setup_fan")
 async def test_optimistic_state(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test a fan without a value_template."""
 
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
     _verify(hass, STATE_ON)
 
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "turn_on"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 1, "turn_on")
 
-    await common.async_turn_off(hass, TEST_ENTITY_ID)
+    await common.async_turn_off(hass, TEST_FAN.entity_id)
     _verify(hass, STATE_OFF)
 
-    assert len(calls) == 2
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 2, "turn_off")
 
     percent = 100
-    await common.async_set_percentage(hass, TEST_ENTITY_ID, percent)
+    await common.async_set_percentage(hass, TEST_FAN.entity_id, percent)
     _verify(hass, STATE_ON, percent)
 
-    assert len(calls) == 3
-    assert calls[-1].data["action"] == "set_percentage"
-    assert calls[-1].data["percentage"] == 100
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 3, "set_percentage", percentage=percent)
 
-    await common.async_turn_off(hass, TEST_ENTITY_ID)
+    await common.async_turn_off(hass, TEST_FAN.entity_id)
     _verify(hass, STATE_OFF, percent)
 
-    assert len(calls) == 4
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 4, "turn_off")
 
     preset = "auto"
-    await common.async_set_preset_mode(hass, TEST_ENTITY_ID, preset)
+    await common.async_set_preset_mode(hass, TEST_FAN.entity_id, preset)
     _verify(hass, STATE_ON, percent, None, None, preset)
 
-    assert len(calls) == 5
-    assert calls[-1].data["action"] == "set_preset_mode"
-    assert calls[-1].data["preset_mode"] == preset
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 5, "set_preset_mode", preset_mode=preset)
 
-    await common.async_turn_off(hass, TEST_ENTITY_ID)
+    await common.async_turn_off(hass, TEST_FAN.entity_id)
     _verify(hass, STATE_OFF, percent, None, None, preset)
 
-    assert len(calls) == 6
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 6, "turn_off")
 
-    await common.async_set_direction(hass, TEST_ENTITY_ID, DIRECTION_FORWARD)
+    await common.async_set_direction(hass, TEST_FAN.entity_id, DIRECTION_FORWARD)
     _verify(hass, STATE_OFF, percent, None, DIRECTION_FORWARD, preset)
 
-    assert len(calls) == 7
-    assert calls[-1].data["action"] == "set_direction"
-    assert calls[-1].data["direction"] == DIRECTION_FORWARD
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 7, "set_direction", direction=DIRECTION_FORWARD)
 
-    await common.async_oscillate(hass, TEST_ENTITY_ID, True)
+    await common.async_oscillate(hass, TEST_FAN.entity_id, True)
     _verify(hass, STATE_OFF, percent, True, DIRECTION_FORWARD, preset)
 
-    assert len(calls) == 8
-    assert calls[-1].data["action"] == "set_oscillating"
-    assert calls[-1].data["oscillating"] is True
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 8, "set_oscillating", oscillating=True)
 
 
 @pytest.mark.parametrize("count", [1])
@@ -1541,45 +1121,29 @@ async def test_optimistic_attributes(
 ) -> None:
     """Test setting percentage with optimistic template."""
 
-    await coro(hass, TEST_ENTITY_ID, value)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+
+    await coro(hass, TEST_FAN.entity_id, value)
     _verify(hass, STATE_ON, **{verify_attr: value})
 
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == action
-    assert calls[-1].data[attribute] == value
-    assert calls[-1].data["caller"] == TEST_ENTITY_ID
+    assert_action(TEST_FAN, calls, 1, action, **{attribute: value})
 
 
-@pytest.mark.parametrize(("count", "extra_config"), [(1, OPTIMISTIC_PERCENTAGE_CONFIG)])
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", OPTIMISTIC_PERCENTAGE_CONFIG)],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_increase_decrease_speed_default_speed_count(
     hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test set valid increase and decrease speed."""
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
     for func, extra, state, value in (
         (common.async_set_percentage, 100, STATE_ON, 100),
         (common.async_decrease_speed, None, STATE_ON, 99),
@@ -1587,131 +1151,80 @@ async def test_increase_decrease_speed_default_speed_count(
         (common.async_decrease_speed, 31, STATE_ON, 67),
         (common.async_decrease_speed, None, STATE_ON, 66),
     ):
-        await func(hass, TEST_ENTITY_ID, extra)
+        await func(hass, TEST_FAN.entity_id, extra)
         _verify(hass, state, value, None, None, None)
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, {**OPTIMISTIC_ON_OFF_ACTIONS, **OSCILLATE_ACTION})]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", {**OPTIMISTIC_ON_OFF_ACTIONS, **OSCILLATE_ACTION})],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_set_invalid_osc_from_initial_state(
     hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test set invalid oscillating when fan is in initial state."""
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
     with pytest.raises(vol.Invalid):
-        await common.async_oscillate(hass, TEST_ENTITY_ID, "invalid")
+        await common.async_oscillate(hass, TEST_FAN.entity_id, "invalid")
     _verify(hass, STATE_ON, None, None, None, None)
 
 
 @pytest.mark.parametrize(
-    ("count", "extra_config"), [(1, {**OPTIMISTIC_ON_OFF_ACTIONS, **OSCILLATE_ACTION})]
+    ("count", "state_template", "extra_config"),
+    [(1, "{{ 'on' }}", {**OPTIMISTIC_ON_OFF_ACTIONS, **OSCILLATE_ACTION})],
 )
 @pytest.mark.parametrize(
-    ("style", "fan_config"),
-    [
-        (
-            ConfigurationStyle.LEGACY,
-            {
-                "value_template": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.MODERN,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-        (
-            ConfigurationStyle.TRIGGER,
-            {
-                "state": "{{ 'on' }}",
-            },
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_state_fan")
 async def test_set_invalid_osc(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set invalid oscillating when fan has valid osc."""
-    await common.async_turn_on(hass, TEST_ENTITY_ID)
-    await common.async_oscillate(hass, TEST_ENTITY_ID, True)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "anything")
+    await common.async_turn_on(hass, TEST_FAN.entity_id)
+    await common.async_oscillate(hass, TEST_FAN.entity_id, True)
     _verify(hass, STATE_ON, None, True, None, None)
 
-    await common.async_oscillate(hass, TEST_ENTITY_ID, False)
+    await common.async_oscillate(hass, TEST_FAN.entity_id, False)
     _verify(hass, STATE_ON, None, False, None, None)
 
     with pytest.raises(vol.Invalid):
-        await common.async_oscillate(hass, TEST_ENTITY_ID, None)
+        await common.async_oscillate(hass, TEST_FAN.entity_id, None)
     _verify(hass, STATE_ON, None, False, None, None)
 
 
-@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize("config", [OPTIMISTIC_ON_OFF_ACTIONS])
 @pytest.mark.parametrize(
-    ("fan_config", "style"),
-    [
-        (
-            {
-                "test_template_fan_01": UNIQUE_ID_CONFIG,
-                "test_template_fan_02": UNIQUE_ID_CONFIG,
-            },
-            ConfigurationStyle.LEGACY,
-        ),
-        (
-            [
-                {
-                    "name": "test_template_fan_01",
-                    **UNIQUE_ID_CONFIG,
-                },
-                {
-                    "name": "test_template_fan_02",
-                    **UNIQUE_ID_CONFIG,
-                },
-            ],
-            ConfigurationStyle.MODERN,
-        ),
-        (
-            [
-                {
-                    "name": "test_template_fan_01",
-                    **UNIQUE_ID_CONFIG,
-                },
-                {
-                    "name": "test_template_fan_02",
-                    **UNIQUE_ID_CONFIG,
-                },
-            ],
-            ConfigurationStyle.TRIGGER,
-        ),
-    ],
+    "style",
+    [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_fan")
-async def test_unique_id(hass: HomeAssistant) -> None:
+async def test_unique_id(
+    hass: HomeAssistant, style: ConfigurationStyle, config: ConfigType
+) -> None:
     """Test unique_id option only creates one fan per id."""
-    assert len(hass.states.async_all()) == 1
+    await setup_and_test_unique_id(hass, TEST_FAN, style, config)
+
+
+@pytest.mark.parametrize("config", [OPTIMISTIC_ON_OFF_ACTIONS])
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+async def test_nested_unique_id(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    config: ConfigType,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a template unique_id propagates to fan unique_ids."""
+    await setup_and_test_nested_unique_id(
+        hass, TEST_FAN, style, entity_registry, config
+    )
 
 
 @pytest.mark.parametrize(
@@ -1723,40 +1236,41 @@ async def test_unique_id(hass: HomeAssistant) -> None:
     [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
 @pytest.mark.parametrize(
-    ("fan_config", "percentage_step"),
+    ("config", "percentage_step"),
     [({"speed_count": 0}, 1), ({"speed_count": 100}, 1), ({"speed_count": 3}, 100 / 3)],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_fan")
 async def test_speed_percentage_step(hass: HomeAssistant, percentage_step) -> None:
     """Test a fan that implements percentage."""
     assert len(hass.states.async_all()) == 1
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     attributes = state.attributes
     assert attributes["percentage_step"] == percentage_step
     assert attributes.get("supported_features") & FanEntityFeature.SET_SPEED
 
 
 @pytest.mark.parametrize(
-    ("count", "fan_config"),
-    [(1, {**OPTIMISTIC_ON_OFF_ACTIONS, **OPTIMISTIC_PRESET_MODE_CONFIG2})],
+    ("count", "config", "extra_config"),
+    [(1, OPTIMISTIC_ON_OFF_ACTIONS, OPTIMISTIC_PRESET_MODE_CONFIG2)],
 )
 @pytest.mark.parametrize(
     "style",
     [ConfigurationStyle.LEGACY, ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
-@pytest.mark.usefixtures("setup_named_fan")
+@pytest.mark.usefixtures("setup_fan")
 async def test_preset_mode_supported_features(hass: HomeAssistant) -> None:
     """Test a fan that implements preset_mode."""
     assert len(hass.states.async_all()) == 1
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     attributes = state.attributes
     assert attributes.get("supported_features") & FanEntityFeature.PRESET_MODE
 
 
 @pytest.mark.parametrize(
-    ("count", "fan_config"), [(1, {"turn_on": [], "turn_off": []})]
+    ("count", "config"),
+    [(1, {"turn_on": [], "turn_off": []})],
 )
 @pytest.mark.parametrize(
     "style",
@@ -1791,74 +1305,30 @@ async def test_preset_mode_supported_features(hass: HomeAssistant) -> None:
         ),
     ],
 )
-@pytest.mark.usefixtures("setup_test_fan_with_extra_config")
+@pytest.mark.usefixtures("setup_fan")
 async def test_empty_action_config(
     hass: HomeAssistant,
     supported_features: FanEntityFeature,
 ) -> None:
     """Test configuration with empty script."""
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.attributes["supported_features"] == (
         FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON | supported_features
     )
 
 
-async def test_nested_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test a template unique_id propagates to switch unique_ids."""
-    with assert_setup_component(1, template.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            template.DOMAIN,
-            {
-                "template": {
-                    "unique_id": "x",
-                    "fan": [
-                        {
-                            **OPTIMISTIC_ON_OFF_ACTIONS,
-                            "name": "test_a",
-                            "unique_id": "a",
-                            "state": "{{ true }}",
-                        },
-                        {
-                            **OPTIMISTIC_ON_OFF_ACTIONS,
-                            "name": "test_b",
-                            "unique_id": "b",
-                            "state": "{{ true }}",
-                        },
-                    ],
-                },
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all("fan")) == 2
-
-    entry = entity_registry.async_get("fan.test_a")
-    assert entry
-    assert entry.unique_id == "x-a"
-
-    entry = entity_registry.async_get("fan.test_b")
-    assert entry
-    assert entry.unique_id == "x-b"
-
-
 @pytest.mark.parametrize(
-    ("count", "fan_config"),
+    ("count", "config", "extra_config"),
     [
         (
             1,
             {
-                "name": TEST_OBJECT_ID,
                 "state": "{{ is_state('sensor.test_sensor', 'on') }}",
                 "turn_on": [],
                 "turn_off": [],
                 "optimistic": True,
             },
+            {},
         )
     ],
 )
@@ -1869,44 +1339,42 @@ async def test_nested_unique_id(
 @pytest.mark.usefixtures("setup_fan")
 async def test_optimistic_option(hass: HomeAssistant) -> None:
     """Test optimistic yaml option."""
-    hass.states.async_set(_STATE_TEST_SENSOR, STATE_OFF)
-    await hass.async_block_till_done()
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, STATE_OFF)
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.state == STATE_OFF
 
     await hass.services.async_call(
         fan.DOMAIN,
         "turn_on",
-        {"entity_id": TEST_ENTITY_ID},
+        {"entity_id": TEST_FAN.entity_id},
         blocking=True,
     )
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.state == STATE_ON
 
-    hass.states.async_set(_STATE_TEST_SENSOR, STATE_ON)
-    await hass.async_block_till_done()
+    # The double trigger is needed because the state machine
+    # suppresses 'off' -> 'off' state changes for TEST_STATE_ENTITY_ID
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, STATE_ON)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, STATE_OFF)
 
-    hass.states.async_set(_STATE_TEST_SENSOR, STATE_OFF)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.state == STATE_OFF
 
 
 @pytest.mark.parametrize(
-    ("count", "fan_config"),
+    ("count", "config", "extra_config"),
     [
         (
             1,
             {
-                "name": TEST_OBJECT_ID,
                 "state": "{{ is_state('sensor.test_sensor', 'on') }}",
                 "turn_on": [],
                 "turn_off": [],
                 "optimistic": False,
             },
+            {},
         )
     ],
 )
@@ -1917,14 +1385,17 @@ async def test_optimistic_option(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_fan")
 async def test_not_optimistic(hass: HomeAssistant) -> None:
     """Test optimistic yaml option set to false."""
+
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, STATE_OFF)
+
     await hass.services.async_call(
         fan.DOMAIN,
         "turn_on",
-        {"entity_id": TEST_ENTITY_ID},
+        {"entity_id": TEST_FAN.entity_id},
         blocking=True,
     )
 
-    state = hass.states.get(TEST_ENTITY_ID)
+    state = hass.states.get(TEST_FAN.entity_id)
     assert state.state == STATE_OFF
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update template fan tests to use new test framework in preparation to remove legacy configuration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
