### PR TITLE
geniushub: fix hvac_action and expose output for cloud API users

### DIFF
--- a/homeassistant/components/geniushub/climate.py
+++ b/homeassistant/components/geniushub/climate.py
@@ -77,11 +77,12 @@ class GeniusClimateZone(GeniusHeatingZone, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation if supported."""
-        if "_state" in self._zone.data:  # only for v3 API
+        if "output" in self._zone.data:
             if self._zone.data["output"] == 1:
                 return HVACAction.HEATING
-            if not self._zone.data["_state"].get("bIsActive"):
-                return HVACAction.OFF
+            if "_state" in self._zone.data:  # v3 API has more detail
+                if not self._zone.data["_state"].get("bIsActive"):
+                    return HVACAction.OFF
             return HVACAction.IDLE
         return None
 

--- a/homeassistant/components/geniushub/entity.py
+++ b/homeassistant/components/geniushub/entity.py
@@ -11,7 +11,7 @@ from homeassistant.util import dt as dt_util
 from . import ATTR_DURATION, ATTR_ZONE_MODE, DOMAIN, SVC_SET_ZONE_OVERRIDE
 
 # temperature is repeated here, as it gives access to high-precision temps
-GH_ZONE_ATTRS = ["mode", "temperature", "type", "occupied", "override"]
+GH_ZONE_ATTRS = ["mode", "temperature", "type", "occupied", "override", "output"]
 GH_DEVICE_ATTRS = {
     "luminance": "luminance",
     "measuredTemperature": "measured_temperature",

--- a/tests/components/geniushub/snapshots/test_climate.ambr
+++ b/tests/components/geniushub/snapshots/test_climate.ambr
@@ -51,6 +51,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 21.5,
       'friendly_name': 'Bedroom',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -64,6 +65,7 @@
       ]),
       'status': dict({
         'mode': 'off',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 23.5,
@@ -135,6 +137,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 21,
       'friendly_name': 'Ensuite',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -150,6 +153,7 @@
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 28,
@@ -221,6 +225,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 21,
       'friendly_name': 'Guest room',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -236,6 +241,7 @@
       'status': dict({
         'mode': 'off',
         'occupied': 'True',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 20,
@@ -307,6 +313,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 21,
       'friendly_name': 'Hall',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -322,6 +329,7 @@
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 20,
@@ -393,6 +401,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 21.5,
       'friendly_name': 'Kitchen',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -408,6 +417,7 @@
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 20,
@@ -478,6 +488,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 20,
       'friendly_name': 'Lounge',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -491,6 +502,7 @@
       ]),
       'status': dict({
         'mode': 'off',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 20,
@@ -562,6 +574,7 @@
     'attributes': ReadOnlyDict({
       'current_temperature': 22,
       'friendly_name': 'Study',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -577,6 +590,7 @@
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 28,

--- a/tests/components/geniushub/snapshots/test_switch.ambr
+++ b/tests/components/geniushub/snapshots/test_switch.ambr
@@ -43,6 +43,7 @@
       'friendly_name': 'Bedroom Socket',
       'status': dict({
         'mode': 'timer',
+        'output': 1,
         'override': dict({
           'duration': 0,
           'setpoint': 'True',
@@ -102,6 +103,7 @@
       'friendly_name': 'Kitchen Socket',
       'status': dict({
         'mode': 'timer',
+        'output': 1,
         'override': dict({
           'duration': 0,
           'setpoint': 'True',
@@ -161,6 +163,7 @@
       'friendly_name': 'Study Socket',
       'status': dict({
         'mode': 'off',
+        'output': 0,
         'override': dict({
           'duration': 0,
           'setpoint': 'True',


### PR DESCRIPTION
Repo:   home-assistant/core
Branch: geniushub-fix-hvac-action-v1-api
URL:    https://github.com/wibbit/core/pull/new/geniushub-fix-hvac-action-v1-api

## Proposed change

The GeniusHub `output` field is the demand signal present in both the v1 (cloud) and v3 (local)
API responses, indicating whether a zone is actively calling for heat. Two issues prevented it
from reaching Home Assistant users:

1. `hvac_action` on climate entities was gated behind `_state`, a field only present in the v3
   (local) API. Cloud API users always received `None` — no indication of whether their zones
   were heating or idle.

2. `output` was absent from `GH_ZONE_ATTRS`, so it was silently dropped from
   `extra_state_attributes` on all zone entities regardless of API version.

**Fix:** Check `output` first (present in both API versions) when determining `hvac_action`:
`output=1` → `HEATING`, `output=0` → `IDLE`. The v3-only `_state.bIsActive` check is
preserved to additionally distinguish `IDLE` from `OFF`.

**Fix:** Add `output` to `GH_ZONE_ATTRS` so it appears in the `status` attribute on climate,
water_heater and switch entities.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44568
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr