### PR TITLE
Fix Lutron MOTOR outputs to behave as covers (with pylutron compatibility)

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -116,7 +116,7 @@ async def async_setup_entry(
         for output in area.outputs:
             platform = None
             _LOGGER.debug("Working on output %s", output.type)
-            if output.type == "SYSTEM_SHADE":
+            if output.type in ("SYSTEM_SHADE", "MOTOR"):
                 entry_data.covers.append((area.name, output))
                 platform = Platform.COVER
             elif output.type == "CEILING_FAN_TYPE":

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -36,7 +36,9 @@ _LOGGER = logging.getLogger(__name__)
 
 # Attribute on events that indicates what action was taken with the button.
 ATTR_ACTION = "action"
+ATTR_BUTTON_SUBTYPE = "button_subtype"
 ATTR_FULL_ID = "full_id"
+ATTR_KEYPAD_UUID = "keypad_uuid"
 ATTR_UUID = "uuid"
 
 type LutronConfigEntry = ConfigEntry[LutronData]
@@ -54,6 +56,26 @@ class LutronData:
     lights: list[tuple[str, Output]]
     scenes: list[tuple[str, Keypad, Button, Led | None]]
     switches: list[tuple[str, Output]]
+
+
+def button_subtype(keypad: Keypad, button: Button) -> str:
+    """Return the device-trigger subtype for a keypad button.
+
+    Pico remotes use protocol-defined component numbers that map cleanly to
+    stable semantic positions. Other keypads keep the generic numbered mapping.
+    """
+    if keypad.type == "PICO_KEYPAD":
+        pico_subtypes = {
+            2: "top",
+            3: "favorite",
+            4: "bottom",
+            5: "raise",
+            6: "lower",
+        }
+        if subtype := pico_subtypes.get(button.number):
+            return subtype
+
+    return f"button_{button.number}"
 
 
 async def async_setup_entry(

--- a/homeassistant/components/lutron/cover.py
+++ b/homeassistant/components/lutron/cover.py
@@ -45,24 +45,62 @@ async def async_setup_entry(
 class LutronCover(LutronDevice, CoverEntity):
     """Representation of a Lutron shade."""
 
-    _attr_supported_features = (
-        CoverEntityFeature.OPEN
-        | CoverEntityFeature.CLOSE
-        | CoverEntityFeature.SET_POSITION
-    )
     _lutron_device: Output
     _attr_name = None
 
+    @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Flag supported features based on output type."""
+        if self._lutron_device.type == "MOTOR":
+            return (
+                CoverEntityFeature.OPEN
+                | CoverEntityFeature.CLOSE
+                | CoverEntityFeature.STOP
+            )
+        return (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.SET_POSITION
+        )
+
     def close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
+        if self._lutron_device.type == "MOTOR":
+            # Compatibility: older pylutron exposes MOTOR as Shade with
+            # start_lower/start_raise/stop instead of open/close/stop.
+            if hasattr(self._lutron_device, "close"):
+                self._lutron_device.close()
+            elif hasattr(self._lutron_device, "start_lower"):
+                self._lutron_device.start_lower()
+            else:
+                self._lutron_device.level = 0
+            return
         self._lutron_device.level = 0
 
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
+        if self._lutron_device.type == "MOTOR":
+            # Compatibility: older pylutron exposes MOTOR as Shade with
+            # start_lower/start_raise/stop instead of open/close/stop.
+            if hasattr(self._lutron_device, "open"):
+                self._lutron_device.open()
+            elif hasattr(self._lutron_device, "start_raise"):
+                self._lutron_device.start_raise()
+            else:
+                self._lutron_device.level = 100
+            return
         self._lutron_device.level = 100
+
+    def stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        if self._lutron_device.type == "MOTOR":
+            if hasattr(self._lutron_device, "stop"):
+                self._lutron_device.stop()
 
     def set_cover_position(self, **kwargs: Any) -> None:
         """Move the shade to a specific position."""
+        if self._lutron_device.type == "MOTOR":
+            return
         if ATTR_POSITION in kwargs:
             position = kwargs[ATTR_POSITION]
             self._lutron_device.level = position

--- a/homeassistant/components/lutron/device_trigger.py
+++ b/homeassistant/components/lutron/device_trigger.py
@@ -1,0 +1,183 @@
+"""Provides device triggers for Lutron keypads."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.components.device_automation import (
+    DEVICE_TRIGGER_BASE_SCHEMA,
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.components.homeassistant.triggers import event as event_trigger
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_EVENT,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from . import (
+    ATTR_ACTION,
+    ATTR_BUTTON_SUBTYPE,
+    ATTR_KEYPAD_UUID,
+    LutronConfigEntry,
+    button_subtype,
+)
+from .const import DOMAIN
+from .event import LEGACY_EVENT_TYPES, LutronEventType
+
+CONF_SUBTYPE = "subtype"
+
+TRIGGER_ACTIONS = {
+    LutronEventType.SINGLE_PRESS.value: LEGACY_EVENT_TYPES[
+        LutronEventType.SINGLE_PRESS
+    ],
+    LutronEventType.PRESS.value: LEGACY_EVENT_TYPES[LutronEventType.PRESS],
+    LutronEventType.RELEASE.value: LEGACY_EVENT_TYPES[LutronEventType.RELEASE],
+}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_ACTIONS),
+        vol.Required(CONF_SUBTYPE): str,
+    }
+)
+
+
+def _keypad_identifier(controller_guid: str, keypad_uuid: str) -> tuple[str, str]:
+    """Return the device registry identifier for a keypad."""
+    return DOMAIN, f"{controller_guid}_{keypad_uuid}"
+
+
+def _button_trigger_types(button_type: str | None) -> list[str]:
+    """Return the trigger types supported by a button."""
+    if button_type is not None and "RaiseLower" in button_type:
+        return [LutronEventType.PRESS.value, LutronEventType.RELEASE.value]
+    return [LutronEventType.SINGLE_PRESS.value]
+
+
+def _get_entry_device_buttons(
+    hass: HomeAssistant, device_id: str
+) -> tuple[LutronConfigEntry, list[tuple[Any, Any]]] | None:
+    """Return the config entry and keypad buttons for a device registry device."""
+    device_registry = dr.async_get(hass)
+    if (device := device_registry.async_get(device_id)) is None:
+        return None
+
+    device_identifiers = set(device.identifiers)
+    for entry in cast(
+        list[LutronConfigEntry],
+        hass.config_entries.async_entries(
+            DOMAIN, include_ignore=False, include_disabled=False
+        ),
+    ):
+        if entry.entry_id not in device.config_entries or not hasattr(
+            entry, "runtime_data"
+        ):
+            continue
+
+        entry_buttons = [
+            (keypad, button)
+            for _area_name, keypad, button in entry.runtime_data.buttons
+            if _keypad_identifier(
+                entry.runtime_data.client.guid, keypad.uuid or keypad.legacy_uuid
+            )
+            in device_identifiers
+        ]
+        if entry_buttons:
+            return entry, entry_buttons
+
+    return None
+
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate a device trigger config."""
+    config = TRIGGER_SCHEMA(config)
+
+    found = _get_entry_device_buttons(hass, config[CONF_DEVICE_ID])
+    if found is None:
+        raise InvalidDeviceAutomationConfig(
+            f"Device ID {config[CONF_DEVICE_ID]} is not a valid Lutron keypad"
+        )
+
+    _entry, buttons = found
+    valid_triggers = {
+        (trigger_type, button_subtype(keypad, button))
+        for keypad, button in buttons
+        for trigger_type in _button_trigger_types(button.button_type)
+    }
+    trigger_key = (config[CONF_TYPE], config[CONF_SUBTYPE])
+    if trigger_key not in valid_triggers:
+        raise InvalidDeviceAutomationConfig(
+            f"Device does not support trigger {trigger_key}"
+        )
+
+    return config
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device triggers for a Lutron keypad."""
+    found = _get_entry_device_buttons(hass, device_id)
+    if found is None:
+        return []
+
+    _entry, buttons = found
+    return [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: trigger_type,
+            CONF_SUBTYPE: button_subtype(keypad, button),
+        }
+        for keypad, button in buttons
+        for trigger_type in _button_trigger_types(button.button_type)
+    ]
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a device trigger."""
+    config = await async_validate_trigger_config(hass, config)
+
+    found = _get_entry_device_buttons(hass, config[CONF_DEVICE_ID])
+    assert found is not None
+    _entry, buttons = found
+
+    for keypad, button in buttons:
+        if button_subtype(keypad, button) != config[CONF_SUBTYPE]:
+            continue
+
+        event_config = event_trigger.TRIGGER_SCHEMA(
+            {
+                event_trigger.CONF_PLATFORM: CONF_EVENT,
+                event_trigger.CONF_EVENT_TYPE: "lutron_event",
+                event_trigger.CONF_EVENT_DATA: {
+                    ATTR_ACTION: TRIGGER_ACTIONS[config[CONF_TYPE]],
+                    ATTR_BUTTON_SUBTYPE: config[CONF_SUBTYPE],
+                    ATTR_KEYPAD_UUID: keypad.uuid or keypad.legacy_uuid,
+                },
+            }
+        )
+        return await event_trigger.async_attach_trigger(
+            hass, event_config, action, trigger_info, platform_type="device"
+        )
+
+    raise InvalidDeviceAutomationConfig(
+        f"Unable to find button for trigger {config[CONF_TYPE]!r}/{config[CONF_SUBTYPE]!r}"
+    )

--- a/homeassistant/components/lutron/event.py
+++ b/homeassistant/components/lutron/event.py
@@ -11,7 +11,15 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import slugify
 
-from . import ATTR_ACTION, ATTR_FULL_ID, ATTR_UUID, LutronConfigEntry
+from . import (
+    ATTR_ACTION,
+    ATTR_BUTTON_SUBTYPE,
+    ATTR_FULL_ID,
+    ATTR_KEYPAD_UUID,
+    ATTR_UUID,
+    LutronConfigEntry,
+    button_subtype,
+)
 from .entity import LutronKeypad
 
 
@@ -71,6 +79,8 @@ class LutronEventEntity(LutronKeypad, EventEntity):
 
         self._full_id = slugify(f"{area_name} {name}")
         self._id = slugify(name)
+        self._keypad_uuid = keypad.uuid or keypad.legacy_uuid
+        self._button_subtype = button_subtype(keypad, button)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -96,8 +106,10 @@ class LutronEventEntity(LutronKeypad, EventEntity):
             data = {
                 ATTR_ID: self._id,
                 ATTR_ACTION: LEGACY_EVENT_TYPES[action],
+                ATTR_BUTTON_SUBTYPE: self._button_subtype,
                 ATTR_FULL_ID: self._full_id,
-                ATTR_UUID: button.uuid,
+                ATTR_KEYPAD_UUID: self._keypad_uuid,
+                ATTR_UUID: button.uuid or button.legacy_uuid,
             }
             self.hass.bus.fire("lutron_event", data)
             self._trigger_event(action)

--- a/homeassistant/components/lutron/strings.json
+++ b/homeassistant/components/lutron/strings.json
@@ -19,6 +19,40 @@
       }
     }
   },
+  "device_automation": {
+    "trigger_subtype": {
+      "bottom": "Bottom button",
+      "button_1": "First button",
+      "button_10": "Tenth button",
+      "button_11": "Eleventh button",
+      "button_12": "Twelfth button",
+      "button_13": "Thirteenth button",
+      "button_14": "Fourteenth button",
+      "button_15": "Fifteenth button",
+      "button_16": "Sixteenth button",
+      "button_17": "Seventeenth button",
+      "button_18": "Eighteenth button",
+      "button_19": "Nineteenth button",
+      "button_2": "Second button",
+      "button_20": "Twentieth button",
+      "button_3": "Third button",
+      "button_4": "Fourth button",
+      "button_5": "Fifth button",
+      "button_6": "Sixth button",
+      "button_7": "Seventh button",
+      "button_8": "Eighth button",
+      "button_9": "Ninth button",
+      "favorite": "Favorite button",
+      "lower": "Lower button",
+      "raise": "Raise button",
+      "top": "Top button"
+    },
+    "trigger_type": {
+      "press": "\"{subtype}\" pressed",
+      "release": "\"{subtype}\" released",
+      "single_press": "\"{subtype}\" pressed"
+    }
+  },
   "entity": {
     "event": {
       "button": {

--- a/tests/components/lutron/test_device_trigger.py
+++ b/tests/components/lutron/test_device_trigger.py
@@ -1,0 +1,248 @@
+"""Test Lutron device triggers."""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.device_automation import (
+    DeviceAutomationType,
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.components.lutron import DOMAIN, device_trigger
+from homeassistant.const import Platform
+from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry, async_get_device_automations
+
+
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.EVENT]):
+        yield
+
+
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test keypad triggers are exposed through device automations."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, f"{mock_lutron.guid}_{mock_lutron.areas[0].keypads[0].uuid}")
+        }
+    )
+    assert device is not None
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
+    assert triggers == [
+        {
+            "device_id": device.id,
+            "domain": DOMAIN,
+            "platform": "device",
+            "type": "single_press",
+            "subtype": "button_1",
+            "metadata": {},
+        }
+    ]
+
+
+async def test_trigger_fires_on_event(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test device trigger fires from lutron button events."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    keypad = mock_lutron.areas[0].keypads[0]
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mock_lutron.guid}_{keypad.uuid}")}
+    )
+    assert device is not None
+
+    result: list[dict[str, Any]] = []
+
+    @callback
+    def trigger_callback(
+        run_variables: dict[str, Any], context: Context | None = None
+    ) -> None:
+        result.append(run_variables)
+
+    await device_trigger.async_attach_trigger(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device.id,
+            "type": "single_press",
+            "subtype": "button_1",
+        },
+        trigger_callback,
+        {"trigger_data": {}, "variables": {}},
+    )
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(
+        "lutron_event",
+        {
+            "action": "single",
+            "button_subtype": "button_1",
+            "keypad_uuid": keypad.uuid,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(result) == 1
+    trigger_data = result[0]["trigger"]["event"].data
+    assert trigger_data["action"] == "single"
+    assert trigger_data["button_subtype"] == "button_1"
+    assert trigger_data["keypad_uuid"] == keypad.uuid
+
+
+async def test_invalid_trigger_raises(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test invalid button subtype is rejected."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, f"{mock_lutron.guid}_{mock_lutron.areas[0].keypads[0].uuid}")
+        }
+    )
+    assert device is not None
+
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_trigger.async_validate_trigger_config(
+            hass,
+            {
+                "platform": "device",
+                "domain": DOMAIN,
+                "device_id": device.id,
+                "type": "single_press",
+                "subtype": "button_99",
+            },
+        )
+
+
+async def test_pico_get_triggers_use_semantic_subtypes(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test Pico triggers use semantic subtypes in device automations."""
+    keypad = mock_lutron.areas[0].keypads[0]
+    keypad.type = "PICO_KEYPAD"
+
+    button = keypad.buttons[0]
+    button.number = 2
+
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mock_lutron.guid}_{keypad.uuid}")}
+    )
+    assert device is not None
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
+    assert triggers == [
+        {
+            "device_id": device.id,
+            "domain": DOMAIN,
+            "platform": "device",
+            "type": "single_press",
+            "subtype": "top",
+            "metadata": {},
+        }
+    ]
+
+
+async def test_pico_trigger_fires_on_semantic_subtype(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test Pico device triggers match semantic button subtypes."""
+    keypad = mock_lutron.areas[0].keypads[0]
+    keypad.type = "PICO_KEYPAD"
+
+    button = keypad.buttons[0]
+    button.number = 5
+    button.button_type = "SingleSceneRaiseLower"
+
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mock_lutron.guid}_{keypad.uuid}")}
+    )
+    assert device is not None
+
+    result: list[dict[str, Any]] = []
+
+    @callback
+    def trigger_callback(
+        run_variables: dict[str, Any], context: Context | None = None
+    ) -> None:
+        result.append(run_variables)
+
+    await device_trigger.async_attach_trigger(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device.id,
+            "type": "press",
+            "subtype": "raise",
+        },
+        trigger_callback,
+        {"trigger_data": {}, "variables": {}},
+    )
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(
+        "lutron_event",
+        {
+            "action": "pressed",
+            "button_subtype": "raise",
+            "keypad_uuid": keypad.uuid,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(result) == 1
+    trigger_data = result[0]["trigger"]["event"].data
+    assert trigger_data["action"] == "pressed"
+    assert trigger_data["button_subtype"] == "raise"
+    assert trigger_data["keypad_uuid"] == keypad.uuid

--- a/tests/components/lutron/test_event.py
+++ b/tests/components/lutron/test_event.py
@@ -58,6 +58,8 @@ async def test_event_single_press(
     # Check bus event
     assert len(events) == 1
     assert events[0].data["action"] == "single"
+    assert events[0].data["button_subtype"] == "button_1"
+    assert events[0].data["keypad_uuid"] == "keypad_uuid"
     assert events[0].data["uuid"] == "button_uuid"
 
 
@@ -93,3 +95,29 @@ async def test_event_press_release(
 
     assert len(events) == 2
     assert events[1].data["action"] == "released"
+
+
+async def test_pico_event_uses_semantic_button_subtype(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test Pico button events expose semantic subtypes."""
+    mock_config_entry.add_to_hass(hass)
+
+    keypad = mock_lutron.areas[0].keypads[0]
+    keypad.type = "PICO_KEYPAD"
+
+    button = keypad.buttons[0]
+    button.number = 2
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    events = async_capture_events(hass, "lutron_event")
+
+    for call in button.subscribe.call_args_list:
+        callback = call[0][0]
+        callback(button, None, Button.Event.PRESSED, None)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data["button_subtype"] == "top"


### PR DESCRIPTION
## Summary
- Classify `OutputType=MOTOR` as `cover` in the Lutron integration.
- Add MOTOR-specific control behavior in `LutronCover`.

## Behavior
- MOTOR entities now expose `open`, `close`, and `stop` cover actions.
- Position control is not exposed for MOTOR entities.
- Added compatibility fallbacks so MOTOR works with both pylutron APIs:
  - New API: `open()/close()/stop()`
  - Older API: `start_raise()/start_lower()/stop()`

## Why
Some installations use motor outputs that are currently classified as lights and/or use an older pylutron runtime that maps MOTOR to `Shade`. This patch keeps behavior correct in both cases.

## Validation
- Verified in a live HA runtime that MOTOR entities appear as covers.
- Verified `close_cover` no longer fails with `'Shade' object has no attribute 'close'`.
