### PR TITLE
Set assumed state on Renault number entity

### DIFF
--- a/homeassistant/components/renault/number.py
+++ b/homeassistant/components/renault/number.py
@@ -87,6 +87,7 @@ async def _set_charge_limits(
     entity.coordinator.data.socMin = min_soc
     entity.coordinator.data.socTarget = target_soc
     entity.coordinator.async_set_updated_data(entity.coordinator.data)
+    entity.coordinator.assumed_state = True
 
 
 async def async_setup_entry(

--- a/homeassistant/components/renault/number.py
+++ b/homeassistant/components/renault/number.py
@@ -86,8 +86,8 @@ async def _set_charge_limits(
 
     entity.coordinator.data.socMin = min_soc
     entity.coordinator.data.socTarget = target_soc
-    entity.coordinator.async_set_updated_data(entity.coordinator.data)
     entity.coordinator.assumed_state = True
+    entity.coordinator.async_set_updated_data(entity.coordinator.data)
 
 
 async def async_setup_entry(

--- a/tests/components/renault/test_number.py
+++ b/tests/components/renault/test_number.py
@@ -132,12 +132,19 @@ async def test_number_action(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     service_data: dict[str, Any],
-    expected_min: int,
-    expected_target: int,
+    expected_min: str,
+    expected_target: str,
 ) -> None:
     """Test that service invokes renault_api with correct data for min charge limit."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+
+    min_charge_level = hass.states.get("number.reg_zoe_40_minimum_charge_level")
+    target_charge_level = hass.states.get("number.reg_zoe_40_target_charge_level")
+    assert min_charge_level.state == "15"
+    assert target_charge_level.state == "80"
+    assert not min_charge_level.attributes.get("assumed_state")
+    assert not target_charge_level.attributes.get("assumed_state")
 
     with patch(
         "renault_api.renault_vehicle.RenaultVehicle.set_battery_soc",
@@ -157,12 +164,12 @@ async def test_number_action(
     mock_action.assert_awaited_once_with(min=expected_min, target=expected_target)
 
     # Verify optimistic update of coordinator data
-    assert hass.states.get("number.reg_zoe_40_minimum_charge_level").state == str(
-        expected_min
-    )
-    assert hass.states.get("number.reg_zoe_40_target_charge_level").state == str(
-        expected_target
-    )
+    min_charge_level = hass.states.get("number.reg_zoe_40_minimum_charge_level")
+    target_charge_level = hass.states.get("number.reg_zoe_40_target_charge_level")
+    assert min_charge_level.state == str(expected_min)
+    assert target_charge_level.state == str(expected_target)
+    assert min_charge_level.attributes.get("assumed_state")
+    assert target_charge_level.attributes.get("assumed_state")
 
 
 @pytest.mark.usefixtures("fixtures_with_no_data")

--- a/tests/components/renault/test_number.py
+++ b/tests/components/renault/test_number.py
@@ -15,7 +15,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.components.renault.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ASSUMED_STATE, ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -132,8 +132,8 @@ async def test_number_action(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     service_data: dict[str, Any],
-    expected_min: str,
-    expected_target: str,
+    expected_min: int,
+    expected_target: int,
 ) -> None:
     """Test that service invokes renault_api with correct data for min charge limit."""
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -143,8 +143,8 @@ async def test_number_action(
     target_charge_level = hass.states.get("number.reg_zoe_40_target_charge_level")
     assert min_charge_level.state == "15"
     assert target_charge_level.state == "80"
-    assert not min_charge_level.attributes.get("assumed_state")
-    assert not target_charge_level.attributes.get("assumed_state")
+    assert not min_charge_level.attributes.get(ATTR_ASSUMED_STATE)
+    assert not target_charge_level.attributes.get(ATTR_ASSUMED_STATE)
 
     with patch(
         "renault_api.renault_vehicle.RenaultVehicle.set_battery_soc",
@@ -168,8 +168,8 @@ async def test_number_action(
     target_charge_level = hass.states.get("number.reg_zoe_40_target_charge_level")
     assert min_charge_level.state == str(expected_min)
     assert target_charge_level.state == str(expected_target)
-    assert min_charge_level.attributes.get("assumed_state")
-    assert target_charge_level.attributes.get("assumed_state")
+    assert min_charge_level.attributes.get(ATTR_ASSUMED_STATE)
+    assert target_charge_level.attributes.get(ATTR_ASSUMED_STATE)
 
 
 @pytest.mark.usefixtures("fixtures_with_no_data")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When we manually update the coordinator data, we should set the assumed state on the coordinator.

It will automatically be reset to False when a real coordinator update occurs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
