### PR TITLE
Use runtime_data in Rabbit Air

### DIFF
--- a/homeassistant/components/rabbitair/__init__.py
+++ b/homeassistant/components/rabbitair/__init__.py
@@ -5,20 +5,16 @@ from __future__ import annotations
 from rabbitair import Client, UdpClient
 
 from homeassistant.components import zeroconf
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-from .coordinator import RabbitAirDataUpdateCoordinator
+from .coordinator import RabbitAirConfigEntry, RabbitAirDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.FAN]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: RabbitAirConfigEntry) -> bool:
     """Set up Rabbit Air from a config entry."""
-
-    hass.data.setdefault(DOMAIN, {})
 
     host: str = entry.data[CONF_HOST]
     token: str = entry.data[CONF_ACCESS_TOKEN]
@@ -30,7 +26,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -39,14 +35,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: RabbitAirConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def update_listener(hass: HomeAssistant, entry: RabbitAirConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/rabbitair/coordinator.py
+++ b/homeassistant/components/rabbitair/coordinator.py
@@ -12,6 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+type RabbitAirConfigEntry = ConfigEntry[RabbitAirDataUpdateCoordinator]
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -43,10 +45,10 @@ class RabbitAirDebouncer(Debouncer[Coroutine[Any, Any, None]]):
 class RabbitAirDataUpdateCoordinator(DataUpdateCoordinator[State]):
     """Class to manage fetching data from single endpoint."""
 
-    config_entry: ConfigEntry
+    config_entry: RabbitAirConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, device: Client
+        self, hass: HomeAssistant, config_entry: RabbitAirConfigEntry, device: Client
     ) -> None:
         """Initialize global data updater."""
         self.device = device

--- a/homeassistant/components/rabbitair/entity.py
+++ b/homeassistant/components/rabbitair/entity.py
@@ -7,13 +7,12 @@ from typing import Any
 
 from rabbitair import Model
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import RabbitAirDataUpdateCoordinator
+from .coordinator import RabbitAirConfigEntry, RabbitAirDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ class RabbitAirBaseEntity(CoordinatorEntity[RabbitAirDataUpdateCoordinator]):
     def __init__(
         self,
         coordinator: RabbitAirDataUpdateCoordinator,
-        entry: ConfigEntry,
+        entry: RabbitAirConfigEntry,
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)

--- a/homeassistant/components/rabbitair/fan.py
+++ b/homeassistant/components/rabbitair/fan.py
@@ -7,7 +7,6 @@ from typing import Any
 from rabbitair import Mode, Model, Speed
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.percentage import (
@@ -15,8 +14,7 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from .const import DOMAIN
-from .coordinator import RabbitAirDataUpdateCoordinator
+from .coordinator import RabbitAirConfigEntry, RabbitAirDataUpdateCoordinator
 from .entity import RabbitAirBaseEntity
 
 SPEED_LIST = [
@@ -40,12 +38,11 @@ PRESET_MODES = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RabbitAirConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a config entry."""
-    coordinator: RabbitAirDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([RabbitAirFanEntity(coordinator, entry)])
+    async_add_entities([RabbitAirFanEntity(entry.runtime_data, entry)])
 
 
 class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
@@ -61,7 +58,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
     def __init__(
         self,
         coordinator: RabbitAirDataUpdateCoordinator,
-        entry: ConfigEntry,
+        entry: RabbitAirConfigEntry,
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator, entry)


### PR DESCRIPTION
## Proposed change

Migrate the `rabbitair` integration to use `runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

- Add `RabbitAirConfigEntry` type alias in the coordinator module
- Use `entry.runtime_data` instead of `hass.data[DOMAIN]` in `__init__.py` and `fan.py`
- Use the typed config entry in `entity.py` and `fan.py`
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Remove unused `DOMAIN` import from `__init__.py` and `fan.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr