### PR TITLE
Use runtime_data in rainforest_eagle integration

### DIFF
--- a/homeassistant/components/rainforest_eagle/__init__.py
+++ b/homeassistant/components/rainforest_eagle/__init__.py
@@ -2,29 +2,27 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-from .coordinator import EagleDataCoordinator
+from .coordinator import EagleDataCoordinator, RainforestEagleConfigEntry
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: RainforestEagleConfigEntry
+) -> bool:
     """Set up Rainforest Eagle from a config entry."""
     coordinator = EagleDataCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: RainforestEagleConfigEntry
+) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/rainforest_eagle/coordinator.py
+++ b/homeassistant/components/rainforest_eagle/coordinator.py
@@ -23,17 +23,21 @@ from .const import (
 )
 from .data import UPDATE_100_ERRORS
 
+type RainforestEagleConfigEntry = ConfigEntry[EagleDataCoordinator]
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class EagleDataCoordinator(DataUpdateCoordinator):
     """Get the latest data from the Eagle device."""
 
-    config_entry: ConfigEntry
+    config_entry: RainforestEagleConfigEntry
     eagle100_reader: Eagle100Reader | None = None
     eagle200_meter: aioeagle.ElectricMeter | None = None
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, hass: HomeAssistant, config_entry: RainforestEagleConfigEntry
+    ) -> None:
         """Initialize the data object."""
         if config_entry.data[CONF_TYPE] == TYPE_EAGLE_100:
             self.model = "EAGLE-100"

--- a/homeassistant/components/rainforest_eagle/diagnostics.py
+++ b/homeassistant/components/rainforest_eagle/diagnostics.py
@@ -5,22 +5,19 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_CLOUD_ID, CONF_INSTALL_CODE, DOMAIN
-from .coordinator import EagleDataCoordinator
+from .const import CONF_CLOUD_ID, CONF_INSTALL_CODE
+from .coordinator import RainforestEagleConfigEntry
 
 TO_REDACT = {CONF_CLOUD_ID, CONF_INSTALL_CODE}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: RainforestEagleConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: EagleDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-
     return {
         "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT),
-        "data": coordinator.data,
+        "data": config_entry.runtime_data.data,
     }

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -8,7 +8,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -17,7 +16,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import EagleDataCoordinator
+from .coordinator import EagleDataCoordinator, RainforestEagleConfigEntry
 
 SENSORS = (
     SensorEntityDescription(
@@ -46,11 +45,11 @@ SENSORS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RainforestEagleConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     entities = [EagleSensor(coordinator, description) for description in SENSORS]
 
     if coordinator.data.get("zigbee:Price") not in (None, "invalid"):


### PR DESCRIPTION
## Proposed change

Migrate the `rainforest_eagle` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

- Add `RainforestEagleConfigEntry` type alias in coordinator module
- Update `__init__.py` to store coordinator in `entry.runtime_data`
- Update `sensor.py` and `diagnostics.py` to retrieve coordinator from `entry.runtime_data`/`config_entry.runtime_data`
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Remove unused `DOMAIN` and `ConfigEntry` imports from multiple modules

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr