### PR TITLE
Use runtime_data in recollect_waste integration

### DIFF
--- a/homeassistant/components/recollect_waste/__init__.py
+++ b/homeassistant/components/recollect_waste/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 
-from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DOMAIN, LOGGER  # noqa: F401
+from .const import CONF_PLACE_ID, CONF_SERVICE_ID, LOGGER
 from .coordinator import RecollectWasteConfigEntry, ReCollectWasteDataUpdateCoordinator
 
 PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]

--- a/homeassistant/components/recollect_waste/__init__.py
+++ b/homeassistant/components/recollect_waste/__init__.py
@@ -9,19 +9,20 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 
-from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DOMAIN, LOGGER
-from .coordinator import ReCollectWasteDataUpdateCoordinator
+from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DOMAIN, LOGGER  # noqa: F401
+from .coordinator import RecollectWasteConfigEntry, ReCollectWasteDataUpdateCoordinator
 
 PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: RecollectWasteConfigEntry
+) -> bool:
     """Set up ReCollect Waste as config entry."""
     coordinator = ReCollectWasteDataUpdateCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -30,18 +31,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(
+    hass: HomeAssistant, entry: RecollectWasteConfigEntry
+) -> None:
     """Handle an options update."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: RecollectWasteConfigEntry
+) -> bool:
     """Unload an ReCollect Waste config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/recollect_waste/calendar.py
+++ b/homeassistant/components/recollect_waste/calendar.py
@@ -7,19 +7,17 @@ import datetime
 from aiorecollect.client import PickupEvent
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import ReCollectWasteDataUpdateCoordinator
+from .coordinator import RecollectWasteConfigEntry, ReCollectWasteDataUpdateCoordinator
 from .entity import ReCollectWasteEntity
 from .util import async_get_pickup_type_names
 
 
 @callback
 def async_get_calendar_event_from_pickup_event(
-    entry: ConfigEntry, pickup_event: PickupEvent
+    entry: RecollectWasteConfigEntry, pickup_event: PickupEvent
 ) -> CalendarEvent:
     """Get a HASS CalendarEvent from an aiorecollect PickupEvent."""
     pickup_type_string = ", ".join(
@@ -36,13 +34,11 @@ def async_get_calendar_event_from_pickup_event(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RecollectWasteConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up ReCollect Waste sensors based on a config entry."""
-    coordinator: ReCollectWasteDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    async_add_entities([ReCollectWasteCalendar(coordinator, entry)])
+    async_add_entities([ReCollectWasteCalendar(entry.runtime_data, entry)])
 
 
 class ReCollectWasteCalendar(ReCollectWasteEntity, CalendarEntity):
@@ -54,7 +50,7 @@ class ReCollectWasteCalendar(ReCollectWasteEntity, CalendarEntity):
     def __init__(
         self,
         coordinator: ReCollectWasteDataUpdateCoordinator,
-        entry: ConfigEntry,
+        entry: RecollectWasteConfigEntry,
     ) -> None:
         """Initialize the ReCollect Waste entity."""
         super().__init__(coordinator, entry)

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -8,17 +8,13 @@ from aiorecollect.client import Client
 from aiorecollect.errors import RecollectError
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
 from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DOMAIN, LOGGER
+from .coordinator import RecollectWasteConfigEntry
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_PLACE_ID): str, vol.Required(CONF_SERVICE_ID): str}
@@ -33,7 +29,7 @@ class RecollectWasteConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: RecollectWasteConfigEntry,
     ) -> RecollectWasteOptionsFlowHandler:
         """Define the config flow to handle options."""
         return RecollectWasteOptionsFlowHandler()

--- a/homeassistant/components/recollect_waste/coordinator.py
+++ b/homeassistant/components/recollect_waste/coordinator.py
@@ -14,15 +14,19 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import CONF_PLACE_ID, CONF_SERVICE_ID, LOGGER
 
+type RecollectWasteConfigEntry = ConfigEntry[ReCollectWasteDataUpdateCoordinator]
+
 DEFAULT_UPDATE_INTERVAL = timedelta(days=1)
 
 
 class ReCollectWasteDataUpdateCoordinator(DataUpdateCoordinator[list[PickupEvent]]):
     """Class to manage fetching ReCollect Waste data."""
 
-    config_entry: ConfigEntry
+    config_entry: RecollectWasteConfigEntry
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, hass: HomeAssistant, config_entry: RecollectWasteConfigEntry
+    ) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,

--- a/homeassistant/components/recollect_waste/diagnostics.py
+++ b/homeassistant/components/recollect_waste/diagnostics.py
@@ -6,12 +6,11 @@ import dataclasses
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_PLACE_ID, DOMAIN
-from .coordinator import ReCollectWasteDataUpdateCoordinator
+from .const import CONF_PLACE_ID
+from .coordinator import RecollectWasteConfigEntry
 
 CONF_AREA_NAME = "area_name"
 CONF_TITLE = "title"
@@ -26,15 +25,13 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: RecollectWasteConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: ReCollectWasteDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
     return async_redact_data(
         {
             "entry": entry.as_dict(),
-            "data": [dataclasses.asdict(event) for event in coordinator.data],
+            "data": [dataclasses.asdict(event) for event in entry.runtime_data.data],
         },
         TO_REDACT,
     )

--- a/homeassistant/components/recollect_waste/entity.py
+++ b/homeassistant/components/recollect_waste/entity.py
@@ -1,11 +1,10 @@
 """Define a base ReCollect Waste entity."""
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DOMAIN
-from .coordinator import ReCollectWasteDataUpdateCoordinator
+from .coordinator import RecollectWasteConfigEntry, ReCollectWasteDataUpdateCoordinator
 
 
 class ReCollectWasteEntity(CoordinatorEntity[ReCollectWasteDataUpdateCoordinator]):
@@ -16,7 +15,7 @@ class ReCollectWasteEntity(CoordinatorEntity[ReCollectWasteDataUpdateCoordinator
     def __init__(
         self,
         coordinator: ReCollectWasteDataUpdateCoordinator,
-        entry: ConfigEntry,
+        entry: RecollectWasteConfigEntry,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -9,12 +9,11 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, LOGGER
-from .coordinator import ReCollectWasteDataUpdateCoordinator
+from .const import LOGGER
+from .coordinator import RecollectWasteConfigEntry, ReCollectWasteDataUpdateCoordinator
 from .entity import ReCollectWasteEntity
 from .util import async_get_pickup_type_names
 
@@ -38,14 +37,12 @@ SENSOR_DESCRIPTIONS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RecollectWasteConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up ReCollect Waste sensors based on a config entry."""
-    coordinator: ReCollectWasteDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
     async_add_entities(
-        ReCollectWasteSensor(coordinator, entry, description)
+        ReCollectWasteSensor(entry.runtime_data, entry, description)
         for description in SENSOR_DESCRIPTIONS
     )
 
@@ -63,7 +60,7 @@ class ReCollectWasteSensor(ReCollectWasteEntity, SensorEntity):
     def __init__(
         self,
         coordinator: ReCollectWasteDataUpdateCoordinator,
-        entry: ConfigEntry,
+        entry: RecollectWasteConfigEntry,
         description: SensorEntityDescription,
     ) -> None:
         """Initialize."""

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 from aiorecollect.errors import RecollectError
 import pytest
 
-from homeassistant.components.recollect_waste import (
+from homeassistant.components.recollect_waste.const import (
     CONF_PLACE_ID,
     CONF_SERVICE_ID,
     DOMAIN,


### PR DESCRIPTION
## Proposed change

Migrate the `recollect_waste` integration to use `runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

- Add `RecollectWasteConfigEntry` type alias in the coordinator module
- Update `__init__.py` to use `entry.runtime_data` instead of `hass.data[DOMAIN]`
- Update `calendar.py`, `sensor.py`, `diagnostics.py`, and `entity.py` to use the typed config entry
- Update `config_flow.py` `async_get_options_flow` to use the typed config entry
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Remove unused `ConfigEntry` imports from multiple modules

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr