### PR TITLE
Use runtime_data in ridwell integration

### DIFF
--- a/homeassistant/components/ridwell/__init__.py
+++ b/homeassistant/components/ridwell/__init__.py
@@ -9,17 +9,17 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 
-from .const import DOMAIN, LOGGER, SENSOR_TYPE_NEXT_PICKUP
-from .coordinator import RidwellDataUpdateCoordinator
+from .const import LOGGER, SENSOR_TYPE_NEXT_PICKUP
+from .coordinator import RidwellConfigEntry, RidwellDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.CALENDAR, Platform.SENSOR, Platform.SWITCH]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: RidwellConfigEntry) -> bool:
     """Set up Ridwell from a config entry."""
     coordinator = RidwellDataUpdateCoordinator(hass, entry)
     await coordinator.async_initialize()
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     entry.async_on_unload(entry.add_update_listener(options_update_listener))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -27,17 +27,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def options_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def options_update_listener(
+    hass: HomeAssistant, entry: RidwellConfigEntry
+) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: RidwellConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/ridwell/calendar.py
+++ b/homeassistant/components/ridwell/calendar.py
@@ -7,7 +7,6 @@ import datetime
 from aioridwell.model import PickupCategory, RidwellAccount, RidwellPickupEvent
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -16,15 +15,14 @@ from .const import (
     CALENDAR_TITLE_ROTATING,
     CALENDAR_TITLE_STATUS,
     CONF_CALENDAR_TITLE,
-    DOMAIN,
 )
-from .coordinator import RidwellDataUpdateCoordinator
+from .coordinator import RidwellConfigEntry, RidwellDataUpdateCoordinator
 from .entity import RidwellEntity
 
 
 @callback
 def async_get_calendar_event_from_pickup_event(
-    pickup_event: RidwellPickupEvent, config_entry: ConfigEntry
+    pickup_event: RidwellPickupEvent, config_entry: RidwellConfigEntry
 ) -> CalendarEvent:
     """Get a HASS CalendarEvent from an aioridwell PickupEvent."""
     pickup_items = []
@@ -66,11 +64,11 @@ def async_get_calendar_event_from_pickup_event(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RidwellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Ridwell calendars based on a config entry."""
-    coordinator: RidwellDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         RidwellCalendar(coordinator, account)

--- a/homeassistant/components/ridwell/config_flow.py
+++ b/homeassistant/components/ridwell/config_flow.py
@@ -9,7 +9,7 @@ from aioridwell import async_get_client
 from aioridwell.errors import InvalidCredentialsError, RidwellError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv, selector
@@ -19,6 +19,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 )
 
 from .const import CALENDAR_TITLE_OPTIONS, CONF_CALENDAR_TITLE, DOMAIN, LOGGER
+from .coordinator import RidwellConfigEntry
 
 STEP_REAUTH_CONFIRM_DATA_SCHEMA = vol.Schema(
     {
@@ -107,7 +108,7 @@ class RidwellConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: RidwellConfigEntry,
     ) -> SchemaOptionsFlowHandler:
         """Get options flow for this handler."""
         try:

--- a/homeassistant/components/ridwell/coordinator.py
+++ b/homeassistant/components/ridwell/coordinator.py
@@ -19,6 +19,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import LOGGER
 
+type RidwellConfigEntry = ConfigEntry[RidwellDataUpdateCoordinator]
+
 UPDATE_INTERVAL = timedelta(hours=1)
 
 
@@ -27,9 +29,9 @@ class RidwellDataUpdateCoordinator(
 ):
     """Class to manage fetching data from single endpoint."""
 
-    config_entry: ConfigEntry
+    config_entry: RidwellConfigEntry
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, config_entry: RidwellConfigEntry) -> None:
         """Initialize."""
         # These will be filled in by async_initialize; we give them these defaults to
         # avoid arduous typing checks down the line:

--- a/homeassistant/components/ridwell/diagnostics.py
+++ b/homeassistant/components/ridwell/diagnostics.py
@@ -6,12 +6,10 @@ import dataclasses
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_UNIQUE_ID, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-from .coordinator import RidwellDataUpdateCoordinator
+from .coordinator import RidwellConfigEntry
 
 CONF_TITLE = "title"
 
@@ -25,17 +23,15 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: RidwellConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: RidwellDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
     return async_redact_data(
         {
             "entry": entry.as_dict(),
             "data": [
                 dataclasses.asdict(event)
-                for events in coordinator.data.values()
+                for events in entry.runtime_data.data.values()
                 for event in events
             ],
         },

--- a/homeassistant/components/ridwell/sensor.py
+++ b/homeassistant/components/ridwell/sensor.py
@@ -13,12 +13,11 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, SENSOR_TYPE_NEXT_PICKUP
-from .coordinator import RidwellDataUpdateCoordinator
+from .const import SENSOR_TYPE_NEXT_PICKUP
+from .coordinator import RidwellConfigEntry, RidwellDataUpdateCoordinator
 from .entity import RidwellEntity
 
 ATTR_CATEGORY = "category"
@@ -35,11 +34,11 @@ SENSOR_DESCRIPTION = SensorEntityDescription(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RidwellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Ridwell sensors based on a config entry."""
-    coordinator: RidwellDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         RidwellSensor(coordinator, account, SENSOR_DESCRIPTION)

--- a/homeassistant/components/ridwell/switch.py
+++ b/homeassistant/components/ridwell/switch.py
@@ -8,13 +8,11 @@ from aioridwell.errors import RidwellError
 from aioridwell.model import EventState, RidwellAccount
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import RidwellDataUpdateCoordinator
+from .coordinator import RidwellConfigEntry, RidwellDataUpdateCoordinator
 from .entity import RidwellEntity
 
 SWITCH_DESCRIPTION = SwitchEntityDescription(
@@ -25,11 +23,11 @@ SWITCH_DESCRIPTION = SwitchEntityDescription(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RidwellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Ridwell sensors based on a config entry."""
-    coordinator: RidwellDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         RidwellSwitch(coordinator, account, SWITCH_DESCRIPTION)


### PR DESCRIPTION
## Proposed change

Migrate the `ridwell` integration to use `runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

- Add `RidwellConfigEntry` type alias in the coordinator module
- Update `__init__.py` to store the coordinator in `entry.runtime_data`
- Update platform modules (`calendar.py`, `sensor.py`, `switch.py`) and `diagnostics.py` to retrieve the coordinator from `entry.runtime_data`
- Update `config_flow.py` `async_get_options_flow` to use the typed config entry
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Remove unused `ConfigEntry` and `DOMAIN` imports

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr