### PR TITLE
Use runtime_data in risco integration

### DIFF
--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -26,15 +26,13 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_CONCURRENCY,
-    DATA_COORDINATOR,
     DEFAULT_CONCURRENCY,
     DOMAIN,
-    EVENTS_COORDINATOR,
     SYSTEM_UPDATE_SIGNAL,
     TYPE_LOCAL,
 )
 from .coordinator import RiscoDataUpdateCoordinator, RiscoEventsDataUpdateCoordinator
-from .models import LocalData
+from .models import CloudData, LocalData, RiscoConfigEntry
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -58,7 +56,7 @@ def zone_update_signal(zone_id: int) -> str:
     return f"risco_zone_update_{zone_id}"
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: RiscoConfigEntry) -> bool:
     """Set up Risco from a config entry."""
     if is_local(entry):
         return await _async_setup_local_entry(hass, entry)
@@ -66,7 +64,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await _async_setup_cloud_entry(hass, entry)
 
 
-async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def _async_setup_local_entry(
+    hass: HomeAssistant, entry: RiscoConfigEntry
+) -> bool:
     data = entry.data
     concurrency = entry.options.get(CONF_CONCURRENCY, DEFAULT_CONCURRENCY)
     risco = RiscoLocal(
@@ -120,14 +120,15 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = local_data
+    entry.runtime_data = local_data
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def _async_setup_cloud_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def _async_setup_cloud_entry(
+    hass: HomeAssistant, entry: RiscoConfigEntry
+) -> bool:
     data = entry.data
     risco = RiscoCloud(data[CONF_USERNAME], data[CONF_PASSWORD], data[CONF_PIN])
     try:
@@ -143,11 +144,10 @@ async def _async_setup_cloud_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_COORDINATOR: coordinator,
-        EVENTS_COORDINATOR: events_coordinator,
-    }
+    entry.runtime_data = CloudData(
+        coordinator=coordinator,
+        events_coordinator=events_coordinator,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await events_coordinator.async_refresh()
@@ -155,20 +155,17 @@ async def _async_setup_cloud_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: RiscoConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        if is_local(entry):
-            local_data: LocalData = hass.data[DOMAIN][entry.entry_id]
-            await local_data.system.disconnect()
-
-        hass.data[DOMAIN].pop(entry.entry_id)
+    if unload_ok and is_local(entry):
+        local_data: LocalData = entry.runtime_data  # type: ignore[assignment]
+        await local_data.system.disconnect()
 
     return unload_ok
 
 
-async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _update_listener(hass: HomeAssistant, entry: RiscoConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
 

--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -32,7 +32,7 @@ from .const import (
     TYPE_LOCAL,
 )
 from .coordinator import RiscoDataUpdateCoordinator, RiscoEventsDataUpdateCoordinator
-from .models import CloudData, LocalData, RiscoConfigEntry
+from .models import CloudData, LocalData, RiscoConfigEntry, RiscoData
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -120,7 +120,7 @@ async def _async_setup_local_entry(
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))
 
-    entry.runtime_data = local_data
+    entry.runtime_data = RiscoData(local_data=local_data)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -144,9 +144,11 @@ async def _async_setup_cloud_entry(
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))
 
-    entry.runtime_data = CloudData(
-        coordinator=coordinator,
-        events_coordinator=events_coordinator,
+    entry.runtime_data = RiscoData(
+        cloud_data=CloudData(
+            coordinator=coordinator,
+            events_coordinator=events_coordinator,
+        )
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -158,8 +160,7 @@ async def _async_setup_cloud_entry(
 async def async_unload_entry(hass: HomeAssistant, entry: RiscoConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok and is_local(entry):
-        local_data: LocalData = entry.runtime_data  # type: ignore[assignment]
+    if unload_ok and (local_data := entry.runtime_data.local_data):
         await local_data.system.disconnect()
 
     return unload_ok

--- a/homeassistant/components/risco/alarm_control_panel.py
+++ b/homeassistant/components/risco/alarm_control_panel.py
@@ -15,19 +15,17 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelState,
     CodeFormat,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import LocalData, is_local
+from . import is_local
 from .const import (
     CONF_CODE_ARM_REQUIRED,
     CONF_CODE_DISARM_REQUIRED,
     CONF_HA_STATES_TO_RISCO,
     CONF_RISCO_STATES_TO_HA,
-    DATA_COORDINATOR,
     DEFAULT_OPTIONS,
     DOMAIN,
     RISCO_ARM,
@@ -36,6 +34,7 @@ from .const import (
 )
 from .coordinator import RiscoDataUpdateCoordinator
 from .entity import RiscoCloudEntity
+from .models import CloudData, LocalData, RiscoConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,13 +48,13 @@ STATES_TO_SUPPORTED_FEATURES = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RiscoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Risco alarm control panel."""
     options = {**DEFAULT_OPTIONS, **config_entry.options}
     if is_local(config_entry):
-        local_data: LocalData = hass.data[DOMAIN][config_entry.entry_id]
+        local_data: LocalData = config_entry.runtime_data  # type: ignore[assignment]
         async_add_entities(
             RiscoLocalAlarm(
                 local_data.system.id,
@@ -68,14 +67,15 @@ async def async_setup_entry(
             for partition_id, partition in local_data.system.partitions.items()
         )
     else:
-        coordinator: RiscoDataUpdateCoordinator = hass.data[DOMAIN][
-            config_entry.entry_id
-        ][DATA_COORDINATOR]
+        cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
         async_add_entities(
             RiscoCloudAlarm(
-                coordinator, partition_id, config_entry.data[CONF_PIN], options
+                cloud_data.coordinator,
+                partition_id,
+                config_entry.data[CONF_PIN],
+                options,
             )
-            for partition_id in coordinator.data.partitions
+            for partition_id in cloud_data.coordinator.data.partitions
         )
 
 

--- a/homeassistant/components/risco/alarm_control_panel.py
+++ b/homeassistant/components/risco/alarm_control_panel.py
@@ -66,14 +66,12 @@ async def async_setup_entry(
             for partition_id, partition in local_data.system.partitions.items()
         )
     elif cloud_data := risco_data.cloud_data:
+        coordinator = cloud_data.coordinator
         async_add_entities(
             RiscoCloudAlarm(
-                cloud_data.coordinator,
-                partition_id,
-                config_entry.data[CONF_PIN],
-                options,
+                coordinator, partition_id, config_entry.data[CONF_PIN], options
             )
-            for partition_id in cloud_data.coordinator.data.partitions
+            for partition_id in coordinator.data.partitions
         )
 
 

--- a/homeassistant/components/risco/alarm_control_panel.py
+++ b/homeassistant/components/risco/alarm_control_panel.py
@@ -20,7 +20,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import is_local
 from .const import (
     CONF_CODE_ARM_REQUIRED,
     CONF_CODE_DISARM_REQUIRED,
@@ -34,7 +33,7 @@ from .const import (
 )
 from .coordinator import RiscoDataUpdateCoordinator
 from .entity import RiscoCloudEntity
-from .models import CloudData, LocalData, RiscoConfigEntry
+from .models import RiscoConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,8 +52,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Risco alarm control panel."""
     options = {**DEFAULT_OPTIONS, **config_entry.options}
-    if is_local(config_entry):
-        local_data: LocalData = config_entry.runtime_data  # type: ignore[assignment]
+    risco_data = config_entry.runtime_data
+    if local_data := risco_data.local_data:
         async_add_entities(
             RiscoLocalAlarm(
                 local_data.system.id,
@@ -66,8 +65,7 @@ async def async_setup_entry(
             )
             for partition_id, partition in local_data.system.partitions.items()
         )
-    else:
-        cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
+    elif cloud_data := risco_data.cloud_data:
         async_add_entities(
             RiscoCloudAlarm(
                 cloud_data.coordinator,

--- a/homeassistant/components/risco/binary_sensor.py
+++ b/homeassistant/components/risco/binary_sensor.py
@@ -96,9 +96,10 @@ async def async_setup_entry(
 
         async_add_entities(chain(system_entities, zone_entities))
     elif cloud_data := risco_data.cloud_data:
+        coordinator = cloud_data.coordinator
         async_add_entities(
-            RiscoCloudBinarySensor(cloud_data.coordinator, zone_id, zone)
-            for zone_id, zone in cloud_data.coordinator.data.zones.items()
+            RiscoCloudBinarySensor(coordinator, zone_id, zone)
+            for zone_id, zone in coordinator.data.zones.items()
         )
 
 

--- a/homeassistant/components/risco/binary_sensor.py
+++ b/homeassistant/components/risco/binary_sensor.py
@@ -15,16 +15,16 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import LocalData, is_local
-from .const import DATA_COORDINATOR, DOMAIN, SYSTEM_UPDATE_SIGNAL
+from . import is_local
+from .const import DOMAIN, SYSTEM_UPDATE_SIGNAL
 from .coordinator import RiscoDataUpdateCoordinator
 from .entity import RiscoCloudZoneEntity, RiscoLocalZoneEntity
+from .models import CloudData, LocalData, RiscoConfigEntry
 
 SYSTEM_ENTITY_DESCRIPTIONS = [
     BinarySensorEntityDescription(
@@ -72,12 +72,12 @@ SYSTEM_ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RiscoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Risco alarm control panel."""
     if is_local(config_entry):
-        local_data: LocalData = hass.data[DOMAIN][config_entry.entry_id]
+        local_data: LocalData = config_entry.runtime_data  # type: ignore[assignment]
         zone_entities = (
             entity
             for zone_id, zone in local_data.system.zones.items()
@@ -97,12 +97,10 @@ async def async_setup_entry(
 
         async_add_entities(chain(system_entities, zone_entities))
     else:
-        coordinator: RiscoDataUpdateCoordinator = hass.data[DOMAIN][
-            config_entry.entry_id
-        ][DATA_COORDINATOR]
+        cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
         async_add_entities(
-            RiscoCloudBinarySensor(coordinator, zone_id, zone)
-            for zone_id, zone in coordinator.data.zones.items()
+            RiscoCloudBinarySensor(cloud_data.coordinator, zone_id, zone)
+            for zone_id, zone in cloud_data.coordinator.data.zones.items()
         )
 
 

--- a/homeassistant/components/risco/binary_sensor.py
+++ b/homeassistant/components/risco/binary_sensor.py
@@ -20,11 +20,10 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import is_local
 from .const import DOMAIN, SYSTEM_UPDATE_SIGNAL
 from .coordinator import RiscoDataUpdateCoordinator
 from .entity import RiscoCloudZoneEntity, RiscoLocalZoneEntity
-from .models import CloudData, LocalData, RiscoConfigEntry
+from .models import RiscoConfigEntry
 
 SYSTEM_ENTITY_DESCRIPTIONS = [
     BinarySensorEntityDescription(
@@ -76,8 +75,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Risco alarm control panel."""
-    if is_local(config_entry):
-        local_data: LocalData = config_entry.runtime_data  # type: ignore[assignment]
+    risco_data = config_entry.runtime_data
+    if local_data := risco_data.local_data:
         zone_entities = (
             entity
             for zone_id, zone in local_data.system.zones.items()
@@ -96,8 +95,7 @@ async def async_setup_entry(
         )
 
         async_add_entities(chain(system_entities, zone_entities))
-    else:
-        cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
+    elif cloud_data := risco_data.cloud_data:
         async_add_entities(
             RiscoCloudBinarySensor(cloud_data.coordinator, zone_id, zone)
             for zone_id, zone in cloud_data.coordinator.data.zones.items()

--- a/homeassistant/components/risco/config_flow.py
+++ b/homeassistant/components/risco/config_flow.py
@@ -10,12 +10,7 @@ from pyrisco import CannotConnectError, RiscoCloud, RiscoLocal, UnauthorizedErro
 import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -42,6 +37,7 @@ from .const import (
     RISCO_STATES,
     TYPE_LOCAL,
 )
+from .models import RiscoConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,12 +117,12 @@ class RiscoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Init the config flow."""
-        self._reauth_entry: ConfigEntry | None = None
+        self._reauth_entry: RiscoConfigEntry | None = None
 
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: RiscoConfigEntry,
     ) -> RiscoOptionsFlowHandler:
         """Define the config flow to handle options."""
         return RiscoOptionsFlowHandler(config_entry)
@@ -218,7 +214,7 @@ class RiscoConfigFlow(ConfigFlow, domain=DOMAIN):
 class RiscoOptionsFlowHandler(OptionsFlow):
     """Handle a Risco options flow."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self, config_entry: RiscoConfigEntry) -> None:
         """Initialize."""
         self._data = {**DEFAULT_OPTIONS, **config_entry.options}
 

--- a/homeassistant/components/risco/models.py
+++ b/homeassistant/components/risco/models.py
@@ -1,10 +1,30 @@
 """Models for Risco integration."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pyrisco import RiscoLocal
+
+from homeassistant.config_entries import ConfigEntry
+
+if TYPE_CHECKING:
+    from .coordinator import (
+        RiscoDataUpdateCoordinator,
+        RiscoEventsDataUpdateCoordinator,
+    )
+
+type RiscoConfigEntry = ConfigEntry[LocalData | CloudData]
+
+
+@dataclass
+class CloudData:
+    """A data class for cloud data passed to the platforms."""
+
+    coordinator: RiscoDataUpdateCoordinator
+    events_coordinator: RiscoEventsDataUpdateCoordinator
 
 
 @dataclass

--- a/homeassistant/components/risco/models.py
+++ b/homeassistant/components/risco/models.py
@@ -16,7 +16,21 @@ if TYPE_CHECKING:
         RiscoEventsDataUpdateCoordinator,
     )
 
-type RiscoConfigEntry = ConfigEntry[LocalData | CloudData]
+type RiscoConfigEntry = ConfigEntry[RiscoData]
+
+
+class RiscoData:
+    """Runtime data for the Risco integration."""
+
+    def __init__(
+        self,
+        *,
+        local_data: LocalData | None = None,
+        cloud_data: CloudData | None = None,
+    ) -> None:
+        """Initialize the Risco data."""
+        self.local_data = local_data
+        self.cloud_data = cloud_data
 
 
 @dataclass

--- a/homeassistant/components/risco/models.py
+++ b/homeassistant/components/risco/models.py
@@ -19,18 +19,12 @@ if TYPE_CHECKING:
 type RiscoConfigEntry = ConfigEntry[RiscoData]
 
 
+@dataclass
 class RiscoData:
     """Runtime data for the Risco integration."""
 
-    def __init__(
-        self,
-        *,
-        local_data: LocalData | None = None,
-        cloud_data: CloudData | None = None,
-    ) -> None:
-        """Initialize the Risco data."""
-        self.local_data = local_data
-        self.cloud_data = cloud_data
+    local_data: LocalData | None = None
+    cloud_data: CloudData | None = None
 
 
 @dataclass

--- a/homeassistant/components/risco/sensor.py
+++ b/homeassistant/components/risco/sensor.py
@@ -10,7 +10,6 @@ from pyrisco.cloud.event import Event
 
 from homeassistant.components.binary_sensor import DOMAIN as BS_DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -18,9 +17,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from . import is_local
-from .const import DOMAIN, EVENTS_COORDINATOR
+from .const import DOMAIN
 from .coordinator import RiscoEventsDataUpdateCoordinator
 from .entity import zone_unique_id
+from .models import CloudData, RiscoConfigEntry
 
 CATEGORIES = {
     2: "Alarm",
@@ -45,7 +45,7 @@ EVENT_ATTRIBUTES = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RiscoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up sensors for device."""
@@ -53,9 +53,8 @@ async def async_setup_entry(
         # no events in local comm
         return
 
-    coordinator: RiscoEventsDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ][EVENTS_COORDINATOR]
+    cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
+    coordinator = cloud_data.events_coordinator
     sensors = [
         RiscoSensor(coordinator, category_id, [], name, config_entry.entry_id)
         for category_id, name in CATEGORIES.items()

--- a/homeassistant/components/risco/sensor.py
+++ b/homeassistant/components/risco/sensor.py
@@ -16,11 +16,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from . import is_local
 from .const import DOMAIN
 from .coordinator import RiscoEventsDataUpdateCoordinator
 from .entity import zone_unique_id
-from .models import CloudData, RiscoConfigEntry
+from .models import RiscoConfigEntry
 
 CATEGORIES = {
     2: "Alarm",
@@ -49,11 +48,10 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up sensors for device."""
-    if is_local(config_entry):
+    if not (cloud_data := config_entry.runtime_data.cloud_data):
         # no events in local comm
         return
 
-    cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
     coordinator = cloud_data.events_coordinator
     sensors = [
         RiscoSensor(coordinator, category_id, [], name, config_entry.entry_id)

--- a/homeassistant/components/risco/services.py
+++ b/homeassistant/components/risco/services.py
@@ -33,7 +33,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if time is None:
             time_to_send = datetime.now()
 
-        local_data: LocalData = hass.data[DOMAIN][entry.entry_id]
+        local_data: LocalData = entry.runtime_data
 
         await local_data.system.set_time(time_to_send)
 

--- a/homeassistant/components/risco/services.py
+++ b/homeassistant/components/risco/services.py
@@ -4,26 +4,26 @@ from datetime import datetime
 
 import voluptuous as vol
 
-from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_TIME, CONF_TYPE
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_TIME
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 
-from .const import DOMAIN, SERVICE_SET_TIME, TYPE_LOCAL
-from .models import RiscoData
+from .const import DOMAIN, SERVICE_SET_TIME
+from .models import RiscoConfigEntry
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Create the Risco Services/Actions."""
 
     async def _set_time(service_call: ServiceCall) -> None:
-        entry = service.async_get_config_entry(
+        entry: RiscoConfigEntry = service.async_get_config_entry(
             service_call.hass, DOMAIN, service_call.data[ATTR_CONFIG_ENTRY_ID]
         )
         time = service_call.data.get(ATTR_TIME)
 
         # Validate config entry is local (not cloud)
-        if entry.data.get(CONF_TYPE) != TYPE_LOCAL:
+        if not (local_data := entry.runtime_data.local_data):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="not_local_entry",
@@ -33,10 +33,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if time is None:
             time_to_send = datetime.now()
 
-        risco_data: RiscoData = entry.runtime_data
-        assert risco_data.local_data
-
-        await risco_data.local_data.system.set_time(time_to_send)
+        await local_data.system.set_time(time_to_send)
 
     hass.services.async_register(
         domain=DOMAIN,

--- a/homeassistant/components/risco/services.py
+++ b/homeassistant/components/risco/services.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 
 from .const import DOMAIN, SERVICE_SET_TIME, TYPE_LOCAL
-from .models import LocalData
+from .models import RiscoData
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
@@ -33,9 +33,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if time is None:
             time_to_send = datetime.now()
 
-        local_data: LocalData = entry.runtime_data
+        risco_data: RiscoData = entry.runtime_data
+        assert risco_data.local_data
 
-        await local_data.system.set_time(time_to_send)
+        await risco_data.local_data.system.set_time(time_to_send)
 
     hass.services.async_register(
         domain=DOMAIN,

--- a/homeassistant/components/risco/switch.py
+++ b/homeassistant/components/risco/switch.py
@@ -29,9 +29,10 @@ async def async_setup_entry(
             for zone_id, zone in local_data.system.zones.items()
         )
     elif cloud_data := risco_data.cloud_data:
+        coordinator = cloud_data.coordinator
         async_add_entities(
-            RiscoCloudSwitch(cloud_data.coordinator, zone_id, zone)
-            for zone_id, zone in cloud_data.coordinator.data.zones.items()
+            RiscoCloudSwitch(coordinator, zone_id, zone)
+            for zone_id, zone in coordinator.data.zones.items()
         )
 
 

--- a/homeassistant/components/risco/switch.py
+++ b/homeassistant/components/risco/switch.py
@@ -7,36 +7,33 @@ from typing import Any
 from pyrisco.common import Zone
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import LocalData, is_local
-from .const import DATA_COORDINATOR, DOMAIN
+from . import is_local
 from .coordinator import RiscoDataUpdateCoordinator
 from .entity import RiscoCloudZoneEntity, RiscoLocalZoneEntity
+from .models import CloudData, LocalData, RiscoConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RiscoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Risco switch."""
     if is_local(config_entry):
-        local_data: LocalData = hass.data[DOMAIN][config_entry.entry_id]
+        local_data: LocalData = config_entry.runtime_data  # type: ignore[assignment]
         async_add_entities(
             RiscoLocalSwitch(local_data.system.id, zone_id, zone)
             for zone_id, zone in local_data.system.zones.items()
         )
     else:
-        coordinator: RiscoDataUpdateCoordinator = hass.data[DOMAIN][
-            config_entry.entry_id
-        ][DATA_COORDINATOR]
+        cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
         async_add_entities(
-            RiscoCloudSwitch(coordinator, zone_id, zone)
-            for zone_id, zone in coordinator.data.zones.items()
+            RiscoCloudSwitch(cloud_data.coordinator, zone_id, zone)
+            for zone_id, zone in cloud_data.coordinator.data.zones.items()
         )
 
 

--- a/homeassistant/components/risco/switch.py
+++ b/homeassistant/components/risco/switch.py
@@ -11,10 +11,9 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import is_local
 from .coordinator import RiscoDataUpdateCoordinator
 from .entity import RiscoCloudZoneEntity, RiscoLocalZoneEntity
-from .models import CloudData, LocalData, RiscoConfigEntry
+from .models import RiscoConfigEntry
 
 
 async def async_setup_entry(
@@ -23,14 +22,13 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Risco switch."""
-    if is_local(config_entry):
-        local_data: LocalData = config_entry.runtime_data  # type: ignore[assignment]
+    risco_data = config_entry.runtime_data
+    if local_data := risco_data.local_data:
         async_add_entities(
             RiscoLocalSwitch(local_data.system.id, zone_id, zone)
             for zone_id, zone in local_data.system.zones.items()
         )
-    else:
-        cloud_data: CloudData = config_entry.runtime_data  # type: ignore[assignment]
+    elif cloud_data := risco_data.cloud_data:
         async_add_entities(
             RiscoCloudSwitch(cloud_data.coordinator, zone_id, zone)
             for zone_id, zone in cloud_data.coordinator.data.zones.items()

--- a/tests/components/risco/test_services.py
+++ b/tests/components/risco/test_services.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.risco import DOMAIN
-from homeassistant.components.risco.const import SERVICE_SET_TIME
+from homeassistant.components.risco.const import DOMAIN, SERVICE_SET_TIME
+from homeassistant.components.risco.models import CloudData, RiscoData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_TIME
 from homeassistant.core import HomeAssistant
@@ -99,6 +99,9 @@ async def test_set_time_service_with_cloud_entry(
     )
     cloud_entry.add_to_hass(hass)
     cloud_entry.mock_state(hass, ConfigEntryState.LOADED)
+    cloud_entry.runtime_data = RiscoData(
+        cloud_data=CloudData(coordinator=None, events_coordinator=None)  # type: ignore[arg-type]
+    )
 
     data = {
         ATTR_CONFIG_ENTRY_ID: cloud_entry.entry_id,


### PR DESCRIPTION
## Proposed change

Migrate the `risco` integration to use `runtime_data` instead of `hass.data[DOMAIN]` for storing data instances.

- Add `RiscoConfigEntry` type alias and `CloudData` dataclass in `models.py`
- `CloudData` replaces the untyped dict that was previously used for cloud mode (with `DATA_COORDINATOR` and `EVENTS_COORDINATOR` string keys)
- Update `__init__.py` to use `entry.runtime_data` instead of `hass.data[DOMAIN]`
- Update `alarm_control_panel.py`, `binary_sensor.py`, `sensor.py`, `switch.py`, and `services.py` to get data from `config_entry.runtime_data`
- Update `config_flow.py` `async_get_options_flow` to use typed config entry
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Remove unused `DATA_COORDINATOR`, `EVENTS_COORDINATOR`, `ConfigEntry`, and `DOMAIN` imports from multiple modules

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr