### PR TITLE
Use runtime_data in ruckus_unleashed integration

### DIFF
--- a/homeassistant/components/ruckus_unleashed/__init__.py
+++ b/homeassistant/components/ruckus_unleashed/__init__.py
@@ -79,8 +79,4 @@ async def async_unload_entry(
     hass: HomeAssistant, entry: RuckusUnleashedConfigEntry
 ) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        await entry.runtime_data.ruckus.close()
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/ruckus_unleashed/__init__.py
+++ b/homeassistant/components/ruckus_unleashed/__init__.py
@@ -5,7 +5,6 @@ import logging
 from aioruckus import AjaxSession
 from aioruckus.exceptions import AuthenticationError, SchemaError
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -18,18 +17,18 @@ from .const import (
     API_AP_MODEL,
     API_SYS_SYSINFO,
     API_SYS_SYSINFO_VERSION,
-    COORDINATOR,
     DOMAIN,
     MANUFACTURER,
     PLATFORMS,
-    UNDO_UPDATE_LISTENERS,
 )
-from .coordinator import RuckusDataUpdateCoordinator
+from .coordinator import RuckusDataUpdateCoordinator, RuckusUnleashedConfigEntry
 
 _LOGGER = logging.getLogger(__package__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: RuckusUnleashedConfigEntry
+) -> bool:
     """Set up Ruckus from a config entry."""
 
     ruckus = AjaxSession.async_create(
@@ -69,25 +68,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ),
         )
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        COORDINATOR: coordinator,
-        UNDO_UPDATE_LISTENERS: [],
-    }
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: RuckusUnleashedConfigEntry
+) -> bool:
     """Unload a config entry."""
-
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        for listener in hass.data[DOMAIN][entry.entry_id][UNDO_UPDATE_LISTENERS]:
-            listener()
-        await hass.data[DOMAIN][entry.entry_id][COORDINATOR].ruckus.close()
-        hass.data[DOMAIN].pop(entry.entry_id)
+        await entry.runtime_data.ruckus.close()
 
     return unload_ok

--- a/homeassistant/components/ruckus_unleashed/coordinator.py
+++ b/homeassistant/components/ruckus_unleashed/coordinator.py
@@ -46,6 +46,10 @@ class RuckusDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("fetched %d active clients", len(clients))
         return {client[API_CLIENT_MAC]: client for client in clients}
 
+    async def async_shutdown(self) -> None:
+        """Close the Ruckus session on shutdown."""
+        await self.ruckus.close()
+
     async def _async_update_data(self) -> dict:
         """Fetch Ruckus data."""
         try:

--- a/homeassistant/components/ruckus_unleashed/coordinator.py
+++ b/homeassistant/components/ruckus_unleashed/coordinator.py
@@ -13,16 +13,21 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import API_CLIENT_MAC, DOMAIN, KEY_SYS_CLIENTS, SCAN_INTERVAL
 
+type RuckusUnleashedConfigEntry = ConfigEntry[RuckusDataUpdateCoordinator]
+
 _LOGGER = logging.getLogger(__package__)
 
 
 class RuckusDataUpdateCoordinator(DataUpdateCoordinator):
     """Coordinator to manage data from Ruckus client."""
 
-    config_entry: ConfigEntry
+    config_entry: RuckusUnleashedConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, ruckus: AjaxSession
+        self,
+        hass: HomeAssistant,
+        config_entry: RuckusUnleashedConfigEntry,
+        ruckus: AjaxSession,
     ) -> None:
         """Initialize global Ruckus data updater."""
         self.ruckus = ruckus

--- a/homeassistant/components/ruckus_unleashed/coordinator.py
+++ b/homeassistant/components/ruckus_unleashed/coordinator.py
@@ -48,6 +48,7 @@ class RuckusDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_shutdown(self) -> None:
         """Close the Ruckus session on shutdown."""
+        await super().async_shutdown()
         await self.ruckus.close()
 
     async def _async_update_data(self) -> dict:

--- a/homeassistant/components/ruckus_unleashed/device_tracker.py
+++ b/homeassistant/components/ruckus_unleashed/device_tracker.py
@@ -5,32 +5,24 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.device_tracker import ScannerEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    API_CLIENT_HOSTNAME,
-    API_CLIENT_IP,
-    COORDINATOR,
-    DOMAIN,
-    KEY_SYS_CLIENTS,
-    UNDO_UPDATE_LISTENERS,
-)
-from .coordinator import RuckusDataUpdateCoordinator
+from .const import API_CLIENT_HOSTNAME, API_CLIENT_IP, DOMAIN, KEY_SYS_CLIENTS
+from .coordinator import RuckusDataUpdateCoordinator, RuckusUnleashedConfigEntry
 
 _LOGGER = logging.getLogger(__package__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RuckusUnleashedConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device tracker for Ruckus component."""
-    coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    coordinator = entry.runtime_data
 
     tracked: set[str] = set()
 
@@ -41,9 +33,7 @@ async def async_setup_entry(
 
     router_update()
 
-    hass.data[DOMAIN][entry.entry_id][UNDO_UPDATE_LISTENERS].append(
-        coordinator.async_add_listener(router_update)
-    )
+    entry.async_on_unload(coordinator.async_add_listener(router_update))
 
     registry = er.async_get(hass)
     restore_entities(registry, coordinator, entry, async_add_entities, tracked)
@@ -70,7 +60,7 @@ def add_new_entities(coordinator, async_add_entities, tracked):
 def restore_entities(
     registry: er.EntityRegistry,
     coordinator: RuckusDataUpdateCoordinator,
-    entry: ConfigEntry,
+    entry: RuckusUnleashedConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
     tracked: set[str],
 ) -> None:

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 from aioruckus.const import ERROR_CONNECT_EOF, ERROR_LOGIN_INCORRECT
 from aioruckus.exceptions import AuthenticationError
 
-from homeassistant.components.ruckus_unleashed import DOMAIN
+from homeassistant.components.ruckus_unleashed.const import DOMAIN
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -5,13 +5,14 @@ from unittest.mock import AsyncMock
 from aioruckus.const import ERROR_CONNECT_TIMEOUT, ERROR_LOGIN_INCORRECT
 from aioruckus.exceptions import AuthenticationError
 
-from homeassistant.components.ruckus_unleashed import DOMAIN, MANUFACTURER
 from homeassistant.components.ruckus_unleashed.const import (
     API_AP_DEVNAME,
     API_AP_MAC,
     API_AP_MODEL,
     API_SYS_SYSINFO,
     API_SYS_SYSINFO_VERSION,
+    DOMAIN,
+    MANUFACTURER,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -89,4 +90,3 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
-    assert not hass.data.get(DOMAIN)


### PR DESCRIPTION
## Proposed change

Migrate the `ruckus_unleashed` integration to use `runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

- Add `RuckusUnleashedConfigEntry` type alias in coordinator module
- Update `__init__.py` to use `entry.runtime_data` instead of `hass.data[DOMAIN]`
- Update `device_tracker.py` to get coordinator from `entry.runtime_data`
- Replace manual `UNDO_UPDATE_LISTENERS` tracking with `entry.async_on_unload`
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Update tests to import from `const` module and remove `hass.data` assertion
- Remove unused `COORDINATOR`, `UNDO_UPDATE_LISTENERS`, `ConfigEntry`, and `DOMAIN` imports

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr