### PR TITLE
Use runtime_data in rympro integration

### DIFF
--- a/homeassistant/components/rympro/__init__.py
+++ b/homeassistant/components/rympro/__init__.py
@@ -6,20 +6,18 @@ import logging
 
 from pyrympro import CannotConnectError, RymPro, UnauthorizedError
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
-from .coordinator import RymProDataUpdateCoordinator
+from .coordinator import RymProConfigEntry, RymProDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: RymProConfigEntry) -> bool:
     """Set up Read Your Meter Pro from a config entry."""
     data = entry.data
     rympro = RymPro(async_get_clientsession(hass))
@@ -41,17 +39,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = RymProDataUpdateCoordinator(hass, entry, rympro)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: RymProConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/rympro/coordinator.py
+++ b/homeassistant/components/rympro/coordinator.py
@@ -13,6 +13,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN
 
+type RymProConfigEntry = ConfigEntry[RymProDataUpdateCoordinator]
+
 SCAN_INTERVAL = 60 * 60
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,10 +23,10 @@ _LOGGER = logging.getLogger(__name__)
 class RymProDataUpdateCoordinator(DataUpdateCoordinator[dict[int, dict]]):
     """Class to manage fetching RYM Pro data."""
 
-    config_entry: ConfigEntry
+    config_entry: RymProConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, rympro: RymPro
+        self, hass: HomeAssistant, config_entry: RymProConfigEntry, rympro: RymPro
     ) -> None:
         """Initialize global RymPro data updater."""
         self.rympro = rympro

--- a/homeassistant/components/rympro/sensor.py
+++ b/homeassistant/components/rympro/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -18,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import RymProDataUpdateCoordinator
+from .coordinator import RymProConfigEntry, RymProDataUpdateCoordinator
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -61,11 +60,11 @@ SENSOR_DESCRIPTIONS: tuple[RymProSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RymProConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up sensors for device."""
-    coordinator: RymProDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     async_add_entities(
         RymProSensor(coordinator, meter_id, description, config_entry.entry_id)
         for meter_id, meter in coordinator.data.items()


### PR DESCRIPTION
## Proposed change

Migrate the `rympro` integration to use `runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator instance.

- Add `RymProConfigEntry` type alias in the coordinator module
- Update `__init__.py` to store the coordinator in `entry.runtime_data`
- Update `sensor.py` to retrieve the coordinator from `config_entry.runtime_data`
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Remove unused `ConfigEntry` and `DOMAIN` imports

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr