### PR TITLE
Use runtime_data in renson integration

### DIFF
--- a/homeassistant/components/renson/__init__.py
+++ b/homeassistant/components/renson/__init__.py
@@ -2,18 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from renson_endura_delta.renson import RensonVentilation
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .coordinator import RensonCoordinator
-
-type RensonConfigEntry = ConfigEntry[RensonData]
+from .coordinator import RensonConfigEntry, RensonCoordinator, RensonData
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -24,14 +19,6 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.TIME,
 ]
-
-
-@dataclass
-class RensonData:
-    """Renson data class."""
-
-    api: RensonVentilation
-    coordinator: RensonCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: RensonConfigEntry) -> bool:

--- a/homeassistant/components/renson/__init__.py
+++ b/homeassistant/components/renson/__init__.py
@@ -11,8 +11,9 @@ from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
 from .coordinator import RensonCoordinator
+
+type RensonConfigEntry = ConfigEntry[RensonData]
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -33,7 +34,7 @@ class RensonData:
     coordinator: RensonCoordinator
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: RensonConfigEntry) -> bool:
     """Set up Renson from a config entry."""
 
     api = RensonVentilation(entry.data[CONF_HOST])
@@ -44,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = RensonData(
+    entry.runtime_data = RensonData(
         api,
         coordinator,
     )
@@ -54,9 +55,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: RensonConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/renson/binary_sensor.py
+++ b/homeassistant/components/renson/binary_sensor.py
@@ -25,8 +25,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonConfigEntry
-from .coordinator import RensonCoordinator
+from .coordinator import RensonConfigEntry, RensonCoordinator
 from .entity import RensonEntity
 
 

--- a/homeassistant/components/renson/binary_sensor.py
+++ b/homeassistant/components/renson/binary_sensor.py
@@ -21,12 +21,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from . import RensonConfigEntry
 from .coordinator import RensonCoordinator
 from .entity import RensonEntity
 
@@ -85,15 +84,13 @@ BINARY_SENSORS: tuple[RensonBinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RensonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Call the Renson integration to setup."""
 
-    api: RensonVentilation = hass.data[DOMAIN][config_entry.entry_id].api
-    coordinator: RensonCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ].coordinator
+    api = config_entry.runtime_data.api
+    coordinator = config_entry.runtime_data.coordinator
 
     async_add_entities(
         RensonBinarySensor(description, api, coordinator)

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -12,13 +12,12 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonCoordinator, RensonData
-from .const import DOMAIN
+from . import RensonConfigEntry
+from .coordinator import RensonCoordinator
 from .entity import RensonEntity
 
 
@@ -53,12 +52,12 @@ ENTITY_DESCRIPTIONS: tuple[RensonButtonEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RensonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Renson button platform."""
 
-    data: RensonData = hass.data[DOMAIN][config_entry.entry_id]
+    data = config_entry.runtime_data
 
     entities = [
         RensonButton(description, data.api, data.coordinator)

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -16,8 +16,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonConfigEntry
-from .coordinator import RensonCoordinator
+from .coordinator import RensonConfigEntry, RensonCoordinator
 from .entity import RensonEntity
 
 

--- a/homeassistant/components/renson/coordinator.py
+++ b/homeassistant/components/renson/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import Any
@@ -15,18 +16,29 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
 
+type RensonConfigEntry = ConfigEntry[RensonData]
+
+
+@dataclass
+class RensonData:
+    """Renson data class."""
+
+    api: RensonVentilation
+    coordinator: RensonCoordinator
+
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class RensonCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Data update coordinator for Renson."""
 
-    config_entry: ConfigEntry
+    config_entry: RensonConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: RensonConfigEntry,
         api: RensonVentilation,
     ) -> None:
         """Initialize my coordinator."""

--- a/homeassistant/components/renson/fan.py
+++ b/homeassistant/components/renson/fan.py
@@ -16,7 +16,6 @@ from renson_endura_delta.renson import Level, RensonVentilation
 import voluptuous as vol
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -27,7 +26,7 @@ from homeassistant.util.percentage import (
 )
 from homeassistant.util.scaling import int_states_in_range
 
-from .const import DOMAIN
+from . import RensonConfigEntry
 from .coordinator import RensonCoordinator
 from .entity import RensonEntity
 
@@ -84,15 +83,13 @@ SPEED_RANGE: tuple[float, float] = (1, 4)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RensonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Renson fan platform."""
 
-    api: RensonVentilation = hass.data[DOMAIN][config_entry.entry_id].api
-    coordinator: RensonCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ].coordinator
+    api = config_entry.runtime_data.api
+    coordinator = config_entry.runtime_data.coordinator
 
     async_add_entities([RensonFan(api, coordinator)])
 

--- a/homeassistant/components/renson/fan.py
+++ b/homeassistant/components/renson/fan.py
@@ -26,8 +26,7 @@ from homeassistant.util.percentage import (
 )
 from homeassistant.util.scaling import int_states_in_range
 
-from . import RensonConfigEntry
-from .coordinator import RensonCoordinator
+from .coordinator import RensonConfigEntry, RensonCoordinator
 from .entity import RensonEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/renson/number.py
+++ b/homeassistant/components/renson/number.py
@@ -12,12 +12,11 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from . import RensonConfigEntry
 from .coordinator import RensonCoordinator
 from .entity import RensonEntity
 
@@ -39,15 +38,13 @@ RENSON_NUMBER_DESCRIPTION = NumberEntityDescription(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RensonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Renson number platform."""
 
-    api: RensonVentilation = hass.data[DOMAIN][config_entry.entry_id].api
-    coordinator: RensonCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ].coordinator
+    api = config_entry.runtime_data.api
+    coordinator = config_entry.runtime_data.coordinator
 
     async_add_entities([RensonNumber(RENSON_NUMBER_DESCRIPTION, api, coordinator)])
 

--- a/homeassistant/components/renson/number.py
+++ b/homeassistant/components/renson/number.py
@@ -16,8 +16,7 @@ from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonConfigEntry
-from .coordinator import RensonCoordinator
+from .coordinator import RensonConfigEntry, RensonCoordinator
 from .entity import RensonEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/renson/sensor.py
+++ b/homeassistant/components/renson/sensor.py
@@ -34,7 +34,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
@@ -45,8 +44,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonData
-from .const import DOMAIN
+from . import RensonConfigEntry
 from .coordinator import RensonCoordinator
 from .entity import RensonEntity
 
@@ -271,12 +269,12 @@ class RensonSensor(RensonEntity, SensorEntity):
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RensonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Renson sensor platform."""
 
-    data: RensonData = hass.data[DOMAIN][config_entry.entry_id]
+    data = config_entry.runtime_data
 
     entities = [
         RensonSensor(description, data.api, data.coordinator) for description in SENSORS

--- a/homeassistant/components/renson/sensor.py
+++ b/homeassistant/components/renson/sensor.py
@@ -44,8 +44,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonConfigEntry
-from .coordinator import RensonCoordinator
+from .coordinator import RensonConfigEntry, RensonCoordinator
 from .entity import RensonEntity
 
 

--- a/homeassistant/components/renson/switch.py
+++ b/homeassistant/components/renson/switch.py
@@ -9,12 +9,11 @@ from renson_endura_delta.field_enum import CURRENT_LEVEL_FIELD, DataType
 from renson_endura_delta.renson import Level, RensonVentilation
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonCoordinator
-from .const import DOMAIN
+from . import RensonConfigEntry
+from .coordinator import RensonCoordinator
 from .entity import RensonEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,14 +66,12 @@ class RensonBreezeSwitch(RensonEntity, SwitchEntity):
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RensonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Call the Renson integration to setup."""
 
-    api: RensonVentilation = hass.data[DOMAIN][config_entry.entry_id].api
-    coordinator: RensonCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ].coordinator
+    api = config_entry.runtime_data.api
+    coordinator = config_entry.runtime_data.coordinator
 
     async_add_entities([RensonBreezeSwitch(api, coordinator)])

--- a/homeassistant/components/renson/switch.py
+++ b/homeassistant/components/renson/switch.py
@@ -12,8 +12,7 @@ from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonConfigEntry
-from .coordinator import RensonCoordinator
+from .coordinator import RensonConfigEntry, RensonCoordinator
 from .entity import RensonEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/renson/time.py
+++ b/homeassistant/components/renson/time.py
@@ -14,8 +14,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonConfigEntry
-from .coordinator import RensonCoordinator
+from .coordinator import RensonConfigEntry, RensonCoordinator
 from .entity import RensonEntity
 
 

--- a/homeassistant/components/renson/time.py
+++ b/homeassistant/components/renson/time.py
@@ -52,8 +52,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Renson time platform."""
 
+    coordinator = config_entry.runtime_data.coordinator
     entities = [
-        RensonTime(description, config_entry.runtime_data.coordinator)
+        RensonTime(description, coordinator)
         for description in ENTITY_DESCRIPTIONS
     ]
 

--- a/homeassistant/components/renson/time.py
+++ b/homeassistant/components/renson/time.py
@@ -10,13 +10,11 @@ from renson_endura_delta.field_enum import DAYTIME_FIELD, NIGHTTIME_FIELD, Field
 from renson_endura_delta.renson import RensonVentilation
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RensonData
-from .const import DOMAIN
+from . import RensonConfigEntry
 from .coordinator import RensonCoordinator
 from .entity import RensonEntity
 
@@ -49,15 +47,14 @@ ENTITY_DESCRIPTIONS: tuple[RensonTimeEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RensonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Renson time platform."""
 
-    data: RensonData = hass.data[DOMAIN][config_entry.entry_id]
-
     entities = [
-        RensonTime(description, data.coordinator) for description in ENTITY_DESCRIPTIONS
+        RensonTime(description, config_entry.runtime_data.coordinator)
+        for description in ENTITY_DESCRIPTIONS
     ]
 
     async_add_entities(entities)

--- a/homeassistant/components/renson/time.py
+++ b/homeassistant/components/renson/time.py
@@ -54,8 +54,7 @@ async def async_setup_entry(
 
     coordinator = config_entry.runtime_data.coordinator
     entities = [
-        RensonTime(description, coordinator)
-        for description in ENTITY_DESCRIPTIONS
+        RensonTime(description, coordinator) for description in ENTITY_DESCRIPTIONS
     ]
 
     async_add_entities(entities)


### PR DESCRIPTION
## Proposed change

Migrate the `renson` integration to use `runtime_data` instead of `hass.data[DOMAIN]` for storing the `RensonData` instance.

- Add `RensonConfigEntry` type alias in ~`__init__.py`~ `coordinator.py`
- Update `async_setup_entry` to store data in `entry.runtime_data`
- Update all platform files (binary_sensor, button, fan, number, sensor, switch, time) to retrieve data from `config_entry.runtime_data`
- Simplify `async_unload_entry` since `hass.data` cleanup is no longer needed
- Remove unused `ConfigEntry` and `DOMAIN` imports from platform modules

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr