### PR TITLE
KNX: Configure entity expose from config panel UI

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -123,6 +123,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     knx_module.ui_time_server_controller.start(
         knx_module.xknx, knx_module.config_store.get_time_server_config()
     )
+    knx_module.ui_expose_controller.start(
+        hass, knx_module.xknx, knx_module.config_store.get_exposes()
+    )
     if CONF_KNX_EXPOSE in config:
         knx_module.yaml_exposures.extend(
             create_combined_knx_exposure(hass, knx_module.xknx, config[CONF_KNX_EXPOSE])
@@ -157,6 +160,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for exposure in knx_module.service_exposures.values():
         exposure.async_remove()
     knx_module.ui_time_server_controller.stop()
+    knx_module.ui_expose_controller.stop()
 
     configured_platforms_yaml = {
         platform

--- a/homeassistant/components/knx/knx_module.py
+++ b/homeassistant/components/knx/knx_module.py
@@ -58,6 +58,7 @@ from .expose import KnxExposeEntity, KnxExposeTime
 from .project import KNXProject
 from .repairs import data_secure_group_key_issue_dispatcher
 from .storage.config_store import KNXConfigStore
+from .storage.expose_controller import ExposeController
 from .storage.time_server import TimeServerController
 from .telegrams import Telegrams
 
@@ -76,6 +77,7 @@ class KNXModule:
         self.connected = False
         self.yaml_exposures: list[KnxExposeEntity | KnxExposeTime] = []
         self.service_exposures: dict[str, KnxExposeEntity | KnxExposeTime] = {}
+        self.ui_expose_controller = ExposeController()
         self.ui_time_server_controller = TimeServerController()
         self.entry = entry
 

--- a/homeassistant/components/knx/storage/config_store.py
+++ b/homeassistant/components/knx/storage/config_store.py
@@ -11,15 +11,16 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import Store
 from homeassistant.util.ulid import ulid_now
 
-from ..const import DOMAIN
+from ..const import DOMAIN, KNX_MODULE_KEY
 from . import migration
 from .const import CONF_DATA
+from .expose_controller import KNXExposeStoreModel, KNXExposeStoreOptionModel
 from .time_server import KNXTimeServerStoreModel
 
 _LOGGER = logging.getLogger(__name__)
 
 STORAGE_VERSION: Final = 2
-STORAGE_VERSION_MINOR: Final = 3
+STORAGE_VERSION_MINOR: Final = 4
 STORAGE_KEY: Final = f"{DOMAIN}/config_store.json"
 
 type KNXPlatformStoreModel = dict[str, dict[str, Any]]  # unique_id: configuration
@@ -32,6 +33,7 @@ class KNXConfigStoreModel(TypedDict):
     """Represent KNX configuration store data."""
 
     entities: KNXEntityStoreModel
+    expose: KNXExposeStoreModel
     time_server: KNXTimeServerStoreModel
 
 
@@ -68,6 +70,10 @@ class _KNXConfigStoreStorage(Store[KNXConfigStoreModel]):
             # version 2.3 introduced in 2026.3
             migration.migrate_2_2_to_2_3(old_data)
 
+        if old_major_version <= 2 and old_minor_version < 4:
+            # version 2.4 introduced in 2026.5
+            migration.migrate_2_3_to_2_4(old_data)
+
         return old_data
 
 
@@ -87,6 +93,7 @@ class KNXConfigStore:
         )
         self.data = KNXConfigStoreModel(  # initialize with default structure
             entities={},
+            expose={},
             time_server={},
         )
         self._platform_controllers: dict[Platform, PlatformControllerBase] = {}
@@ -98,6 +105,10 @@ class KNXConfigStore:
             _LOGGER.debug(
                 "Loaded KNX config data from storage. %s entity platforms",
                 len(self.data["entities"]),
+            )
+            _LOGGER.debug(
+                "Loaded KNX config data from storage. %s exposes",
+                len(self.data["expose"]),
             )
 
     def add_platform(
@@ -183,6 +194,48 @@ class KNXConfigStore:
             if registry_entry.unique_id in unique_ids
         ]
 
+    def get_exposes(self) -> KNXExposeStoreModel:
+        """Return KNX entity state expose configuration."""
+        return self.data["expose"]
+
+    def get_expose_groups(self) -> dict[str, list[str]]:
+        """Return KNX entity state exposes and their group addresses."""
+        return {
+            entity_id: [option["ga"]["write"] for option in config]
+            for entity_id, config in self.data["expose"].items()
+        }
+
+    def get_expose_config(self, entity_id: str) -> list[KNXExposeStoreOptionModel]:
+        """Return KNX entity state expose configuration for an entity."""
+        return self.data["expose"].get(entity_id, [])
+
+    async def update_expose(
+        self, entity_id: str, expose_config: list[KNXExposeStoreOptionModel]
+    ) -> None:
+        """Update KNX expose configuration for an entity."""
+        knx_module = self.hass.data[KNX_MODULE_KEY]
+        expose_controller = knx_module.ui_expose_controller
+        expose_controller.update_entity_expose(
+            self.hass, knx_module.xknx, entity_id, expose_config
+        )
+
+        self.data["expose"][entity_id] = expose_config
+        await self._store.async_save(self.data)
+
+    async def delete_expose(self, entity_id: str) -> None:
+        """Delete KNX expose configuration for an entity."""
+        knx_module = self.hass.data[KNX_MODULE_KEY]
+        expose_controller = knx_module.ui_expose_controller
+        expose_controller.remove_entity_expose(entity_id)
+
+        try:
+            del self.data["expose"][entity_id]
+        except KeyError as err:
+            raise ConfigStoreException(
+                f"Entity not found in expose configuration: {entity_id}"
+            ) from err
+        await self._store.async_save(self.data)
+
     @callback
     def get_time_server_config(self) -> KNXTimeServerStoreModel:
         """Return KNX time server configuration."""
@@ -191,7 +244,7 @@ class KNXConfigStore:
     async def update_time_server_config(self, config: KNXTimeServerStoreModel) -> None:
         """Update time server configuration."""
         self.data["time_server"] = config
-        knx_module = self.hass.data.get(DOMAIN)
+        knx_module = self.hass.data[KNX_MODULE_KEY]
         if knx_module:
             knx_module.ui_time_server_controller.start(knx_module.xknx, config)
         await self._store.async_save(self.data)

--- a/homeassistant/components/knx/storage/expose_controller.py
+++ b/homeassistant/components/knx/storage/expose_controller.py
@@ -50,10 +50,6 @@ def validate_expose_template_no_coerce(value: str) -> str:
         raise vol.Invalid(
             "Static templates are not supported. Template should start with '{{' and end with '}}'"
         )
-    if "value" not in value:
-        raise vol.Invalid(
-            "Expose value template must contain 'value' variable, e.g. '{{ value | int * 2 }}'"
-        )
     return value  # return original string for storage and later template creation
 
 

--- a/homeassistant/components/knx/storage/expose_controller.py
+++ b/homeassistant/components/knx/storage/expose_controller.py
@@ -1,0 +1,158 @@
+"""KNX configuration storage for entity state exposes."""
+
+from typing import Any, NotRequired, TypedDict
+
+import voluptuous as vol
+from xknx import XKNX
+from xknx.dpt import DPTBase
+from xknx.telegram.address import parse_device_group_address
+
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import (
+    config_validation as cv,
+    selector,
+    template as template_helper,
+)
+
+from ..expose import KnxExposeEntity, KnxExposeOptions
+from .entity_store_validation import validate_config_store_data
+from .knx_selector import GASelector
+
+type KNXExposeStoreModel = dict[
+    str, list[KNXExposeStoreOptionModel]  # entity_id: configuration
+]
+
+
+class KNXExposeStoreOptionModel(TypedDict):
+    """Represent KNX entity state expose configuration for an entity."""
+
+    ga: dict[str, Any]  # group address configuration with write and dpt
+    attribute: NotRequired[str]
+    cooldown: NotRequired[float]
+    default: NotRequired[Any]
+    periodic_send: NotRequired[float]
+    respond_to_read: NotRequired[bool]
+    value_template: NotRequired[str]
+
+
+class KNXExposeDataModel(TypedDict):
+    """Represent a loaded KNX expose config for validation."""
+
+    entity_id: str
+    options: list[KNXExposeStoreOptionModel]
+
+
+def validate_expose_template_no_coerce(value: str) -> str:
+    """Validate a value is a valid expose template without coercing it to a Template object."""
+    temp = cv.template(value)  # validate template
+    if temp.is_static:
+        raise vol.Invalid(
+            "Static templates are not supported. Template should start with '{{' and end with '}}'"
+        )
+    if "value" not in value:
+        raise vol.Invalid(
+            "Expose value template must contain 'value' variable, e.g. '{{ value | int * 2 }}'"
+        )
+    return value  # return original string for storage and later template creation
+
+
+EXPOSE_OPTION_SCHEMA = vol.Schema(
+    {
+        vol.Required("ga"): GASelector(
+            state=False,
+            passive=False,
+            write_required=True,
+            dpt=["numeric", "enum", "complex", "string"],
+        ),
+        vol.Optional("attribute"): str,
+        vol.Optional("default"): object,
+        vol.Optional("cooldown"): cv.positive_float,  # frontend renders to duration
+        vol.Optional("periodic_send"): cv.positive_float,
+        vol.Optional("respond_to_read"): bool,
+        vol.Optional("value_template"): validate_expose_template_no_coerce,
+    }
+)
+
+EXPOSE_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(),
+        vol.Required("options"): [EXPOSE_OPTION_SCHEMA],
+    },
+    extra=vol.REMOVE_EXTRA,
+)
+
+
+def validate_expose_data(data: dict) -> KNXExposeDataModel:
+    """Validate and convert expose configuration data."""
+    return validate_config_store_data(EXPOSE_CONFIG_SCHEMA, data)  # type: ignore[return-value]
+
+
+def _store_to_expose_option(
+    hass: HomeAssistant, config: KNXExposeStoreOptionModel
+) -> KnxExposeOptions:
+    """Convert config store option model to expose options."""
+    ga = parse_device_group_address(config["ga"]["write"])
+    dpt: type[DPTBase] = DPTBase.parse_transcoder(config["ga"]["dpt"])  # type: ignore[assignment]
+    value_template = None
+    if (_value_template_config := config.get("value_template")) is not None:
+        value_template = template_helper.Template(_value_template_config, hass)
+    return KnxExposeOptions(
+        group_address=ga,
+        dpt=dpt,
+        attribute=config.get("attribute"),
+        cooldown=config.get("cooldown", 0),
+        default=config.get("default"),
+        periodic_send=config.get("periodic_send", 0),
+        respond_to_read=config.get("respond_to_read", True),
+        value_template=value_template,
+    )
+
+
+class ExposeController:
+    """Controller class for UI entity exposures."""
+
+    def __init__(self) -> None:
+        """Initialize entity expose controller."""
+        self._entity_exposes: dict[str, KnxExposeEntity] = {}
+
+    @callback
+    def stop(self) -> None:
+        """Shutdown entity expose controller."""
+        for expose in self._entity_exposes.values():
+            expose.async_remove()
+        self._entity_exposes.clear()
+
+    @callback
+    def start(
+        self, hass: HomeAssistant, xknx: XKNX, config: KNXExposeStoreModel
+    ) -> None:
+        """Update entity expose configuration."""
+        if self._entity_exposes:
+            self.stop()
+        for entity_id, options in config.items():
+            self.update_entity_expose(hass, xknx, entity_id, options)
+
+    @callback
+    def update_entity_expose(
+        self,
+        hass: HomeAssistant,
+        xknx: XKNX,
+        entity_id: str,
+        expose_config: list[KNXExposeStoreOptionModel],
+    ) -> None:
+        """Update entity expose configuration for an entity."""
+        self.remove_entity_expose(entity_id)
+
+        expose_options = [
+            _store_to_expose_option(hass, config) for config in expose_config
+        ]
+        expose = KnxExposeEntity(hass, xknx, entity_id, expose_options)
+        self._entity_exposes[entity_id] = expose
+        expose.async_register()
+
+    @callback
+    def remove_entity_expose(self, entity_id: str) -> None:
+        """Remove entity expose configuration for an entity."""
+        if entity_id in self._entity_exposes:
+            self._entity_exposes.pop(entity_id).async_remove()

--- a/homeassistant/components/knx/storage/migration.py
+++ b/homeassistant/components/knx/storage/migration.py
@@ -55,3 +55,8 @@ def migrate_2_1_to_2_2(data: dict[str, Any]) -> None:
 def migrate_2_2_to_2_3(data: dict[str, Any]) -> None:
     """Migrate from schema 2.2 to schema 2.3."""
     data.setdefault("time_server", {})
+
+
+def migrate_2_3_to_2_4(data: dict[str, Any]) -> None:
+    """Migrate from schema 2.3 to schema 2.4."""
+    data.setdefault("expose", {})

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -950,6 +950,48 @@
       "description": "Add and manage KNX entities",
       "title": "Entities"
     },
+    "expose": {
+      "create": {
+        "add_expose": "Add expose",
+        "attribute": {
+          "description": "Expose changes of a specific attribute of the entity instead of the state. Optional. If the attribute is not set, the entity state is exposed."
+        },
+        "cooldown": {
+          "description": "Minimum time between consecutive sends. This can be used to prevent high traffic on the KNX bus when values change very frequently. Only the most recent value during the cooldown period is sent.",
+          "label": "Cooldown"
+        },
+        "default": {
+          "description": "The value to send if the entity state is `unavailable` or `unknown`, or if the attribute is not set. If `default` is omitted, nothing is sent in these cases, but the last known value remains available for read requests.",
+          "label": "Default value"
+        },
+        "entity": {
+          "description": "Home Assistant entity to expose state changes to the KNX bus.",
+          "label": "Entity"
+        },
+        "ga": {
+          "label": "Group address"
+        },
+        "periodic_send": {
+          "description": "Time interval to automatically resend the current value to the KNX bus, even if it hasn’t changed.",
+          "label": "Periodic send interval"
+        },
+        "respond_to_read": {
+          "description": "[%key:component::knx::config_panel::entities::create::_::knx::respond_to_read::description%]",
+          "label": "[%key:component::knx::config_panel::entities::create::_::knx::respond_to_read::label%]"
+        },
+        "section_advanced_options": {
+          "title": "Advanced options"
+        },
+        "show_raw_values": "Show raw values",
+        "title": "Add exposure",
+        "value_template": {
+          "description": "Optionally transform the entity state or attribute value before sending it to KNX using a template. The template receives the entity state or attribute value as `value` variable.",
+          "label": "Value template"
+        }
+      },
+      "description": "Expose Home Assistant entity states to the KNX bus",
+      "title": "Expose"
+    },
     "group_monitor": {
       "description": "Monitor KNX group communication",
       "title": "Group monitor"

--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -35,6 +35,7 @@ from .storage.entity_store_validation import (
     EntityStoreValidationSuccess,
     validate_entity_data,
 )
+from .storage.expose_controller import validate_expose_data
 from .storage.serialize import get_serialized_schema
 from .storage.time_server import validate_time_server_data
 from .telegrams import (
@@ -68,6 +69,11 @@ async def register_panel(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_get_schema)
     websocket_api.async_register_command(hass, ws_get_time_server_config)
     websocket_api.async_register_command(hass, ws_update_time_server_config)
+    websocket_api.async_register_command(hass, ws_get_expose_groups)
+    websocket_api.async_register_command(hass, ws_get_expose_config)
+    websocket_api.async_register_command(hass, ws_update_expose)
+    websocket_api.async_register_command(hass, ws_delete_expose)
+    websocket_api.async_register_command(hass, ws_validate_expose)
 
     if DOMAIN not in hass.data.get("frontend_panels", {}):
         await hass.http.async_register_static_paths(
@@ -586,6 +592,142 @@ def ws_create_device(
         configuration_url=f"homeassistant://knx/entities/view?device_id={_device.id}",
     )
     connection.send_result(msg["id"], _device.dict_repr)
+
+
+########
+# Expose
+########
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "knx/get_expose_groups",
+    }
+)
+@provide_knx
+@callback
+def ws_get_expose_groups(
+    hass: HomeAssistant,
+    knx: KNXModule,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Get exposes from config store."""
+    connection.send_result(msg["id"], knx.config_store.get_expose_groups())
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "knx/get_expose_config",
+        vol.Required("entity_id"): str,
+    }
+)
+@provide_knx
+@callback
+def ws_get_expose_config(
+    hass: HomeAssistant,
+    knx: KNXModule,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Get expose configuration from config store."""
+    connection.send_result(
+        msg["id"], knx.config_store.get_expose_config(msg["entity_id"])
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "knx/update_expose",
+        vol.Required("entity_id"): str,
+        vol.Required("options"): list,  # validation done in handler
+    }
+)
+@websocket_api.async_response
+@provide_knx
+async def ws_update_expose(
+    hass: HomeAssistant,
+    knx: KNXModule,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Update expose configuration in config store."""
+    try:
+        validated_data = validate_expose_data(msg)
+    except EntityStoreValidationException as exc:
+        connection.send_result(msg["id"], exc.validation_error)
+        return
+    try:
+        await knx.config_store.update_expose(
+            validated_data["entity_id"], validated_data["options"]
+        )
+    except ConfigStoreException as err:
+        connection.send_error(
+            msg["id"], websocket_api.const.ERR_HOME_ASSISTANT_ERROR, str(err)
+        )
+        return
+    connection.send_result(
+        msg["id"], EntityStoreValidationSuccess(success=True, entity_id=None)
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "knx/delete_expose",
+        vol.Required("entity_id"): str,
+    }
+)
+@websocket_api.async_response
+@provide_knx
+async def ws_delete_expose(
+    hass: HomeAssistant,
+    knx: KNXModule,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Delete expose configuration from config store."""
+    try:
+        await knx.config_store.delete_expose(msg["entity_id"])
+    except ConfigStoreException as err:
+        connection.send_error(
+            msg["id"], websocket_api.const.ERR_HOME_ASSISTANT_ERROR, str(err)
+        )
+        return
+    connection.send_result(msg["id"])
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "knx/validate_expose",
+        vol.Required("entity_id"): str,
+        vol.Required("options"): list,  # validation done in handler
+    }
+)
+@callback
+def ws_validate_expose(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Validate expose data."""
+    try:
+        validate_expose_data(msg)
+    except EntityStoreValidationException as exc:
+        connection.send_result(msg["id"], exc.validation_error)
+        return
+    connection.send_result(
+        msg["id"], EntityStoreValidationSuccess(success=True, entity_id=None)
+    )
+
+
+#############
+# Time server
+#############
 
 
 @websocket_api.require_admin

--- a/tests/components/knx/fixtures/config_store_binarysensor.json
+++ b/tests/components/knx/fixtures/config_store_binarysensor.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "minor_version": 3,
+  "minor_version": 4,
   "key": "knx/config_store.json",
   "data": {
     "entities": {
@@ -22,6 +22,7 @@
         }
       }
     },
+    "expose": {},
     "time_server": {}
   }
 }

--- a/tests/components/knx/fixtures/config_store_light.json
+++ b/tests/components/knx/fixtures/config_store_light.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "minor_version": 3,
+  "minor_version": 4,
   "key": "knx/config_store.json",
   "data": {
     "entities": {
@@ -138,6 +138,7 @@
         }
       }
     },
+    "expose": {},
     "time_server": {}
   }
 }

--- a/tests/components/knx/snapshots/test_diagnostic.ambr
+++ b/tests/components/knx/snapshots/test_diagnostic.ambr
@@ -12,6 +12,8 @@
     'config_store': dict({
       'entities': dict({
       }),
+      'expose': dict({
+      }),
       'time_server': dict({
       }),
     }),
@@ -44,6 +46,8 @@
     'config_store': dict({
       'entities': dict({
       }),
+      'expose': dict({
+      }),
       'time_server': dict({
       }),
     }),
@@ -68,6 +72,8 @@
     }),
     'config_store': dict({
       'entities': dict({
+      }),
+      'expose': dict({
       }),
       'time_server': dict({
       }),
@@ -133,6 +139,8 @@
             }),
           }),
         }),
+      }),
+      'expose': dict({
       }),
       'time_server': dict({
       }),

--- a/tests/components/knx/test_config_store.py
+++ b/tests/components/knx/test_config_store.py
@@ -445,6 +445,131 @@ async def test_validate_entity(
     assert res["result"]["error_base"].startswith("required key not provided")
 
 
+########
+# EXPOSE
+########
+
+
+async def test_update_expose_error(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test expose update validation errors."""
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/update_expose",
+            "entity_id": "switch.test",
+            "options": [{"ga": {"dpt": "1.001"}}],
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False
+    assert res["result"]["errors"][0]["path"] == ["options", "0", "ga", "write"]
+    assert res["result"]["errors"][0]["error_message"] == "required key not provided"
+
+
+async def test_validate_expose(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test expose validation endpoint."""
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/validate_expose",
+            "entity_id": "switch.test",
+            "options": [{"ga": {"write": "1/2/3", "dpt": "1.001"}}],
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is True
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/validate_expose",
+            "entity_id": "switch.test",
+            "options": [{"ga": {"write": "1/2/3", "dpt": "invalid"}}],
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False
+    assert res["result"]["errors"][0]["path"] == ["options", "0", "ga", "dpt"]
+
+
+async def test_delete_expose(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test expose deletion."""
+    ENTITY_ID = "switch.test"
+
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+
+    expose_options = [{"ga": {"write": "2/2/2", "dpt": "1.001"}}]
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/update_expose",
+            "entity_id": ENTITY_ID,
+            "options": expose_options,
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert ENTITY_ID in hass_storage[KNX_CONFIG_STORAGE_KEY]["data"]["expose"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/delete_expose",
+            "entity_id": ENTITY_ID,
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert ENTITY_ID not in hass_storage[KNX_CONFIG_STORAGE_KEY]["data"]["expose"]
+
+
+async def test_delete_expose_error(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test expose deletion errors."""
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/delete_expose",
+            "entity_id": "switch.non_existing_entity",
+        }
+    )
+    res = await client.receive_json()
+    assert not res["success"], res
+    assert res["error"]["code"] == "home_assistant_error"
+    assert res["error"]["message"].startswith(
+        "Entity not found in expose configuration"
+    )
+
+
+###########
+# MIGRATION
+###########
+
+
 async def test_migration_1_to_2(
     hass: HomeAssistant,
     knx: KNXTestKit,
@@ -460,12 +585,12 @@ async def test_migration_1_to_2(
     assert hass_storage[KNX_CONFIG_STORAGE_KEY] == new_data
 
 
-async def test_migration_2_1_to_2_3(
+async def test_migration_2_1_to_2_4(
     hass: HomeAssistant,
     knx: KNXTestKit,
     hass_storage: dict[str, Any],
 ) -> None:
-    """Test migration from schema 2.1 to schema 2.3."""
+    """Test migration from schema 2.1 to schema 2.4."""
     await knx.setup_integration(
         config_store_fixture="config_store_binarysensor_v2_1.json",
         state_updater=False,

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -1,12 +1,16 @@
 """Test KNX expose."""
 
 from datetime import timedelta
+from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.knx.const import CONF_KNX_EXPOSE, DOMAIN, KNX_ADDRESS
 from homeassistant.components.knx.schema import ExposeSchema
+from homeassistant.components.knx.storage.config_store import (
+    STORAGE_KEY as KNX_CONFIG_STORAGE_KEY,
+)
 from homeassistant.const import (
     CONF_ATTRIBUTE,
     CONF_ENTITY_ID,
@@ -18,6 +22,7 @@ from homeassistant.core import HomeAssistant
 from .conftest import KNXTestKit
 
 from tests.common import async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 
 async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -376,6 +381,115 @@ async def test_expose_conversion_exception(
         f'Could not expose fake.entity fake_attribute value "{invalid_attribute}" to KNX:'
         in caplog.text
     )
+
+
+async def test_ui_expose_create_and_update(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test expose create and update."""
+    ENTITY_ID = "light.test"
+    GROUP_ADDRESS_1 = "1/1/1"
+    GROUP_ADDRESS_2 = "2/2/2"
+
+    await knx.setup_integration()
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "knx/update_expose",
+            "entity_id": ENTITY_ID,
+            "options": [{"ga": {"write": GROUP_ADDRESS_1, "dpt": "1.001"}}],
+        }
+    )
+    res = await ws_client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is True, res["result"]
+
+    assert ENTITY_ID in hass_storage[KNX_CONFIG_STORAGE_KEY]["data"]["expose"]
+
+    hass.states.async_set(ENTITY_ID, "on", {"brightness": 30})
+    await hass.async_block_till_done()
+    await knx.assert_write(GROUP_ADDRESS_1, True)
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "knx/update_expose",
+            "entity_id": ENTITY_ID,
+            "options": [
+                {"ga": {"write": GROUP_ADDRESS_1, "dpt": "1.001"}},
+                {
+                    "ga": {"write": GROUP_ADDRESS_2, "dpt": "5.001"},
+                    "attribute": "brightness",
+                },
+            ],
+        }
+    )
+    res = await ws_client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is True, res["result"]
+
+    hass.states.async_set(ENTITY_ID, "on", {"brightness": 50})
+    await hass.async_block_till_done()
+    await knx.assert_write(GROUP_ADDRESS_1, True)
+    await knx.assert_write(GROUP_ADDRESS_2, (128,))
+
+
+async def test_ui_expose_with_options(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    freezer: FrozenDateTimeFactory,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test expose create with options from UI."""
+    ENTITY_ID = "light.test"
+    GROUP_ADDRESS_1 = "1/1/1"
+
+    await knx.setup_integration()
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "knx/update_expose",
+            "entity_id": ENTITY_ID,
+            "options": [
+                {
+                    "ga": {"write": GROUP_ADDRESS_1, "dpt": "5.010"},
+                    "attribute": "brightness",
+                    "cooldown": 2.5,
+                    "default": 0,
+                    "periodic_send": 60.0,
+                    "respond_to_read": False,
+                    "value_template": "{{ 50 if value >= 50 else 1 }}",
+                }
+            ],
+        }
+    )
+    res = await ws_client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is True, res["result"]
+
+    # Change attribute to None - 1 because of value template
+    hass.states.async_set(ENTITY_ID, "on", {"brightness": 10})
+    await hass.async_block_till_done()
+    await knx.assert_write(GROUP_ADDRESS_1, (1,))
+    # Change attribute to 2 - skip because of cooldown
+    hass.states.async_set(ENTITY_ID, "on", {"brightness": 100})
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()
+    # Wait for cooldown to pass
+    freezer.tick(timedelta(seconds=2.5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    await knx.assert_write(GROUP_ADDRESS_1, (50,))
+    # Wait for periodictime to pass
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    await knx.assert_write(GROUP_ADDRESS_1, (50,))
 
 
 @pytest.mark.freeze_time("2022-1-7 9:13:14")  # UTC -> +1h = Vienna in winter (9 -> 0xA)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for configuring KNX exposes of HA entity states in the config panel UI in addition to YAML.

In order to use this, an update to the `knx-frontend` package will be required. https://github.com/XKNX/knx-frontend/pull/357

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
