### PR TITLE
Don't use async_update_reload_and_abort with update listeners in tele…

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -913,6 +913,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TelegramBotConfigEntry) 
 async def update_listener(hass: HomeAssistant, entry: TelegramBotConfigEntry) -> None:
     """Handle config changes."""
     entry.runtime_data.parse_mode = entry.options[ATTR_PARSER]
+    if entry.runtime_data.old_config_data != entry.data:
+        # Reload if config data has changed
+        hass.config_entries.async_schedule_reload(entry.entry_id)
 
     # reload entities
     await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -302,6 +302,7 @@ class TelegramNotificationService:
         """Initialize the service."""
         self.app = app
         self.config = config
+        self.old_config_data = config.data.copy()
         self._parsers: dict[str, str | None] = {
             PARSER_HTML: ParseMode.HTML,
             PARSER_MD: ParseMode.MARKDOWN,

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -369,7 +369,7 @@ class TelegramBotConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if self.source == SOURCE_RECONFIGURE:
             user_input.update(self._step_user_data)
-            return self.async_update_reload_and_abort(
+            return self.async_update_and_abort(
                 self._get_reconfigure_entry(),
                 title=self._bot_name,
                 data_updates=user_input,
@@ -534,7 +534,7 @@ class TelegramBotConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input[CONF_PLATFORM] != PLATFORM_WEBHOOKS:
             await self._shutdown_bot()
 
-            return self.async_update_reload_and_abort(
+            return self.async_update_and_abort(
                 self._get_reconfigure_entry(), title=bot_name, data_updates=user_input
             )
 
@@ -579,7 +579,7 @@ class TelegramBotConfigFlow(ConfigFlow, domain=DOMAIN):
                 description_placeholders=description_placeholders,
             )
 
-        return self.async_update_reload_and_abort(
+        return self.async_update_and_abort(
             self._get_reauth_entry(), title=bot_name, data_updates=updated_data
         )
 

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -75,11 +75,14 @@ async def test_options_flow(
 
 async def test_reconfigure_flow_broadcast(
     hass: HomeAssistant,
-    mock_webhooks_config_entry: MockConfigEntry,
+    mock_register_webhook: None,
     mock_external_calls: None,
+    mock_webhooks_config_entry: MockConfigEntry,
 ) -> None:
     """Test reconfigure flow for broadcast bot."""
     mock_webhooks_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_webhooks_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     result = await mock_webhooks_config_entry.start_reconfigure_flow(hass)
     assert result["step_id"] == "reconfigure"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Change `telegram_bot` to use `async_update_and_abort` instead to manage reloading from the existing update listener

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 