### PR TITLE
List serial ports via USB integration helpers (Q-Z)

### DIFF
--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -31,8 +31,8 @@ def _format_id(value: str | int | None) -> str:
 
 def _generate_unique_id(info: usb.USBDevice | usb.SerialDevice | UsbServiceInfo) -> str:
     """Generate unique id from usb attributes."""
-    vid = info.vid if not isinstance(info, usb.SerialDevice) else None
-    pid = info.pid if not isinstance(info, usb.SerialDevice) else None
+    vid = info.vid if isinstance(info, (usb.USBDevice, UsbServiceInfo)) else None
+    pid = info.pid if isinstance(info, (usb.USBDevice, UsbServiceInfo)) else None
 
     return (
         f"{_format_id(vid)}:{_format_id(pid)}_{info.serial_number}"

--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -123,7 +123,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
         existing_devices = [
             entry.data[CONF_DEVICE] for entry in self._async_current_entries()
         ]
-        unused_ports = [
+        port_map = {
             usb.human_readable_device_name(
                 port.device,
                 port.serial_number,
@@ -131,16 +131,16 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
                 port.description,
                 port.vid if isinstance(port, usb.USBDevice) else None,
                 port.pid if isinstance(port, usb.USBDevice) else None,
-            )
+            ): port
             for port in ports
             if port.device not in existing_devices
-        ]
-        if not unused_ports:
+        }
+        if not port_map:
             return self.async_abort(reason="no_devices_found")
 
         errors = {}
         if user_input is not None and user_input.get(CONF_DEVICE, "").strip():
-            port = ports[unused_ports.index(str(user_input[CONF_DEVICE]))]
+            port = port_map[user_input[CONF_DEVICE]]
             dev_path = port.device
             unique_id = _generate_unique_id(port)
             await self.async_set_unique_id(unique_id)
@@ -153,5 +153,5 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 return await self.async_step_meters()
 
-        schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(unused_ports)})
+        schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(port_map)})
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)

--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -8,8 +8,6 @@ from typing import Any
 from aioraven.data import MeterType
 from aioraven.device import RAVEnConnectionError
 from aioraven.serial import RAVEnSerialDevice
-import serial.tools.list_ports
-from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
 
 from homeassistant.components import usb
@@ -25,16 +23,19 @@ from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from .const import DEFAULT_NAME, DOMAIN
 
 
-def _format_id(value: str | int) -> str:
+def _format_id(value: str | int | None) -> str:
     if isinstance(value, str):
         return value
     return f"{value or 0:04X}"
 
 
-def _generate_unique_id(info: ListPortInfo | UsbServiceInfo) -> str:
+def _generate_unique_id(info: usb.USBDevice | usb.SerialDevice | UsbServiceInfo) -> str:
     """Generate unique id from usb attributes."""
+    vid = info.vid if not isinstance(info, usb.SerialDevice) else None
+    pid = info.pid if not isinstance(info, usb.SerialDevice) else None
+
     return (
-        f"{_format_id(info.vid)}:{_format_id(info.pid)}_{info.serial_number}"
+        f"{_format_id(vid)}:{_format_id(pid)}_{info.serial_number}"
         f"_{info.manufacturer}_{info.description}"
     )
 
@@ -101,8 +102,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle USB Discovery."""
-        device = discovery_info.device
-        dev_path = await self.hass.async_add_executor_job(usb.get_serial_by_id, device)
+        dev_path = discovery_info.device
         unique_id = _generate_unique_id(discovery_info)
         await self.async_set_unique_id(unique_id)
         try:
@@ -119,7 +119,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a flow initiated by the user."""
         if self._async_in_progress():
             return self.async_abort(reason="already_in_progress")
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        ports = await usb.async_scan_serial_ports(self.hass)
         existing_devices = [
             entry.data[CONF_DEVICE] for entry in self._async_current_entries()
         ]
@@ -129,8 +129,8 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
                 port.serial_number,
                 port.manufacturer,
                 port.description,
-                port.vid,
-                port.pid,
+                port.vid if isinstance(port, usb.USBDevice) else None,
+                port.pid if isinstance(port, usb.USBDevice) else None,
             )
             for port in ports
             if port.device not in existing_devices
@@ -141,9 +141,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None and user_input.get(CONF_DEVICE, "").strip():
             port = ports[unused_ports.index(str(user_input[CONF_DEVICE]))]
-            dev_path = await self.hass.async_add_executor_job(
-                usb.get_serial_by_id, port.device
-            )
+            dev_path = port.device
             unique_id = _generate_unique_id(port)
             await self.async_set_unique_id(unique_id)
             try:

--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -153,5 +153,5 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 return await self.async_step_meters()
 
-        schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(port_map)})
+        schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(list(port_map))})
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -6,14 +6,12 @@ import asyncio
 from contextlib import suppress
 import copy
 import itertools
-import os
 from typing import Any, TypedDict, cast
 
 import RFXtrx as rfxtrxmod
-import serial
-import serial.tools.list_ports
 import voluptuous as vol
 
+from homeassistant.components import usb
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -556,9 +554,7 @@ class RfxtrxConfigFlow(ConfigFlow, domain=DOMAIN):
             if user_selection == CONF_MANUAL_PATH:
                 return await self.async_step_setup_serial_manual_path()
 
-            dev_path = await self.hass.async_add_executor_job(
-                get_serial_by_id, user_selection
-            )
+            dev_path = user_selection
 
             try:
                 data = await self.async_validate_rfx(device=dev_path)
@@ -568,11 +564,12 @@ class RfxtrxConfigFlow(ConfigFlow, domain=DOMAIN):
             if not errors:
                 return self.async_create_entry(title="RFXTRX", data=data)
 
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        ports = await usb.async_scan_serial_ports(self.hass)
         list_of_ports = {}
         for port in ports:
             list_of_ports[port.device] = (
-                f"{port}, s/n: {port.serial_number or 'n/a'}"
+                f"{port.device} - {port.description or 'n/a'}"
+                f", s/n: {port.serial_number or 'n/a'}"
                 + (f" - {port.manufacturer}" if port.manufacturer else "")
             )
         list_of_ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
@@ -651,18 +648,6 @@ def _test_transport(host: str | None, port: int | None, device: str | None) -> b
         return False
 
     return True
-
-
-def get_serial_by_id(dev_path: str) -> str:
-    """Return a /dev/serial/by-id match for given device if available."""
-    by_id = "/dev/serial/by-id"
-    if not os.path.isdir(by_id):
-        return dev_path
-
-    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
-        if os.path.realpath(path) == dev_path:
-            return path
-    return dev_path
 
 
 class CannotConnect(HomeAssistantError):

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -3,6 +3,7 @@
   "name": "RFXCOM RFXtrx",
   "codeowners": ["@danielhiversen", "@elupus", "@RobBie1221"],
   "config_flow": true,
+  "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "integration_type": "hub",
   "iot_class": "local_push",

--- a/homeassistant/components/route_b_smart_meter/config_flow.py
+++ b/homeassistant/components/route_b_smart_meter/config_flow.py
@@ -4,11 +4,13 @@ import logging
 from typing import Any
 
 from momonga import Momonga, MomongaSkJoinFailure, MomongaSkScanFailure
-from serial.tools.list_ports import comports
-from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
 
-from homeassistant.components.usb import get_serial_by_id, human_readable_device_name
+from homeassistant.components.usb import (
+    USBDevice,
+    async_scan_serial_ports,
+    human_readable_device_name,
+)
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_PASSWORD
 from homeassistant.core import callback
@@ -25,14 +27,14 @@ def _validate_input(device: str, id: str, password: str) -> None:
         pass
 
 
-def _human_readable_device_name(port: UsbServiceInfo | ListPortInfo) -> str:
+def _human_readable_device_name(port: UsbServiceInfo | USBDevice) -> str:
     return human_readable_device_name(
         port.device,
         port.serial_number,
         port.manufacturer,
         port.description,
-        str(port.vid) if port.vid else None,
-        str(port.pid) if port.pid else None,
+        port.vid,
+        port.pid,
     )
 
 
@@ -45,11 +47,9 @@ class BRouteConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @callback
     def _get_discovered_device_id_and_name(
-        self, device_options: dict[str, ListPortInfo]
+        self, device_options: dict[str, USBDevice]
     ) -> tuple[str | None, str | None]:
-        discovered_device_id = (
-            get_serial_by_id(self.device.device) if self.device else None
-        )
+        discovered_device_id = self.device.device if self.device else None
         discovered_device = (
             device_options.get(discovered_device_id) if discovered_device_id else None
         )
@@ -60,10 +60,10 @@ class BRouteConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return discovered_device_id, discovered_device_name
 
-    async def _get_usb_devices(self) -> dict[str, ListPortInfo]:
+    async def _get_usb_devices(self) -> dict[str, USBDevice]:
         """Return a list of available USB devices."""
-        devices = await self.hass.async_add_executor_job(comports)
-        return {get_serial_by_id(port.device): port for port in devices}
+        devices = await async_scan_serial_ports(self.hass)
+        return {port.device: port for port in devices if isinstance(port, USBDevice)}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/route_b_smart_meter/manifest.json
+++ b/homeassistant/components/route_b_smart_meter/manifest.json
@@ -13,5 +13,5 @@
     "momonga.sk_wrapper_logger"
   ],
   "quality_scale": "bronze",
-  "requirements": ["pyserial==3.5", "momonga==0.3.0"]
+  "requirements": ["momonga==0.3.0"]
 }

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -6,12 +6,12 @@ from pathlib import Path
 import shutil
 from typing import Any, Final
 
-import serial.tools.list_ports
 import velbusaio.controller
 from velbusaio.exceptions import VelbusConnectionFailed
 from velbusaio.vlp_reader import VlpFile
 import voluptuous as vol
 
+from homeassistant.components import usb
 from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.config_entries import (
     SOURCE_RECONFIGURE,
@@ -115,9 +115,10 @@ class VelbusConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle usb select step."""
         step_errors: dict[str, str] = {}
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        ports = await usb.async_scan_serial_ports(self.hass)
         list_of_ports = [
-            f"{p}{', s/n: ' + p.serial_number if p.serial_number else ''}"
+            f"{p.device} - {p.description or 'n/a'}"
+            f"{', s/n: ' + p.serial_number if p.serial_number else ''}"
             + (f" - {p.manufacturer}" if p.manufacturer else "")
             for p in ports
         ]

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any
 
 from awesomeversion import AwesomeVersion
-from serial.tools import list_ports
 import voluptuous as vol
 from zwave_js_server.client import Client
 from zwave_js_server.exceptions import FailedCommand
@@ -160,30 +159,22 @@ async def validate_input(hass: HomeAssistant, user_input: dict) -> VersionInfo:
         raise InvalidInput("cannot_connect") from err
 
 
-def get_usb_ports() -> dict[str, str]:
+async def async_get_usb_ports(hass: HomeAssistant) -> dict[str, str]:
     """Return a dict of USB ports and their friendly names."""
-    ports = list_ports.comports()
     port_descriptions = {}
-    for port in ports:
+    for port in await usb.async_scan_serial_ports(hass):
         if (port.manufacturer, port.description) in IGNORED_USB_DEVICES:
             continue
 
-        vid: str | None = None
-        pid: str | None = None
-        if port.vid is not None and port.pid is not None:
-            usb_device = usb.usb_device_from_port(port)
-            vid = usb_device.vid
-            pid = usb_device.pid
-        dev_path = usb.get_serial_by_id(port.device)
         human_name = usb.human_readable_device_name(
-            dev_path,
+            port.device,
             port.serial_number,
             port.manufacturer,
             port.description,
-            vid,
-            pid,
+            port.vid if isinstance(port, usb.USBDevice) else None,
+            port.pid if isinstance(port, usb.USBDevice) else None,
         )
-        port_descriptions[dev_path] = human_name
+        port_descriptions[port.device] = human_name
 
     # Filter out "n/a" descriptions only if there are other ports available
     non_na_ports = {
@@ -194,11 +185,6 @@ def get_usb_ports() -> dict[str, str]:
 
     # If we have non-"n/a" ports, return only those; otherwise return all ports as-is
     return non_na_ports or port_descriptions
-
-
-async def async_get_usb_ports(hass: HomeAssistant) -> dict[str, str]:
-    """Return a dict of USB ports and their friendly names."""
-    return await hass.async_add_executor_job(get_usb_ports)
 
 
 class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.68.0"],
+  "requirements": ["zwave-js-server-python==0.68.0"],
   "usb": [
     {
       "known_devices": ["Aeotec Z-Stick Gen5+", "Z-WaveMe UZB"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2468,7 +2468,6 @@ pyserial-asyncio-fast==0.16
 # homeassistant.components.acer_projector
 # homeassistant.components.route_b_smart_meter
 # homeassistant.components.usb
-# homeassistant.components.zwave_js
 pyserial==3.5
 
 # homeassistant.components.sesame

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2466,7 +2466,6 @@ pysenz==1.0.2
 pyserial-asyncio-fast==0.16
 
 # homeassistant.components.acer_projector
-# homeassistant.components.route_b_smart_meter
 # homeassistant.components.usb
 pyserial==3.5
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2107,7 +2107,6 @@ pysensibo==1.2.1
 pysenz==1.0.2
 
 # homeassistant.components.acer_projector
-# homeassistant.components.route_b_smart_meter
 # homeassistant.components.usb
 pyserial==3.5
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2109,7 +2109,6 @@ pysenz==1.0.2
 # homeassistant.components.acer_projector
 # homeassistant.components.route_b_smart_meter
 # homeassistant.components.usb
-# homeassistant.components.zwave_js
 pyserial==3.5
 
 # homeassistant.components.seventeentrack

--- a/tests/components/rainforest_raven/const.py
+++ b/tests/components/rainforest_raven/const.py
@@ -17,8 +17,8 @@ from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 DISCOVERY_INFO = UsbServiceInfo(
     device="/dev/ttyACM0",
-    pid="0x0003",
-    vid="0x04B4",
+    pid="0003",
+    vid="04B4",
     serial_number="1234",
     description="RFA-Z105-2 HW2.7.3 EMU-2",
     manufacturer="Rainforest Automation, Inc.",
@@ -30,8 +30,8 @@ DEVICE_NAME = usb.human_readable_device_name(
     DISCOVERY_INFO.serial_number,
     DISCOVERY_INFO.manufacturer,
     DISCOVERY_INFO.description,
-    int(DISCOVERY_INFO.vid, 0),
-    int(DISCOVERY_INFO.pid, 0),
+    DISCOVERY_INFO.vid,
+    DISCOVERY_INFO.pid,
 )
 
 

--- a/tests/components/rainforest_raven/test_config_flow.py
+++ b/tests/components/rainforest_raven/test_config_flow.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock, patch
 
 from aioraven.device import RAVEnConnectionError
 import pytest
-from serial.tools.list_ports_common import ListPortInfo
 
 from homeassistant.components.rainforest_raven.const import DOMAIN
+from homeassistant.components.usb import USBDevice
 from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.const import CONF_DEVICE, CONF_MAC, CONF_SOURCE
 from homeassistant.core import HomeAssistant
@@ -55,17 +55,21 @@ def mock_device_timeout(mock_device: AsyncMock) -> AsyncMock:
 
 
 @pytest.fixture
-def mock_comports() -> Generator[list[ListPortInfo]]:
+def mock_comports() -> Generator[list[USBDevice]]:
     """Mock serial port list."""
-    port = ListPortInfo(DISCOVERY_INFO.device)
-    port.serial_number = DISCOVERY_INFO.serial_number
-    port.manufacturer = DISCOVERY_INFO.manufacturer
-    port.device = DISCOVERY_INFO.device
-    port.description = DISCOVERY_INFO.description
-    port.pid = int(DISCOVERY_INFO.pid, 0)
-    port.vid = int(DISCOVERY_INFO.vid, 0)
+    port = USBDevice(
+        device=DISCOVERY_INFO.device,
+        vid=f"{int(DISCOVERY_INFO.vid, 16):04X}",
+        pid=f"{int(DISCOVERY_INFO.pid, 16):04X}",
+        serial_number=DISCOVERY_INFO.serial_number,
+        manufacturer=DISCOVERY_INFO.manufacturer,
+        description=DISCOVERY_INFO.description,
+    )
     comports = [port]
-    with patch("serial.tools.list_ports.comports", return_value=comports):
+    with patch(
+        "homeassistant.components.rainforest_raven.config_flow.usb.async_scan_serial_ports",
+        return_value=comports,
+    ):
         yield comports
 
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -1,13 +1,12 @@
 """Test the Rfxtrx config flow."""
 
-import os
-from unittest.mock import MagicMock, patch, sentinel
+from unittest.mock import patch
 
 from RFXtrx import RFXtrxTransportError
-import serial.tools.list_ports
 
 from homeassistant import config_entries
-from homeassistant.components.rfxtrx import DOMAIN, config_flow
+from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.components.usb import SerialDevice
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -18,15 +17,14 @@ from tests.common import MockConfigEntry
 SOME_PROTOCOLS = ["ac", "arc"]
 
 
-def com_port():
+def com_port() -> SerialDevice:
     """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = "/dev/ttyUSB1234"
-    port.description = "Some serial port"
-
-    return port
+    return SerialDevice(
+        device="/dev/ttyUSB1234",
+        serial_number="1234",
+        manufacturer="Virtual serial port",
+        description="Some serial port",
+    )
 
 
 async def start_options_flow(
@@ -76,7 +74,10 @@ async def test_setup_network(transport_mock, hass: HomeAssistant) -> None:
     }
 
 
-@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.config_flow.usb.async_scan_serial_ports",
+    return_value=[com_port()],
+)
 async def test_setup_serial(com_mock, transport_mock, hass: HomeAssistant) -> None:
     """Test we can setup serial."""
     port = com_port()
@@ -114,7 +115,10 @@ async def test_setup_serial(com_mock, transport_mock, hass: HomeAssistant) -> No
     }
 
 
-@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.config_flow.usb.async_scan_serial_ports",
+    return_value=[com_port()],
+)
 async def test_setup_serial_manual(
     com_mock, transport_mock, hass: HomeAssistant
 ) -> None:
@@ -189,7 +193,10 @@ async def test_setup_network_fail(transport_mock, hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.config_flow.usb.async_scan_serial_ports",
+    return_value=[com_port()],
+)
 async def test_setup_serial_fail(com_mock, transport_mock, hass: HomeAssistant) -> None:
     """Test setup serial failed connection."""
     transport_mock.return_value.connect.side_effect = RFXtrxTransportError
@@ -221,7 +228,10 @@ async def test_setup_serial_fail(com_mock, transport_mock, hass: HomeAssistant) 
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.config_flow.usb.async_scan_serial_ports",
+    return_value=[com_port()],
+)
 async def test_setup_serial_manual_fail(
     com_mock, transport_mock, hass: HomeAssistant
 ) -> None:
@@ -885,51 +895,3 @@ async def test_options_configure_rfy_cover_device(
     assert isinstance(
         entry.data["devices"]["0C1a0000010203010000000000"]["device_id"], list
     )
-
-
-def test_get_serial_by_id_no_dir() -> None:
-    """Test serial by id conversion if there's no /dev/serial/by-id."""
-    p1 = patch("os.path.isdir", MagicMock(return_value=False))
-    p2 = patch("os.scandir")
-    with p1 as is_dir_mock, p2 as scan_mock:
-        res = config_flow.get_serial_by_id(sentinel.path)
-        assert res is sentinel.path
-        assert is_dir_mock.call_count == 1
-        assert scan_mock.call_count == 0
-
-
-def test_get_serial_by_id() -> None:
-    """Test serial by id conversion."""
-
-    def _realpath(path):
-        if path is sentinel.matched_link:
-            return sentinel.path
-        return sentinel.serial_link_path
-
-    with (
-        patch("os.path.isdir", MagicMock(return_value=True)) as is_dir_mock,
-        patch("os.scandir") as scan_mock,
-        patch("os.path.realpath", side_effect=_realpath),
-    ):
-        res = config_flow.get_serial_by_id(sentinel.path)
-        assert res is sentinel.path
-        assert is_dir_mock.call_count == 1
-        assert scan_mock.call_count == 1
-
-        entry1 = MagicMock(spec_set=os.DirEntry)
-        entry1.is_symlink.return_value = True
-        entry1.path = sentinel.some_path
-
-        entry2 = MagicMock(spec_set=os.DirEntry)
-        entry2.is_symlink.return_value = False
-        entry2.path = sentinel.other_path
-
-        entry3 = MagicMock(spec_set=os.DirEntry)
-        entry3.is_symlink.return_value = True
-        entry3.path = sentinel.matched_link
-
-        scan_mock.return_value = [entry1, entry2, entry3]
-        res = config_flow.get_serial_by_id(sentinel.path)
-        assert res is sentinel.matched_link
-        assert is_dir_mock.call_count == 2
-        assert scan_mock.call_count == 2

--- a/tests/components/route_b_smart_meter/test_config_flow.py
+++ b/tests/components/route_b_smart_meter/test_config_flow.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from momonga import MomongaSkJoinFailure, MomongaSkScanFailure
 import pytest
-from serial.tools.list_ports_linux import SysFS
 
 from homeassistant.components.route_b_smart_meter.const import DOMAIN, ENTRY_TITLE
+from homeassistant.components.usb import SerialDevice, USBDevice
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
@@ -15,18 +15,27 @@ from homeassistant.data_entry_flow import FlowResultType
 
 
 @pytest.fixture
-def mock_comports() -> Generator[AsyncMock]:
-    """Override comports."""
-    device = SysFS("/dev/ttyUSB42")
-    device.vid = 0x1234
-    device.pid = 0x5678
-    device.serial_number = "123456"
-    device.manufacturer = "Test"
-    device.description = "Test Device"
+def mock_serial_ports() -> Generator[AsyncMock]:
+    """Override scan_serial_ports."""
+    device = USBDevice(
+        device="/dev/ttyUSB42",
+        vid="1234",
+        pid="5678",
+        serial_number="123456",
+        manufacturer="Test",
+        description="Test Device",
+    )
+
+    unrelated_device = SerialDevice(
+        device="/dev/ttyUSB41",
+        serial_number=None,
+        manufacturer=None,
+        description=None,
+    )
 
     with patch(
-        "homeassistant.components.route_b_smart_meter.config_flow.comports",
-        return_value=[SysFS("/dev/ttyUSB41"), device],
+        "homeassistant.components.route_b_smart_meter.config_flow.async_scan_serial_ports",
+        return_value=[unrelated_device, device],
     ) as mock:
         yield mock
 
@@ -34,7 +43,7 @@ def mock_comports() -> Generator[AsyncMock]:
 async def test_step_user_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_comports: AsyncMock,
+    mock_serial_ports: AsyncMock,
     mock_momonga: Mock,
     user_input: dict[str, str],
 ) -> None:
@@ -55,7 +64,7 @@ async def test_step_user_form(
     assert result["data"] == user_input
     assert result["result"].unique_id == user_input[CONF_ID]
     mock_setup_entry.assert_called_once()
-    mock_comports.assert_called()
+    mock_serial_ports.assert_called()
     mock_momonga.assert_called_once_with(
         dev=user_input[CONF_DEVICE],
         rbid=user_input[CONF_ID],
@@ -76,7 +85,7 @@ async def test_step_user_form_errors(
     error: Exception,
     message: str,
     mock_setup_entry: AsyncMock,
-    mock_comports: AsyncMock,
+    mock_serial_ports: AsyncMock,
     mock_momonga: AsyncMock,
     user_input: dict[str, str],
 ) -> None:
@@ -93,7 +102,7 @@ async def test_step_user_form_errors(
     assert result_configure["type"] is FlowResultType.FORM
     assert result_configure["errors"] == {"base": message}
     await hass.async_block_till_done()
-    mock_comports.assert_called()
+    mock_serial_ports.assert_called()
     mock_momonga.assert_called_once_with(
         dev=user_input[CONF_DEVICE],
         rbid=user_input[CONF_ID],

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -7,9 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-import serial.tools.list_ports
 from velbusaio.exceptions import VelbusConnectionFailed
 
+from homeassistant.components.usb import SerialDevice
 from homeassistant.components.velbus.const import CONF_TLS, CONF_VLP_FILE, DOMAIN
 from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_SOURCE
@@ -34,14 +34,14 @@ DISCOVERY_INFO = UsbServiceInfo(
 USB_DEV = "/dev/ttyACME100 - Some serial port, s/n: 1234 - Virtual serial port"
 
 
-def com_port():
+def com_port() -> SerialDevice:
     """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo(PORT_SERIAL)
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = PORT_SERIAL
-    port.description = "Some serial port"
-    return port
+    return SerialDevice(
+        device=PORT_SERIAL,
+        serial_number="1234",
+        manufacturer="Virtual serial port",
+        description="Some serial port",
+    )
 
 
 @pytest.fixture
@@ -192,7 +192,10 @@ async def test_user_network_connect_failure(
 
 
 @pytest.mark.usefixtures("controller_connection_failed")
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.velbus.config_flow.usb.async_scan_serial_ports",
+    new=AsyncMock(return_value=[com_port()]),
+)
 async def test_user_usb_connect_failure(hass: HomeAssistant) -> None:
     """Test user usb step."""
     result = await hass.config_entries.flow.async_init(
@@ -215,7 +218,10 @@ async def test_user_usb_connect_failure(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("controller")
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.velbus.config_flow.usb.async_scan_serial_ports",
+    new=AsyncMock(return_value=[com_port()]),
+)
 async def test_user_usb_success(hass: HomeAssistant) -> None:
     """Test user usb step."""
     result = await hass.config_entries.flow.async_init(
@@ -413,7 +419,10 @@ async def test_network_abort_if_already_setup(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("controller")
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.velbus.config_flow.usb.async_scan_serial_ports",
+    new=AsyncMock(return_value=[com_port()]),
+)
 async def test_flow_usb(hass: HomeAssistant) -> None:
     """Test usb discovery flow."""
     result = await hass.config_entries.flow.async_init(
@@ -435,7 +444,10 @@ async def test_flow_usb(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("controller")
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.velbus.config_flow.usb.async_scan_serial_ports",
+    new=AsyncMock(return_value=[com_port()]),
+)
 async def test_flow_usb_if_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if Velbus USB discovbery aborts in case it is already setup."""
     entry = MockConfigEntry(
@@ -465,7 +477,10 @@ async def test_flow_usb_if_already_setup(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("controller_connection_failed")
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.velbus.config_flow.usb.async_scan_serial_ports",
+    new=AsyncMock(return_value=[com_port()]),
+)
 async def test_flow_usb_failed(hass: HomeAssistant) -> None:
     """Test usb discovery flow with a failed velbus test."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import Generator
-from copy import copy
 from ipaddress import ip_address
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -12,14 +11,14 @@ from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import AddonsOptions, Discovery
 import aiohttp
 import pytest
-from serial.tools.list_ports_common import ListPortInfo
 from voluptuous import InInvalid
 from zwave_js_server.exceptions import FailedCommand
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.zwave_js.config_flow import TITLE, get_usb_ports
+from homeassistant.components.usb import SerialDevice, USBDevice
+from homeassistant.components.zwave_js.config_flow import TITLE, async_get_usb_ports
 from homeassistant.components.zwave_js.const import (
     ADDON_SLUG,
     CONF_ADDON_DEVICE,
@@ -164,37 +163,42 @@ def mock_addon_setup_time() -> Generator[None]:
 
 
 @pytest.fixture(name="serial_port")
-def serial_port_fixture() -> ListPortInfo:
+def serial_port_fixture() -> USBDevice:
     """Return a mock serial port."""
-    port = ListPortInfo("/test", skip_link_detection=True)
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = "/test"
-    port.description = "Some serial port"
-    port.pid = 9876
-    port.vid = 5678
+    return USBDevice(
+        device="/test",
+        vid="162E",
+        pid="269C",
+        serial_number="1234",
+        manufacturer="Virtual serial port",
+        description="Some serial port",
+    )
 
-    return port
 
-
-@pytest.fixture(name="mock_list_ports", autouse=True)
-def mock_list_ports_fixture(serial_port) -> Generator[MagicMock]:
-    """Mock list ports."""
+@pytest.fixture(name="mock_scan_serial_ports", autouse=True)
+def mock_scan_serial_ports_fixture(serial_port: USBDevice) -> Generator[MagicMock]:
+    """Mock scan serial ports."""
     with patch(
-        "homeassistant.components.zwave_js.config_flow.list_ports.comports"
-    ) as mock_list_ports:
-        another_port = copy(serial_port)
-        another_port.device = "/new"
-        another_port.description = "New serial port"
-        another_port.serial_number = "5678"
-        another_port.pid = 8765
-        no_vid_port = copy(serial_port)
-        no_vid_port.device = "/no_vid"
-        no_vid_port.description = "Port without vid"
-        no_vid_port.serial_number = "9123"
-        no_vid_port.vid = None
-        mock_list_ports.return_value = [serial_port, another_port, no_vid_port]
-        yield mock_list_ports
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports"
+    ) as mock_scan:
+        another_port = USBDevice(
+            device="/new",
+            vid="162E",
+            pid="223D",
+            serial_number="5678",
+            manufacturer="Virtual serial port",
+            description="New serial port",
+        )
+
+        no_vid_port = SerialDevice(
+            device="/no_vid",
+            description="Port without vid",
+            serial_number="9123",
+            manufacturer=None,
+        )
+
+        mock_scan.return_value = [serial_port, another_port, no_vid_port]
+        yield mock_scan
 
 
 @pytest.fixture(name="mock_usb_serial_by_id", autouse=True)
@@ -4888,44 +4892,92 @@ async def test_configure_addon_usb_ports_failure(
         assert result["reason"] == "usb_ports_failed"
 
 
-async def test_get_usb_ports_filtering() -> None:
+async def test_get_usb_ports_filtering(hass: HomeAssistant) -> None:
     """Test that get_usb_ports filters out 'n/a' descriptions when other ports are available."""
     mock_ports = [
-        ListPortInfo("/dev/ttyUSB0"),
-        ListPortInfo("/dev/ttyUSB1"),
-        ListPortInfo("/dev/ttyUSB2"),
-        ListPortInfo("/dev/ttyUSB3"),
+        USBDevice(
+            device="/dev/ttyUSB0",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="n/a",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB1",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="Device A",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB2",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="N/A",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB3",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="Device B",
+        ),
     ]
-    mock_ports[0].description = "n/a"
-    mock_ports[1].description = "Device A"
-    mock_ports[2].description = "N/A"
-    mock_ports[3].description = "Device B"
 
-    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
-        result = get_usb_ports()
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports",
+        return_value=mock_ports,
+    ):
+        result = await async_get_usb_ports(hass)
 
         descriptions = list(result.values())
 
         # Verify that only non-"n/a" descriptions are returned
         assert descriptions == [
-            "Device A - /dev/ttyUSB1, s/n: n/a",
-            "Device B - /dev/ttyUSB3, s/n: n/a",
+            "Device A - /dev/ttyUSB1, s/n: n/a - 1234:5678",
+            "Device B - /dev/ttyUSB3, s/n: n/a - 1234:5678",
         ]
 
 
-async def test_get_usb_ports_all_na() -> None:
+async def test_get_usb_ports_all_na(hass: HomeAssistant) -> None:
     """Test that get_usb_ports returns all ports as-is when only 'n/a' descriptions exist."""
     mock_ports = [
-        ListPortInfo("/dev/ttyUSB0"),
-        ListPortInfo("/dev/ttyUSB1"),
-        ListPortInfo("/dev/ttyUSB2"),
+        USBDevice(
+            device="/dev/ttyUSB0",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="n/a",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB1",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="N/A",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB2",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="n/a",
+        ),
     ]
-    mock_ports[0].description = "n/a"
-    mock_ports[1].description = "N/A"
-    mock_ports[2].description = "n/a"
 
-    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
-        result = get_usb_ports()
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports",
+        return_value=mock_ports,
+    ):
+        result = await async_get_usb_ports(hass)
 
         descriptions = list(result.values())
 
@@ -4940,65 +4992,121 @@ async def test_get_usb_ports_all_na() -> None:
         assert "/dev/ttyUSB2" in device_paths
 
 
-async def test_get_usb_ports_mixed_case_filtering() -> None:
+async def test_get_usb_ports_mixed_case_filtering(hass: HomeAssistant) -> None:
     """Test that get_usb_ports filters out 'n/a' descriptions with different case variations."""
     mock_ports = [
-        ListPortInfo("/dev/ttyUSB0"),
-        ListPortInfo("/dev/ttyUSB1"),
-        ListPortInfo("/dev/ttyUSB2"),
-        ListPortInfo("/dev/ttyUSB3"),
-        ListPortInfo("/dev/ttyUSB4"),
+        USBDevice(
+            device="/dev/ttyUSB0",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="n/a",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB1",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="Device A",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB2",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="N/A",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB3",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="n/A",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB4",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="Device B",
+        ),
     ]
-    mock_ports[0].description = "n/a"
-    mock_ports[1].description = "Device A"
-    mock_ports[2].description = "N/A"
-    mock_ports[3].description = "n/A"
-    mock_ports[4].description = "Device B"
 
-    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
-        result = get_usb_ports()
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports",
+        return_value=mock_ports,
+    ):
+        result = await async_get_usb_ports(hass)
 
         descriptions = list(result.values())
 
         # Verify that only non-"n/a" descriptions are returned (case-insensitive filtering)
         assert descriptions == [
-            "Device A - /dev/ttyUSB1, s/n: n/a",
-            "Device B - /dev/ttyUSB4, s/n: n/a",
+            "Device A - /dev/ttyUSB1, s/n: n/a - 1234:5678",
+            "Device B - /dev/ttyUSB4, s/n: n/a - 1234:5678",
         ]
 
 
-async def test_get_usb_ports_empty_list() -> None:
+async def test_get_usb_ports_empty_list(hass: HomeAssistant) -> None:
     """Test that get_usb_ports handles empty port list."""
-    with patch("serial.tools.list_ports.comports", return_value=[]):
-        result = get_usb_ports()
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports",
+        return_value=[],
+    ):
+        result = await async_get_usb_ports(hass)
 
         # Verify that empty dict is returned
         assert result == {}
 
 
-async def test_get_usb_ports_single_na_port() -> None:
+async def test_get_usb_ports_single_na_port(hass: HomeAssistant) -> None:
     """Test that get_usb_ports returns single 'n/a' port when it's the only one available."""
-    mock_ports = [ListPortInfo("/dev/ttyUSB0")]
-    mock_ports[0].description = "n/a"
+    mock_ports = [
+        USBDevice(
+            device="/dev/ttyUSB0",
+            vid="1234",
+            pid="5678",
+            serial_number=None,
+            manufacturer=None,
+            description="n/a",
+        ),
+    ]
 
-    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
-        result = get_usb_ports()
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports",
+        return_value=mock_ports,
+    ):
+        result = await async_get_usb_ports(hass)
 
         descriptions = list(result.values())
 
         # Verify that the single "n/a" port is returned
         assert descriptions == [
-            "n/a - /dev/ttyUSB0, s/n: n/a",
+            "n/a - /dev/ttyUSB0, s/n: n/a - 1234:5678",
         ]
 
 
-async def test_get_usb_ports_single_valid_port() -> None:
+async def test_get_usb_ports_single_valid_port(hass: HomeAssistant) -> None:
     """Test that get_usb_ports returns single valid port."""
-    mock_ports = [ListPortInfo("/dev/ttyUSB0")]
-    mock_ports[0].description = "Device A"
+    mock_ports = [
+        SerialDevice(
+            device="/dev/ttyUSB0",
+            serial_number=None,
+            manufacturer=None,
+            description="Device A",
+        ),
+    ]
 
-    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
-        result = get_usb_ports()
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports",
+        return_value=mock_ports,
+    ):
+        result = await async_get_usb_ports(hass)
 
         descriptions = list(result.values())
 
@@ -5008,48 +5116,76 @@ async def test_get_usb_ports_single_valid_port() -> None:
         ]
 
 
-async def test_get_usb_ports_ignored_devices() -> None:
+async def test_get_usb_ports_ignored_devices(hass: HomeAssistant) -> None:
     """Test that get_usb_ports filters out ignored non-Z-Wave devices."""
     mock_ports = [
-        ListPortInfo("/dev/ttyUSB0"),
-        ListPortInfo("/dev/ttyUSB1"),
-        ListPortInfo("/dev/ttyUSB2"),
-        ListPortInfo("/dev/ttyUSB3"),
-        ListPortInfo("/dev/ttyUSB4"),
-        ListPortInfo("/dev/ttyUSB5"),
+        # ZBT-2, should be filtered
+        USBDevice(
+            device="/dev/ttyUSB0",
+            vid="10C4",
+            pid="EA60",
+            serial_number=None,
+            manufacturer="Nabu Casa",
+            description="ZBT-2",
+        ),
+        # ZBT-1, should be filtered
+        USBDevice(
+            device="/dev/ttyUSB1",
+            vid="10C4",
+            pid="EA60",
+            serial_number=None,
+            manufacturer="Nabu Casa",
+            description="SkyConnect v1.0",
+        ),
+        # SkyConnect, should be filtered
+        USBDevice(
+            device="/dev/ttyUSB2",
+            vid="10C4",
+            pid="EA60",
+            serial_number=None,
+            manufacturer="Nabu Casa",
+            description="Home Assistant Connect ZBT-1",
+        ),
+        # ZWA-2, should be shown
+        USBDevice(
+            device="/dev/ttyUSB3",
+            vid="10C4",
+            pid="EA60",
+            serial_number=None,
+            manufacturer="Nabu Casa",
+            description="ZWA-2",
+        ),
+        # unknown device with manufacturer/description, should be shown
+        USBDevice(
+            device="/dev/ttyUSB4",
+            vid="10C4",
+            pid="EA60",
+            serial_number=None,
+            manufacturer="Another Manufacturer",
+            description="Z-Wave USB Adapter",
+        ),
+        # unknown device with no manufacturer/description, should be shown
+        USBDevice(
+            device="/dev/ttyUSB5",
+            vid="10C4",
+            pid="EA60",
+            serial_number=None,
+            manufacturer=None,
+            description=None,
+        ),
     ]
-    # ZBT-2, should be filtered
-    mock_ports[0].manufacturer = "Nabu Casa"
-    mock_ports[0].description = "ZBT-2"
 
-    # ZBT-1, should be filtered
-    mock_ports[2].manufacturer = "Nabu Casa"
-    mock_ports[2].description = "Home Assistant Connect ZBT-1"
-
-    # SkyConnect, should be filtered
-    mock_ports[1].manufacturer = "Nabu Casa"
-    mock_ports[1].description = "SkyConnect v1.0"
-
-    # ZWA-2, should be shown
-    mock_ports[3].manufacturer = "Nabu Casa"
-    mock_ports[3].description = "ZWA-2"
-
-    # unknown device with manufacturer/description, should be shown
-    mock_ports[4].manufacturer = "Another Manufacturer"
-    mock_ports[4].description = "Z-Wave USB Adapter"
-
-    # unknown device with no manufacturer/description, should be shown
-    mock_ports[5].manufacturer = None
-    mock_ports[5].description = None
-
-    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
-        result = get_usb_ports()
+    with patch(
+        "homeassistant.components.zwave_js.config_flow.usb.async_scan_serial_ports",
+        return_value=mock_ports,
+    ):
+        result = await async_get_usb_ports(hass)
         descriptions = list(result.values())
 
         assert descriptions == [
-            "ZWA-2 - /dev/ttyUSB3, s/n: n/a - Nabu Casa",
-            "Z-Wave USB Adapter - /dev/ttyUSB4, s/n: n/a - Another Manufacturer",
-            "/dev/ttyUSB5, s/n: n/a",
+            "ZWA-2 - /dev/ttyUSB3, s/n: n/a - Nabu Casa - 10C4:EA60",
+            "Z-Wave USB Adapter - /dev/ttyUSB4, s/n: n/a - Another Manufacturer - 10C4:EA60",
+            "/dev/ttyUSB5, s/n: n/a - 10C4:EA60",
         ]
 
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -5128,7 +5128,7 @@ async def test_get_usb_ports_ignored_devices(hass: HomeAssistant) -> None:
             manufacturer="Nabu Casa",
             description="ZBT-2",
         ),
-        # ZBT-1, should be filtered
+        # SkyConnect, should be filtered
         USBDevice(
             device="/dev/ttyUSB1",
             vid="10C4",
@@ -5137,7 +5137,7 @@ async def test_get_usb_ports_ignored_devices(hass: HomeAssistant) -> None:
             manufacturer="Nabu Casa",
             description="SkyConnect v1.0",
         ),
-        # SkyConnect, should be filtered
+        # ZBT-1, should be filtered
         USBDevice(
             device="/dev/ttyUSB2",
             vid="10C4",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Part of https://github.com/OpenHomeFoundation/roadmap/issues/77.

This PR replaces integration-specific methods to list serial ports with the USB integration's `scan_serial_ports` helper. For integrations that skipped non-USB serial ports, this behavior has not changed. This is purely a code quality refactor.

Some integrations relied on pyserial's implicit formatting for `ListPortInfo` objects, where `str(p)` became `{p.device} - {p.description or "n/a"}`. This has been made more explicit. Future cleanup efforts can target 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
