### PR TITLE
Govee light local availability test cleanup

### DIFF
--- a/tests/components/govee_light_local/test_light.py
+++ b/tests/components/govee_light_local/test_light.py
@@ -794,12 +794,17 @@ def _status_response(
     )
 
 
-async def test_device_becomes_unavailable_after_timeout(
+async def test_device_availability(
     hass: HomeAssistant,
     mock_govee_api: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that a device goes unavailable when no status response arrives."""
+    """Test device availability tracks lastseen against DEVICE_TIMEOUT.
+
+    Walks the full timeline in a single fixture: stays available below the
+    timeout, goes unavailable past it, and recovers when a status response
+    refreshes ``lastseen``.
+    """
     device = GoveeDevice(
         controller=mock_govee_api,
         ip="192.168.1.100",
@@ -819,9 +824,18 @@ async def test_device_becomes_unavailable_after_timeout(
     assert state is not None
     assert state.state == STATE_OFF
 
-    # Advance past DEVICE_TIMEOUT without firing any status responses, and
-    # tick the coordinator forward so a state write occurs.
-    freezer.tick(DEVICE_TIMEOUT + SCAN_INTERVAL)
+    # Advance but stay below DEVICE_TIMEOUT: the device must remain available
+    # even though no status responses have arrived.
+    freezer.tick(DEVICE_TIMEOUT - SCAN_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.H615A")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    # Advance past DEVICE_TIMEOUT: the device should go unavailable.
+    freezer.tick(SCAN_INTERVAL * 2)
     async_fire_time_changed(hass, dt_util.utcnow())
     await hass.async_block_till_done()
 
@@ -829,38 +843,8 @@ async def test_device_becomes_unavailable_after_timeout(
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-
-async def test_device_recovers_after_status_response(
-    hass: HomeAssistant,
-    mock_govee_api: MagicMock,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test that an unavailable device recovers when it responds again."""
-    device = GoveeDevice(
-        controller=mock_govee_api,
-        ip="192.168.1.100",
-        fingerprint="asdawdqwdqwd",
-        sku="H615A",
-        capabilities=DEFAULT_CAPABILITIES,
-    )
-    mock_govee_api.devices = [device]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Drive it unavailable first.
-    freezer.tick(DEVICE_TIMEOUT + SCAN_INTERVAL)
-    async_fire_time_changed(hass, dt_util.utcnow())
-    await hass.async_block_till_done()
-
-    state = hass.states.get("light.H615A")
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
-
-    # A status response refreshes lastseen and fires the entity callback.
+    # A status response refreshes lastseen and fires the entity callback, so
+    # the device recovers without waiting for another coordinator poll.
     device.update(_status_response())
     await hass.async_block_till_done()
 

--- a/tests/components/govee_light_local/test_light.py
+++ b/tests/components/govee_light_local/test_light.py
@@ -1,10 +1,12 @@
 """Test Govee light local."""
 
 from errno import EADDRINUSE, ENETDOWN
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from typing import Any
+from unittest.mock import AsyncMock, call, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from govee_local_api import GoveeDevice
+from govee_local_api.light_capabilities import ON_OFF_CAPABILITIES
 from govee_local_api.message import DevStatusResponse
 import pytest
 
@@ -16,6 +18,7 @@ from homeassistant.components.govee_light_local.const import (
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
+    ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_RGB_COLOR,
@@ -84,7 +87,7 @@ async def test_light_unknown_device(
             ip="192.168.1.101",
             fingerprint="unkown_device",
             sku="XYZK",
-            capabilities=None,
+            capabilities=ON_OFF_CAPABILITIES,
         )
     ]
 
@@ -194,7 +197,7 @@ async def test_light_setup_error(
     assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_light_on_off(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
+async def test_light_on_off(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test light on and then off."""
 
     mock_govee_api.devices = [
@@ -269,12 +272,12 @@ async def test_light_on_off(hass: HomeAssistant, mock_govee_api: MagicMock) -> N
 )
 async def test_turn_on_call_order(
     hass: HomeAssistant,
-    mock_govee_api: MagicMock,
+    mock_govee_api: AsyncMock,
     attribute: str,
     value: str | int | list[int],
     mock_call: str,
     mock_call_args: list[str],
-    mock_call_kwargs: dict[str, any],
+    mock_call_kwargs: dict[str, Any],
 ) -> None:
     """Test that turn_on is called after set_brightness/set_color/set_preset."""
     mock_govee_api.devices = [
@@ -318,7 +321,7 @@ async def test_turn_on_call_order(
     )
 
 
-async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
+async def test_light_brightness(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test changing brightness."""
     mock_govee_api.devices = [
         GoveeDevice(
@@ -345,7 +348,7 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {"entity_id": light.entity_id, "brightness_pct": 50},
+        {"entity_id": light.entity_id, ATTR_BRIGHTNESS_PCT: 50},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -385,8 +388,8 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) 
     mock_govee_api.set_brightness.assert_awaited_with(mock_govee_api.devices[0], 100)
 
 
-async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
-    """Test changing brightness."""
+async def test_light_color(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
+    """Test changing color."""
     mock_govee_api.devices = [
         GoveeDevice(
             controller=mock_govee_api,
@@ -421,7 +424,7 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> No
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_RGB_COLOR] == (100, 255, 50)
-    assert light.attributes["color_mode"] == ColorMode.RGB
+    assert light.attributes[ATTR_COLOR_MODE] == ColorMode.RGB
 
     mock_govee_api.set_color.assert_awaited_with(
         mock_govee_api.devices[0], rgb=(100, 255, 50), temperature=None
@@ -430,7 +433,7 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> No
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {"entity_id": light.entity_id, "color_temp_kelvin": 4400},
+        {"entity_id": light.entity_id, ATTR_COLOR_TEMP_KELVIN: 4400},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -438,15 +441,15 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> No
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["color_temp_kelvin"] == 4400
-    assert light.attributes["color_mode"] == ColorMode.COLOR_TEMP
+    assert light.attributes[ATTR_COLOR_TEMP_KELVIN] == 4400
+    assert light.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
 
     mock_govee_api.set_color.assert_awaited_with(
         mock_govee_api.devices[0], rgb=None, temperature=4400
     )
 
 
-async def test_scene_on(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
+async def test_scene_on(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test turning on scene."""
 
     mock_govee_api.devices = [
@@ -487,7 +490,7 @@ async def test_scene_on(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
 
 
 async def test_scene_restore_rgb(
-    hass: HomeAssistant, mock_govee_api: MagicMock
+    hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test restore rgb color."""
 
@@ -570,7 +573,7 @@ async def test_scene_restore_rgb(
 
 
 async def test_scene_restore_temperature(
-    hass: HomeAssistant, mock_govee_api: MagicMock
+    hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test restore color temperature."""
 
@@ -601,7 +604,7 @@ async def test_scene_restore_temperature(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {"entity_id": light.entity_id, "color_temp_kelvin": initial_color},
+        {"entity_id": light.entity_id, ATTR_COLOR_TEMP_KELVIN: initial_color},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -609,7 +612,7 @@ async def test_scene_restore_temperature(
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["color_temp_kelvin"] == initial_color
+    assert light.attributes[ATTR_COLOR_TEMP_KELVIN] == initial_color
     mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
 
     # Activate scene
@@ -640,11 +643,11 @@ async def test_scene_restore_temperature(
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_EFFECT] is None
-    assert light.attributes["color_temp_kelvin"] == initial_color
+    assert light.attributes[ATTR_COLOR_TEMP_KELVIN] == initial_color
 
 
 async def test_update_callback_registered_and_triggers_state_update(
-    hass: HomeAssistant, mock_govee_api: MagicMock
+    hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test that update callback is registered and triggers state update."""
     device = GoveeDevice(
@@ -679,7 +682,7 @@ async def test_update_callback_registered_and_triggers_state_update(
 
 
 async def test_update_callback_cleared_on_remove(
-    hass: HomeAssistant, mock_govee_api: MagicMock
+    hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test that update callback is cleared when entity is removed."""
     device = GoveeDevice(
@@ -705,7 +708,7 @@ async def test_update_callback_cleared_on_remove(
     assert device.update_callback is None
 
 
-async def test_scene_none(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
+async def test_scene_none(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test turn on 'none' scene."""
 
     mock_govee_api.devices = [
@@ -796,7 +799,7 @@ def _status_response(
 
 async def test_device_availability(
     hass: HomeAssistant,
-    mock_govee_api: MagicMock,
+    mock_govee_api: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test device availability tracks lastseen against DEVICE_TIMEOUT.
@@ -855,7 +858,7 @@ async def test_device_availability(
 
 async def test_one_silent_device_does_not_affect_others(
     hass: HomeAssistant,
-    mock_govee_api: MagicMock,
+    mock_govee_api: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that one silent device does not pull the others unavailable."""


### PR DESCRIPTION
## Proposed change
Two related changes.

First up, and what was asked for in #167566, we consolidate Govee local device availability tests:

    Fold the recovery check into a single test that walks the full
    availability timeline: stays available below DEVICE_TIMEOUT, goes
    unavailable past it, and recovers when a status response refreshes
    lastseen. Addresses review feedback on #167566.

And then, while we were there and looking at the tests, found some other cleanup-y tasks:

    - Replace `capabilities=None` in `test_light_unknown_device` with
      `ON_OFF_CAPABILITIES`. The library's `GoveeDevice` declares
      `capabilities: GoveeLightCapabilities` (non-optional), and its
      discovery path in `controller.py` returns `ON_OFF_CAPABILITIES` for
      unknown SKUs, never `None`. The test now matches the real contract.
    - Fix `mock_call_kwargs: dict[str, any]` typo in `test_turn_on_call_order`
      (built-in `any` function) to `dict[str, Any]`.
    - Use the already-imported `ATTR_BRIGHTNESS_PCT` and
      `ATTR_COLOR_TEMP_KELVIN` constants instead of raw strings, and import
      `ATTR_COLOR_MODE` to replace the remaining hardcoded attribute keys.
    - Annotate `mock_govee_api` consistently as `AsyncMock` (matches the
      conftest fixture's actual type); drop now-unused `MagicMock` import.
    - Fix copy-paste docstring in `test_light_color` (was "Test changing
      brightness").

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
