### PR TITLE
smartthings: add Samsung OCF AC purify switch

### DIFF
--- a/homeassistant/components/smartthings/icons.json
+++ b/homeassistant/components/smartthings/icons.json
@@ -246,6 +246,9 @@
       "power_freeze": {
         "default": "mdi:snowflake"
       },
+      "purify": {
+        "default": "mdi:air-purifier"
+      },
       "rinse_plus": {
         "default": "mdi:water-plus"
       },

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -1014,6 +1014,9 @@
       "power_freeze": {
         "name": "Power freeze"
       },
+      "purify": {
+        "name": "Purify"
+      },
       "rinse_plus": {
         "name": "Rinse plus"
       },

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -80,6 +80,13 @@ SWITCH = SmartThingsSwitchEntityDescription(
 CAPABILITY_TO_COMMAND_SWITCHES: dict[
     Capability | str, SmartThingsCommandSwitchEntityDescription
 ] = {
+    Capability.CUSTOM_SPI_MODE: SmartThingsCommandSwitchEntityDescription(
+        key=Capability.CUSTOM_SPI_MODE,
+        translation_key="purify",
+        status_attribute=Attribute.SPI_MODE,
+        command=Command.SET_SPI_MODE,
+        entity_category=EntityCategory.CONFIG,
+    ),
     Capability.SAMSUNG_CE_AIR_CONDITIONER_LIGHTING: SmartThingsCommandSwitchEntityDescription(
         key=Capability.SAMSUNG_CE_AIR_CONDITIONER_LIGHTING,
         translation_key="display_lighting",

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -199,56 +199,6 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ac_cac_01001][switch.ar_varanda_purify-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.ar_varanda_purify',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Purify',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Purify',
-    'platform': 'smartthings',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'purify',
-    'unique_id': '23c6d296-4656-20d8-f6eb-2ff13e041753_main_custom.spiMode_spiMode_spiMode',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[da_ac_cac_01001][switch.ar_varanda_purify-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Ar Varanda Purify',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.ar_varanda_purify',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_all_entities[da_ac_cac_01001][switch.ar_varanda_sound_effect-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -149,6 +149,156 @@
     'state': 'on',
   })
 # ---
+# name: test_all_entities[da_ac_rac_000001][switch.ac_office_granit_purify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ac_office_granit_purify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Purify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Purify',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'purify',
+    'unique_id': '96a5ef74-5832-a84b-f1f7-ca799957065d_main_custom.spiMode_spiMode_spiMode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ac_rac_000001][switch.ac_office_granit_purify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AC Office Granit Purify',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ac_office_granit_purify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_ac_rac_000003][switch.clim_salon_purify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.clim_salon_purify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Purify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Purify',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'purify',
+    'unique_id': '1e3f7ca2-e005-e1a4-f6d7-bc231e3f7977_main_custom.spiMode_spiMode_spiMode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ac_rac_000003][switch.clim_salon_purify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clim Salon Purify',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.clim_salon_purify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_ac_rac_01001][switch.aire_dormitorio_principal_purify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.aire_dormitorio_principal_purify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Purify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Purify',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'purify',
+    'unique_id': '4ece486b-89db-f06a-d54d-748b676b4d8e_main_custom.spiMode_spiMode_spiMode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ac_rac_01001][switch.aire_dormitorio_principal_purify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Aire Dormitorio Principal Purify',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aire_dormitorio_principal_purify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_all_entities[da_ac_cac_01001][switch.ar_varanda_sound_effect-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -199,7 +199,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ac_rac_000003][switch.clim_salon_purify-entry]
+# name: test_all_entities[da_ac_cac_01001][switch.ar_varanda_purify-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -213,7 +213,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.clim_salon_purify',
+    'entity_id': 'switch.ar_varanda_purify',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -232,67 +232,17 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'purify',
-    'unique_id': '1e3f7ca2-e005-e1a4-f6d7-bc231e3f7977_main_custom.spiMode_spiMode_spiMode',
+    'unique_id': '23c6d296-4656-20d8-f6eb-2ff13e041753_main_custom.spiMode_spiMode_spiMode',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ac_rac_000003][switch.clim_salon_purify-state]
+# name: test_all_entities[da_ac_cac_01001][switch.ar_varanda_purify-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Clim Salon Purify',
+      'friendly_name': 'Ar Varanda Purify',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.clim_salon_purify',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_all_entities[da_ac_rac_01001][switch.aire_dormitorio_principal_purify-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.aire_dormitorio_principal_purify',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Purify',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Purify',
-    'platform': 'smartthings',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'purify',
-    'unique_id': '4ece486b-89db-f06a-d54d-748b676b4d8e_main_custom.spiMode_spiMode_spiMode',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[da_ac_rac_01001][switch.aire_dormitorio_principal_purify-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Aire Dormitorio Principal Purify',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.aire_dormitorio_principal_purify',
+    'entity_id': 'switch.ar_varanda_purify',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -183,6 +183,39 @@ async def test_custom_commands(
     )
 
 
+@pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])
+@pytest.mark.parametrize(
+    ("action", "argument"),
+    [
+        (SERVICE_TURN_ON, "on"),
+        (SERVICE_TURN_OFF, "off"),
+    ],
+)
+async def test_ac_purify_switch(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    action: str,
+    argument: str,
+) -> None:
+    """Test Samsung OCF AC purify switch."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        action,
+        {ATTR_ENTITY_ID: "switch.ac_office_granit_purify"},
+        blocking=True,
+    )
+    devices.execute_device_command.assert_called_once_with(
+        "96a5ef74-5832-a84b-f1f7-ca799957065d",
+        Capability.CUSTOM_SPI_MODE,
+        Command.SET_SPI_MODE,
+        MAIN,
+        argument,
+    )
+
+
 @pytest.mark.parametrize("device_fixture", ["c2c_arlo_pro_3_switch"])
 async def test_state_update(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Expose Samsung OCF air conditioner `custom.spiMode` as a SmartThings config switch.

Although the SmartThings capability is named `spiMode`, the user-facing Samsung feature is called `Purify` in Samsung's mobile app and on the physical remote, so this patch exposes it with that name in Home Assistant.

This adds:
- a SmartThings switch mapping for `Capability.CUSTOM_SPI_MODE`
- the `Purify` translation string
- an icon for the switch
- SmartThings switch test coverage and snapshots


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Real-device validation:
- Verified on Samsung OCF AC hardware `ARTIK051_KRAC_18K` (`DA-AC-RAC-000001`)
- Turning the created `Purify` switch on/off successfully toggles the Purify function on the unit

Implementation note:
- `pysmartthings` already supports `Capability.CUSTOM_SPI_MODE`, `Attribute.SPI_MODE`, and `Command.SET_SPI_MODE`
- this patch adds the missing Home Assistant entity mapping and test coverage

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
