### PR TITLE
Expose  async serial port scanning helper in USB integration

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.components.homeassistant_hardware.util import guess_firmware_
 from homeassistant.components.usb import (
     USBDevice,
     async_register_port_event_callback,
-    scan_serial_ports,
+    async_scan_serial_ports,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -163,7 +163,7 @@ async def async_migrate_entry(
                 key not in config_entry.data
                 for key in (VID, PID, MANUFACTURER, PRODUCT, SERIAL_NUMBER)
             ):
-                serial_ports = await hass.async_add_executor_job(scan_serial_ports)
+                serial_ports = await async_scan_serial_ports(hass)
                 serial_ports_info = {port.device: port for port in serial_ports}
                 device = config_entry.data[DEVICE]
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -37,7 +37,8 @@ from .models import (
     USBDevice,
 )
 from .utils import (
-    scan_serial_ports,
+    async_scan_serial_ports,
+    scan_serial_ports,  # noqa: F401
     usb_device_from_path,  # noqa: F401
     usb_device_from_port,  # noqa: F401
     usb_device_matches_matcher,
@@ -433,7 +434,7 @@ class USBDiscovery:
             # Only consider USB-serial ports for discovery
             usb_ports = [
                 p
-                for p in await self.hass.async_add_executor_job(scan_serial_ports)
+                for p in await async_scan_serial_ports(self.hass)
                 if isinstance(p, USBDevice)
             ]
 

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Awaitable, Sequence
 import dataclasses
 import fnmatch
 import os
@@ -10,6 +10,7 @@ import os
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
 
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.loader import USBMatcher
 
@@ -74,6 +75,14 @@ def scan_serial_ports() -> Sequence[USBDevice | SerialDevice]:
         serial_ports.append(device)
 
     return serial_ports
+
+
+@callback
+def async_scan_serial_ports(
+    hass: HomeAssistant,
+) -> Awaitable[Sequence[USBDevice | SerialDevice]]:
+    """Scan serial ports and return USB and other serial devices, async."""
+    return hass.async_add_executor_job(scan_serial_ports)
 
 
 def usb_device_from_path(device_path: str) -> USBDevice | None:

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Sequence
+from collections.abc import Sequence
 import dataclasses
 import fnmatch
 import os
@@ -10,7 +10,7 @@ import os
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.loader import USBMatcher
 
@@ -77,12 +77,11 @@ def scan_serial_ports() -> Sequence[USBDevice | SerialDevice]:
     return serial_ports
 
 
-@callback
-def async_scan_serial_ports(
+async def async_scan_serial_ports(
     hass: HomeAssistant,
-) -> Awaitable[Sequence[USBDevice | SerialDevice]]:
+) -> Sequence[USBDevice | SerialDevice]:
     """Scan serial ports and return USB and other serial devices, async."""
-    return hass.async_add_executor_job(scan_serial_ports)
+    return await hass.async_add_executor_job(scan_serial_ports)
 
 
 def usb_device_from_path(device_path: str) -> USBDevice | None:

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -26,7 +26,11 @@ from homeassistant.components.homeassistant_hardware.firmware_config_flow import
     ZigbeeFlowStrategy,
 )
 from homeassistant.components.homeassistant_yellow import hardware as yellow_hardware
-from homeassistant.components.usb import SerialDevice, USBDevice, scan_serial_ports
+from homeassistant.components.usb import (
+    SerialDevice,
+    USBDevice,
+    async_scan_serial_ports,
+)
 from homeassistant.config_entries import (
     SOURCE_IGNORE,
     SOURCE_ZEROCONF,
@@ -155,7 +159,7 @@ def _format_serial_port_choice(
 async def list_serial_ports(hass: HomeAssistant) -> list[USBDevice | SerialDevice]:
     """List all serial ports, including the Yellow radio and the multi-PAN addon."""
     ports: list[USBDevice | SerialDevice] = []
-    ports.extend(await hass.async_add_executor_job(scan_serial_ports))
+    ports.extend(await async_scan_serial_ports(hass))
 
     # Add useful info to the Yellow's serial port selection screen
     try:

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -265,7 +265,7 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
     fixable_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.homeassistant_sky_connect.scan_serial_ports",
+        "homeassistant.components.homeassistant_sky_connect.async_scan_serial_ports",
         return_value=[
             USBDevice(
                 device="/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_4f5f3b26d59f8714a78b599690741999-if00-port0",

--- a/tests/components/usb/__init__.py
+++ b/tests/components/usb/__init__.py
@@ -21,7 +21,7 @@ def force_usb_polling_watcher():
 
 def patch_scanned_serial_ports(**kwargs) -> None:
     """Patch the USB integration's list of scanned serial ports."""
-    return patch("homeassistant.components.usb.scan_serial_ports", **kwargs)
+    return patch("homeassistant.components.usb.utils.scan_serial_ports", **kwargs)
 
 
 async def async_request_scan(hass: HomeAssistant) -> None:

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -12,7 +12,10 @@ from homeassistant import config_entries
 from homeassistant.components import usb
 from homeassistant.components.usb import DOMAIN
 from homeassistant.components.usb.models import SerialDevice, USBDevice
-from homeassistant.components.usb.utils import scan_serial_ports, usb_device_from_path
+from homeassistant.components.usb.utils import (
+    async_scan_serial_ports,
+    usb_device_from_path,
+)
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -1293,8 +1296,10 @@ async def test_register_port_event_callback_failure(
     assert "Failure 2" in caplog.text
 
 
-def test_scan_serial_ports_with_unique_symlinks() -> None:
-    """Test scan_serial_ports returns devices with unique /dev/serial/by-id paths."""
+async def test_async_scan_serial_ports_with_unique_symlinks(
+    hass: HomeAssistant,
+) -> None:
+    """Test async_scan_serial_ports returns devices with unique /dev/serial/by-id paths."""
     entry1 = MagicMock(spec_set=os.DirEntry)
     entry1.is_symlink.return_value = True
     entry1.path = "/dev/serial/by-id/usb-device1"
@@ -1335,7 +1340,7 @@ def test_scan_serial_ports_with_unique_symlinks() -> None:
             return_value=[mock_port1, mock_port2],
         ),
     ):
-        devices = scan_serial_ports()
+        devices = await async_scan_serial_ports(hass)
 
     assert len(devices) == 2
     assert devices[0].device == "/dev/serial/by-id/usb-device1"
@@ -1344,8 +1349,10 @@ def test_scan_serial_ports_with_unique_symlinks() -> None:
     assert devices[1].vid == "ABCD"
 
 
-def test_scan_serial_ports_without_unique_symlinks() -> None:
-    """Test scan_serial_ports returns devices with original paths when no symlinks exist."""
+async def test_async_scan_serial_ports_without_unique_symlinks(
+    hass: HomeAssistant,
+) -> None:
+    """Test async_scan_serial_ports returns devices with original paths when no symlinks exist."""
     mock_port = MagicMock()
     mock_port.device = "/dev/ttyUSB0"
     mock_port.vid = 0x1234
@@ -1362,15 +1369,15 @@ def test_scan_serial_ports_without_unique_symlinks() -> None:
             return_value=[mock_port],
         ),
     ):
-        devices = scan_serial_ports()
+        devices = await async_scan_serial_ports(hass)
 
     assert len(devices) == 1
     assert devices[0].device == "/dev/ttyUSB0"
     assert devices[0].vid == "1234"
 
 
-def test_scan_serial_ports_no_vid_pid() -> None:
-    """Test scan_serial_ports returns devices without VID:PID."""
+async def test_async_scan_serial_ports_no_vid_pid(hass: HomeAssistant) -> None:
+    """Test async_scan_serial_ports returns devices without VID:PID."""
     mock_port = MagicMock()
     mock_port.device = "/dev/ttyAMA1"
     mock_port.vid = None
@@ -1387,7 +1394,7 @@ def test_scan_serial_ports_no_vid_pid() -> None:
             return_value=[mock_port],
         ),
     ):
-        devices = scan_serial_ports()
+        devices = await async_scan_serial_ports(hass)
 
     assert len(devices) == 1
     assert isinstance(devices[0], SerialDevice)

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -2844,7 +2844,7 @@ async def test_config_flow_port_yellow_port_name(
     with (
         patch("homeassistant.components.zha.config_flow.yellow_hardware.async_info"),
         patch(
-            "homeassistant.components.zha.config_flow.scan_serial_ports",
+            "homeassistant.components.zha.config_flow.async_scan_serial_ports",
             return_value=[port],
         ),
     ):
@@ -2866,7 +2866,7 @@ async def test_config_flow_ports_no_hassio(hass: HomeAssistant) -> None:
     with (
         patch("homeassistant.components.zha.config_flow.is_hassio", return_value=False),
         patch(
-            "homeassistant.components.zha.config_flow.scan_serial_ports",
+            "homeassistant.components.zha.config_flow.async_scan_serial_ports",
             return_value=[],
         ),
     ):
@@ -2884,7 +2884,7 @@ async def test_config_flow_port_multiprotocol_port_name(hass: HomeAssistant) -> 
             "homeassistant.components.hassio.addon_manager.AddonManager.async_get_addon_info"
         ) as async_get_addon_info,
         patch(
-            "homeassistant.components.zha.config_flow.scan_serial_ports",
+            "homeassistant.components.zha.config_flow.async_scan_serial_ports",
             return_value=[],
         ),
     ):
@@ -2909,7 +2909,7 @@ async def test_config_flow_port_no_multiprotocol(hass: HomeAssistant) -> None:
             side_effect=AddonError,
         ),
         patch(
-            "homeassistant.components.zha.config_flow.scan_serial_ports",
+            "homeassistant.components.zha.config_flow.async_scan_serial_ports",
             return_value=[],
         ),
     ):
@@ -2974,7 +2974,7 @@ async def test_list_serial_ports_ignored_devices(hass: HomeAssistant) -> None:
     with (
         patch("homeassistant.components.zha.config_flow.is_hassio", return_value=False),
         patch(
-            "homeassistant.components.zha.config_flow.scan_serial_ports",
+            "homeassistant.components.zha.config_flow.async_scan_serial_ports",
             return_value=mock_ports,
         ),
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds `async_scan_serial_ports` to simplify code using the USB integration's `scan_serial_ports` helper.

Useful for https://github.com/home-assistant/core/pull/167695 and https://github.com/home-assistant/core/pull/167701.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
