### PR TITLE
Allow trigger based template entities to skip option validation

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -281,6 +281,9 @@ class TriggerBinarySensorEntity(TriggerEntity, AbstractTemplateBinarySensor):
 
     domain = BINARY_SENSOR_DOMAIN
 
+    # delay on and delay off are validated when the state is validated.
+    skip_validation = (CONF_DELAY_ON, CONF_DELAY_OFF)
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -282,7 +282,7 @@ class TriggerBinarySensorEntity(TriggerEntity, AbstractTemplateBinarySensor):
     domain = BINARY_SENSOR_DOMAIN
 
     # delay on and delay off are validated when the state is validated.
-    skip_validation = (CONF_DELAY_ON, CONF_DELAY_OFF)
+    skip_rendered_result = (CONF_DELAY_ON, CONF_DELAY_OFF)
 
     def __init__(
         self,

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -6,8 +6,6 @@ from collections.abc import Callable
 import logging
 from typing import Any
 
-import voluptuous as vol
-
 from homeassistant.const import CONF_VARIABLES
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
@@ -35,6 +33,8 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
 ):
     """Template entity based on trigger data."""
 
+    skip_validation: tuple[str, ...] | None
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -49,6 +49,10 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
         self._entity_variables: ScriptVariables | None = config.get(CONF_VARIABLES)
         self._rendered_entity_variables: dict | None = None
         self._state_render_error = False
+
+        self._skip_rendered_validation: list[str] = []
+        if self.skip_validation is not None:
+            self._skip_rendered_validation.extend(self.skip_validation)
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
@@ -209,6 +213,9 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
             return True
 
         for option, entity_template in self._templates.items():
+            if option in self._skip_rendered_validation:
+                continue
+
             # Capture templates that did not render a result due to an exception and
             # ensure the state object updates. _SENTINEL is used to differentiate
             # templates that render None.
@@ -216,26 +223,11 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
                 write_state = True
                 continue
 
-            if entity_template.validator:
-                try:
-                    value = entity_template.validator(rendered)
-                except vol.Invalid as ex:
-                    _LOGGER.error(
-                        (
-                            "Error validating template result '%s' "
-                            "from template '%s' "
-                            "for attribute '%s' in entity %s "
-                            "validation message '%s'"
-                        ),
-                        rendered,
-                        entity_template.template,
-                        entity_template.attribute,
-                        self.entity_id,
-                        ex.msg,
-                    )
-                    value = None
-            else:
-                value = rendered
+            value = (
+                entity_template.validator(rendered)
+                if entity_template.validator
+                else rendered
+            )
 
             if entity_template.on_update:
                 entity_template.on_update(value)

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import logging
 from typing import Any
 
 from homeassistant.const import CONF_VARIABLES
@@ -23,8 +22,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import TriggerUpdateCoordinator
 from .entity import AbstractTemplateEntity
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class TriggerEntity(  # pylint: disable=hass-enforce-class-module
     TriggerBaseEntity,
@@ -33,7 +30,7 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
 ):
     """Template entity based on trigger data."""
 
-    skip_rendered_result: tuple[str, ...] | None
+    skip_rendered_result: tuple[str, ...] | None = None
 
     def __init__(
         self,

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -33,7 +33,7 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
 ):
     """Template entity based on trigger data."""
 
-    skip_validation: tuple[str, ...] | None
+    skip_rendered_result: tuple[str, ...] | None
 
     def __init__(
         self,
@@ -50,9 +50,9 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
         self._rendered_entity_variables: dict | None = None
         self._state_render_error = False
 
-        self._skip_rendered_validation: list[str] = []
-        if self.skip_validation is not None:
-            self._skip_rendered_validation.extend(self.skip_validation)
+        self._skip_rendered_result: list[str] = []
+        if self.skip_rendered_result is not None:
+            self._skip_rendered_result.extend(self.skip_rendered_result)
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
@@ -213,7 +213,7 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
             return True
 
         for option, entity_template in self._templates.items():
-            if option in self._skip_rendered_validation:
+            if option in self._skip_rendered_result:
                 continue
 
             # Capture templates that did not render a result due to an exception and

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import logging
 from typing import Any
+
+import voluptuous as vol
 
 from homeassistant.const import CONF_VARIABLES
 from homeassistant.core import HomeAssistant, callback
@@ -21,6 +24,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import TriggerUpdateCoordinator
 from .entity import AbstractTemplateEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TriggerEntity(  # pylint: disable=hass-enforce-class-module
@@ -211,11 +216,26 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
                 write_state = True
                 continue
 
-            value = (
-                entity_template.validator(rendered)
-                if entity_template.validator
-                else rendered
-            )
+            if entity_template.validator:
+                try:
+                    value = entity_template.validator(rendered)
+                except vol.Invalid as ex:
+                    _LOGGER.error(
+                        (
+                            "Error validating template result '%s' "
+                            "from template '%s' "
+                            "for attribute '%s' in entity %s "
+                            "validation message '%s'"
+                        ),
+                        rendered,
+                        entity_template.template,
+                        entity_template.attribute,
+                        self.entity_id,
+                        ex.msg,
+                    )
+                    value = None
+            else:
+                value = rendered
 
             if entity_template.on_update:
                 entity_template.on_update(value)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Trigger based binary sensors were validating delay_on and delay_off rendered results twice.  This was causing an warning and an exception in the logs when only a warning should have been produced.

Because of this, tests/components/template/test_binary_sensor.py -> test_trigger_with_negative_time_periods has been intermittently failing.

This PR gives trigger based template entities the option to skip rendered results for specified options.  `delay_on`, `delay_off`, and `auto_off` are only used in conjunction with the binary_sensors state.  These options should only be validated when the state is rendered, therefore these options should be skipped during the TriggerEntity._handle_rendered_results for loop.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/167707
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
