### PR TITLE
Make the scaffold script ask for the integration type

### DIFF
--- a/script/scaffold/__main__.py
+++ b/script/scaffold/__main__.py
@@ -84,7 +84,7 @@ def main() -> int:
         # If it's a new integration and it's not a config flow,
         # create a config flow too.
         if not args.template.startswith("config_flow"):
-            if info.helper:
+            if info.integration_type == "helper":
                 template = "config_flow_helper"
             elif info.oauth2:
                 template = "config_flow_oauth2"

--- a/script/scaffold/gather_info.py
+++ b/script/scaffold/gather_info.py
@@ -125,16 +125,17 @@ More info @ https://developers.home-assistant.io/docs/creating_integration_manif
                     "prompt": f"""What is the integration type?
 
 Valid types are {", ".join(IntegrationType)}.
-You may leave it empty here, but it is recommended to provide one. Also note that it might even be required.
+This field is recommended and required in some cases. To intentionally leave it unset, type 'omit'.
 
 More info @ https://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type
 """,
                     "validators": [
                         [
-                            f"You need to leave it empty or pick one of {', '.join(IntegrationType)}",
-                            lambda value: value == "" or value in IntegrationType,
+                            f"You need to pick one of {', '.join(IntegrationType)} or 'omit'.",
+                            lambda value: value in IntegrationType or value == "omit",
                         ]
                     ],
+                    "converter": lambda value: None if value == "omit" else value,
                 },
                 "oauth2": {
                     "prompt": "Can the user authenticate the device using OAuth2? (yes/no)",

--- a/script/scaffold/gather_info.py
+++ b/script/scaffold/gather_info.py
@@ -4,6 +4,7 @@ import json
 
 from homeassistant.util import slugify
 from script.hassfest.manifest import SUPPORTED_IOT_CLASSES
+from script.hassfest.model import IntegrationType
 
 from .const import COMPONENT_DIR
 from .error import ExitApp
@@ -120,10 +121,20 @@ More info @ https://developers.home-assistant.io/docs/creating_integration_manif
                     "default": "no",
                     **YES_NO,
                 },
-                "helper": {
-                    "prompt": "Is this a helper integration? (yes/no)",
-                    "default": "no",
-                    **YES_NO,
+                "integration_type": {
+                    "prompt": f"""What is the integration type?
+
+Valid types are {", ".join(IntegrationType)}.
+You may leave it empty here, but it is recommended to provide one. Also note that it might even be required.
+
+More info @ https://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type
+""",
+                    "validators": [
+                        [
+                            f"You need to leave it empty or pick one of {', '.join(IntegrationType)}",
+                            lambda value: value == "" or value in IntegrationType,
+                        ]
+                    ],
                 },
                 "oauth2": {
                     "prompt": "Can the user authenticate the device using OAuth2? (yes/no)",

--- a/script/scaffold/generate.py
+++ b/script/scaffold/generate.py
@@ -75,6 +75,8 @@ def _custom_tasks(template, info: Info) -> None:
 
         if info.requirement:
             changes["requirements"] = [info.requirement]
+        if info.integration_type:
+            changes["integration_type"] = info.integration_type
 
         info.update_manifest(**changes)
 

--- a/script/scaffold/model.py
+++ b/script/scaffold/model.py
@@ -26,7 +26,7 @@ class Info:
     authentication: str = attr.ib(default=None)
     discoverable: str = attr.ib(default=None)
     oauth2: str = attr.ib(default=None)
-    helper: str = attr.ib(default=None)
+    integration_type: str = attr.ib(default=None)
 
     files_added: set[Path] = attr.ib(factory=set)
     tests_added: set[Path] = attr.ib(factory=set)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Setting the `integration_type` became required for core integrations with a config flow. The scaffold script was not asking for it. In turn, this caused scaffolding to fail for such integrations (see issue #167233).

The proposed change is to make the scaffolding script ask for the `integration_type`:
```
What is the integration type?

Valid types are device, entity, hardware, helper, hub, service, system, virtual.
This field is recommended and required in some cases. To intentionally leave it unset, type 'omit'.

More info @ https://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type
```

This replaces the "Is this a helper integration? (yes/no)" question, since a helper is an integration type.

Since providing an integration type is recommended, this question is always asked for new integrations, even when providing an integration type is not required. However, the user may refuse to do so with an explicit opt-out.

If an integration type is required, but the user explicitly omitted it, the script will fail with:
```
* [ERROR] [INTEGRATION_TYPE] Integration has a config flow but is missing an `integration_type` in the manifest
```
If we want the script to be non-failing in that case, we would need to ask for the integration type after deciding that the integration needs a config flow. However, since the script may be called with a config flow template on an existing integration without an integration type, this would mean we would need to ask manifest questions on an already existing integration. For this, because the error message is self-explanatory, and to keep the PR minimal, I left it failing for these cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167233
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
