### PR TITLE
Fix auth store save race while serializing refresh tokens

### DIFF
--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -522,6 +522,12 @@ class AuthStore:
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, Any]]]:
         """Return the data to store."""
+        # This method is called by storage from an executor thread while auth
+        # data can still be updated on the event loop thread.
+        # Take snapshots to avoid iterating over dicts that may be mutated.
+        users_snapshot = tuple(self._users.copy().values())
+        groups_snapshot = tuple(self._groups.copy().values())
+
         users = [
             {
                 "id": user.id,
@@ -532,11 +538,11 @@ class AuthStore:
                 "system_generated": user.system_generated,
                 "local_only": user.local_only,
             }
-            for user in self._users.values()
+            for user in users_snapshot
         ]
 
         groups = []
-        for group in self._groups.values():
+        for group in groups_snapshot:
             g_dict: dict[str, Any] = {
                 "id": group.id,
                 # Name not read for sys groups. Kept here for backwards compat
@@ -556,8 +562,8 @@ class AuthStore:
                 "auth_provider_id": credential.auth_provider_id,
                 "data": credential.data,
             }
-            for user in self._users.values()
-            for credential in user.credentials
+            for user in users_snapshot
+            for credential in tuple(user.credentials)
         ]
 
         refresh_tokens = [
@@ -584,8 +590,8 @@ class AuthStore:
                 else None,
                 "version": refresh_token.version,
             }
-            for user in self._users.values()
-            for refresh_token in user.refresh_tokens.values()
+            for user in users_snapshot
+            for refresh_token in user.refresh_tokens.copy().values()
         ]
 
         return {

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -201,7 +201,7 @@ class _MutatingRefreshTokenDict(dict[str, auth_models.RefreshToken]):
     def values(self):
         """Return values that mutate the dict during iteration."""
         parent = self
-        iterator = super().values().__iter__()
+        iterator = iter(super().values())
 
         def _iter():
             mutated = False

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -7,7 +7,7 @@ from unittest.mock import PropertyMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.auth import auth_store
+from homeassistant.auth import auth_store, models as auth_models
 from homeassistant.core import HomeAssistant
 
 MOCK_STORAGE_DATA = {
@@ -193,6 +193,45 @@ async def test_system_groups_store_id_and_name(
         {"id": auth_store.GROUP_ID_USER, "name": auth_store.GROUP_NAME_USER},
         {"id": auth_store.GROUP_ID_READ_ONLY, "name": auth_store.GROUP_NAME_READ_ONLY},
     ]
+
+
+class _MutatingRefreshTokenDict(dict[str, auth_models.RefreshToken]):
+    """Dict that mutates while values() is iterated."""
+
+    def values(self):
+        """Return values that mutate the dict during iteration."""
+        parent = self
+        iterator = super().values().__iter__()
+
+        def _iter():
+            mutated = False
+            for token in iterator:
+                if not mutated:
+                    parent["inserted-during-iteration"] = token
+                    mutated = True
+                yield token
+
+        return _iter()
+
+    def copy(self) -> dict[str, auth_models.RefreshToken]:
+        """Return a plain dict snapshot."""
+        return dict(self.items())
+
+
+async def test_data_to_save_refresh_tokens_mutated_during_iteration(
+    hass: HomeAssistant,
+) -> None:
+    """Test _data_to_save tolerates refresh token mutation during iteration."""
+    store = auth_store.AuthStore(hass)
+    await store.async_load()
+    user = await store.async_create_user("Test User")
+    refresh_token = await store.async_create_refresh_token(user)
+    user.refresh_tokens = _MutatingRefreshTokenDict({refresh_token.id: refresh_token})
+
+    data = store._data_to_save()
+
+    assert len(data["refresh_tokens"]) == 1
+    assert data["refresh_tokens"][0]["id"] == refresh_token.id
 
 
 async def test_loading_only_once(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Fixes #135542

## Breaking change
None.

## Proposed change
`AuthStore._data_to_save` can run from the storage executor while auth data is still being updated on the event loop thread. Iterating live mutable collection views in that path can raise `RuntimeError: dictionary changed size during iteration`.

This change snapshots users/groups/credentials/refresh tokens before serialization and adds a regression test that mutates `refresh_tokens` during `values()` iteration. Stored schema and behavior remain unchanged.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #135542
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
