### PR TITLE
Replace `ding` with new `ring` event in Ring integration doorbell

### DIFF
--- a/homeassistant/components/ring/event.py
+++ b/homeassistant/components/ring/event.py
@@ -7,6 +7,7 @@ from ring_doorbell import RingCapability, RingEvent as RingAlert
 from ring_doorbell.const import KIND_DING, KIND_INTERCOM_UNLOCK, KIND_MOTION
 
 from homeassistant.components.event import (
+    DoorbellEventType,
     EventDeviceClass,
     EventEntity,
     EventEntityDescription,
@@ -34,7 +35,7 @@ EVENT_DESCRIPTIONS: tuple[RingEventEntityDescription, ...] = (
         key=KIND_DING,
         translation_key=KIND_DING,
         device_class=EventDeviceClass.DOORBELL,
-        event_types=[KIND_DING],
+        event_types=[DoorbellEventType.RING],
         capability=RingCapability.DING,
     ),
     RingEventEntityDescription(
@@ -100,7 +101,10 @@ class RingEvent(RingBaseEntity[RingListenCoordinator, RingDeviceT], EventEntity)
     @callback
     def _handle_coordinator_update(self) -> None:
         if (alert := self._get_coordinator_alert()) and not alert.is_update:
-            self._async_handle_event(alert.kind)
+            if alert.kind == KIND_DING:
+                self._async_handle_event(DoorbellEventType.RING)
+            else:
+                self._async_handle_event(alert.kind)
         super()._handle_coordinator_update()
 
     @property

--- a/homeassistant/components/ring/strings.json
+++ b/homeassistant/components/ring/strings.json
@@ -73,7 +73,14 @@
     },
     "event": {
       "ding": {
-        "name": "Ding"
+        "name": "Ding",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "ring": "[%key:component::event::entity_component::doorbell::state_attributes::event_type::state::ring%]"
+            }
+          }
+        }
       },
       "intercom_unlock": {
         "name": "Intercom unlock"

--- a/tests/components/ring/snapshots/test_event.ambr
+++ b/tests/components/ring/snapshots/test_event.ambr
@@ -7,7 +7,7 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'ding',
+        <DoorbellEventType.RING: 'ring'>,
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -47,7 +47,7 @@
       'device_class': 'doorbell',
       'event_type': None,
       'event_types': list([
-        'ding',
+        <DoorbellEventType.RING: 'ring'>,
       ]),
       'friendly_name': 'Front Door Ding',
     }),
@@ -187,7 +187,7 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'ding',
+        <DoorbellEventType.RING: 'ring'>,
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -227,7 +227,7 @@
       'device_class': 'doorbell',
       'event_type': None,
       'event_types': list([
-        'ding',
+        <DoorbellEventType.RING: 'ring'>,
       ]),
       'friendly_name': 'Ingress Ding',
     }),

--- a/tests/components/ring/test_event.py
+++ b/tests/components/ring/test_event.py
@@ -9,6 +9,7 @@ import pytest
 from ring_doorbell import Ring
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.event import ATTR_EVENT_TYPE, DoorbellEventType
 from homeassistant.components.ring.binary_sensor import RingEvent
 from homeassistant.components.ring.coordinator import RingEventListener
 from homeassistant.const import Platform
@@ -35,26 +36,38 @@ async def test_states(
 
 
 @pytest.mark.parametrize(
-    ("device_id", "device_name", "alert_kind", "device_class"),
+    ("device_id", "device_name", "alert_kind", "device_class", "event_type"),
     [
         pytest.param(
             FRONT_DOOR_DEVICE_ID,
             "front_door",
             "motion",
             "motion",
+            "motion",
             id="front_door_motion",
         ),
         pytest.param(
-            FRONT_DOOR_DEVICE_ID, "front_door", "ding", "doorbell", id="front_door_ding"
+            FRONT_DOOR_DEVICE_ID,
+            "front_door",
+            "ding",
+            "doorbell",
+            DoorbellEventType.RING,
+            id="front_door_ding",
         ),
         pytest.param(
-            INGRESS_DEVICE_ID, "ingress", "ding", "doorbell", id="ingress_ding"
+            INGRESS_DEVICE_ID,
+            "ingress",
+            "ding",
+            "doorbell",
+            DoorbellEventType.RING,
+            id="ingress_ding",
         ),
         pytest.param(
             INGRESS_DEVICE_ID,
             "ingress",
             "intercom_unlock",
             "button",
+            "intercom_unlock",
             id="ingress_unlock",
         ),
     ],
@@ -68,6 +81,7 @@ async def test_event(
     device_name: str,
     alert_kind: str,
     device_class: str,
+    event_type: str,
 ) -> None:
     """Test the Ring event platforms."""
 
@@ -96,3 +110,4 @@ async def test_event(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == start_time_str
+    assert state.attributes[ATTR_EVENT_TYPE] == event_type


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If you are currently using the event type `ding`, you need to replace it with the new standardized event `ring`. 
This change intends to standardize the event type across different integrations, so they can be seamlessly used in the new triggers and conditions.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed in https://github.com/home-assistant/core/pull/167630#discussion_r3047829080 replace the old `ding` event with the new `ring` one.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
