### PR TITLE
Refactor Ultima fixtures to reduce duplication

### DIFF
--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -124,6 +124,20 @@ def mock_smlight_client(request: pytest.FixtureRequest) -> Generator[MagicMock]:
         yield api
 
 
+MOCK_ULTIMA = Info(
+    MAC="AA:BB:CC:DD:EE:FF",
+    model="SLZB-Ultima3",
+)
+
+
+@pytest.fixture
+def mock_ultima_client(mock_smlight_client: MagicMock) -> MagicMock:
+    """Configure api client to return an Ultima device."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    return mock_smlight_client
+
+
 async def setup_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -133,8 +133,7 @@ MOCK_ULTIMA = Info(
 @pytest.fixture
 def mock_ultima_client(mock_smlight_client: MagicMock) -> MagicMock:
     """Configure api client to return an Ultima device."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    mock_smlight_client.get_info.side_effect = lambda *arg, **kwargs: MOCK_ULTIMA
     return mock_smlight_client
 
 

--- a/tests/components/smlight/test_infrared.py
+++ b/tests/components/smlight/test_infrared.py
@@ -36,20 +36,12 @@ def platforms() -> list[Platform]:
     return [Platform.INFRARED]
 
 
-MOCK_ULTIMA = Info(
-    MAC="AA:BB:CC:DD:EE:FF",
-    model="SLZB-Ultima3",
-)
-
-
 async def test_infrared_setup_ultima(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test infrared entity is created for Ultima devices."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     state = hass.states.get("infrared.mock_title_ir_emitter")
@@ -76,11 +68,9 @@ async def test_infrared_not_created_non_ultima(
 async def test_infrared_send_command(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test sending IR command."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "infrared.mock_title_ir_emitter"
@@ -93,7 +83,7 @@ async def test_infrared_send_command(
         MockCommand(),
     )
 
-    mock_smlight_client.actions.send_ir_code.assert_called_once_with(
+    mock_ultima_client.actions.send_ir_code.assert_called_once_with(
         IRPayload.from_raw_timings([9000, 4500, 560, 1690], freq=38000)
     )
 
@@ -101,18 +91,16 @@ async def test_infrared_send_command(
 async def test_infrared_send_command_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test connection error handling."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "infrared.mock_title_ir_emitter"
     state = hass.states.get(entity_id)
     assert state is not None
 
-    mock_smlight_client.actions.send_ir_code.side_effect = SmlightError("Failed")
+    mock_ultima_client.actions.send_ir_code.side_effect = SmlightError("Failed")
 
     with pytest.raises(HomeAssistantError) as exc_info:
         await async_send_command(
@@ -126,18 +114,16 @@ async def test_infrared_send_command_error(
 async def test_infrared_send_empty_command_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test ValueError from pysmlight is surfaced as HomeAssistantError."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "infrared.mock_title_ir_emitter"
     state = hass.states.get(entity_id)
     assert state is not None
 
-    mock_smlight_client.actions.send_ir_code.side_effect = ValueError("empty payload")
+    mock_ultima_client.actions.send_ir_code.side_effect = ValueError("empty payload")
 
     with pytest.raises(HomeAssistantError) as exc_info:
         await async_send_command(
@@ -152,11 +138,9 @@ async def test_infrared_send_empty_command_error(
 async def test_infrared_state_updated_after_send(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test that entity state is updated with a timestamp after a successful send."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "infrared.mock_title_ir_emitter"

--- a/tests/components/smlight/test_infrared.py
+++ b/tests/components/smlight/test_infrared.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock
 
 from infrared_protocols import Command, Timing
-from pysmlight import Info
 from pysmlight.exceptions import SmlightError
 from pysmlight.models import IRPayload
 import pytest
@@ -54,11 +53,6 @@ async def test_infrared_not_created_non_ultima(
     mock_smlight_client: MagicMock,
 ) -> None:
     """Test infrared entity is not created for non-Ultima devices."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = Info(
-        MAC="AA:BB:CC:DD:EE:FF",
-        model="SLZB-MR1",
-    )
     await setup_integration(hass, mock_config_entry)
 
     state = hass.states.get("infrared.mock_title_ir_emitter")

--- a/tests/components/smlight/test_light.py
+++ b/tests/components/smlight/test_light.py
@@ -40,12 +40,6 @@ def platforms() -> Platform | list[Platform]:
     return [Platform.LIGHT]
 
 
-MOCK_ULTIMA = Info(
-    MAC="AA:BB:CC:DD:EE:FF",
-    model="SLZB-Ultima3",
-)
-
-
 def _build_fire_sse_ambilight(
     hass: HomeAssistant, mock_smlight_client: MagicMock
 ) -> Callable[[dict[str, object]], Awaitable[None]]:
@@ -63,12 +57,10 @@ async def test_light_setup_ultima(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test light entity is created for Ultima devices."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     entry = await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
@@ -96,20 +88,18 @@ async def test_light_not_created_non_ultima(
 async def test_light_turn_on_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test turning light on and off."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
     state = hass.states.get(entity_id)
     assert state.state != STATE_UNAVAILABLE
 
-    fire_ambi = _build_fire_sse_ambilight(hass, mock_smlight_client)
+    fire_ambi = _build_fire_sse_ambilight(hass, mock_ultima_client)
 
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -117,7 +107,7 @@ async def test_light_turn_on_off(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_called_once_with(
+    mock_ultima_client.actions.ambilight.assert_called_once_with(
         AmbilightPayload(ultLedMode=AmbiEffect.WSULT_SOLID)
     )
     await fire_ambi({"ultLedMode": 0, "ultLedBri": 158, "ultLedColor": 0x7FACFF})
@@ -125,7 +115,7 @@ async def test_light_turn_on_off(
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
@@ -133,7 +123,7 @@ async def test_light_turn_on_off(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_called_once_with(
+    mock_ultima_client.actions.ambilight.assert_called_once_with(
         AmbilightPayload(ultLedMode=AmbiEffect.WSULT_OFF)
     )
     await fire_ambi({"ultLedMode": 1})
@@ -145,20 +135,18 @@ async def test_light_turn_on_off(
 async def test_light_brightness(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test setting brightness."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
 
-    fire_ambi = _build_fire_sse_ambilight(hass, mock_smlight_client)
+    fire_ambi = _build_fire_sse_ambilight(hass, mock_ultima_client)
 
     # Seed current state as on so brightness-only update does not force solid mode.
     await fire_ambi({"ultLedMode": 0, "ultLedBri": 158, "ultLedColor": 0x7FACFF})
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -167,7 +155,7 @@ async def test_light_brightness(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_called_once_with(
+    mock_ultima_client.actions.ambilight.assert_called_once_with(
         AmbilightPayload(ultLedBri=200)
     )
     await fire_ambi({"ultLedMode": 0, "ultLedBri": 200, "ultLedColor": 0x7FACFF})
@@ -180,18 +168,16 @@ async def test_light_brightness(
 async def test_light_rgb_color(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test setting RGB color."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
 
-    fire_ambi = _build_fire_sse_ambilight(hass, mock_smlight_client)
+    fire_ambi = _build_fire_sse_ambilight(hass, mock_ultima_client)
 
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -199,7 +185,7 @@ async def test_light_rgb_color(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_called_once_with(
+    mock_ultima_client.actions.ambilight.assert_called_once_with(
         AmbilightPayload(ultLedMode=AmbiEffect.WSULT_SOLID, ultLedColor="#ff8040")
     )
     await fire_ambi({"ultLedMode": 0, "ultLedColor": 0xFF8040})
@@ -212,19 +198,17 @@ async def test_light_rgb_color(
 async def test_light_effect(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test setting effect."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
 
-    fire_ambi = _build_fire_sse_ambilight(hass, mock_smlight_client)
+    fire_ambi = _build_fire_sse_ambilight(hass, mock_ultima_client)
 
     # Test Rainbow effect
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -232,13 +216,13 @@ async def test_light_effect(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_called_once_with(
+    mock_ultima_client.actions.ambilight.assert_called_once_with(
         AmbilightPayload(ultLedMode=AmbiEffect.WSULT_RAINBOW)
     )
     await fire_ambi({"ultLedMode": 3})
 
     # Test Blur effect
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -246,7 +230,7 @@ async def test_light_effect(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_called_once_with(
+    mock_ultima_client.actions.ambilight.assert_called_once_with(
         AmbilightPayload(ultLedMode=AmbiEffect.WSULT_BLUR)
     )
     await fire_ambi({"ultLedMode": 2})
@@ -259,16 +243,14 @@ async def test_light_effect(
 async def test_light_invalid_effect(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test handling of invalid effect name is ignored."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
 
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -276,25 +258,23 @@ async def test_light_invalid_effect(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_not_called()
+    mock_ultima_client.actions.ambilight.assert_not_called()
 
 
 async def test_light_turn_on_when_on_is_noop(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test calling turn_on with no attributes does nothing when already on."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
-    fire_ambi = _build_fire_sse_ambilight(hass, mock_smlight_client)
+    fire_ambi = _build_fire_sse_ambilight(hass, mock_ultima_client)
 
     await fire_ambi({"ultLedMode": 0})
 
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.reset_mock()
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
@@ -302,21 +282,19 @@ async def test_light_turn_on_when_on_is_noop(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_not_called()
+    mock_ultima_client.actions.ambilight.assert_not_called()
 
 
 async def test_light_state_handles_invalid_attributes_from_sse(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test state update gracefully handles invalid mode and invalid hex color."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
-    fire_ambi = _build_fire_sse_ambilight(hass, mock_smlight_client)
+    fire_ambi = _build_fire_sse_ambilight(hass, mock_ultima_client)
 
     await fire_ambi({"ultLedMode": None, "ultLedColor": "#GG0000"})
 
@@ -335,18 +313,16 @@ async def test_light_state_handles_invalid_attributes_from_sse(
 async def test_ambilight_connection_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test connection error handling."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
     await setup_integration(hass, mock_config_entry)
 
     entity_id = "light.mock_title_ambilight"
     state = hass.states.get(entity_id)
     assert state.state != STATE_UNAVAILABLE
 
-    mock_smlight_client.actions.ambilight.side_effect = SmlightConnectionError
+    mock_ultima_client.actions.ambilight.side_effect = SmlightConnectionError
 
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -356,10 +332,10 @@ async def test_ambilight_connection_error(
             blocking=True,
         )
 
-    mock_smlight_client.actions.ambilight.side_effect = None
-    mock_smlight_client.actions.ambilight.reset_mock()
+    mock_ultima_client.actions.ambilight.side_effect = None
+    mock_ultima_client.actions.ambilight.reset_mock()
 
-    fire_ambi = _build_fire_sse_ambilight(hass, mock_smlight_client)
+    fire_ambi = _build_fire_sse_ambilight(hass, mock_ultima_client)
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -368,7 +344,7 @@ async def test_ambilight_connection_error(
         blocking=True,
     )
 
-    mock_smlight_client.actions.ambilight.assert_called_once_with(
+    mock_ultima_client.actions.ambilight.assert_called_once_with(
         AmbilightPayload(ultLedMode=AmbiEffect.WSULT_SOLID)
     )
 

--- a/tests/components/smlight/test_light.py
+++ b/tests/components/smlight/test_light.py
@@ -40,10 +40,10 @@ def platforms() -> Platform | list[Platform]:
 
 
 def _build_fire_sse_ambilight(
-    hass: HomeAssistant, mock_smlight_client: MagicMock
+    hass: HomeAssistant, mock_ultima_client: MagicMock
 ) -> Callable[[dict[str, object]], Awaitable[None]]:
     """Build helper to push ambilight SSE events and wait for state updates."""
-    page_callback = mock_smlight_client.sse.register_page_cb.call_args[0][1]
+    page_callback = mock_ultima_client.sse.register_page_cb.call_args[0][1]
 
     async def fire_ambi(changes: dict[str, object]) -> None:
         page_callback(changes)

--- a/tests/components/smlight/test_light.py
+++ b/tests/components/smlight/test_light.py
@@ -3,7 +3,6 @@
 from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock
 
-from pysmlight import Info
 from pysmlight.const import AmbiEffect
 from pysmlight.exceptions import SmlightConnectionError
 from pysmlight.models import AmbilightPayload
@@ -74,11 +73,6 @@ async def test_light_not_created_non_ultima(
     mock_smlight_client: MagicMock,
 ) -> None:
     """Test light entity is not created for non-Ultima devices."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = Info(
-        MAC="AA:BB:CC:DD:EE:FF",
-        model="SLZB-MR1",
-    )
     await setup_integration(hass, mock_config_entry)
 
     state = hass.states.get("light.mock_title_ambilight")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor tests with a shared test fixture for SLZB-Ultima devices. This reduces duplication of inline mock setup across many tests. Will also be used in futher pending platforms for Ultima.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
