### PR TITLE
Use runtime_data in seventeentrack integration

### DIFF
--- a/homeassistant/components/seventeentrack/__init__.py
+++ b/homeassistant/components/seventeentrack/__init__.py
@@ -3,7 +3,6 @@
 from pyseventeentrack import Client as SeventeenTrackClient
 from pyseventeentrack.errors import SeventeenTrackError
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -12,7 +11,7 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
-from .coordinator import SeventeenTrackCoordinator
+from .coordinator import SeventeenTrackConfigEntry, SeventeenTrackCoordinator
 from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -28,7 +27,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: SeventeenTrackConfigEntry
+) -> bool:
     """Set up 17Track from a config entry."""
 
     session = async_create_clientsession(hass)
@@ -43,6 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await seventeen_coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = seventeen_coordinator
+    entry.runtime_data = seventeen_coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/seventeentrack/config_flow.py
+++ b/homeassistant/components/seventeentrack/config_flow.py
@@ -9,7 +9,7 @@ from pyseventeentrack import Client as SeventeenTrackClient
 from pyseventeentrack.errors import SeventeenTrackError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -25,6 +25,7 @@ from .const import (
     DEFAULT_SHOW_DELIVERED,
     DOMAIN,
 )
+from .coordinator import SeventeenTrackConfigEntry
 
 CONF_SHOW = {
     vol.Optional(CONF_SHOW_ARCHIVED, default=DEFAULT_SHOW_ARCHIVED): bool,
@@ -54,7 +55,7 @@ class SeventeenTrackConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: SeventeenTrackConfigEntry,
     ) -> SchemaOptionsFlowHandler:
         """Get options flow for this handler."""
         return SchemaOptionsFlowHandler(config_entry, OPTIONS_FLOW)

--- a/homeassistant/components/seventeentrack/coordinator.py
+++ b/homeassistant/components/seventeentrack/coordinator.py
@@ -20,6 +20,8 @@ from .const import (
     LOGGER,
 )
 
+type SeventeenTrackConfigEntry = ConfigEntry[SeventeenTrackCoordinator]
+
 
 @dataclass
 class SeventeenTrackData:
@@ -32,12 +34,12 @@ class SeventeenTrackData:
 class SeventeenTrackCoordinator(DataUpdateCoordinator[SeventeenTrackData]):
     """Class to manage fetching 17Track data."""
 
-    config_entry: ConfigEntry
+    config_entry: SeventeenTrackConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: SeventeenTrackConfigEntry,
         client: SeventeenTrackClient,
     ) -> None:
         """Initialize."""

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -3,25 +3,24 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import SeventeenTrackCoordinator
 from .const import ATTRIBUTION, DOMAIN
+from .coordinator import SeventeenTrackConfigEntry, SeventeenTrackCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SeventeenTrackConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a 17Track sensor entry."""
 
-    coordinator: SeventeenTrackCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     async_add_entities(
         SeventeenTrackSummarySensor(status, coordinator)

--- a/homeassistant/components/seventeentrack/services.py
+++ b/homeassistant/components/seventeentrack/services.py
@@ -16,7 +16,6 @@ from homeassistant.core import (
 from homeassistant.helpers import config_validation as cv, selector, service
 from homeassistant.util import slugify
 
-from . import SeventeenTrackCoordinator
 from .const import (
     ATTR_DESTINATION_COUNTRY,
     ATTR_INFO_TEXT,
@@ -34,6 +33,7 @@ from .const import (
     SERVICE_ARCHIVE_PACKAGE,
     SERVICE_GET_PACKAGES,
 )
+from .coordinator import SeventeenTrackConfigEntry
 
 SERVICE_GET_PACKAGES_SCHEMA: Final = vol.Schema(
     {
@@ -72,13 +72,11 @@ async def _get_packages(call: ServiceCall) -> ServiceResponse:
     """Get packages from 17Track."""
     package_states = call.data.get(ATTR_PACKAGE_STATE, [])
 
-    entry = service.async_get_config_entry(
+    entry: SeventeenTrackConfigEntry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
 
-    seventeen_coordinator: SeventeenTrackCoordinator = call.hass.data[DOMAIN][
-        entry.entry_id
-    ]
+    seventeen_coordinator = entry.runtime_data
     live_packages = sorted(
         await seventeen_coordinator.client.profile.packages(
             show_archived=seventeen_coordinator.show_archived
@@ -99,13 +97,11 @@ async def _add_package(call: ServiceCall) -> None:
     tracking_number = call.data[ATTR_PACKAGE_TRACKING_NUMBER]
     friendly_name = call.data[ATTR_PACKAGE_FRIENDLY_NAME]
 
-    entry = service.async_get_config_entry(
+    entry: SeventeenTrackConfigEntry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
 
-    seventeen_coordinator: SeventeenTrackCoordinator = call.hass.data[DOMAIN][
-        entry.entry_id
-    ]
+    seventeen_coordinator = entry.runtime_data
 
     await seventeen_coordinator.client.profile.add_package(
         tracking_number, friendly_name
@@ -115,13 +111,11 @@ async def _add_package(call: ServiceCall) -> None:
 async def _archive_package(call: ServiceCall) -> None:
     tracking_number = call.data[ATTR_PACKAGE_TRACKING_NUMBER]
 
-    entry = service.async_get_config_entry(
+    entry: SeventeenTrackConfigEntry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
 
-    seventeen_coordinator: SeventeenTrackCoordinator = call.hass.data[DOMAIN][
-        entry.entry_id
-    ]
+    seventeen_coordinator = entry.runtime_data
 
     await seventeen_coordinator.client.profile.archive_package(tracking_number)
 


### PR DESCRIPTION
## Proposed change

Migrate the `seventeentrack` integration to use `runtime_data` instead of storing the coordinator in `hass.data[DOMAIN]`.

- Add `SeventeenTrackConfigEntry` type alias in `coordinator.py`
- Update `__init__.py` to store coordinator in `entry.runtime_data`
- Update `sensor.py` to retrieve coordinator from `config_entry.runtime_data`
- Update `services.py` to retrieve coordinator from `entry.runtime_data`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr