### PR TITLE
Use runtime_data in smart_meter_texas integration

### DIFF
--- a/homeassistant/components/smart_meter_texas/__init__.py
+++ b/homeassistant/components/smart_meter_texas/__init__.py
@@ -13,7 +13,6 @@ from .coordinator import (
     SmartMeterTexasConfigEntry,
     SmartMeterTexasCoordinator,
     SmartMeterTexasData,
-    SmartMeterTexasRuntimeData,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,10 +47,7 @@ async def async_setup_entry(
     # too long to update.
     coordinator = SmartMeterTexasCoordinator(hass, entry, smart_meter_texas_data)
 
-    entry.runtime_data = SmartMeterTexasRuntimeData(
-        coordinator=coordinator,
-        smart_meter_data=smart_meter_texas_data,
-    )
+    entry.runtime_data = coordinator
 
     entry.async_create_background_task(
         hass, coordinator.async_refresh(), "smart_meter_texas-coordinator-refresh"

--- a/homeassistant/components/smart_meter_texas/__init__.py
+++ b/homeassistant/components/smart_meter_texas/__init__.py
@@ -5,20 +5,25 @@ import logging
 from smart_meter_texas import Account
 from smart_meter_texas.exceptions import SmartMeterTexasAuthError
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DATA_COORDINATOR, DATA_SMART_METER, DOMAIN
-from .coordinator import SmartMeterTexasCoordinator, SmartMeterTexasData
+from .coordinator import (
+    SmartMeterTexasConfigEntry,
+    SmartMeterTexasCoordinator,
+    SmartMeterTexasData,
+    SmartMeterTexasRuntimeData,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: SmartMeterTexasConfigEntry
+) -> bool:
     """Set up Smart Meter Texas from a config entry."""
 
     username = entry.data[CONF_USERNAME]
@@ -43,11 +48,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # too long to update.
     coordinator = SmartMeterTexasCoordinator(hass, entry, smart_meter_texas_data)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_COORDINATOR: coordinator,
-        DATA_SMART_METER: smart_meter_texas_data,
-    }
+    entry.runtime_data = SmartMeterTexasRuntimeData(
+        coordinator=coordinator,
+        smart_meter_data=smart_meter_texas_data,
+    )
 
     entry.async_create_background_task(
         hass, coordinator.async_refresh(), "smart_meter_texas-coordinator-refresh"
@@ -58,10 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: SmartMeterTexasConfigEntry
+) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/smart_meter_texas/const.py
+++ b/homeassistant/components/smart_meter_texas/const.py
@@ -5,9 +5,6 @@ from datetime import timedelta
 SCAN_INTERVAL = timedelta(hours=1)
 DEBOUNCE_COOLDOWN = 1800  # Seconds
 
-DATA_COORDINATOR = "coordinator"
-DATA_SMART_METER = "smart_meter_data"
-
 DOMAIN = "smart_meter_texas"
 
 METER_NUMBER = "meter_number"

--- a/homeassistant/components/smart_meter_texas/coordinator.py
+++ b/homeassistant/components/smart_meter_texas/coordinator.py
@@ -1,6 +1,5 @@
 """DataUpdateCoordinator for the Smart Meter Texas integration."""
 
-from dataclasses import dataclass
 import logging
 
 from smart_meter_texas import Account, Client, Meter
@@ -53,15 +52,7 @@ class SmartMeterTexasData:
         return self.meters
 
 
-type SmartMeterTexasConfigEntry = ConfigEntry[SmartMeterTexasRuntimeData]
-
-
-@dataclass
-class SmartMeterTexasRuntimeData:
-    """Runtime data for Smart Meter Texas."""
-
-    coordinator: SmartMeterTexasCoordinator
-    smart_meter_data: SmartMeterTexasData
+type SmartMeterTexasConfigEntry = ConfigEntry[SmartMeterTexasCoordinator]
 
 
 class SmartMeterTexasCoordinator(DataUpdateCoordinator[SmartMeterTexasData]):
@@ -86,10 +77,10 @@ class SmartMeterTexasCoordinator(DataUpdateCoordinator[SmartMeterTexasData]):
                 hass, _LOGGER, cooldown=DEBOUNCE_COOLDOWN, immediate=True
             ),
         )
-        self._smart_meter_texas_data = smart_meter_texas_data
+        self.smart_meter_texas_data = smart_meter_texas_data
 
     async def _async_update_data(self) -> SmartMeterTexasData:
         """Fetch latest data."""
         _LOGGER.debug("Fetching latest data")
-        await self._smart_meter_texas_data.read_meters()
-        return self._smart_meter_texas_data
+        await self.smart_meter_texas_data.read_meters()
+        return self.smart_meter_texas_data

--- a/homeassistant/components/smart_meter_texas/coordinator.py
+++ b/homeassistant/components/smart_meter_texas/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for the Smart Meter Texas integration."""
 
+from dataclasses import dataclass
 import logging
 
 from smart_meter_texas import Account, Client, Meter
@@ -52,15 +53,26 @@ class SmartMeterTexasData:
         return self.meters
 
 
+type SmartMeterTexasConfigEntry = ConfigEntry[SmartMeterTexasRuntimeData]
+
+
+@dataclass
+class SmartMeterTexasRuntimeData:
+    """Runtime data for Smart Meter Texas."""
+
+    coordinator: SmartMeterTexasCoordinator
+    smart_meter_data: SmartMeterTexasData
+
+
 class SmartMeterTexasCoordinator(DataUpdateCoordinator[SmartMeterTexasData]):
     """Class to manage fetching Smart Meter Texas data."""
 
-    config_entry: ConfigEntry
+    config_entry: SmartMeterTexasConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: ConfigEntry,
+        entry: SmartMeterTexasConfigEntry,
         smart_meter_texas_data: SmartMeterTexasData,
     ) -> None:
         """Initialize the coordinator."""

--- a/homeassistant/components/smart_meter_texas/coordinator.py
+++ b/homeassistant/components/smart_meter_texas/coordinator.py
@@ -55,7 +55,7 @@ class SmartMeterTexasData:
 type SmartMeterTexasConfigEntry = ConfigEntry[SmartMeterTexasCoordinator]
 
 
-class SmartMeterTexasCoordinator(DataUpdateCoordinator[SmartMeterTexasData]):
+class SmartMeterTexasCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching Smart Meter Texas data."""
 
     config_entry: SmartMeterTexasConfigEntry
@@ -79,8 +79,7 @@ class SmartMeterTexasCoordinator(DataUpdateCoordinator[SmartMeterTexasData]):
         )
         self.smart_meter_texas_data = smart_meter_texas_data
 
-    async def _async_update_data(self) -> SmartMeterTexasData:
+    async def _async_update_data(self) -> None:
         """Fetch latest data."""
         _LOGGER.debug("Fetching latest data")
         await self.smart_meter_texas_data.read_meters()
-        return self.smart_meter_texas_data

--- a/homeassistant/components/smart_meter_texas/sensor.py
+++ b/homeassistant/components/smart_meter_texas/sensor.py
@@ -9,32 +9,24 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DATA_COORDINATOR,
-    DATA_SMART_METER,
-    DOMAIN,
-    ELECTRIC_METER,
-    ESIID,
-    METER_NUMBER,
-)
-from .coordinator import SmartMeterTexasCoordinator
+from .const import ELECTRIC_METER, ESIID, METER_NUMBER
+from .coordinator import SmartMeterTexasConfigEntry, SmartMeterTexasCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SmartMeterTexasConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Smart Meter Texas sensors."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
-    meters = hass.data[DOMAIN][config_entry.entry_id][DATA_SMART_METER].meters
+    coordinator = config_entry.runtime_data.coordinator
+    meters = config_entry.runtime_data.smart_meter_data.meters
 
     async_add_entities(
         [SmartMeterTexasSensor(meter, coordinator) for meter in meters], False

--- a/homeassistant/components/smart_meter_texas/sensor.py
+++ b/homeassistant/components/smart_meter_texas/sensor.py
@@ -25,8 +25,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Smart Meter Texas sensors."""
-    coordinator = config_entry.runtime_data.coordinator
-    meters = config_entry.runtime_data.smart_meter_data.meters
+    coordinator = config_entry.runtime_data
+    meters = coordinator.smart_meter_texas_data.meters
 
     async_add_entities(
         [SmartMeterTexasSensor(meter, coordinator) for meter in meters], False


### PR DESCRIPTION
## Proposed change

Migrate the `smart_meter_texas` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing runtime data.

- Add `SmartMeterTexasConfigEntry` type alias ~and `SmartMeterTexasRuntimeData` dataclass~ in `coordinator.py`
- Update `__init__.py` to store data in `entry.runtime_data` instead of `hass.data[DOMAIN]`
- Simplify `async_unload_entry` by removing manual `hass.data` cleanup
- Update `sensor.py` to retrieve coordinator and meters from `config_entry.runtime_data`
- Remove unused `DATA_COORDINATOR` and `DATA_SMART_METER` constants from `const.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr