### PR TITLE
Use runtime_data in somfy_mylink integration

### DIFF
--- a/homeassistant/components/somfy_mylink/__init__.py
+++ b/homeassistant/components/somfy_mylink/__init__.py
@@ -1,6 +1,8 @@
 """Component for the Somfy MyLink device supporting the Synergy API."""
 
+from dataclasses import dataclass
 import logging
+from typing import Any
 
 from somfy_mylink_synergy import SomfyMyLinkSynergy
 
@@ -9,15 +11,23 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONF_SYSTEM_ID, DATA_SOMFY_MYLINK, DOMAIN, MYLINK_STATUS, PLATFORMS
+from .const import CONF_SYSTEM_ID, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
+type SomfyMyLinkConfigEntry = ConfigEntry[SomfyMyLinkRuntimeData]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+@dataclass
+class SomfyMyLinkRuntimeData:
+    """Runtime data for Somfy MyLink."""
+
+    somfy_mylink: SomfyMyLinkSynergy
+    mylink_status: dict[str, Any]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: SomfyMyLinkConfigEntry) -> bool:
     """Set up Somfy MyLink from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-
     config = entry.data
     somfy_mylink = SomfyMyLinkSynergy(
         config[CONF_SYSTEM_ID], config[CONF_HOST], config[CONF_PORT]
@@ -42,18 +52,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if "result" not in mylink_status:
         raise ConfigEntryNotReady("The Somfy MyLink device returned an empty result")
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_SOMFY_MYLINK: somfy_mylink,
-        MYLINK_STATUS: mylink_status,
-    }
+    entry.runtime_data = SomfyMyLinkRuntimeData(
+        somfy_mylink=somfy_mylink,
+        mylink_status=mylink_status,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: SomfyMyLinkConfigEntry
+) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/somfy_mylink/config_flow.py
+++ b/homeassistant/components/somfy_mylink/config_flow.py
@@ -10,7 +10,6 @@ from somfy_mylink_synergy import SomfyMyLinkSynergy
 import voluptuous as vol
 
 from homeassistant.config_entries import (
-    ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
@@ -22,6 +21,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
+from . import SomfyMyLinkConfigEntry
 from .const import (
     CONF_REVERSE,
     CONF_REVERSED_TARGET_IDS,
@@ -30,7 +30,6 @@ from .const import (
     CONF_TARGET_NAME,
     DEFAULT_PORT,
     DOMAIN,
-    MYLINK_STATUS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,7 +118,7 @@ class SomfyConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: SomfyMyLinkConfigEntry,
     ) -> OptionsFlowHandler:
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
@@ -128,7 +127,9 @@ class SomfyConfigFlow(ConfigFlow, domain=DOMAIN):
 class OptionsFlowHandler(OptionsFlowWithReload):
     """Handle a option flow for somfy_mylink."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    config_entry: SomfyMyLinkConfigEntry
+
+    def __init__(self, config_entry: SomfyMyLinkConfigEntry) -> None:
         """Initialize options flow."""
         self.options = deepcopy(dict(config_entry.options))
         self._target_id: str | None = None
@@ -136,9 +137,7 @@ class OptionsFlowHandler(OptionsFlowWithReload):
     @callback
     def _async_callback_targets(self):
         """Return the list of targets."""
-        return self.hass.data[DOMAIN][self.config_entry.entry_id][MYLINK_STATUS][
-            "result"
-        ]
+        return self.config_entry.runtime_data.mylink_status["result"]
 
     @callback
     def _async_get_target_name(self, target_id) -> str:

--- a/homeassistant/components/somfy_mylink/const.py
+++ b/homeassistant/components/somfy_mylink/const.py
@@ -10,8 +10,6 @@ CONF_TARGET_ID = "target_id"
 
 DEFAULT_PORT = 44100
 
-DATA_SOMFY_MYLINK = "somfy_mylink_data"
-MYLINK_STATUS = "mylink_status"
 DOMAIN = "somfy_mylink"
 
 PLATFORMS = [Platform.COVER]

--- a/homeassistant/components/somfy_mylink/cover.py
+++ b/homeassistant/components/somfy_mylink/cover.py
@@ -4,19 +4,13 @@ import logging
 from typing import Any
 
 from homeassistant.components.cover import CoverDeviceClass, CoverEntity, CoverState
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import (
-    CONF_REVERSED_TARGET_IDS,
-    DATA_SOMFY_MYLINK,
-    DOMAIN,
-    MANUFACTURER,
-    MYLINK_STATUS,
-)
+from . import SomfyMyLinkConfigEntry
+from .const import CONF_REVERSED_TARGET_IDS, DOMAIN, MANUFACTURER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,15 +22,14 @@ MYLINK_COVER_TYPE_TO_DEVICE_CLASS = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SomfyMyLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Discover and configure Somfy covers."""
     reversed_target_ids = config_entry.options.get(CONF_REVERSED_TARGET_IDS, {})
 
-    data = hass.data[DOMAIN][config_entry.entry_id]
-    mylink_status = data[MYLINK_STATUS]
-    somfy_mylink = data[DATA_SOMFY_MYLINK]
+    mylink_status = config_entry.runtime_data.mylink_status
+    somfy_mylink = config_entry.runtime_data.somfy_mylink
     cover_list = []
 
     for cover in mylink_status["result"]:


### PR DESCRIPTION
## Proposed change

Migrate the `somfy_mylink` integration to use `runtime_data` instead of storing data in `hass.data[DOMAIN]`.

- Add `SomfyMyLinkConfigEntry` type alias and `SomfyMyLinkRuntimeData` dataclass in `__init__.py`
- Update `__init__.py` to use `entry.runtime_data` instead of `hass.data[DOMAIN]` and simplify `async_unload_entry`
- Update `cover.py` to get data from `config_entry.runtime_data`
- Update `config_flow.py` options flow to use `self.config_entry.runtime_data`
- Remove unused `DATA_SOMFY_MYLINK` and `MYLINK_STATUS` constants from `const.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr