### PR TITLE
Fix SwitchBot encrypted device method selection not resetting on back

### DIFF
--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -96,7 +96,7 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_advs: dict[str, SwitchBotAdvertisement] = {}
         self._cloud_username: str | None = None
         self._cloud_password: str | None = None
-        self._encryption_method_selecting: bool = False
+        self._encryption_method_selected = False
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -199,11 +199,11 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         description_placeholders: dict[str, str] = {}
 
         if user_input is None:
-            if not self._encryption_method_selecting and not (
+            if not self._encryption_method_selected and not (
                 self._cloud_username and self._cloud_password
             ):
                 return await self.async_step_encrypted_choose_method()
-            self._encryption_method_selecting = False
+            self._encryption_method_selected = False
 
         # If we have saved credentials from cloud login, try them first
         if user_input is None and self._cloud_username and self._cloud_password:
@@ -266,7 +266,7 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the SwitchBot API chose method step."""
         assert self._discovered_adv is not None
 
-        self._encryption_method_selecting = True
+        self._encryption_method_selected = True
         return self.async_show_menu(
             step_id="encrypted_choose_method",
             menu_options=["encrypted_auth", "encrypted_key"],
@@ -283,9 +283,9 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         assert self._discovered_adv is not None
 
         if user_input is None:
-            if not self._encryption_method_selecting:
+            if not self._encryption_method_selected:
                 return await self.async_step_encrypted_choose_method()
-            self._encryption_method_selecting = False
+            self._encryption_method_selected = False
 
         if user_input is not None:
             model: SwitchbotModel = self._discovered_adv.data["modelName"]

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -96,6 +96,7 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_advs: dict[str, SwitchBotAdvertisement] = {}
         self._cloud_username: str | None = None
         self._cloud_password: str | None = None
+        self._encryption_method_selecting: bool = False
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -197,6 +198,13 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         assert self._discovered_adv is not None
         description_placeholders: dict[str, str] = {}
 
+        if user_input is None:
+            if not self._encryption_method_selecting and not (
+                self._cloud_username and self._cloud_password
+            ):
+                return await self.async_step_encrypted_choose_method()
+            self._encryption_method_selecting = False
+
         # If we have saved credentials from cloud login, try them first
         if user_input is None and self._cloud_username and self._cloud_password:
             user_input = {
@@ -258,6 +266,7 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the SwitchBot API chose method step."""
         assert self._discovered_adv is not None
 
+        self._encryption_method_selecting = True
         return self.async_show_menu(
             step_id="encrypted_choose_method",
             menu_options=["encrypted_auth", "encrypted_key"],
@@ -272,6 +281,12 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the encryption key step."""
         errors: dict[str, str] = {}
         assert self._discovered_adv is not None
+
+        if user_input is None:
+            if not self._encryption_method_selecting:
+                return await self.async_step_encrypted_choose_method()
+            self._encryption_method_selecting = False
+
         if user_input is not None:
             model: SwitchbotModel = self._discovered_adv.data["modelName"]
             cls = ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS[model]

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -221,6 +221,113 @@ async def test_bluetooth_discovery_key(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_bluetooth_discovery_encrypted_key_back_navigation(
+    hass: HomeAssistant,
+) -> None:
+    """Test that resuming an abandoned encrypted_key flow resets to the method menu."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=WOLOCK_SERVICE_INFO,
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "encrypted_choose_method"
+
+    # User selects encrypted_key
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "encrypted_key"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "encrypted_key"
+
+    # Simulate user closing dialog and re-opening: call the step with no input
+    # (as HA does when resuming an in-progress flow)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=None
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "encrypted_choose_method"
+
+    # User can now pick a method again and complete the flow
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "encrypted_key"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "encrypted_key"
+
+    with (
+        patch_async_setup_entry() as mock_setup_entry,
+        patch(
+            "switchbot.SwitchbotLock.verify_encryption_key",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEY_ID: "ff",
+                CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_bluetooth_discovery_encrypted_auth_back_navigation(
+    hass: HomeAssistant,
+) -> None:
+    """Test that resuming an abandoned encrypted_auth flow resets to the method menu."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=WOLOCK_SERVICE_INFO,
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "encrypted_choose_method"
+
+    # User selects encrypted_auth
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "encrypted_auth"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "encrypted_auth"
+
+    # Simulate user closing dialog and re-opening: call the step with no input
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=None
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "encrypted_choose_method"
+
+    # User can switch to encrypted_key and complete the flow
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "encrypted_key"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "encrypted_key"
+
+    with (
+        patch_async_setup_entry() as mock_setup_entry,
+        patch(
+            "switchbot.SwitchbotLock.verify_encryption_key",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEY_ID: "ff",
+                CONF_ENCRYPTION_KEY: "ffffffffffffffffffffffffffffffff",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_bluetooth_discovery_already_setup(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device when already setup."""
     entry = MockConfigEntry(
@@ -1208,12 +1315,22 @@ async def test_user_cloud_login_then_encrypted_device(hass: HomeAssistant) -> No
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encrypted_auth"
 
+    # Simulate the user navigating away and re-opening the dialog.
+    # The failed auto-auth cleared credentials, so calling with None now
+    # redirects back to the method selection menu.
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         None,
     )
     await hass.async_block_till_done()
 
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "encrypted_choose_method"
+
+    # User selects encrypted_auth again and manually enters credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "encrypted_auth"}
+    )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encrypted_auth"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Allow users to re-select the login method when adding a device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
