### PR TITLE
Fix deprecated asyncio.get_event_loop() in emulated_hue upnp

### DIFF
--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -171,7 +171,7 @@ async def async_create_upnp_datagram_endpoint(
 
     ssdp_socket.bind(("" if upnp_bind_multicast else host_ip_addr, BROADCAST_PORT))
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     transport_protocol = await loop.create_datagram_endpoint(
         lambda: UPNPResponderProtocol(loop, ssdp_socket, advertise_ip, advertise_port),


### PR DESCRIPTION
Fixes #167755

## What changed

Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in `async_create_upnp_datagram_endpoint()` inside `homeassistant/components/emulated_hue/upnp.py`.

`asyncio.get_event_loop()` is deprecated since Python 3.10 and emits `DeprecationWarning` when there's no current event loop set. Since `async_create_upnp_datagram_endpoint` is an `async def`, a running loop is always present, so `asyncio.get_running_loop()` is the right call — it's faster, raises `RuntimeError` instead of silently creating a loop, and carries no deprecation baggage.

## Changes

- `homeassistant/components/emulated_hue/upnp.py`: one-line change

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (`python -m pytest tests/components/emulated_hue/`)
- [x] There is no commented out code in this PR