### PR TITLE
Set proper state for the internet_access switches in FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -453,10 +453,13 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
                 if not attributes.get("MACAddress"):
                     continue
 
+                wan_access_result = None
                 if (wan_access := attributes.get("X_AVM-DE_WANAccess")) is not None:
-                    wan_access_result = "granted" in wan_access
-                else:
-                    wan_access_result = None
+                    # wan_access can be "granted", "denied", "unknown" or "error"
+                    if "granted" in wan_access:
+                        wan_access_result = True
+                    elif "denied" in wan_access:
+                        wan_access_result = False
 
                 hosts[attributes["MACAddress"]] = Device(
                     name=attributes["HostName"],

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -351,7 +351,7 @@ async def test_switch_device_wan_access(
     wan_access_data: str | None,
     expected_state: str,
 ) -> None:
-    """Test Fritz!Tools switches has proper WAN access state."""
+    """Test Fritz!Tools switches have proper WAN access state."""
 
     entity_id = "switch.printer_internet_access"
 

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -358,7 +358,7 @@ async def test_switch_device_wan_access(
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    attributes = MOCK_HOST_ATTRIBUTES_DATA.copy()
+    attributes = deepcopy(MOCK_HOST_ATTRIBUTES_DATA)
     for host in attributes:
         host["X_AVM-DE_WANAccess"] = wan_access_data
 

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -333,30 +333,42 @@ async def test_switch_no_mesh_wifi_uplink(
     await hass.async_block_till_done(wait_background_tasks=True)
 
 
-async def test_switch_device_no_wan_access(
+@pytest.mark.parametrize(
+    ("wan_access_data", "expected_state"),
+    [
+        (None, STATE_UNAVAILABLE),
+        ("unknown", STATE_UNAVAILABLE),
+        ("error", STATE_UNAVAILABLE),
+        ("granted", STATE_ON),
+        ("denied", STATE_OFF),
+    ],
+)
+async def test_switch_device_wan_access(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
     fs_class_mock,
+    wan_access_data: str | None,
+    expected_state: str,
 ) -> None:
-    """Test Fritz!Tools switches when device has no WAN access."""
+    """Test Fritz!Tools switches has proper WAN access state."""
 
     entity_id = "switch.printer_internet_access"
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    attributes = [
-        {k: v for k, v in host.items() if k != "X_AVM-DE_WANAccess"}
-        for host in MOCK_HOST_ATTRIBUTES_DATA
-    ]
+    attributes = MOCK_HOST_ATTRIBUTES_DATA.copy()
+    for host in attributes:
+        host["X_AVM-DE_WANAccess"] = wan_access_data
+
     fh_class_mock.get_hosts_attributes = MagicMock(return_value=attributes)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == expected_state
 
 
 async def test_switch_device_no_ip_address(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes the state of the internet access switches to better reflect the real state, as it will also consider state errors from the device as an UNKNOWN state (_instead of OFF state_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167753
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
