### PR TITLE
Fix device_class removal in template binary sensors

### DIFF
--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -180,18 +180,16 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
         }
 
     if domain == Platform.BINARY_SENSOR:
-        schema |= _SCHEMA_STATE
-        if flow_type == "config":
-            schema |= {
-                vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=[cls.value for cls in BinarySensorDeviceClass],
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                        translation_key="binary_sensor_device_class",
-                        sort=True,
-                    ),
+        schema |= _SCHEMA_STATE | {
+            vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[cls.value for cls in BinarySensorDeviceClass],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    translation_key="binary_sensor_device_class",
+                    sort=True,
                 ),
-            }
+            ),
+        }
 
     if domain == Platform.BUTTON:
         schema |= {

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -608,6 +608,7 @@
       },
       "binary_sensor": {
         "data": {
+          "device_class": "[%key:component::template::common::device_class%]",
           "device_id": "[%key:common::config_flow::data::device%]",
           "state": "[%key:component::template::common::state%]"
         },

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -580,7 +580,7 @@ async def test_config_flow_device(
             {"device_class": "motion"},
             {"device_class": "window"},
             "state",
-            ("motion",),
+            "motion",
         ),
         (
             "sensor",
@@ -595,7 +595,7 @@ async def test_config_flow_device(
             {},
             {},
             "state",
-            (),
+            None,
         ),
         (
             "button",
@@ -623,7 +623,7 @@ async def test_config_flow_device(
                 ],
             },
             "state",
-            (),
+            None,
         ),
         (
             "cover",
@@ -634,7 +634,7 @@ async def test_config_flow_device(
             {"set_cover_position": []},
             {"set_cover_position": []},
             "state",
-            (),
+            None,
         ),
         (
             "event",
@@ -645,7 +645,7 @@ async def test_config_flow_device(
             {"event_types": "{{ ['single', 'double'] }}"},
             {"event_types": "{{ ['single', 'double'] }}"},
             "event_type",
-            (),
+            None,
         ),
         (
             "fan",
@@ -656,7 +656,7 @@ async def test_config_flow_device(
             {"turn_on": [], "turn_off": []},
             {"turn_on": [], "turn_off": []},
             "state",
-            (),
+            None,
         ),
         (
             "image",
@@ -674,7 +674,7 @@ async def test_config_flow_device(
                 "verify_ssl": True,
             },
             "url",
-            (),
+            None,
         ),
         (
             "light",
@@ -685,7 +685,7 @@ async def test_config_flow_device(
             {"turn_on": [], "turn_off": []},
             {"turn_on": [], "turn_off": []},
             "state",
-            (),
+            None,
         ),
         (
             "lock",
@@ -696,7 +696,7 @@ async def test_config_flow_device(
             {"lock": [], "unlock": []},
             {"lock": [], "unlock": []},
             "state",
-            (),
+            None,
         ),
         (
             "number",
@@ -727,7 +727,7 @@ async def test_config_flow_device(
                 },
             },
             "state",
-            (),
+            None,
         ),
         (
             "alarm_control_panel",
@@ -738,7 +738,7 @@ async def test_config_flow_device(
             {"code_arm_required": True, "code_format": "number"},
             {"code_arm_required": True, "code_format": "number"},
             "value_template",
-            (),
+            None,
         ),
         (
             "select",
@@ -749,7 +749,7 @@ async def test_config_flow_device(
             {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
             {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
             "state",
-            (),
+            None,
         ),
         (
             "switch",
@@ -760,7 +760,7 @@ async def test_config_flow_device(
             {},
             {},
             "value_template",
-            (),
+            None,
         ),
         (
             "update",
@@ -771,7 +771,7 @@ async def test_config_flow_device(
             {"latest_version": "{{ '2.0' }}"},
             {"latest_version": "{{ '2.0' }}"},
             "installed_version",
-            (),
+            None,
         ),
         (
             "vacuum",
@@ -782,7 +782,7 @@ async def test_config_flow_device(
             {"start": []},
             {"start": []},
             "state",
-            (),
+            None,
         ),
         (
             "weather",
@@ -793,7 +793,7 @@ async def test_config_flow_device(
             {"temperature": "{{ 20 }}", "humidity": "{{ 50 }}"},
             {"temperature": "{{ 20 }}", "humidity": "{{ 50 }}"},
             "condition",
-            (),
+            None,
         ),
     ],
 )
@@ -808,7 +808,7 @@ async def test_options(
     extra_options: dict[str, Any],
     options_options: dict[str, Any],
     key_template: str,
-    suggested_device_class: tuple[str, ...],
+    suggested_device_class: str | None,
 ) -> None:
     """Test reconfiguring."""
     input_entities = ["one", "two"]
@@ -846,11 +846,10 @@ async def test_options(
         result["data_schema"].schema, key_template
     ) == old_state_template.get(key_template)
     assert "name" not in result["data_schema"].schema
-    for device_class in suggested_device_class:
-        assert (
-            get_schema_suggested_value(result["data_schema"].schema, "device_class")
-            == device_class
-        )
+    assert (
+        get_schema_suggested_value(result["data_schema"].schema, "device_class")
+        == suggested_device_class
+    )
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -900,6 +899,63 @@ async def test_options(
     assert (
         get_schema_suggested_value(result["data_schema"].schema, key_template) is None
     )
+
+
+@pytest.mark.freeze_time("2024-07-09 00:00:00+00:00")
+async def test_options_binary_sensor_remove_device_class(hass: HomeAssistant) -> None:
+    """Test removing the binary sensor device class in options."""
+    hass.states.async_set("binary_sensor.one", "on", {})
+    hass.states.async_set("binary_sensor.two", "off", {})
+
+    old_state_template = {
+        "state": "{{ states('binary_sensor.one') == 'on' or states('binary_sensor.two') == 'on' }}"
+    }
+    new_state_template = {
+        "state": "{{ states('binary_sensor.one') == 'on' and states('binary_sensor.two') == 'on' }}"
+    }
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My template",
+            "template_type": "binary_sensor",
+            **old_state_template,
+            "device_class": "motion",
+        },
+        title="My template",
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "binary_sensor"
+    assert (
+        get_schema_suggested_value(result["data_schema"].schema, "device_class")
+        == "motion"
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            **new_state_template,
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "name": "My template",
+        "template_type": "binary_sensor",
+        **new_state_template,
+    }
+    assert config_entry.options == {
+        "name": "My template",
+        "template_type": "binary_sensor",
+        **new_state_template,
+    }
+    assert "device_class" not in config_entry.options
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -564,6 +564,7 @@ async def test_config_flow_device(
         "extra_options",
         "options_options",
         "key_template",
+        "suggested_device_class",
     ),
     [
         (
@@ -579,6 +580,7 @@ async def test_config_flow_device(
             {"device_class": "motion"},
             {"device_class": "window"},
             "state",
+            ("motion",),
         ),
         (
             "sensor",
@@ -593,6 +595,7 @@ async def test_config_flow_device(
             {},
             {},
             "state",
+            (),
         ),
         (
             "button",
@@ -620,6 +623,7 @@ async def test_config_flow_device(
                 ],
             },
             "state",
+            (),
         ),
         (
             "cover",
@@ -630,6 +634,7 @@ async def test_config_flow_device(
             {"set_cover_position": []},
             {"set_cover_position": []},
             "state",
+            (),
         ),
         (
             "event",
@@ -640,6 +645,7 @@ async def test_config_flow_device(
             {"event_types": "{{ ['single', 'double'] }}"},
             {"event_types": "{{ ['single', 'double'] }}"},
             "event_type",
+            (),
         ),
         (
             "fan",
@@ -650,6 +656,7 @@ async def test_config_flow_device(
             {"turn_on": [], "turn_off": []},
             {"turn_on": [], "turn_off": []},
             "state",
+            (),
         ),
         (
             "image",
@@ -667,6 +674,7 @@ async def test_config_flow_device(
                 "verify_ssl": True,
             },
             "url",
+            (),
         ),
         (
             "light",
@@ -677,6 +685,7 @@ async def test_config_flow_device(
             {"turn_on": [], "turn_off": []},
             {"turn_on": [], "turn_off": []},
             "state",
+            (),
         ),
         (
             "lock",
@@ -687,6 +696,7 @@ async def test_config_flow_device(
             {"lock": [], "unlock": []},
             {"lock": [], "unlock": []},
             "state",
+            (),
         ),
         (
             "number",
@@ -717,6 +727,7 @@ async def test_config_flow_device(
                 },
             },
             "state",
+            (),
         ),
         (
             "alarm_control_panel",
@@ -727,6 +738,7 @@ async def test_config_flow_device(
             {"code_arm_required": True, "code_format": "number"},
             {"code_arm_required": True, "code_format": "number"},
             "value_template",
+            (),
         ),
         (
             "select",
@@ -737,6 +749,7 @@ async def test_config_flow_device(
             {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
             {"options": "{{ ['off', 'on', 'auto'] }}", "select_option": []},
             "state",
+            (),
         ),
         (
             "switch",
@@ -747,6 +760,7 @@ async def test_config_flow_device(
             {},
             {},
             "value_template",
+            (),
         ),
         (
             "update",
@@ -757,6 +771,7 @@ async def test_config_flow_device(
             {"latest_version": "{{ '2.0' }}"},
             {"latest_version": "{{ '2.0' }}"},
             "installed_version",
+            (),
         ),
         (
             "vacuum",
@@ -767,6 +782,7 @@ async def test_config_flow_device(
             {"start": []},
             {"start": []},
             "state",
+            (),
         ),
         (
             "weather",
@@ -777,6 +793,7 @@ async def test_config_flow_device(
             {"temperature": "{{ 20 }}", "humidity": "{{ 50 }}"},
             {"temperature": "{{ 20 }}", "humidity": "{{ 50 }}"},
             "condition",
+            (),
         ),
     ],
 )
@@ -791,6 +808,7 @@ async def test_options(
     extra_options: dict[str, Any],
     options_options: dict[str, Any],
     key_template: str,
+    suggested_device_class: tuple[str, ...],
 ) -> None:
     """Test reconfiguring."""
     input_entities = ["one", "two"]
@@ -828,10 +846,10 @@ async def test_options(
         result["data_schema"].schema, key_template
     ) == old_state_template.get(key_template)
     assert "name" not in result["data_schema"].schema
-    if template_type == "binary_sensor":
+    for device_class in suggested_device_class:
         assert (
             get_schema_suggested_value(result["data_schema"].schema, "device_class")
-            == "motion"
+            == device_class
         )
 
     result = await hass.config_entries.options.async_configure(

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -576,8 +576,8 @@ async def test_config_flow_device(
             },
             ["on", "off"],
             {"one": "on", "two": "off"},
-            {},
-            {},
+            {"device_class": "motion"},
+            {"device_class": "window"},
             "state",
         ),
         (
@@ -828,6 +828,11 @@ async def test_options(
         result["data_schema"].schema, key_template
     ) == old_state_template.get(key_template)
     assert "name" not in result["data_schema"].schema
+    if template_type == "binary_sensor":
+        assert (
+            get_schema_suggested_value(result["data_schema"].schema, "device_class")
+            == "motion"
+        )
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -842,6 +847,7 @@ async def test_options(
         "template_type": template_type,
         **new_state_template,
         **extra_options,
+        **options_options,
     }
     assert config_entry.data == {}
     assert config_entry.options == {
@@ -849,6 +855,7 @@ async def test_options(
         "template_type": template_type,
         **new_state_template,
         **extra_options,
+        **options_options,
     }
     assert config_entry.title == "My template"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes template options flow to allow device class to be set and unset. Previously this was not possible and the user would have to delete the template binary sensor and start again 

https://github.com/user-attachments/assets/8cd8e953-4f8b-49cc-a91a-a137140aa4df

Related issues / tasks:

- https://github.com/home-assistant/frontend/issues/51481
- https://github.com/home-assistant/frontend/issues/21123
- https://github.com/home-assistant/core/issues/145552


Companion PR for frontend to hide "Show as", to be consistent with template sensors: https://github.com/home-assistant/frontend/pull/51486

Can be merged separately

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/51481
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/51486

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
