### PR TITLE
Add button platform to victron_gx integration

### DIFF
--- a/homeassistant/components/victron_gx/__init__.py
+++ b/homeassistant/components/victron_gx/__init__.py
@@ -12,6 +12,7 @@ from .hub import Hub, VictronGxConfigEntry
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
     Platform.SENSOR,
 ]
 

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -1,0 +1,61 @@
+"""Support for Victron GX button entities."""
+
+import logging
+from typing import Any
+
+from victron_mqtt import (
+    Device as VictronVenusDevice,
+    Metric as VictronVenusMetric,
+    MetricKind,
+    WritableMetric as VictronVenusWritableMetric,
+)
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import SWITCH_ON_ID
+from .entity import VictronBaseEntity
+from .hub import VictronGxConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0  # There is no I/O in the entity itself.
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: VictronGxConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Victron GX button entities from a config entry."""
+    hub = config_entry.runtime_data
+
+    def on_new_metric(
+        device: VictronVenusDevice,
+        metric: VictronVenusMetric,
+        device_info: DeviceInfo,
+        installation_id: str,
+    ) -> None:
+        """Handle new button metric discovery."""
+        assert isinstance(metric, VictronVenusWritableMetric)
+        async_add_entities(
+            [VictronButton(device, metric, device_info, installation_id)]
+        )
+
+    hub.register_new_metric_callback(MetricKind.BUTTON, on_new_metric)
+
+
+class VictronButton(VictronBaseEntity, ButtonEntity):
+    """Implementation of a Victron GX button entity."""
+
+    @callback
+    def _on_update_cb(self, value: Any) -> None:
+        pass
+
+    def press(self) -> None:
+        """Press the button."""
+        assert isinstance(self._metric, VictronVenusWritableMetric)
+        _LOGGER.debug("Pressing button: %s", self._attr_unique_id)
+        self._metric.set(SWITCH_ON_ID)

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -52,6 +52,7 @@ class VictronButton(VictronBaseEntity, ButtonEntity):
 
     @callback
     def _on_update_cb(self, value: Any) -> None:
+        # Buttons are stateless in HA; incoming metric updates are intentionally ignored.
         pass
 
     def press(self) -> None:

--- a/homeassistant/components/victron_gx/const.py
+++ b/homeassistant/components/victron_gx/const.py
@@ -5,3 +5,7 @@ DOMAIN = "victron_gx"
 CONF_INSTALLATION_ID = "installation_id"
 CONF_MODEL = "model"
 CONF_SERIAL = "serial"
+
+# Not using GenericOnOff as some entities use different enums.
+# It has to have id "on" to be on and "off" to be off.
+SWITCH_ON_ID = "on"

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -11,9 +11,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 # Entities that should be marked as diagnostic
-ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat"]
+ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat", "platform_device_reboot"]
 # Entities that should be disabled by default
-ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat"]
+ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat", "platform_device_reboot"]
 
 
 class VictronBaseEntity(Entity):

--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -74,7 +74,7 @@ class Hub:
             installation_id=config.get(CONF_INSTALLATION_ID) or None,
             model_name=config.get(CONF_MODEL) or None,
             serial=config.get(CONF_SERIAL) or None,
-            operation_mode=OperationMode.READ_ONLY,
+            operation_mode=OperationMode.FULL,
             update_frequency_seconds=UPDATE_INTERVAL_SECONDS,
         )
         self._hub.on_new_metric = self._on_new_metric

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -47,6 +47,15 @@
     }
   },
   "entity": {
+    "button": {
+      "platform_device_reboot": {
+        "name": "Device reboot",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      }
+    },
     "sensor": {
       "acload_current": {
         "name": "Load current"

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -49,11 +49,7 @@
   "entity": {
     "button": {
       "platform_device_reboot": {
-        "name": "Device reboot",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
+        "name": "Device reboot"
       }
     },
     "sensor": {

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -1,0 +1,88 @@
+"""Tests for Victron GX MQTT button entities."""
+
+from __future__ import annotations
+
+from victron_mqtt import Hub as VictronVenusHub
+from victron_mqtt.testing import finalize_injection, inject_message
+
+from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .const import MOCK_INSTALLATION_ID
+
+from tests.common import MockConfigEntry
+
+
+async def test_victron_button(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test BUTTON MetricKind - platform reboot button is created."""
+    victron_hub, mock_config_entry = init_integration
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
+        '{"value": 0}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity.entity_id == "button.victron_venus_device_reboot"
+    assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_system_0_platform_device_reboot"
+    assert entity.translation_key == "platform_device_reboot"
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == "unknown"
+
+    # Verify device info was registered correctly
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    )
+    assert device is not None
+    assert device.manufacturer == "Victron Energy"
+
+
+async def test_victron_button_press(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test button _on_update_cb and pressing it via service call."""
+    victron_hub, mock_config_entry = init_integration
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
+        '{"value": 0}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    entity_id = entities[0].entity_id
+
+    # Inject an update to exercise _on_update_cb (the pass branch)
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
+        '{"value": 1}',
+    )
+    await hass.async_block_till_done()
+
+    # Call the press service to cover press()
+    await hass.services.async_call(
+        "button", "press", {"entity_id": entity_id}, blocking=True
+    )


### PR DESCRIPTION
## Proposed change

Add button platform to victron_gx integration

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44599
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
