### PR TITLE
Bump victron-mqtt to 2026.4.3

### DIFF
--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["victron-mqtt==2026.4.2"],
+  "requirements": ["victron-mqtt==2026.4.3"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -90,18 +90,6 @@
       "acload_voltage_phase": {
         "name": "Voltage on {phase}"
       },
-      "acsystem_mode": {
-        "state": {
-          "charger_only": "Charger only",
-          "inverter_only": "Inverter only",
-          "off": "Off",
-          "on": "On",
-          "passthrough": "Passthrough"
-        }
-      },
-      "alternator_charge_current_limit": {
-        "name": "Charge current limit"
-      },
       "alternator_dc_current": {
         "name": "DC output current"
       },
@@ -127,14 +115,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",
@@ -384,14 +372,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",
@@ -429,14 +417,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",
@@ -489,17 +477,17 @@
         "name": "State",
         "state": {
           "alarm": "Alarm",
-          "closed": "Closed",
-          "high": "High",
-          "low": "Low",
-          "no": "No",
-          "off": "Off",
+          "closed": "[%key:common::state::closed%]",
+          "high": "[%key:common::state::high%]",
+          "low": "[%key:common::state::low%]",
+          "no": "[%key:common::state::no%]",
+          "off": "[%key:common::state::off%]",
           "ok": "Ok",
-          "on": "On",
-          "open": "Open",
+          "on": "[%key:common::state::on%]",
+          "open": "[%key:common::state::open%]",
           "running": "Running",
-          "stopped": "Stopped",
-          "yes": "Yes"
+          "stopped": "[%key:common::state::stopped%]",
+          "yes": "[%key:common::state::yes%]"
         }
       },
       "digitalinput_type": {
@@ -509,7 +497,7 @@
           "bilge_pump": "Bilge pump",
           "burglar_alarm": "Burglar alarm",
           "co2_alarm": "CO2 alarm",
-          "disabled": "Disabled",
+          "disabled": "[%key:common::state::disabled%]",
           "door_alarm": "Door alarm",
           "fire_alarm": "Fire alarm",
           "generator": "Generator",
@@ -526,14 +514,6 @@
       },
       "evcharger_min_set_current": {
         "name": "Minimum set current"
-      },
-      "evcharger_mode": {
-        "name": "Mode",
-        "state": {
-          "auto": "Auto",
-          "manual": "Manual",
-          "scheduled_charge": "Scheduled Charge"
-        }
       },
       "evcharger_position": {
         "name": "Position",
@@ -558,20 +538,17 @@
       "evcharger_session_time": {
         "name": "Last session time"
       },
-      "evcharger_set_current": {
-        "name": "Set current"
-      },
       "evcharger_status": {
         "name": "Status",
         "state": {
           "charged": "Charged",
-          "charging": "Charging",
+          "charging": "[%key:common::state::charging%]",
           "charging_limit": "Charging limit",
-          "connected": "Connected",
+          "connected": "[%key:common::state::connected%]",
           "cp_input_test_error": "CP input test error",
-          "disconnected": "Disconnected",
+          "disconnected": "[%key:common::state::disconnected%]",
           "ground_test_error": "Ground test error",
-          "low_soc": "Low SOC",
+          "low_soc": "Low SoC",
           "overheating_detected": "Overheating detected",
           "overvoltage_detected": "Overvoltage detected",
           "reserved15": "Reserved",
@@ -593,60 +570,6 @@
       "evcharger_total_energy": {
         "name": "Total energy"
       },
-      "generator_gen_id_cool_down_timer": {
-        "name": "Generator cooldown timer"
-      },
-      "generator_gen_id_qh_start_on_soc": {
-        "name": "Generator QH start on SOC"
-      },
-      "generator_gen_id_qh_start_on_voltage": {
-        "name": "Generator QH start on voltage"
-      },
-      "generator_gen_id_qh_stop_on_soc": {
-        "name": "Generator QH stop on SOC"
-      },
-      "generator_gen_id_qh_stop_on_voltage": {
-        "name": "Generator QH stop on voltage"
-      },
-      "generator_gen_id_service_interval": {
-        "name": "Generator service interval"
-      },
-      "generator_gen_id_shut_down_timer": {
-        "name": "Generator shutdown timer"
-      },
-      "generator_gen_id_start_on_soc": {
-        "name": "Generator start on SOC"
-      },
-      "generator_gen_id_start_on_soc_timer": {
-        "name": "Generator start on SOC timer"
-      },
-      "generator_gen_id_start_on_temp_timer": {
-        "name": "Generator start on temp timer"
-      },
-      "generator_gen_id_start_on_voltage": {
-        "name": "Generator start on voltage"
-      },
-      "generator_gen_id_start_on_voltage_timer": {
-        "name": "Generator start on voltage timer"
-      },
-      "generator_gen_id_stop_on_soc": {
-        "name": "Generator stop on SOC"
-      },
-      "generator_gen_id_stop_on_soc_timer": {
-        "name": "Generator stop on SOC timer"
-      },
-      "generator_gen_id_stop_on_temp_timer": {
-        "name": "Generator stop on temp timer"
-      },
-      "generator_gen_id_stop_on_voltage": {
-        "name": "Generator stop on voltage"
-      },
-      "generator_gen_id_stop_on_voltage_timer": {
-        "name": "Generator stop on voltage timer"
-      },
-      "generator_gen_id_warm_up_timer": {
-        "name": "Generator warm-up timer"
-      },
       "generator_run_state": {
         "name": "Run state",
         "state": {
@@ -656,10 +579,10 @@
           "inv_overload": "Inv Overload",
           "inv_temp": "Inv Temp",
           "lost_comms": "Lost Comms",
-          "manual": "Manual",
-          "soc": "SOC",
+          "manual": "[%key:common::state::manual%]",
+          "soc": "SoC",
           "stop_on_ac1": "Stop On AC1",
-          "stopped": "Stopped",
+          "stopped": "[%key:common::state::stopped%]",
           "test_run": "Test Run"
         }
       },
@@ -772,16 +695,6 @@
       "heatpump_voltage_phase": {
         "name": "Voltage on {phase}"
       },
-      "hub4_ac_grid_setpoint": {
-        "name": "AC grid setpoint"
-      },
-      "inverter_mode": {
-        "state": {
-          "eco": "Eco",
-          "inverter": "Inverter",
-          "off": "Off"
-        }
-      },
       "inverter_output_apparent_power_phase": {
         "name": "Output apparent power {phase}"
       },
@@ -807,14 +720,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",
@@ -868,22 +781,16 @@
         "state": {
           "ac_input_1": "AC Input 1",
           "ac_input_2": "AC Input 2",
-          "disconnected": "Disconnected"
+          "disconnected": "[%key:common::state::disconnected%]"
         }
-      },
-      "multi_ess_ac_power_setpoint": {
-        "name": "ESS AC power setpoint"
-      },
-      "multi_ess_min_soc_limit": {
-        "name": "ESS minimum SOC limit"
       },
       "multi_ess_mode": {
         "name": "ESS mode",
         "state": {
           "external_control": "External control",
           "keep_charged": "keep charged",
-          "self_consumption": "self consumption",
-          "self_consumption_batterylife": "self consumption (batterylife)"
+          "self_consumption": "Self-consumption",
+          "self_consumption_batterylife": "Self-consumption (batterylife)"
         }
       },
       "multi_inverter_power_setpoint": {
@@ -914,7 +821,7 @@
         "state": {
           "mppt_active": "MPPT active",
           "not_available": "Not available",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "voltage_current_limited": "Voltage/current limited"
         }
       },
@@ -927,9 +834,6 @@
       },
       "multi_pv_power_total": {
         "name": "PV power total"
-      },
-      "multi_shore_current_limit": {
-        "name": "Shore current limit"
       },
       "multi_solar_to_acin1": {
         "name": "Solar to AC-in-1"
@@ -947,14 +851,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",
@@ -975,10 +879,6 @@
       },
       "multi_yield_yesterday": {
         "name": "Yield yesterday"
-      },
-      "multiplus_assist_current_boost_factor": {
-        "name": "Assist current boost factor",
-        "unit_of_measurement": "factor"
       },
       "platform_venus_firmware_available_version": {
         "name": "Available version"
@@ -1077,7 +977,7 @@
         "state": {
           "mppt_active": "MPPT active",
           "not_available": "Not available",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "voltage_current_limited": "Voltage/current limited"
         }
       },
@@ -1088,14 +988,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",
@@ -1131,7 +1031,7 @@
         "state": {
           "mppt_active": "MPPT active",
           "not_available": "Not available",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "voltage_current_limited": "Voltage/current limited"
         }
       },
@@ -1162,10 +1062,6 @@
       "switch_output_custom_name": {
         "name": "{output} custom name"
       },
-      "switch_output_dimming": {
-        "name": "{output} dimming",
-        "unit_of_measurement": "%"
-      },
       "switchable_output_output_custom_name": {
         "name": "Switchable output {output} custom name"
       },
@@ -1179,17 +1075,8 @@
           "unknown": "Unknown"
         }
       },
-      "system_ac_export_limit": {
-        "name": "AC export limit"
-      },
-      "system_ac_input_limit": {
-        "name": "AC input limit"
-      },
       "system_ac_loads_phase": {
         "name": "AC loads on {phase}"
-      },
-      "system_ac_power_set_point": {
-        "name": "AC power setpoint"
       },
       "system_consumption_current_phase": {
         "name": "Consumption current {phase}"
@@ -1206,10 +1093,10 @@
         "name": "Consumption power {phase}"
       },
       "system_control_active_soc_limit": {
-        "name": "Active SOC limit"
+        "name": "Active SoC limit"
       },
       "system_control_scheduled_soc": {
-        "name": "Scheduled SOC"
+        "name": "Scheduled SoC"
       },
       "system_critical_loads_phase": {
         "name": "Critical loads on {phase}"
@@ -1235,9 +1122,9 @@
       "system_dc_battery_state": {
         "name": "DC battery state",
         "state": {
-          "charging": "Charging",
-          "discharging": "Discharging",
-          "idle": "Idle"
+          "charging": "[%key:common::state::charging%]",
+          "discharging": "[%key:common::state::discharging%]",
+          "idle": "[%key:common::state::idle%]"
         }
       },
       "system_dc_battery_voltage": {
@@ -1266,7 +1153,7 @@
           "no_error": "No Error",
           "no_ess": "No ESS",
           "no_schedule": "No Matching Schedule",
-          "soc_low": "SOC low"
+          "soc_low": "SoC low"
         }
       },
       "system_dynamicess_last_scheduled_end": {
@@ -1276,15 +1163,15 @@
         "name": "Dynamic ESS last scheduled start"
       },
       "system_dynamicess_minimum_soc": {
-        "name": "Dynamic ESS minimum SOC"
+        "name": "Dynamic ESS minimum SoC"
       },
       "system_dynamicess_reactive_strategy": {
         "name": "Dynamic ESS reactive strategy",
         "state": {
           "dess_disabled": "DESS Disabled",
-          "ess_low_soc": "ESS Low SOC",
+          "ess_low_soc": "ESS Low SoC",
           "idle_maintain_surplus": "Idle Maintain Surplus",
-          "idle_maintain_targetsoc": "Idle Maintain Target SOC",
+          "idle_maintain_targetsoc": "Idle Maintain Target SoC",
           "idle_no_opportunity": "Idle No Opportunity",
           "idle_scheduled_feedin": "Idle Scheduled Feed-In",
           "keep_battery_charged": "Keep Battery Charged",
@@ -1307,7 +1194,7 @@
           "selfconsume_unmapped_state": "Self-Consume Unmapped State",
           "selfconsume_unpredicted": "Self-Consume Unpredicted",
           "unknown_operating_mode": "Unknown Operating Mode",
-          "unscheduled_charge_catchup_targetsoc": "Unscheduled Charge Catch-Up Target SOC"
+          "unscheduled_charge_catchup_targetsoc": "Unscheduled Charge Catch-Up Target SoC"
         }
       },
       "system_dynamicess_restrictions": {
@@ -1329,85 +1216,11 @@
           "probattery": "Pro Battery",
           "progrid": "Pro Grid",
           "selfconsume": "Self-Consume",
-          "targetsoc": "Target SOC"
+          "targetsoc": "Target SoC"
         }
       },
       "system_dynamicess_target_soc": {
-        "name": "Dynamic ESS target SOC"
-      },
-      "system_ess_batterylife_state": {
-        "name": "ESS BatteryLife state",
-        "state": {
-          "keep_batteries_charged": "'Keep batteries charged' mode enabled",
-          "recharge": "Recharge, SOC dropped 5% or more below MinSOC",
-          "recharge_no_battery_life": "Recharge, SOC dropped 5% or more below MinSOC (No BatteryLife)",
-          "self_consumption": "Self consumption",
-          "self_consumption_soc_above_min": "Self consumption, SoC at or above minimum SoC",
-          "self_consumption_soc_at_100": "Self consumption, SoC at 100%",
-          "self_consumption_soc_below_min": "Self consumption, SoC is below minimum SoC",
-          "self_consumption_soc_exceeds_85": "Self consumption, SoC exceeds 85%",
-          "soc_below_battery_life_dynamic_soc_limit": "SoC below BatteryLife dynamic SoC limit",
-          "soc_below_soc_limit_24_hours": "SoC has been below SoC limit for more than 24 hours. Charging with battery with 5amps",
-          "sustain": "Multi/Quattro is in sustain",
-          "with_battery_life": "Optimized mode with BatteryLife"
-        }
-      },
-      "system_ess_max_charge_current": {
-        "name": "ESS max charge current"
-      },
-      "system_ess_max_charge_power": {
-        "name": "ESS max charge power limit"
-      },
-      "system_ess_max_charge_voltage": {
-        "name": "ESS max charge voltage"
-      },
-      "system_ess_max_feed_in_power": {
-        "name": "ESS max feed-in power"
-      },
-      "system_ess_max_inverter_power_limit": {
-        "name": "ESS max inverter power limit"
-      },
-      "system_ess_min_soc_limit": {
-        "name": "ESS min SOC limit"
-      },
-      "system_ess_mode": {
-        "name": "ESS mode (Hub4)",
-        "state": {
-          "external_control": "External control",
-          "phase_compensation_disabled": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
-          "phase_compensation_enabled": "Optimized mode or 'keep batteries charged' and phase compensation enabled"
-        }
-      },
-      "system_ess_schedule_charge_slot_days": {
-        "name": "ESS BatteryLife schedule charge {slot} days",
-        "state": {
-          "disabled_every_day": "Disabled (Every day)",
-          "disabled_friday": "Disabled (Friday)",
-          "disabled_monday": "Disabled (Monday)",
-          "disabled_saturday": "Disabled (Saturday)",
-          "disabled_sunday": "Disabled (Sunday)",
-          "disabled_thursday": "Disabled (Thursday)",
-          "disabled_tuesday": "Disabled (Tuesday)",
-          "disabled_wednesday": "Disabled (Wednesday)",
-          "disabled_weekdays": "Disabled (Weekdays)",
-          "disabled_weekend": "Disabled (Weekends)",
-          "every_day": "Every day",
-          "friday": "Friday",
-          "monday": "Monday",
-          "saturday": "Saturday",
-          "sunday": "Sunday",
-          "thursday": "Thursday",
-          "tuesday": "Tuesday",
-          "wednesday": "Wednesday",
-          "weekdays": "Weekdays",
-          "weekends": "Weekends"
-        }
-      },
-      "system_ess_schedule_charge_slot_duration": {
-        "name": "ESS BatteryLife schedule charge {slot} duration"
-      },
-      "system_ess_schedule_charge_slot_soc": {
-        "name": "ESS BatteryLife schedule charge {slot} SOC"
+        "name": "Dynamic ESS target SoC"
       },
       "system_generator_load_phase": {
         "name": "Genset load {phase}"
@@ -1438,16 +1251,6 @@
       "system_relay_relay_custom_name": {
         "name": "Relay {relay} custom name"
       },
-      "system_settings_dess_mode": {
-        "name": "DESS mode",
-        "state": {
-          "auto_vrm": "Auto / VRM",
-          "buy": "Buy",
-          "node_red": "Node-RED",
-          "off": "Off",
-          "sell": "Sell"
-        }
-      },
       "system_state": {
         "name": "System state",
         "state": {
@@ -1455,14 +1258,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",
@@ -1512,21 +1315,14 @@
         "name": "Humidity",
         "unit_of_measurement": "%"
       },
-      "temperature_offset": {
-        "name": "Offset"
-      },
       "temperature_pressure": {
         "name": "Pressure",
         "unit_of_measurement": "hPa"
       },
-      "temperature_scale": {
-        "name": "Scale factor",
-        "unit_of_measurement": "factor"
-      },
       "temperature_status": {
         "name": "Sensor status",
         "state": {
-          "disconnected": "Disconnected",
+          "disconnected": "[%key:common::state::disconnected%]",
           "ok": "Ok",
           "reverse_polarity": "Reverse polarity",
           "short_circuited": "Short circuited",
@@ -1547,12 +1343,6 @@
           "room": "Room",
           "water_heater": "Water Heater"
         }
-      },
-      "transfer_switch_generator_current_limit": {
-        "name": "Generator AC current limit"
-      },
-      "vebus_ac_power_setpoint_phase": {
-        "name": "AC power setpoint {phase}"
       },
       "vebus_device_device_number_input_power_l1": {
         "name": "{device_number} line 1 input power"
@@ -1707,8 +1497,8 @@
       "vebus_inverter_ignoreacin1_state": {
         "name": "State of ignore AC-in-1",
         "state": {
-          "off": "Off",
-          "on": "On"
+          "off": "[%key:common::state::off%]",
+          "on": "[%key:common::state::on%]"
         }
       },
       "vebus_inverter_input_apparent_power_phase": {
@@ -1725,14 +1515,6 @@
       },
       "vebus_inverter_input_voltage_phase": {
         "name": "Input voltage {phase}"
-      },
-      "vebus_inverter_mode": {
-        "state": {
-          "charger_only": "Charger Only",
-          "inverter_only": "Inverter Only",
-          "off": "Off",
-          "on": "On"
-        }
       },
       "vebus_inverter_output_apparent_power_phase": {
         "name": "Output apparent power {phase}"
@@ -1756,14 +1538,14 @@
           "auto_equalize": "Auto Equalize / Recondition",
           "battery_safe": "Battery Safe",
           "bulk": "Bulk",
-          "discharging": "Discharging",
+          "discharging": "[%key:common::state::discharging%]",
           "equalize": "Equalize",
           "external_control": "External Control",
-          "fault": "Fault",
+          "fault": "[%key:common::state::fault%]",
           "float": "Float",
           "inverting": "Inverting",
           "low_power": "Low Power",
-          "off": "Off",
+          "off": "[%key:common::state::off%]",
           "passthrough": "Passthrough",
           "power_assist": "Power Assist",
           "power_supply": "Power Supply",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3237,7 +3237,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.2
+victron-mqtt==2026.4.3
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2740,7 +2740,7 @@ venstarcolortouch==0.21
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.2
+victron-mqtt==2026.4.3
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.4.2` to `2026.4.3` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json`, `requirements_all.txt`, and `requirements_test_all.txt`
- Update entity translations (`strings.json`) from latest topic definitions. All of those deletes are coming from duplicate entries which I cleaned up.

Changelog: https://github.com/tomer-w/victron_mqtt/releases/tag/v2026.4.3

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40m+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr