### PR TITLE
Improve services.yaml in Evohome to improve UI/UX

### DIFF
--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -10,7 +10,6 @@ from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_M
 from evohomeasync2.schemas.const import (
     S2_DURATION as SZ_DURATION,
     S2_PERIOD as SZ_PERIOD,
-    SystemMode,
 )
 import voluptuous as vol
 
@@ -28,16 +27,14 @@ from .coordinator import EvoDataUpdateCoordinator
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
     # unsupported modes are rejected at runtime with ServiceValidationError
-    vol.Required(ATTR_MODE): vol.Coerce(SystemMode),
+    vol.Required(ATTR_MODE): cv.string,  # ... so, don't use SystemMode enum here
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),
-        msg="Use either duration or period, or neither, but not both",
     ),
     vol.Exclusive(ATTR_PERIOD, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(days=1), max=timedelta(days=99)),
-        msg="Use either duration or period, or neither, but not both",
     ),
 }
 

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -10,6 +10,7 @@ from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_M
 from evohomeasync2.schemas.const import (
     S2_DURATION as SZ_DURATION,
     S2_PERIOD as SZ_PERIOD,
+    SystemMode,
 )
 import voluptuous as vol
 
@@ -27,14 +28,16 @@ from .coordinator import EvoDataUpdateCoordinator
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
     # unsupported modes are rejected at runtime with ServiceValidationError
-    vol.Required(ATTR_MODE): cv.string,  # avoid vol.In(SystemMode)
+    vol.Required(ATTR_MODE): vol.Coerce(SystemMode),
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),
+        msg="Use either duration or period, or neither, but not both",
     ),
     vol.Exclusive(ATTR_PERIOD, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(days=1), max=timedelta(days=99)),
+        msg="Use either duration or period, or neither, but not both",
     ),
 }
 

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -4,6 +4,7 @@
 set_system_mode:
   fields:
     mode:
+      required: true
       example: Away
       selector:
         select:
@@ -21,7 +22,8 @@ set_system_mode:
     duration:
       example: '{"hours": 18}'
       selector:
-        object:
+        duration:
+          enable_second: false
 
 reset_system:
 
@@ -32,6 +34,8 @@ set_zone_override:
     entity:
       integration: evohome
       domain: climate
+      supported_features:
+        - climate.ClimateEntityFeature.TARGET_TEMPERATURE
   fields:
     setpoint:
       required: true
@@ -43,10 +47,13 @@ set_zone_override:
     duration:
       example: '{"minutes": 135}'
       selector:
-        object:
+        duration:
+          enable_second: false
 
 clear_zone_override:
   target:
     entity:
       integration: evohome
       domain: climate
+      supported_features:
+        - climate.ClimateEntityFeature.TARGET_TEMPERATURE

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -5,6 +5,7 @@ set_system_mode:
   fields:
     mode:
       required: true
+      default: Auto
       example: Away
       selector:
         select:

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -45,7 +45,7 @@ set_zone_override:
           max: 35.0
           step: 0.1
     duration:
-      example: '{"minutes": 135}'
+      example: "02:15:00"
       selector:
         duration:
           enable_second: false

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -20,7 +20,7 @@ set_system_mode:
       selector:
         object:
     duration:
-      example: "18:00:00"
+      example: "18:00"
       selector:
         duration:
           enable_second: false
@@ -45,7 +45,7 @@ set_zone_override:
           max: 35.0
           step: 0.1
     duration:
-      example: "02:15:00"
+      example: "02:15"
       selector:
         duration:
           enable_second: false

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -20,7 +20,7 @@ set_system_mode:
       selector:
         object:
     duration:
-      example: '{"hours": 18}'
+      example: "18:00:00"
       selector:
         duration:
           enable_second: false

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -4,13 +4,13 @@
       "message": "The requested system mode is not supported: {error}"
     },
     "mode_cant_be_temporary": {
-      "message": "The mode `{mode}` does not support `Duration` or `Period`"
+      "message": "The mode `{mode}` does not support 'Duration' or 'Period'"
     },
     "mode_cant_have_duration": {
-      "message": "The mode `{mode}` does not support `Duration`; use `Period` instead"
+      "message": "The mode `{mode}` does not support 'Duration'; use 'Period' instead"
     },
     "mode_cant_have_period": {
-      "message": "The mode `{mode}` does not support `Period`; use `Duration` instead"
+      "message": "The mode `{mode}` does not support 'Period'; use 'Duration' instead"
     },
     "mode_not_supported": {
       "message": "The mode `{mode}` is not supported by this controller"

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -51,7 +51,7 @@
       "name": "Set system mode"
     },
     "set_zone_override": {
-      "description": "Overrides a zone's setpoint, either indefinitely, or for a specified period of time, after which it will revert to following its schedule.",
+      "description": "Overrides the zone's setpoint, either indefinitely, or for a specified period of time, after which it will revert to following its schedule.",
       "fields": {
         "duration": {
           "description": "The zone will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -4,13 +4,13 @@
       "message": "The requested system mode is not supported: {error}"
     },
     "mode_cant_be_temporary": {
-      "message": "The mode `{mode}` does not support `duration` or `period`"
+      "message": "The mode `{mode}` does not support `Duration` or `Period`"
     },
     "mode_cant_have_duration": {
-      "message": "The mode `{mode}` does not support `duration`; use `period` instead"
+      "message": "The mode `{mode}` does not support `Duration`; use `Period` instead"
     },
     "mode_cant_have_period": {
-      "message": "The mode `{mode}` does not support `period`; use `duration` instead"
+      "message": "The mode `{mode}` does not support `Period`; use `Duration` instead"
     },
     "mode_not_supported": {
       "message": "The mode `{mode}` is not supported by this controller"
@@ -29,14 +29,14 @@
       "name": "Refresh system"
     },
     "reset_system": {
-      "description": "Sets the system to Auto mode and resets all the zones to follow their schedules. Not all Evohome systems support this feature (i.e. AutoWithReset mode).",
+      "description": "Sets the system to `Auto` mode and resets all the zones to follow their schedules. Not all Evohome systems support this feature (i.e. `AutoWithReset` mode).",
       "name": "Reset system"
     },
     "set_system_mode": {
-      "description": "Sets the system mode, either indefinitely, or for a specified period of time, after which it will revert to Auto. Not all systems support all modes.",
+      "description": "Sets the system mode, either indefinitely, or for a specified period of time, after which it will revert to `Auto`. Not all systems support all modes.",
       "fields": {
         "duration": {
-          "description": "The duration in hours; used only with AutoWithEco mode (up to 24 hours).",
+          "description": "The duration in hours; used only with `AutoWithEco` mode (up to 24 hours).",
           "name": "Duration"
         },
         "mode": {
@@ -44,7 +44,7 @@
           "name": "[%key:common::config_flow::data::mode%]"
         },
         "period": {
-          "description": "A period of time in days; used only with Away, DayOff, or Custom mode. The system will revert to Auto mode at midnight (up to 99 days, today is day 1).",
+          "description": "A period of time in days; used only with `Away`, `DayOff`, or `Custom` mode. The system will revert to `Auto` mode at midnight (up to 99 days, today is day 1).",
           "name": "Period"
         }
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR improves the Evohome integration’s **services.yaml** metadata to make service fields and targeting clearer in the UI and service docs.

Changes:
 - mark `set_system_mode.mode` as required
 - switch `duration` fields from a generic object selector to the duration selector (seconds disabled)
 - restrict `set_zone_override` / `clear_zone_override` targets to climate entities supporting `TARGET_TEMPERATURE`
 
 This PR make changes to keep this code consistent with other PRs, but it is out of scope there:
  - https://github.com/home-assistant/core/pull/167359#discussion_r3036842045

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
