### PR TITLE
Add diagnostics support to Victron GX

### DIFF
--- a/homeassistant/components/victron_gx/diagnostics.py
+++ b/homeassistant/components/victron_gx/diagnostics.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
+from .const import CONF_INSTALLATION_ID, CONF_SERIAL
 from .hub import VictronGxConfigEntry
 
-TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
+TO_REDACT = {CONF_USERNAME, CONF_PASSWORD, CONF_HOST, CONF_SERIAL, CONF_INSTALLATION_ID}
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/victron_gx/diagnostics.py
+++ b/homeassistant/components/victron_gx/diagnostics.py
@@ -1,0 +1,22 @@
+"""Diagnostics support for victron_gx."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from .hub import VictronGxConfigEntry
+
+TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: VictronGxConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
+    }

--- a/homeassistant/components/victron_gx/quality_scale.yaml
+++ b/homeassistant/components/victron_gx/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info: done
   discovery: done
   docs-data-update: todo

--- a/tests/components/victron_gx/snapshots/test_diagnostics.ambr
+++ b/tests/components/victron_gx/snapshots/test_diagnostics.ambr
@@ -2,12 +2,12 @@
 # name: test_diagnostics
   dict({
     'entry_data': dict({
-      'host': '192.168.1.100',
-      'installation_id': '123',
+      'host': '**REDACTED**',
+      'installation_id': '**REDACTED**',
       'model': 'Cerbo GX',
       'password': '**REDACTED**',
       'port': 1883,
-      'serial': 'HQ2234ABCDE',
+      'serial': '**REDACTED**',
       'ssl': False,
       'username': '**REDACTED**',
     }),

--- a/tests/components/victron_gx/snapshots/test_diagnostics.ambr
+++ b/tests/components/victron_gx/snapshots/test_diagnostics.ambr
@@ -1,0 +1,15 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'entry_data': dict({
+      'host': '192.168.1.100',
+      'installation_id': '123',
+      'model': 'Cerbo GX',
+      'password': '**REDACTED**',
+      'port': 1883,
+      'serial': 'HQ2234ABCDE',
+      'ssl': False,
+      'username': '**REDACTED**',
+    }),
+  })
+# ---

--- a/tests/components/victron_gx/test_diagnostics.py
+++ b/tests/components/victron_gx/test_diagnostics.py
@@ -20,9 +20,7 @@ async def test_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics."""
-    with patch(
-        "homeassistant.components.victron_gx.hub.VictronVenusHub"
-    ):
+    with patch("homeassistant.components.victron_gx.hub.VictronVenusHub"):
         result = await get_diagnostics_for_config_entry(
             hass, hass_client, mock_config_entry
         )

--- a/tests/components/victron_gx/test_diagnostics.py
+++ b/tests/components/victron_gx/test_diagnostics.py
@@ -1,0 +1,29 @@
+"""Tests for victron_gx diagnostics."""
+
+from unittest.mock import patch
+
+from syrupy.assertion import SnapshotAssertion
+from victron_mqtt import Hub as VictronVenusHub
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics."""
+    with patch(
+        "homeassistant.components.victron_gx.hub.VictronVenusHub"
+    ):
+        result = await get_diagnostics_for_config_entry(
+            hass, hass_client, mock_config_entry
+        )
+    assert result == snapshot


### PR DESCRIPTION
## Proposed change

Add diagnostics support to the Victron GX integration for the gold quality scale rule.

- Add `diagnostics.py` with `async_get_config_entry_diagnostics` that exposes redacted config entry data
- Redact sensitive data (`username`, `password`) using `async_redact_data`
- Add snapshot test in `test_diagnostics.py`
- Update `quality_scale.yaml` to mark `diagnostics` as `done`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that has not yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
