### PR TITLE
Add exception translations to victron_gx integration

### DIFF
--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -87,11 +87,15 @@ class Hub:
             await self._hub.connect()
         except AuthenticationError as auth_error:
             raise ConfigEntryAuthFailed(
-                f"Authentication failed for {self.host}: {auth_error}"
+                translation_domain=DOMAIN,
+                translation_key="authentication_failed",
+                translation_placeholders={"host": self.host},
             ) from auth_error
         except CannotConnectError as connect_error:
             raise ConfigEntryNotReady(
-                f"Cannot connect to the hub at {self.host}: {connect_error}"
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                translation_placeholders={"host": self.host},
             ) from connect_error
 
     async def stop(self) -> None:

--- a/homeassistant/components/victron_gx/quality_scale.yaml
+++ b/homeassistant/components/victron_gx/quality_scale.yaml
@@ -57,7 +57,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations:
     status: exempt
     comment: |

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -678,7 +678,7 @@
       },
       "gps_course": {
         "name": "Course",
-        "unit_of_measurement": "\u00b0"
+        "unit_of_measurement": "°"
       },
       "gps_latitude": {
         "name": "Latitude",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -678,7 +678,7 @@
       },
       "gps_course": {
         "name": "Course",
-        "unit_of_measurement": "°"
+        "unit_of_measurement": "\u00b0"
       },
       "gps_latitude": {
         "name": "Latitude",
@@ -1776,6 +1776,14 @@
           "sustain_alt": "Sustain Alt"
         }
       }
+    }
+  },
+  "exceptions": {
+    "authentication_failed": {
+      "message": "Authentication failed for {host}."
+    },
+    "cannot_connect": {
+      "message": "Cannot connect to the hub at {host}."
     }
   }
 }


### PR DESCRIPTION
## Proposed change

Add exception translations to the victron_gx integration (gold quality scale rule).

- Updates `hub.py` to use `translation_domain`, `translation_key`, and `translation_placeholders` for `ConfigEntryAuthFailed` and `ConfigEntryNotReady` exceptions instead of f-string messages
- Adds `exceptions` section to `strings.json` with translated messages
- Updates `quality_scale.yaml` to mark `exception-translations` as `done`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
