### PR TITLE
Update template button tests to use new framework

### DIFF
--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -7,10 +7,8 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant import setup
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.template import DOMAIN
-from homeassistant.components.template.button import DEFAULT_NAME
 from homeassistant.components.template.const import CONF_PICTURE
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
@@ -19,15 +17,72 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_FRIENDLY_NAME,
     CONF_ICON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import MockConfigEntry, assert_setup_component
+from .conftest import (
+    ConfigurationStyle,
+    TemplatePlatformSetup,
+    assert_action,
+    async_trigger,
+    make_test_action,
+    setup_and_test_nested_unique_id,
+    setup_and_test_unique_id,
+    setup_entity,
+)
 
-_TEST_BUTTON = "button.template_button"
-_TEST_OPTIONS_BUTTON = "button.test"
+from tests.common import MockConfigEntry
+
+TEST_ATTRIBUTE_ENTITY_ID = "sensor.test_attribute"
+TEST_AVAILABILITY_ENTITY = "binary_sensor.availability"
+TEST_BUTTON = TemplatePlatformSetup(BUTTON_DOMAIN, None, "template_button", {})
+PRESS_ACTION = make_test_action("press")
+
+
+@pytest.fixture
+async def setup_button(hass: HomeAssistant, count: int, config: dict[str, Any]) -> None:
+    """Do setup of button integration."""
+    await setup_entity(hass, TEST_BUTTON, ConfigurationStyle.MODERN, count, config)
+
+
+@pytest.fixture
+async def setup_single_attribute_button(
+    hass: HomeAssistant,
+    attribute: str,
+    attribute_template: str,
+    config: dict,
+) -> None:
+    """Do setup of button integration with a single attribute."""
+    await setup_entity(
+        hass,
+        TEST_BUTTON,
+        ConfigurationStyle.MODERN,
+        1,
+        config,
+        extra_config={attribute: attribute_template}
+        if attribute and attribute_template
+        else {},
+    )
+
+
+def _verify(
+    hass: HomeAssistant,
+    expected_value: str,
+    attributes: dict[str, Any] | None = None,
+    entity_id: str = TEST_BUTTON.entity_id,
+) -> None:
+    """Verify button's state."""
+    attributes = attributes or {}
+    if CONF_FRIENDLY_NAME not in attributes:
+        attributes[CONF_FRIENDLY_NAME] = TEST_BUTTON.object_id
+    state = hass.states.get(entity_id)
+    assert state.state == expected_value
+    assert state.attributes == attributes
 
 
 @pytest.mark.parametrize(
@@ -74,50 +129,20 @@ async def test_setup_config_entry(
     assert state == snapshot
 
 
+@pytest.mark.parametrize(("count", "config"), [(1, PRESS_ACTION)])
+@pytest.mark.usefixtures("setup_button")
 async def test_missing_optional_config(hass: HomeAssistant) -> None:
     """Test: missing optional template is ok."""
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "button": {
-                        "press": {"service": "script.press"},
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     _verify(hass, STATE_UNKNOWN)
 
 
+@pytest.mark.parametrize(("count", "config"), [(1, {"press": []})])
+@pytest.mark.usefixtures("setup_button")
 async def test_missing_emtpy_press_action_config(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test: missing optional template is ok."""
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "button": {
-                        "press": [],
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     _verify(hass, STATE_UNKNOWN)
 
     now = dt.datetime.now(dt.UTC)
@@ -125,7 +150,7 @@ async def test_missing_emtpy_press_action_config(
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {CONF_ENTITY_ID: _TEST_BUTTON},
+        {CONF_ENTITY_ID: TEST_BUTTON.entity_id},
         blocking=True,
     )
 
@@ -135,63 +160,40 @@ async def test_missing_emtpy_press_action_config(
     )
 
 
+@pytest.mark.parametrize(("count", "config"), [(0, {})])
+@pytest.mark.usefixtures("setup_button")
 async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
-    with assert_setup_component(0, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {"template": {"button": {}}},
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     assert hass.states.async_all("button") == []
 
 
-async def test_all_optional_config(
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                **PRESS_ACTION,
+                "device_class": "restart",
+            },
+        )
+    ],
+)
+@pytest.mark.usefixtures("setup_button")
+async def test_device_class_option(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
     calls: list[ServiceCall],
 ) -> None:
-    """Test: including all optional templates is ok."""
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "unique_id": "test",
-                    "button": {
-                        "press": {
-                            "service": "test.automation",
-                            "data_template": {"caller": "{{ this.entity_id }}"},
-                        },
-                        "device_class": "restart",
-                        "unique_id": "test",
-                        "name": "test",
-                        "icon": "mdi:test",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    """Test optional options is ok."""
     _verify(
         hass,
         STATE_UNKNOWN,
         {
             CONF_DEVICE_CLASS: "restart",
-            CONF_FRIENDLY_NAME: "test",
-            CONF_ICON: "mdi:test",
+            CONF_FRIENDLY_NAME: TEST_BUTTON.object_id,
         },
-        _TEST_OPTIONS_BUTTON,
+        TEST_BUTTON.entity_id,
     )
 
     now = dt.datetime.now(dt.UTC)
@@ -199,47 +201,77 @@ async def test_all_optional_config(
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {CONF_ENTITY_ID: _TEST_OPTIONS_BUTTON},
+        {CONF_ENTITY_ID: TEST_BUTTON.entity_id},
         blocking=True,
     )
 
-    assert len(calls) == 1
-    assert calls[0].data["caller"] == _TEST_OPTIONS_BUTTON
-
+    assert_action(TEST_BUTTON, calls, 1, "press")
     _verify(
         hass,
         now.isoformat(),
         {
             CONF_DEVICE_CLASS: "restart",
-            CONF_FRIENDLY_NAME: "test",
-            CONF_ICON: "mdi:test",
+            CONF_FRIENDLY_NAME: TEST_BUTTON.object_id,
         },
-        _TEST_OPTIONS_BUTTON,
+        TEST_BUTTON.entity_id,
     )
 
-    assert entity_registry.async_get_entity_id("button", "template", "test-test")
+
+@pytest.mark.parametrize("config", [PRESS_ACTION])
+@pytest.mark.parametrize(
+    ("attribute", "attribute_template", "attribute_name", "expected"),
+    [
+        (
+            CONF_ICON,
+            "{{ 'mdi:test' if is_state('sensor.test_attribute', 'on') else '' }}",
+            ATTR_ICON,
+            "mdi:test",
+        ),
+        (
+            CONF_PICTURE,
+            "{{ 'test.jpg' if is_state('sensor.test_attribute', 'on') else '' }}",
+            ATTR_ENTITY_PICTURE,
+            "test.jpg",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("setup_single_attribute_button")
+async def test_options_that_are_templates(
+    hass: HomeAssistant,
+    attribute_name: str,
+    expected: str,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+) -> None:
+    """Test button options that are templates."""
+    expected_attributes = {attribute_name: expected}
+
+    _verify(hass, STATE_UNKNOWN, {attribute_name: ""})
+
+    await async_trigger(hass, TEST_ATTRIBUTE_ENTITY_ID, STATE_ON)
+
+    _verify(hass, STATE_UNKNOWN, expected_attributes)
+
+    now = dt.datetime.now(dt.UTC)
+    freezer.move_to(now)
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {CONF_ENTITY_ID: TEST_BUTTON.entity_id},
+        blocking=True,
+    )
+
+    assert_action(TEST_BUTTON, calls, 1, "press")
+    _verify(hass, now.isoformat(), expected_attributes)
 
 
+@pytest.mark.parametrize("config", [PRESS_ACTION])
+@pytest.mark.parametrize(
+    ("attribute", "attribute_template"), [("name", "Button {{ 1 + 1 }}")]
+)
+@pytest.mark.usefixtures("setup_single_attribute_button")
 async def test_name_template(hass: HomeAssistant) -> None:
     """Test: name template."""
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "button": {
-                        "press": {"service": "script.press"},
-                        "name": "Button {{ 1 + 1 }}",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     _verify(
         hass,
         STATE_UNKNOWN,
@@ -250,86 +282,20 @@ async def test_name_template(hass: HomeAssistant) -> None:
     )
 
 
-@pytest.mark.parametrize(
-    ("field", "attribute", "test_template", "expected"),
-    [
-        (CONF_ICON, ATTR_ICON, "mdi:test{{ 1 + 1 }}", "mdi:test2"),
-        (CONF_PICTURE, ATTR_ENTITY_PICTURE, "test{{ 1 + 1 }}.jpg", "test2.jpg"),
-    ],
-)
-async def test_templated_optional_config(
-    hass: HomeAssistant,
-    field: str,
-    attribute: str,
-    test_template: str,
-    expected: str,
-) -> None:
-    """Test optional config templates."""
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "button": {
-                        "press": {"service": "script.press"},
-                        field: test_template,
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    _verify(
-        hass,
-        STATE_UNKNOWN,
-        {
-            attribute: expected,
-        },
-        "button.template_button",
+async def test_unique_id(hass: HomeAssistant) -> None:
+    """Test unique_id option only creates one button per id."""
+    await setup_and_test_unique_id(
+        hass, TEST_BUTTON, ConfigurationStyle.MODERN, PRESS_ACTION
     )
 
 
-async def test_unique_id(hass: HomeAssistant) -> None:
-    """Test: unique id is ok."""
-    with assert_setup_component(1, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "unique_id": "test",
-                    "button": {
-                        "press": {"service": "script.press"},
-                        "unique_id": "test",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    _verify(hass, STATE_UNKNOWN)
-
-
-def _verify(
-    hass: HomeAssistant,
-    expected_value: str,
-    attributes: dict[str, Any] | None = None,
-    entity_id: str = _TEST_BUTTON,
+async def test_nested_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Verify button's state."""
-    attributes = attributes or {}
-    if CONF_FRIENDLY_NAME not in attributes:
-        attributes[CONF_FRIENDLY_NAME] = DEFAULT_NAME
-    state = hass.states.get(entity_id)
-    assert state.state == expected_value
-    assert state.attributes == attributes
+    """Test a template unique_id propagates to button unique_ids."""
+    await setup_and_test_nested_unique_id(
+        hass, TEST_BUTTON, ConfigurationStyle.MODERN, entity_registry, PRESS_ACTION
+    )
 
 
 async def test_device_id(
@@ -376,3 +342,42 @@ async def test_device_id(
     template_entity = entity_registry.async_get("button.my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
+
+
+@pytest.mark.parametrize(
+    ("config", "attribute", "attribute_template"),
+    [
+        (
+            PRESS_ACTION,
+            "availability",
+            "{{ is_state('binary_sensor.availability', 'on') }}",
+        )
+    ],
+)
+@pytest.mark.usefixtures("setup_single_attribute_button")
+async def test_available_template_with_entities(hass: HomeAssistant) -> None:
+    """Test availability templates with values from other entities."""
+
+    await async_trigger(hass, TEST_AVAILABILITY_ENTITY, STATE_ON)
+
+    # Device State should not be unavailable
+    assert hass.states.get(TEST_BUTTON.entity_id).state != STATE_UNAVAILABLE
+
+    # When Availability template returns false
+    await async_trigger(hass, TEST_AVAILABILITY_ENTITY, STATE_OFF)
+
+    # device state should be unavailable
+    assert hass.states.get(TEST_BUTTON.entity_id).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("config", "attribute", "attribute_template"),
+    [(PRESS_ACTION, "availability", "{{ x - 12 }}")],
+)
+@pytest.mark.usefixtures("setup_single_attribute_button")
+async def test_invalid_availability_template_keeps_component_available(
+    hass: HomeAssistant, caplog_setup_text
+) -> None:
+    """Test that an invalid availability keeps the device available."""
+    assert hass.states.get(TEST_BUTTON.entity_id).state != STATE_UNAVAILABLE
+    assert "UndefinedError: 'x' is undefined" in caplog_setup_text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update template button tests to use new test framework.  Also add availability template tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
