### PR TITLE
Fix Victron BLE false reauth triggered by unknown enum bitmask combinations

### DIFF
--- a/homeassistant/components/victron_ble/__init__.py
+++ b/homeassistant/components/victron_ble/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import REAUTH_AFTER_FAILURES
+from .const import REAUTH_AFTER_FAILURES, VICTRON_IDENTIFIER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,21 +38,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         nonlocal consecutive_failures
         update = data.update(service_info)
 
-        # If the device type was recognized (devices dict populated) but
-        # only signal strength came back, decryption likely failed.
-        # Unsupported devices have an empty devices dict and won't trigger this.
-        if update.devices and len(update.entity_values) <= 1:
-            consecutive_failures += 1
-            if consecutive_failures >= REAUTH_AFTER_FAILURES:
-                _LOGGER.debug(
-                    "Triggering reauth for %s after %d consecutive failures",
-                    address,
-                    consecutive_failures,
-                )
-                entry.async_start_reauth(hass)
+        # Only consider a reauth when the device type is recognised (devices
+        # populated) but the advertisement key fails the quick-check built into
+        # validate_advertisement_key.  Using the key check instead of counting
+        # entity values avoids false positives: some devices legitimately return
+        # few (or zero) sensor values when in certain error or alarm states.
+        raw_data = service_info.manufacturer_data.get(VICTRON_IDENTIFIER)
+        if update.devices and raw_data is not None:
+            if not data.validate_advertisement_key(raw_data):
+                consecutive_failures += 1
+                if consecutive_failures >= REAUTH_AFTER_FAILURES:
+                    _LOGGER.debug(
+                        "Triggering reauth for %s after %d consecutive failures",
+                        address,
+                        consecutive_failures,
+                    )
+                    entry.async_start_reauth(hass)
+                    consecutive_failures = 0
+            else:
                 consecutive_failures = 0
-        else:
-            consecutive_failures = 0
 
         return update
 

--- a/homeassistant/components/victron_ble/__init__.py
+++ b/homeassistant/components/victron_ble/__init__.py
@@ -57,6 +57,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     consecutive_failures = 0
             else:
                 consecutive_failures = 0
+        else:
+            consecutive_failures = 0
 
         return update
 

--- a/tests/components/victron_ble/fixtures.py
+++ b/tests/components/victron_ble/fixtures.py
@@ -187,6 +187,20 @@ VICTRON_VEBUS_BAD_KEY_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+# Same DC/DC converter but with OffReason=0x81 (NO_INPUT_POWER|ENGINE_SHUTDOWN),
+# a real bitmask combination that the current OffReason enum doesn't handle.
+# The key check byte is valid so validate_advertisement_key passes, but
+# parsing raises ValueError → sparse update (signal strength only).
+VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO = BluetoothServiceInfo(
+    name="DC/DC Converter",
+    address="01:02:03:04:05:08",
+    rssi=-60,
+    manufacturer_data={0x02E1: bytes.fromhex("1000c0a304121d64ca8d442b90bbde6a8cba")},
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
 VICTRON_VEBUS_SENSORS = {
     "inverter_charger_device_state": "float",
     "inverter_charger_battery_voltage": "14.45",

--- a/tests/components/victron_ble/test_sensor.py
+++ b/tests/components/victron_ble/test_sensor.py
@@ -235,9 +235,19 @@ async def test_reauth_not_triggered_on_unknown_enum_value(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    for _ in range(REAUTH_AFTER_FAILURES + 1):
+    service_info = VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO
+    for idx in range(REAUTH_AFTER_FAILURES + 1):
         inject_bluetooth_service_info(
-            hass, VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO
+            hass,
+            BluetoothServiceInfo(
+                name=service_info.name,
+                address=service_info.address,
+                rssi=service_info.rssi - idx,
+                manufacturer_data=service_info.manufacturer_data,
+                service_data=service_info.service_data,
+                service_uuids=service_info.service_uuids,
+                source=service_info.source,
+            ),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/victron_ble/test_sensor.py
+++ b/tests/components/victron_ble/test_sensor.py
@@ -24,6 +24,7 @@ from .fixtures import (
     VICTRON_BATTERY_SENSE_TOKEN,
     VICTRON_DC_DC_CONVERTER_SERVICE_INFO,
     VICTRON_DC_DC_CONVERTER_TOKEN,
+    VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO,
     VICTRON_DC_ENERGY_METER_SERVICE_INFO,
     VICTRON_DC_ENERGY_METER_TOKEN,
     VICTRON_SMART_BATTERY_PROTECT_SERVICE_INFO,
@@ -206,6 +207,42 @@ async def test_reauth_triggered_only_once(
     # Still only one reauth flow
     flows = hass.config_entries.flow.async_progress_by_handler("victron_ble")
     assert len(flows) == 1
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_reauth_not_triggered_on_unknown_enum_value(
+    hass: HomeAssistant,
+) -> None:
+    """Test reauth is NOT triggered when a valid key yields a sparse update.
+
+    Some devices report bitmask combinations for OffReason or AlarmReason that
+    are not in the enum (e.g. NO_INPUT_POWER|ENGINE_SHUTDOWN = 0x81 on a DC-DC
+    converter that stopped due to both conditions simultaneously). The parser
+    raises ValueError, producing a sparse update (signal strength only).
+    This must not be mistaken for a wrong encryption key.
+
+    Regression test for https://github.com/home-assistant/core/issues/167105
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO.address,
+            CONF_ACCESS_TOKEN: VICTRON_DC_DC_CONVERTER_TOKEN,
+        },
+        unique_id=VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO.address,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    for _ in range(REAUTH_AFTER_FAILURES + 1):
+        inject_bluetooth_service_info(
+            hass, VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO
+        )
+        await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 0
 
 
 @pytest.mark.usefixtures("enable_bluetooth")


### PR DESCRIPTION
## Proposed change

Replace the entity-count reauth heuristic in the `victron_ble` integration with a call to `validate_advertisement_key()`, which checks the 1-byte key-check value embedded in every Victron BLE advertisement.

**Root cause:** The previous heuristic fired a reauth flow whenever a recognised device produced ≤1 entity values on update. This was to try to detect failures to decrypt the bluetooth advertisements - because BLE is passive, there is no confirmed auth failure to rely on. But when `victron-ble` raises `ValueError` parsing an unknown enum bitmask (e.g. `OffReason(0x81)` = `NO_INPUT_POWER | ENGINE_SHUTDOWN` on a DC-DC converter or Battery Protect in a combined alarm/off state), `parse()` returns `None`, leaving only the signal-strength entity value — even though the encryption key is perfectly valid. This caused repeated false reauth flows.

**Fix:** Use `validate_advertisement_key()` to test the advertisement key directly. Also resets `consecutive_failures` to 0 on a successful key validation so that intermittent parse errors (e.g. unknown enum values) do not accumulate toward the reauth threshold.

**Trade-off:** `validate_advertisement_key()` is a 1-byte prefix check (1/256 false-negative rate for a wrong key that collides on its first byte). This is an accepted limitation of the passive Victron BLE advertisement format — full decryption-based key verification is not possible without additional round-trips.

_Note: the underlying problem of an unknown enum for a bitmask combination has to be fixed in the upstream `victron-ble` dependency: see https://github.com/keshavdv/victron-ble/pull/86_

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #167105
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr