### PR TITLE
iaqualink: move custom update logic to DataUpdateCoordinator

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -167,9 +167,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    for coordinator in runtime_data.coordinators.values():
-        coordinator.async_set_updated_data(None)
-
     return True
 
 

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -114,17 +114,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
         thermostats=[],
     )
     for system in systems_list:
+        coordinator = AqualinkDataUpdateCoordinator(hass, entry, system)
+        runtime_data.coordinators[system.serial] = coordinator
+        await coordinator.async_config_entry_first_refresh()
+
         try:
             devices = await system.get_devices()
         except AqualinkServiceException as svc_exception:
-            await aqualink.close()
             raise ConfigEntryNotReady(
                 f"Error while attempting to retrieve devices list: {svc_exception}"
             ) from svc_exception
-
-        runtime_data.coordinators[system.serial] = AqualinkDataUpdateCoordinator(
-            hass, entry, system
-        )
 
         device_registry = dr.async_get(hass)
         device_registry.async_get_or_create(

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from datetime import datetime
 from functools import wraps
 import logging
 from typing import Any, Concatenate
@@ -32,12 +31,11 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
 )
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
 
-from .const import DOMAIN, UPDATE_INTERVAL
+from .const import DOMAIN
+from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,6 +59,7 @@ class AqualinkRuntimeData:
     """Runtime data for Aqualink."""
 
     client: AqualinkClient
+    coordinator: AqualinkDataUpdateCoordinator
     # These will contain the initialized devices
     binary_sensors: list[AqualinkBinarySensor]
     lights: list[AqualinkLight]
@@ -105,8 +104,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
         await aqualink.close()
         raise ConfigEntryError("No systems detected or supported")
 
+    coordinator = AqualinkDataUpdateCoordinator(hass, entry, systems)
+
     runtime_data = AqualinkRuntimeData(
-        aqualink, binary_sensors=[], lights=[], sensors=[], switches=[], thermostats=[]
+        aqualink,
+        coordinator,
+        binary_sensors=[],
+        lights=[],
+        sensors=[],
+        switches=[],
+        thermostats=[],
     )
     for system in systems:
         try:
@@ -158,31 +165,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    async def _async_systems_update(_: datetime) -> None:
-        """Refresh internal state for all systems."""
-        for system in systems:
-            prev = system.online
-
-            try:
-                await system.update()
-            except (AqualinkServiceException, httpx.HTTPError) as svc_exception:
-                if prev is not None:
-                    _LOGGER.warning(
-                        "Failed to refresh system %s state: %s",
-                        system.serial,
-                        svc_exception,
-                    )
-                await system.aqualink.close()
-            else:
-                cur = system.online
-                if cur and not prev:
-                    _LOGGER.warning("System %s reconnected to iAqualink", system.serial)
-
-            async_dispatcher_send(hass, DOMAIN)
-
-    entry.async_on_unload(
-        async_track_time_interval(hass, _async_systems_update, UPDATE_INTERVAL)
-    )
+    coordinator.async_set_updated_data(None)
 
     return True
 
@@ -204,6 +187,6 @@ def refresh_system[_AqualinkEntityT: AqualinkEntity, **_P](
     ) -> None:
         """Call decorated function and send update signal to all entities."""
         await func(self, *args, **kwargs)
-        async_dispatcher_send(self.hass, DOMAIN)
+        await self.coordinator.async_request_refresh()
 
     return wrapper

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -121,6 +121,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
         try:
             devices = await system.get_devices()
         except AqualinkServiceException as svc_exception:
+            await aqualink.close()
             raise ConfigEntryNotReady(
                 f"Error while attempting to retrieve devices list: {svc_exception}"
             ) from svc_exception

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -59,7 +59,7 @@ class AqualinkRuntimeData:
     """Runtime data for Aqualink."""
 
     client: AqualinkClient
-    coordinator: AqualinkDataUpdateCoordinator
+    coordinators: dict[str, AqualinkDataUpdateCoordinator]
     # These will contain the initialized devices
     binary_sensors: list[AqualinkBinarySensor]
     lights: list[AqualinkLight]
@@ -99,23 +99,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
             f"Error while attempting to retrieve systems list: {svc_exception}"
         ) from svc_exception
 
-    systems = list(systems.values())
-    if not systems:
+    systems_list = list(systems.values())
+    if not systems_list:
         await aqualink.close()
         raise ConfigEntryError("No systems detected or supported")
 
-    coordinator = AqualinkDataUpdateCoordinator(hass, entry, systems)
-
     runtime_data = AqualinkRuntimeData(
         aqualink,
-        coordinator,
+        coordinators={},
         binary_sensors=[],
         lights=[],
         sensors=[],
         switches=[],
         thermostats=[],
     )
-    for system in systems:
+    for system in systems_list:
         try:
             devices = await system.get_devices()
         except AqualinkServiceException as svc_exception:
@@ -123,6 +121,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
             raise ConfigEntryNotReady(
                 f"Error while attempting to retrieve devices list: {svc_exception}"
             ) from svc_exception
+
+        runtime_data.coordinators[system.serial] = AqualinkDataUpdateCoordinator(
+            hass, entry, system
+        )
 
         device_registry = dr.async_get(hass)
         device_registry.async_get_or_create(
@@ -165,7 +167,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    coordinator.async_set_updated_data(None)
+    for coordinator in runtime_data.coordinators.values():
+        coordinator.async_set_updated_data(None)
 
     return True
 

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -190,6 +190,6 @@ def refresh_system[_AqualinkEntityT: AqualinkEntity, **_P](
     ) -> None:
         """Call decorated function and send update signal to all entities."""
         await func(self, *args, **kwargs)
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_set_updated_data(None)
 
     return wrapper

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -187,6 +187,6 @@ def refresh_system[_AqualinkEntityT: AqualinkEntity, **_P](
     ) -> None:
         """Call decorated function and send update signal to all entities."""
         await func(self, *args, **kwargs)
-        self.coordinator.async_set_updated_data(None)
+        self.coordinator.async_update_listeners()
 
     return wrapper

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -26,7 +26,9 @@ async def async_setup_entry(
     """Set up discovered binary sensors."""
     async_add_entities(
         (
-            HassAqualinkBinarySensor(config_entry.runtime_data.coordinator, dev)
+            HassAqualinkBinarySensor(
+                config_entry.runtime_data.coordinators[dev.system.serial], dev
+            )
             for dev in config_entry.runtime_data.binary_sensors
         ),
     )

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AqualinkConfigEntry
+from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
 
 PARALLEL_UPDATES = 0
@@ -25,10 +26,9 @@ async def async_setup_entry(
     """Set up discovered binary sensors."""
     async_add_entities(
         (
-            HassAqualinkBinarySensor(dev)
+            HassAqualinkBinarySensor(config_entry.runtime_data.coordinator, dev)
             for dev in config_entry.runtime_data.binary_sensors
         ),
-        True,
     )
 
 
@@ -37,9 +37,11 @@ class HassAqualinkBinarySensor(
 ):
     """Representation of a binary sensor."""
 
-    def __init__(self, dev: AqualinkBinarySensor) -> None:
+    def __init__(
+        self, coordinator: AqualinkDataUpdateCoordinator, dev: AqualinkBinarySensor
+    ) -> None:
         """Initialize AquaLink binary sensor."""
-        super().__init__(dev)
+        super().__init__(coordinator, dev)
         self._attr_name = dev.label
         if dev.label == "Freeze Protection":
             self._attr_device_class = BinarySensorDeviceClass.COLD

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -25,12 +25,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered binary sensors."""
     async_add_entities(
-        (
-            HassAqualinkBinarySensor(
-                config_entry.runtime_data.coordinators[dev.system.serial], dev
-            )
-            for dev in config_entry.runtime_data.binary_sensors
-        ),
+        HassAqualinkBinarySensor(
+            config_entry.runtime_data.coordinators[dev.system.serial], dev
+        )
+        for dev in config_entry.runtime_data.binary_sensors
     )
 
 

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -36,7 +36,9 @@ async def async_setup_entry(
     """Set up discovered switches."""
     async_add_entities(
         (
-            HassAqualinkThermostat(config_entry.runtime_data.coordinator, dev)
+            HassAqualinkThermostat(
+                config_entry.runtime_data.coordinators[dev.system.serial], dev
+            )
             for dev in config_entry.runtime_data.thermostats
         ),
     )

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -35,12 +35,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered switches."""
     async_add_entities(
-        (
-            HassAqualinkThermostat(
-                config_entry.runtime_data.coordinators[dev.system.serial], dev
-            )
-            for dev in config_entry.runtime_data.thermostats
-        ),
+        HassAqualinkThermostat(
+            config_entry.runtime_data.coordinators[dev.system.serial], dev
+        )
+        for dev in config_entry.runtime_data.thermostats
     )
 
 

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AqualinkConfigEntry, refresh_system
+from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
 from .utils import await_or_reraise
 
@@ -34,8 +35,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered switches."""
     async_add_entities(
-        (HassAqualinkThermostat(dev) for dev in config_entry.runtime_data.thermostats),
-        True,
+        (
+            HassAqualinkThermostat(config_entry.runtime_data.coordinator, dev)
+            for dev in config_entry.runtime_data.thermostats
+        ),
     )
 
 
@@ -49,9 +52,11 @@ class HassAqualinkThermostat(AqualinkEntity[AqualinkThermostat], ClimateEntity):
         | ClimateEntityFeature.TURN_ON
     )
 
-    def __init__(self, dev: AqualinkThermostat) -> None:
+    def __init__(
+        self, coordinator: AqualinkDataUpdateCoordinator, dev: AqualinkThermostat
+    ) -> None:
         """Initialize AquaLink thermostat."""
-        super().__init__(dev)
+        super().__init__(coordinator, dev)
         self._attr_name = dev.label.split(" ")[0]
         self._attr_temperature_unit = (
             UnitOfTemperature.FAHRENHEIT

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -41,3 +41,5 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             raise UpdateFailed(
                 f"Unable to update iAqualink system {self.system.serial}: {err}"
             ) from err
+        if self.system.online is not True:
+            raise UpdateFailed(f"iAqualink system {self.system.serial} is offline")

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -32,6 +32,7 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             update_interval=UPDATE_INTERVAL,
         )
         self.systems = systems
+        self._logged_unavailable: set[str] = set()
 
     async def _async_update_data(self) -> None:
         """Refresh internal state for all systems."""
@@ -41,15 +42,17 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             try:
                 await system.update()
             except AqualinkServiceException, httpx.HTTPError:
-                if prev is not None:
-                    self.logger.warning(
-                        "Failed to refresh system %s state",
-                        system.serial,
-                    )
+                if prev is not None and system.serial not in self._logged_unavailable:
+                    self.logger.info("System %s unavailable", system.serial)
+                    self._logged_unavailable.add(system.serial)
                 await system.aqualink.close()
             else:
                 cur = system.online
-                if cur and not prev:
-                    self.logger.warning(
+                if cur and system.serial in self._logged_unavailable:
+                    self.logger.info(
                         "System %s reconnected to iAqualink", system.serial
                     )
+                    self._logged_unavailable.discard(system.serial)
+                elif not cur and prev and system.serial not in self._logged_unavailable:
+                    self.logger.info("System %s unavailable", system.serial)
+                    self._logged_unavailable.add(system.serial)

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -10,7 +10,7 @@ from iaqualink.exception import AqualinkServiceException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, UPDATE_INTERVAL
 
@@ -21,7 +21,7 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Data coordinator for Aqualink systems."""
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, systems: list[Any]
+        self, hass: HomeAssistant, config_entry: ConfigEntry, system: Any
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -31,28 +31,13 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             name=DOMAIN,
             update_interval=UPDATE_INTERVAL,
         )
-        self.systems = systems
-        self._logged_unavailable: set[str] = set()
+        self.system = system
 
     async def _async_update_data(self) -> None:
-        """Refresh internal state for all systems."""
-        for system in self.systems:
-            prev = system.online
-
-            try:
-                await system.update()
-            except AqualinkServiceException, httpx.HTTPError:
-                if prev is not None and system.serial not in self._logged_unavailable:
-                    self.logger.info("System %s unavailable", system.serial)
-                    self._logged_unavailable.add(system.serial)
-                await system.aqualink.close()
-            else:
-                cur = system.online
-                if cur and system.serial in self._logged_unavailable:
-                    self.logger.info(
-                        "System %s reconnected to iAqualink", system.serial
-                    )
-                    self._logged_unavailable.discard(system.serial)
-                elif not cur and prev and system.serial not in self._logged_unavailable:
-                    self.logger.info("System %s unavailable", system.serial)
-                    self._logged_unavailable.add(system.serial)
+        """Refresh internal state for a system."""
+        try:
+            await self.system.update()
+        except (AqualinkServiceException, httpx.HTTPError) as err:
+            raise UpdateFailed(
+                f"Unable to update iAqualink system {self.system.serial}: {err}"
+            ) from err

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -28,7 +28,7 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             hass,
             _LOGGER,
             config_entry=config_entry,
-            name=DOMAIN,
+            name=f"{DOMAIN}_{system.serial}",
             update_interval=UPDATE_INTERVAL,
         )
         self.system = system

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -1,0 +1,55 @@
+"""Data update coordinator for iaqualink."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from iaqualink.exception import AqualinkServiceException
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, UPDATE_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
+    """Data coordinator for Aqualink systems."""
+
+    def __init__(
+        self, hass: HomeAssistant, config_entry: ConfigEntry, systems: list[Any]
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=UPDATE_INTERVAL,
+        )
+        self.systems = systems
+
+    async def _async_update_data(self) -> None:
+        """Refresh internal state for all systems."""
+        for system in self.systems:
+            prev = system.online
+
+            try:
+                await system.update()
+            except AqualinkServiceException, httpx.HTTPError:
+                if prev is not None:
+                    self.logger.warning(
+                        "Failed to refresh system %s state",
+                        system.serial,
+                    )
+                await system.aqualink.close()
+            else:
+                cur = system.online
+                if cur and not prev:
+                    self.logger.warning(
+                        "System %s reconnected to iAqualink", system.serial
+                    )

--- a/homeassistant/components/iaqualink/entity.py
+++ b/homeassistant/components/iaqualink/entity.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from iaqualink.device import AqualinkDevice
 
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import AqualinkDataUpdateCoordinator
 
 
-class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](Entity):
+class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](
+    CoordinatorEntity[AqualinkDataUpdateCoordinator]
+):
     """Abstract class for all Aqualink platforms.
 
     Entity state is updated via the interval timer within the integration.
@@ -23,8 +25,11 @@ class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](Entity):
 
     _attr_should_poll = False
 
-    def __init__(self, dev: AqualinkDeviceT) -> None:
+    def __init__(
+        self, coordinator: AqualinkDataUpdateCoordinator, dev: AqualinkDeviceT
+    ) -> None:
         """Initialize the entity."""
+        super().__init__(coordinator)
         self.dev = dev
         self._attr_unique_id = f"{dev.system.serial}_{dev.name}"
         self._attr_device_info = DeviceInfo(
@@ -33,12 +38,6 @@ class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](Entity):
             manufacturer=dev.manufacturer,
             model=dev.model,
             name=dev.label,
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Set up a listener when this entity is added to HA."""
-        self.async_on_remove(
-            async_dispatcher_connect(self.hass, DOMAIN, self.async_write_ha_state)
         )
 
     @property

--- a/homeassistant/components/iaqualink/entity.py
+++ b/homeassistant/components/iaqualink/entity.py
@@ -16,11 +16,10 @@ class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](
 ):
     """Abstract class for all Aqualink platforms.
 
-    Entity state is updated via the interval timer within the integration.
-    Any entity state change via the iaqualink library triggers an internal
-    state refresh which is then propagated to all the entities in the system
-    via the refresh_system decorator above to the _update_callback in this
-    class.
+    Entity availability and periodic refreshes are driven by the per-system
+    DataUpdateCoordinator. State changes initiated through the iaqualink
+    library are propagated back to Home Assistant through the coordinator-aware
+    entity update flow.
     """
 
     def __init__(

--- a/homeassistant/components/iaqualink/entity.py
+++ b/homeassistant/components/iaqualink/entity.py
@@ -41,8 +41,3 @@ class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](
     def assumed_state(self) -> bool:
         """Return whether the state is based on actual reading from the device."""
         return self.dev.system.online in [False, None]
-
-    @property
-    def available(self) -> bool:
-        """Return whether the device is available or not."""
-        return self.dev.system.online is True

--- a/homeassistant/components/iaqualink/entity.py
+++ b/homeassistant/components/iaqualink/entity.py
@@ -23,8 +23,6 @@ class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](
     class.
     """
 
-    _attr_should_poll = False
-
     def __init__(
         self, coordinator: AqualinkDataUpdateCoordinator, dev: AqualinkDeviceT
     ) -> None:

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -31,12 +31,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered lights."""
     async_add_entities(
-        (
-            HassAqualinkLight(
-                config_entry.runtime_data.coordinators[dev.system.serial], dev
-            )
-            for dev in config_entry.runtime_data.lights
-        ),
+        HassAqualinkLight(
+            config_entry.runtime_data.coordinators[dev.system.serial], dev
+        )
+        for dev in config_entry.runtime_data.lights
     )
 
 

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AqualinkConfigEntry, refresh_system
+from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
 from .utils import await_or_reraise
 
@@ -30,17 +31,21 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered lights."""
     async_add_entities(
-        (HassAqualinkLight(dev) for dev in config_entry.runtime_data.lights),
-        True,
+        (
+            HassAqualinkLight(config_entry.runtime_data.coordinator, dev)
+            for dev in config_entry.runtime_data.lights
+        ),
     )
 
 
 class HassAqualinkLight(AqualinkEntity[AqualinkLight], LightEntity):
     """Representation of a light."""
 
-    def __init__(self, dev: AqualinkLight) -> None:
+    def __init__(
+        self, coordinator: AqualinkDataUpdateCoordinator, dev: AqualinkLight
+    ) -> None:
         """Initialize AquaLink light."""
-        super().__init__(dev)
+        super().__init__(coordinator, dev)
         self._attr_name = dev.label
         if dev.supports_effect:
             self._attr_effect_list = list(dev.supported_effects)

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -32,7 +32,9 @@ async def async_setup_entry(
     """Set up discovered lights."""
     async_add_entities(
         (
-            HassAqualinkLight(config_entry.runtime_data.coordinator, dev)
+            HassAqualinkLight(
+                config_entry.runtime_data.coordinators[dev.system.serial], dev
+            )
             for dev in config_entry.runtime_data.lights
         ),
     )

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AqualinkConfigEntry
+from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
 
 PARALLEL_UPDATES = 0
@@ -22,17 +23,21 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered sensors."""
     async_add_entities(
-        (HassAqualinkSensor(dev) for dev in config_entry.runtime_data.sensors),
-        True,
+        (
+            HassAqualinkSensor(config_entry.runtime_data.coordinator, dev)
+            for dev in config_entry.runtime_data.sensors
+        ),
     )
 
 
 class HassAqualinkSensor(AqualinkEntity[AqualinkSensor], SensorEntity):
     """Representation of a sensor."""
 
-    def __init__(self, dev: AqualinkSensor) -> None:
+    def __init__(
+        self, coordinator: AqualinkDataUpdateCoordinator, dev: AqualinkSensor
+    ) -> None:
         """Initialize AquaLink sensor."""
-        super().__init__(dev)
+        super().__init__(coordinator, dev)
         self._attr_name = dev.label
         if not dev.name.endswith("_temp"):
             return

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -24,7 +24,9 @@ async def async_setup_entry(
     """Set up discovered sensors."""
     async_add_entities(
         (
-            HassAqualinkSensor(config_entry.runtime_data.coordinator, dev)
+            HassAqualinkSensor(
+                config_entry.runtime_data.coordinators[dev.system.serial], dev
+            )
             for dev in config_entry.runtime_data.sensors
         ),
     )

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -23,12 +23,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered sensors."""
     async_add_entities(
-        (
-            HassAqualinkSensor(
-                config_entry.runtime_data.coordinators[dev.system.serial], dev
-            )
-            for dev in config_entry.runtime_data.sensors
-        ),
+        HassAqualinkSensor(
+            config_entry.runtime_data.coordinators[dev.system.serial], dev
+        )
+        for dev in config_entry.runtime_data.sensors
     )
 
 

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AqualinkConfigEntry, refresh_system
+from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
 from .utils import await_or_reraise
 
@@ -24,17 +25,21 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered switches."""
     async_add_entities(
-        (HassAqualinkSwitch(dev) for dev in config_entry.runtime_data.switches),
-        True,
+        (
+            HassAqualinkSwitch(config_entry.runtime_data.coordinator, dev)
+            for dev in config_entry.runtime_data.switches
+        ),
     )
 
 
 class HassAqualinkSwitch(AqualinkEntity[AqualinkSwitch], SwitchEntity):
     """Representation of a switch."""
 
-    def __init__(self, dev: AqualinkSwitch) -> None:
+    def __init__(
+        self, coordinator: AqualinkDataUpdateCoordinator, dev: AqualinkSwitch
+    ) -> None:
         """Initialize AquaLink switch."""
-        super().__init__(dev)
+        super().__init__(coordinator, dev)
         name = self._attr_name = dev.label
         if name == "Cleaner":
             self._attr_icon = "mdi:robot-vacuum"

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -25,10 +25,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered switches."""
     async_add_entities(
-        (
-            HassAqualinkSwitch(config_entry.runtime_data.coordinator, dev)
-            for dev in config_entry.runtime_data.switches
-        ),
+        HassAqualinkSwitch(config_entry.runtime_data.coordinator, dev)
+        for dev in config_entry.runtime_data.switches
     )
 
 

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -25,8 +25,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered switches."""
     async_add_entities(
-        HassAqualinkSwitch(config_entry.runtime_data.coordinator, dev)
-        for dev in config_entry.runtime_data.switches
+        (
+            HassAqualinkSwitch(
+                config_entry.runtime_data.coordinators[dev.system.serial], dev
+            )
+            for dev in config_entry.runtime_data.switches
+        ),
     )
 
 

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -25,12 +25,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up discovered switches."""
     async_add_entities(
-        (
-            HassAqualinkSwitch(
-                config_entry.runtime_data.coordinators[dev.system.serial], dev
-            )
-            for dev in config_entry.runtime_data.switches
-        ),
+        HassAqualinkSwitch(
+            config_entry.runtime_data.coordinators[dev.system.serial], dev
+        )
+        for dev in config_entry.runtime_data.switches
     )
 
 

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -12,9 +12,13 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
+
 
 async def test_already_configured(
-    hass: HomeAssistant, config_entry, config_data
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    config_data: dict[str, str],
 ) -> None:
     """Test config flow when iaqualink component is already setup."""
     config_entry.add_to_hass(hass)
@@ -40,7 +44,9 @@ async def test_without_config(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
 
-async def test_with_invalid_credentials(hass: HomeAssistant, config_data) -> None:
+async def test_with_invalid_credentials(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
     """Test config flow with invalid username and/or password."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
@@ -56,7 +62,9 @@ async def test_with_invalid_credentials(hass: HomeAssistant, config_data) -> Non
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_service_exception(hass: HomeAssistant, config_data) -> None:
+async def test_service_exception(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
     """Test config flow encountering service exception."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
@@ -72,7 +80,9 @@ async def test_service_exception(hass: HomeAssistant, config_data) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_with_existing_config(hass: HomeAssistant, config_data) -> None:
+async def test_with_existing_config(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
     """Test config flow with existing configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -16,7 +16,6 @@ from iaqualink.systems.iaqua.device import (
     IaquaThermostat,
 )
 from iaqualink.systems.iaqua.system import IaquaSystem
-import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -27,7 +26,6 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .conftest import get_aqualink_device, get_aqualink_system
@@ -44,17 +42,23 @@ async def _advance_coordinator_time(
     await hass.async_block_till_done()
 
 
-async def test_system_coordinator_raises_update_failed(
+async def test_system_refresh_failure_marks_entities_unavailable(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     client: AqualinkClient,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test a system coordinator raises UpdateFailed on update errors."""
+    """Test a system refresh failure marks attached entities unavailable."""
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
     systems = {system.serial: system}
-    system.get_devices = AsyncMock(return_value={})
+    light = get_aqualink_device(
+        system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
+    )
+    devices = {light.name: light}
+    system.get_devices = AsyncMock(return_value=devices)
 
     with (
         patch(
@@ -69,11 +73,22 @@ async def test_system_coordinator_raises_update_failed(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    coordinator = config_entry.runtime_data.coordinators[system.serial]
-    system.update = AsyncMock(side_effect=AqualinkServiceException)
+    name = f"{LIGHT_DOMAIN}.{light.name}"
+    state = hass.states.get(name)
+    assert state is not None
+    assert state.state == STATE_ON
 
-    with pytest.raises(UpdateFailed):
-        await coordinator._async_update_data()
+    async def fail_update() -> None:
+        system.online = None
+        raise AqualinkServiceException
+
+    system.update = AsyncMock(side_effect=fail_update)
+
+    await _advance_coordinator_time(hass, freezer)
+
+    state = hass.states.get(name)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_setup_login_exception(

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -391,9 +391,15 @@ async def test_multiple_updates(
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
     systems = {system.serial: system}
 
-    system.get_devices = AsyncMock(return_value={})
+    light = get_aqualink_device(
+        system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
+    )
+    devices = {light.name: light}
+
+    system.get_devices = AsyncMock(return_value=devices)
 
     with (
         patch(
@@ -410,11 +416,22 @@ async def test_multiple_updates(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
+    entity_id = f"{LIGHT_DOMAIN}.{light.name}"
+
+    def assert_state(expected_state: str) -> None:
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == expected_state
+
     def set_online_to_true():
         system.online = True
 
     def set_online_to_false():
         system.online = False
+
+    async def fail_update() -> None:
+        system.online = None
+        raise AqualinkServiceException
 
     system.update = AsyncMock()
 
@@ -422,46 +439,64 @@ async def test_multiple_updates(
     system.online = True
     system.update.side_effect = set_online_to_true
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 1
+    assert_state(STATE_ON)
 
     # True -> False
     system.online = True
     system.update.side_effect = set_online_to_false
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 2
+    assert_state(STATE_UNAVAILABLE)
 
     # True -> None / ServiceException
     system.online = True
-    system.update.side_effect = AqualinkServiceException
+    system.update.side_effect = fail_update
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 3
+    assert_state(STATE_UNAVAILABLE)
 
     # False -> False
     system.online = False
     system.update.side_effect = set_online_to_false
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 4
+    assert_state(STATE_UNAVAILABLE)
 
     # False -> True
     system.online = False
     system.update.side_effect = set_online_to_true
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 5
+    assert_state(STATE_ON)
 
     # False -> None / ServiceException
     system.online = False
-    system.update.side_effect = AqualinkServiceException
+    system.update.side_effect = fail_update
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 6
+    assert_state(STATE_UNAVAILABLE)
 
     # None -> None / ServiceException
     system.online = None
-    system.update.side_effect = AqualinkServiceException
+    system.update.side_effect = fail_update
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 7
+    assert_state(STATE_UNAVAILABLE)
 
     # None -> True
     system.online = None
     system.update.side_effect = set_online_to_true
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 8
+    assert_state(STATE_ON)
 
     # None -> False
     system.online = None
     system.update.side_effect = set_online_to_false
     await _advance_coordinator_time(hass, freezer)
+    assert system.update.await_count == 9
+    assert_state(STATE_UNAVAILABLE)
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -1,6 +1,5 @@
 """Tests for iAqualink integration."""
 
-import logging
 from unittest.mock import AsyncMock, patch
 
 from iaqualink.exception import (
@@ -25,17 +24,49 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .conftest import get_aqualink_device, get_aqualink_system
 
 
 async def _refresh_coordinator(hass: HomeAssistant, config_entry) -> None:
-    await config_entry.runtime_data.coordinator.async_refresh()
+    coordinator = next(iter(config_entry.runtime_data.coordinators.values()))
+    await coordinator.async_refresh()
     await hass.async_block_till_done()
 
 
-async def test_setup_login_service_exception(hass: HomeAssistant, config_entry) -> None:
-    """Test setup encountering a transient service exception during login."""
+async def test_system_coordinator_raises_update_failed(
+    hass: HomeAssistant, config_entry, client
+) -> None:
+    """Test a system coordinator raises UpdateFailed on update errors."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    systems = {system.serial: system}
+    system.get_devices = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = config_entry.runtime_data.coordinators[system.serial]
+    system.update = AsyncMock(side_effect=AqualinkServiceException)
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_setup_login_exception(hass: HomeAssistant, config_entry) -> None:
+    """Test setup encountering a login exception."""
     config_entry.add_to_hass(hass)
 
     with patch(
@@ -237,9 +268,7 @@ async def test_setup_all_good_all_device_types(
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_multiple_updates(
-    hass: HomeAssistant, config_entry, caplog: pytest.LogCaptureFixture, client
-) -> None:
+async def test_multiple_updates(hass: HomeAssistant, config_entry, client) -> None:
     """Test all possible results of online status transition after update."""
     config_entry.add_to_hass(hass)
 
@@ -247,8 +276,6 @@ async def test_multiple_updates(
     systems = {system.serial: system}
 
     system.get_devices = AsyncMock(return_value={})
-
-    caplog.set_level(logging.INFO)
 
     with (
         patch(
@@ -275,70 +302,48 @@ async def test_multiple_updates(
 
     # True -> True
     system.online = True
-    caplog.clear()
     system.update.side_effect = set_online_to_true
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 0
 
     # True -> False
     system.online = True
-    caplog.clear()
     system.update.side_effect = set_online_to_false
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 1
-    assert "unavailable" in caplog.text
 
     # True -> None / ServiceException
     system.online = True
-    caplog.clear()
     system.update.side_effect = AqualinkServiceException
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 0
 
     # False -> False
     system.online = False
-    caplog.clear()
     system.update.side_effect = set_online_to_false
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 0
 
     # False -> True
     system.online = False
-    caplog.clear()
     system.update.side_effect = set_online_to_true
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 1
-    assert "reconnected" in caplog.text
 
     # False -> None / ServiceException
     system.online = False
-    caplog.clear()
     system.update.side_effect = AqualinkServiceException
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 1
-    assert "unavailable" in caplog.text
 
     # None -> None / ServiceException
     system.online = None
-    caplog.clear()
     system.update.side_effect = AqualinkServiceException
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 0
 
     # None -> True
     system.online = None
-    caplog.clear()
     system.update.side_effect = set_online_to_true
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 1
-    assert "reconnected" in caplog.text
 
     # None -> False
     system.online = None
-    caplog.clear()
     system.update.side_effect = set_online_to_false
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 0
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -19,23 +19,18 @@ import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.iaqualink.const import UPDATE_INTERVAL
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
 
 from .conftest import get_aqualink_device, get_aqualink_system
 
-from tests.common import async_fire_time_changed
 
-
-async def _ffwd_next_update_interval(hass: HomeAssistant) -> None:
-    now = dt_util.utcnow()
-    async_fire_time_changed(hass, now + UPDATE_INTERVAL)
+async def _refresh_coordinator(hass: HomeAssistant, config_entry) -> None:
+    await config_entry.runtime_data.coordinator.async_refresh()
     await hass.async_block_till_done()
 
 
@@ -282,21 +277,21 @@ async def test_multiple_updates(
     system.online = True
     caplog.clear()
     system.update.side_effect = set_online_to_true
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 0
 
     # True -> False
     system.online = True
     caplog.clear()
     system.update.side_effect = set_online_to_false
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 0
 
     # True -> None / ServiceException
     system.online = True
     caplog.clear()
     system.update.side_effect = AqualinkServiceException
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 1
     assert "Failed" in caplog.text
 
@@ -304,14 +299,14 @@ async def test_multiple_updates(
     system.online = False
     caplog.clear()
     system.update.side_effect = set_online_to_false
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 0
 
     # False -> True
     system.online = False
     caplog.clear()
     system.update.side_effect = set_online_to_true
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 1
     assert "reconnected" in caplog.text
 
@@ -319,7 +314,7 @@ async def test_multiple_updates(
     system.online = False
     caplog.clear()
     system.update.side_effect = AqualinkServiceException
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 1
     assert "Failed" in caplog.text
 
@@ -327,14 +322,14 @@ async def test_multiple_updates(
     system.online = None
     caplog.clear()
     system.update.side_effect = AqualinkServiceException
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 0
 
     # None -> True
     system.online = None
     caplog.clear()
     system.update.side_effect = set_online_to_true
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 1
     assert "reconnected" in caplog.text
 
@@ -342,7 +337,7 @@ async def test_multiple_updates(
     system.online = None
     caplog.clear()
     system.update.side_effect = set_online_to_false
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 0
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
@@ -386,19 +381,19 @@ async def test_entity_assumed_and_available(
 
     # None means maybe.
     light.system.online = None
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     state = hass.states.get(name)
     assert state.state == STATE_UNAVAILABLE
     assert state.attributes.get(ATTR_ASSUMED_STATE) is True
 
     light.system.online = False
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     state = hass.states.get(name)
     assert state.state == STATE_UNAVAILABLE
     assert state.attributes.get(ATTR_ASSUMED_STATE) is True
 
     light.system.online = True
-    await _ffwd_next_update_interval(hass)
+    await _refresh_coordinator(hass, config_entry)
     state = hass.states.get(name)
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_ASSUMED_STATE) is None

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
@@ -18,6 +19,7 @@ import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.iaqualink.const import UPDATE_INTERVAL
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -25,13 +27,19 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .conftest import get_aqualink_device, get_aqualink_system
 
+from tests.common import async_fire_time_changed
 
-async def _refresh_coordinator(hass: HomeAssistant, config_entry) -> None:
-    coordinator = next(iter(config_entry.runtime_data.coordinators.values()))
-    await coordinator.async_refresh()
+
+async def _advance_coordinator_time(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Advance time to trigger coordinator update interval."""
+    freezer.tick(delta=UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow())
     await hass.async_block_till_done()
 
 
@@ -268,7 +276,9 @@ async def test_setup_all_good_all_device_types(
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_multiple_updates(hass: HomeAssistant, config_entry, client) -> None:
+async def test_multiple_updates(
+    hass: HomeAssistant, config_entry, client, freezer: FrozenDateTimeFactory
+) -> None:
     """Test all possible results of online status transition after update."""
     config_entry.add_to_hass(hass)
 
@@ -303,47 +313,47 @@ async def test_multiple_updates(hass: HomeAssistant, config_entry, client) -> No
     # True -> True
     system.online = True
     system.update.side_effect = set_online_to_true
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # True -> False
     system.online = True
     system.update.side_effect = set_online_to_false
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # True -> None / ServiceException
     system.online = True
     system.update.side_effect = AqualinkServiceException
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # False -> False
     system.online = False
     system.update.side_effect = set_online_to_false
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # False -> True
     system.online = False
     system.update.side_effect = set_online_to_true
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # False -> None / ServiceException
     system.online = False
     system.update.side_effect = AqualinkServiceException
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # None -> None / ServiceException
     system.online = None
     system.update.side_effect = AqualinkServiceException
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # None -> True
     system.online = None
     system.update.side_effect = set_online_to_true
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     # None -> False
     system.online = None
     system.update.side_effect = set_online_to_false
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -352,7 +362,7 @@ async def test_multiple_updates(hass: HomeAssistant, config_entry, client) -> No
 
 
 async def test_entity_assumed_and_available(
-    hass: HomeAssistant, config_entry, client
+    hass: HomeAssistant, config_entry, client, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test assumed_state and_available properties for all values of online."""
     config_entry.add_to_hass(hass)
@@ -386,19 +396,19 @@ async def test_entity_assumed_and_available(
 
     # None means maybe.
     light.system.online = None
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
     state = hass.states.get(name)
     assert state.state == STATE_UNAVAILABLE
     assert state.attributes.get(ATTR_ASSUMED_STATE) is True
 
     light.system.online = False
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
     state = hass.states.get(name)
     assert state.state == STATE_UNAVAILABLE
     assert state.attributes.get(ATTR_ASSUMED_STATE) is True
 
     light.system.online = True
-    await _refresh_coordinator(hass, config_entry)
+    await _advance_coordinator_time(hass, freezer)
     state = hass.states.get(name)
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_ASSUMED_STATE) is None

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -47,7 +47,7 @@ async def _advance_coordinator_time(
     """Advance time to trigger coordinator update interval."""
     freezer.tick(delta=UPDATE_INTERVAL)
     async_fire_time_changed(hass, dt_util.utcnow())
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_system_refresh_failure_marks_entities_unavailable(

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -24,7 +24,15 @@ from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -89,6 +97,71 @@ async def test_system_refresh_failure_marks_entities_unavailable(
     state = hass.states.get(name)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_light_service_calls_update_entity_state(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+) -> None:
+    """Test light service calls update entity state from device properties."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    systems = {system.serial: system}
+    light = get_aqualink_device(
+        system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
+    )
+    devices = {light.name: light}
+    system.get_devices = AsyncMock(return_value=devices)
+
+    async def turn_off() -> None:
+        light.data["state"] = "0"
+
+    async def turn_on() -> None:
+        light.data["state"] = "1"
+
+    light.turn_off = AsyncMock(side_effect=turn_off)
+    light.turn_on = AsyncMock(side_effect=turn_on)
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_id = f"{LIGHT_DOMAIN}.{light.name}"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
 
 
 async def test_setup_login_exception(

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
+from iaqualink.client import AqualinkClient
 from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
@@ -31,7 +32,7 @@ from homeassistant.util import dt as dt_util
 
 from .conftest import get_aqualink_device, get_aqualink_system
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def _advance_coordinator_time(
@@ -44,7 +45,9 @@ async def _advance_coordinator_time(
 
 
 async def test_system_coordinator_raises_update_failed(
-    hass: HomeAssistant, config_entry, client
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
 ) -> None:
     """Test a system coordinator raises UpdateFailed on update errors."""
     config_entry.add_to_hass(hass)
@@ -73,7 +76,9 @@ async def test_system_coordinator_raises_update_failed(
         await coordinator._async_update_data()
 
 
-async def test_setup_login_exception(hass: HomeAssistant, config_entry) -> None:
+async def test_setup_login_exception(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test setup encountering a login exception."""
     config_entry.add_to_hass(hass)
 
@@ -101,7 +106,9 @@ async def test_setup_login_unauthorized(hass: HomeAssistant, config_entry) -> No
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_login_timeout(hass: HomeAssistant, config_entry) -> None:
+async def test_setup_login_timeout(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test setup encountering a timeout while logging in."""
     config_entry.add_to_hass(hass)
 
@@ -115,7 +122,9 @@ async def test_setup_login_timeout(hass: HomeAssistant, config_entry) -> None:
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_systems_exception(hass: HomeAssistant, config_entry) -> None:
+async def test_setup_systems_exception(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test setup encountering an exception while retrieving systems."""
     config_entry.add_to_hass(hass)
 
@@ -135,7 +144,9 @@ async def test_setup_systems_exception(hass: HomeAssistant, config_entry) -> Non
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_no_systems_recognized(hass: HomeAssistant, config_entry) -> None:
+async def test_setup_no_systems_recognized(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test setup ending in no systems recognized."""
     config_entry.add_to_hass(hass)
 
@@ -156,7 +167,9 @@ async def test_setup_no_systems_recognized(hass: HomeAssistant, config_entry) ->
 
 
 async def test_setup_devices_exception(
-    hass: HomeAssistant, config_entry, client
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
 ) -> None:
     """Test setup encountering an exception while retrieving devices."""
     config_entry.add_to_hass(hass)
@@ -186,7 +199,9 @@ async def test_setup_devices_exception(
 
 
 async def test_setup_all_good_no_recognized_devices(
-    hass: HomeAssistant, config_entry, client
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
 ) -> None:
     """Test setup ending in no devices recognized."""
     config_entry.add_to_hass(hass)
@@ -230,7 +245,9 @@ async def test_setup_all_good_no_recognized_devices(
 
 
 async def test_setup_all_good_all_device_types(
-    hass: HomeAssistant, config_entry, client
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
 ) -> None:
     """Test setup ending in one device of each type recognized."""
     config_entry.add_to_hass(hass)
@@ -277,7 +294,10 @@ async def test_setup_all_good_all_device_types(
 
 
 async def test_multiple_updates(
-    hass: HomeAssistant, config_entry, client, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test all possible results of online status transition after update."""
     config_entry.add_to_hass(hass)
@@ -362,7 +382,10 @@ async def test_multiple_updates(
 
 
 async def test_entity_assumed_and_available(
-    hass: HomeAssistant, config_entry, client, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test assumed_state and_available properties for all values of online."""
     config_entry.add_to_hass(hass)

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -248,7 +248,7 @@ async def test_multiple_updates(
 
     system.get_devices = AsyncMock(return_value={})
 
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.INFO)
 
     with (
         patch(
@@ -285,15 +285,15 @@ async def test_multiple_updates(
     caplog.clear()
     system.update.side_effect = set_online_to_false
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 0
+    assert len(caplog.records) == 1
+    assert "unavailable" in caplog.text
 
     # True -> None / ServiceException
     system.online = True
     caplog.clear()
     system.update.side_effect = AqualinkServiceException
     await _refresh_coordinator(hass, config_entry)
-    assert len(caplog.records) == 1
-    assert "Failed" in caplog.text
+    assert len(caplog.records) == 0
 
     # False -> False
     system.online = False
@@ -316,7 +316,7 @@ async def test_multiple_updates(
     system.update.side_effect = AqualinkServiceException
     await _refresh_coordinator(hass, config_entry)
     assert len(caplog.records) == 1
-    assert "Failed" in caplog.text
+    assert "unavailable" in caplog.text
 
     # None -> None / ServiceException
     system.online = None

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -61,6 +61,7 @@ async def test_system_refresh_failure_marks_entities_unavailable(
 
     system = get_aqualink_system(client, cls=IaquaSystem)
     system.online = True
+    system.update = AsyncMock()
     systems = {system.serial: system}
     light = get_aqualink_device(
         system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
@@ -109,6 +110,7 @@ async def test_light_service_calls_update_entity_state(
 
     system = get_aqualink_system(client, cls=IaquaSystem)
     system.online = True
+    system.update = AsyncMock()
     systems = {system.serial: system}
     light = get_aqualink_device(
         system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
@@ -263,6 +265,7 @@ async def test_setup_devices_exception(
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
+    system.update = AsyncMock()
     systems = {system.serial: system}
 
     with (
@@ -295,6 +298,8 @@ async def test_setup_all_good_no_recognized_devices(
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
     systems = {system.serial: system}
 
     device = get_aqualink_device(system, name="dev_1")
@@ -341,16 +346,38 @@ async def test_setup_all_good_all_device_types(
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
     systems = {system.serial: system}
 
     devices = [
-        get_aqualink_device(system, name="aux_1", cls=IaquaAuxSwitch),
-        get_aqualink_device(system, name="freeze_protection", cls=IaquaBinarySensor),
-        get_aqualink_device(system, name="aux_2", cls=IaquaLightSwitch),
-        get_aqualink_device(system, name="ph", cls=IaquaSensor),
-        get_aqualink_device(system, name="pool_set_point", cls=IaquaThermostat),
+        get_aqualink_device(
+            system, name="aux_1", cls=IaquaAuxSwitch, data={"state": "0"}
+        ),
+        get_aqualink_device(
+            system, name="freeze_protection", cls=IaquaBinarySensor, data={"state": "0"}
+        ),
+        get_aqualink_device(
+            system, name="aux_2", cls=IaquaLightSwitch, data={"state": "0"}
+        ),
+        get_aqualink_device(system, name="ph", cls=IaquaSensor, data={"state": "7.2"}),
+        get_aqualink_device(
+            system, name="pool_set_point", cls=IaquaThermostat, data={"state": "0"}
+        ),
     ]
     devices = {d.name: d for d in devices}
+
+    pool_heater = get_aqualink_device(
+        system, name="pool_heater", cls=IaquaAuxSwitch, data={"state": "0"}
+    )
+    pool_temp = get_aqualink_device(
+        system, name="pool_temp", cls=IaquaSensor, data={"state": "72"}
+    )
+    system.devices = {
+        **{d.name: d for d in devices.values()},
+        pool_heater.name: pool_heater,
+        pool_temp.name: pool_temp,
+    }
 
     system.get_devices = AsyncMock(return_value=devices)
 
@@ -392,6 +419,7 @@ async def test_multiple_updates(
 
     system = get_aqualink_system(client, cls=IaquaSystem)
     system.online = True
+    system.update = AsyncMock()
     systems = {system.serial: system}
 
     light = get_aqualink_device(
@@ -514,6 +542,7 @@ async def test_entity_assumed_and_available(
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
     systems = {system.serial: system}
 
     light = get_aqualink_device(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move the custom logic to refresh device states to a DataUpdateCoordinator class in coordinator.py.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
