### PR TITLE
Change default icon of Evohome's WaterHeater entities

### DIFF
--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -68,7 +68,6 @@ async def async_setup_platform(
 class EvoDHW(EvoChild, WaterHeaterEntity):
     """Base for any evohome-compatible DHW controller."""
 
-    _attr_icon = "mdi:water-boiler"
     _attr_name = "DHW controller"
     _attr_operation_list = list(HA_STATE_TO_EVO)
     _attr_supported_features = (

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -68,8 +68,8 @@ async def async_setup_platform(
 class EvoDHW(EvoChild, WaterHeaterEntity):
     """Base for any evohome-compatible DHW controller."""
 
+    _attr_icon = "mdi:water-boiler"
     _attr_name = "DHW controller"
-    _attr_icon = "mdi:thermometer-lines"
     _attr_operation_list = list(HA_STATE_TO_EVO)
     _attr_supported_features = (
         WaterHeaterEntityFeature.AWAY_MODE

--- a/tests/components/evohome/snapshots/test_water_heater.ambr
+++ b/tests/components/evohome/snapshots/test_water_heater.ambr
@@ -25,7 +25,7 @@
       'away_mode': 'on',
       'current_temperature': 23.0,
       'friendly_name': 'Domestic Hot Water',
-      'icon': 'mdi:thermometer-lines',
+      'icon': 'mdi:water-boiler',
       'max_temp': 60.0,
       'min_temp': 43.3,
       'operation_list': list([
@@ -72,7 +72,7 @@
       'away_mode': 'on',
       'current_temperature': 23.0,
       'friendly_name': 'Domestic Hot Water',
-      'icon': 'mdi:thermometer-lines',
+      'icon': 'mdi:water-boiler',
       'max_temp': 60.0,
       'min_temp': 43.3,
       'operation_list': list([

--- a/tests/components/evohome/snapshots/test_water_heater.ambr
+++ b/tests/components/evohome/snapshots/test_water_heater.ambr
@@ -25,7 +25,6 @@
       'away_mode': 'on',
       'current_temperature': 23.0,
       'friendly_name': 'Domestic Hot Water',
-      'icon': 'mdi:water-boiler',
       'max_temp': 60.0,
       'min_temp': 43.3,
       'operation_list': list([
@@ -72,7 +71,6 @@
       'away_mode': 'on',
       'current_temperature': 23.0,
       'friendly_name': 'Domestic Hot Water',
-      'icon': 'mdi:water-boiler',
       'max_temp': 60.0,
       'min_temp': 43.3,
       'operation_list': list([


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes the icon of Evohome's **WaterHeater** entities from `mdi:thermometer-lines` to the default, `mdi:water-boiler`.

The driving rationale is to present a more consistent UI/UX with other entities within the integration:
 - controllers: `mdi:thermostat-box`, with `mdi:thermostat-box-auto`
 - zones: `mdi:thermostat`, with `mdi:thermostat-auto`
 - DHW: `mdi:water-boiler`, with `mdi:water-boiler-auto`
 
 The `-auto` is used for the reset **Button** entities that correspond to each device type.
  - and a future PR may well use it for the 'primary' entity classes, if they're in auto mode

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
