### PR TITLE
Fix Victron BLE storage errors caused by non-serializable value_fn callable in sensor entity description

### DIFF
--- a/homeassistant/components/victron_ble/sensor.py
+++ b/homeassistant/components/victron_ble/sensor.py
@@ -1,6 +1,5 @@
 """Sensor platform for Victron BLE."""
 
-from collections.abc import Callable
 from dataclasses import dataclass
 import logging
 from typing import Any
@@ -182,10 +181,6 @@ PARALLEL_UPDATES = 0
 class VictronBLESensorEntityDescription(SensorEntityDescription):
     """Describes Victron BLE sensor entity."""
 
-    value_fn: Callable[[float | int | str | None], float | int | str | None] = (
-        lambda x: x
-    )
-
 
 SENSOR_DESCRIPTIONS = {
     Keys.AC_IN_POWER: VictronBLESensorEntityDescription(
@@ -258,7 +253,6 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.ENUM,
         translation_key="charger_error",
         options=CHARGER_ERROR_OPTIONS,
-        value_fn=error_to_state,
     ),
     Keys.CONSUMED_AMPERE_HOURS: VictronBLESensorEntityDescription(
         key=Keys.CONSUMED_AMPERE_HOURS,
@@ -538,4 +532,6 @@ class VictronBLESensorEntity(PassiveBluetoothProcessorEntity, SensorEntity):
         """Return the state of the sensor."""
         value = self.processor.entity_data.get(self.entity_key)
 
-        return self.entity_description.value_fn(value)
+        if self.entity_description.key == Keys.CHARGER_ERROR:
+            return error_to_state(value)
+        return value

--- a/tests/components/victron_ble/test_sensor.py
+++ b/tests/components/victron_ble/test_sensor.py
@@ -1,16 +1,21 @@
 """Test updating sensors in the victron_ble integration."""
 
+import json
 import time
 
 from home_assistant_bluetooth import BluetoothServiceInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bluetooth.passive_update_processor import (
+    serialize_entity_description,
+)
 from homeassistant.components.victron_ble.const import (
     DOMAIN,
     REAUTH_AFTER_FAILURES,
     VICTRON_IDENTIFIER,
 )
+from homeassistant.components.victron_ble.sensor import SENSOR_DESCRIPTIONS
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -57,6 +62,26 @@ SOLAR_CHARGER_ERROR_PAYLOADS = {
     # ChargerError.NETWORK_A -> mapped to state "network"
     "network": "100242a0016207adcef77b605d7e0ee21b24df5c0404040410951e81ea42b0492e356ad5ed8f7eb7",
 }
+
+
+def test_sensor_descriptions_are_json_serializable() -> None:
+    """Ensure entity descriptions contain no non-JSON-serializable fields.
+
+    The passive Bluetooth processor persists entity descriptions to storage
+    between HA restarts via serialize_entity_description(). Fields that are
+    Python callables (e.g. a value_fn lambda) cannot be serialized and cause
+    repeated 'Bad data' errors in the homeassistant.helpers.storage logger.
+
+    Regression test for https://github.com/home-assistant/core/issues/167224
+    """
+    for key, description in SENSOR_DESCRIPTIONS.items():
+        serialized = serialize_entity_description(description)
+        try:
+            json.dumps(serialized)
+        except TypeError as err:
+            raise AssertionError(
+                f"SENSOR_DESCRIPTIONS[{key!r}] produced a non-serializable value: {err}"
+            ) from err
 
 
 @pytest.mark.usefixtures("enable_bluetooth")


### PR DESCRIPTION
## Proposed change

Remove the `value_fn` field from `VictronBLESensorEntityDescription` (a frozen dataclass extending `SensorEntityDescription`) to fix repeated storage serialization errors in Home Assistant logs.

**Root cause:** The `value_fn: Callable` field was used exclusively by the `charger_error` sensor to map raw error codes to state strings (e.g. `internal_supply_a/b/c/d` → `internal_supply`). The passive Bluetooth processor serializes entity descriptions to storage between restarts, but Python callables cannot be JSON-serialized. This produced repeated log errors of the form:

```
Error writing config for bluetooth.passive_update_processor:
Bad data at $.data...value_fn=<function error_to_state>
```

The field was present from the original integration PR (#148043) and the serialization issue manifested when the passive Bluetooth processor gained state persistence.

**Fix:** Remove `value_fn` from the dataclass entirely. Apply the `error_to_state` mapping directly in `native_value` when `entity_description.key == Keys.CHARGER_ERROR`. Remove the now-unused `Callable` import.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #167224
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr