### PR TITLE
Update template select tests to use new framework

### DIFF
--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -30,8 +30,10 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
+    assert_action,
     async_get_flow_preview_state,
     async_trigger,
+    make_test_action,
     make_test_trigger,
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
@@ -41,7 +43,7 @@ from .conftest import (
 from tests.common import MockConfigEntry, assert_setup_component
 from tests.conftest import WebSocketGenerator
 
-TEST_STATE_ENTITY_ID = "select.test_state"
+TEST_STATE_ENTITY_ID = "sensor.test_state"
 TEST_AVAILABILITY_ENTITY_ID = "binary_sensor.test_availability"
 
 TEST_SELECT = TemplatePlatformSetup(
@@ -56,14 +58,7 @@ TEST_OPTIONS_WITHOUT_STATE = {
     "select_option": [],
 }
 TEST_OPTIONS = {"state": "test", **TEST_OPTIONS_WITHOUT_STATE}
-TEST_OPTION_ACTION = {
-    "action": "test.automation",
-    "data": {
-        "action": "select_option",
-        "caller": "{{ this.entity_id }}",
-        "option": "{{ option }}",
-    },
-}
+TEST_OPTION_ACTION = make_test_action("select_option", {"option": "{{ option }}"})
 
 
 @pytest.fixture
@@ -181,9 +176,9 @@ async def test_missing_required_keys(hass: HomeAssistant) -> None:
         (
             1,
             {
-                "options": "{{ state_attr('select.test_state', 'options') or [] }}",
-                "select_option": [TEST_OPTION_ACTION],
-                "state": "{{ states('select.test_state') }}",
+                "options": "{{ state_attr('sensor.test_state', 'options') or [] }}",
+                **TEST_OPTION_ACTION,
+                "state": "{{ states('sensor.test_state') }}",
             },
         )
     ],
@@ -214,10 +209,7 @@ async def test_template_select(hass: HomeAssistant, calls: list[ServiceCall]) ->
     )
 
     # Check this variable can be used in set_value script
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "select_option"
-    assert calls[-1].data["caller"] == TEST_SELECT.entity_id
-    assert calls[-1].data["option"] == "c"
+    assert_action(TEST_SELECT, calls, 1, "select_option", option="c")
 
     await async_trigger(hass, TEST_STATE_ENTITY_ID, "c", attributes)
     _verify(hass, "c", ["a", "b", "c"])
@@ -247,7 +239,7 @@ def _verify(
         (
             {
                 **TEST_OPTIONS,
-                CONF_ICON: "{% if states.select.test_state.state == 'yes' %}mdi:check{% endif %}",
+                CONF_ICON: "{% if states.sensor.test_state.state == 'yes' %}mdi:check{% endif %}",
             },
             ATTR_ICON,
             "mdi:check",
@@ -255,7 +247,7 @@ def _verify(
         (
             {
                 **TEST_OPTIONS,
-                CONF_PICTURE: "{% if states.select.test_state.state == 'yes' %}check.jpg{% endif %}",
+                CONF_PICTURE: "{% if states.sensor.test_state.state == 'yes' %}check.jpg{% endif %}",
             },
             ATTR_ENTITY_PICTURE,
             "check.jpg",
@@ -410,7 +402,7 @@ async def test_optimistic(hass: HomeAssistant) -> None:
         (
             1,
             {
-                "state": "{{ states('select.test_state') }}",
+                "state": "{{ states('sensor.test_state') }}",
                 "optimistic": False,
                 "options": "{{ ['test', 'yes', 'no'] }}",
                 "select_option": [],
@@ -448,7 +440,7 @@ async def test_not_optimistic(hass: HomeAssistant) -> None:
             {
                 "options": "{{ ['test', 'yes', 'no'] }}",
                 "select_option": [],
-                "state": "{{ states('select.test_state') }}",
+                "state": "{{ states('sensor.test_state') }}",
                 "availability": "{{ is_state('binary_sensor.test_availability', 'on') }}",
             },
         )
@@ -485,6 +477,29 @@ async def test_availability(hass: HomeAssistant) -> None:
 
     state = hass.states.get(TEST_SELECT.entity_id)
     assert state.state == "yes"
+
+
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {"availability": "{{ x - 12 }}", **TEST_OPTIONS},
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.usefixtures("setup_select")
+async def test_invalid_availability_template_keeps_component_available(
+    hass: HomeAssistant, caplog_setup_text: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that an invalid availability keeps the device available."""
+    await async_trigger(hass, TEST_AVAILABILITY_ENTITY_ID, "anything")
+    assert hass.states.get(TEST_SELECT.entity_id).state != STATE_UNAVAILABLE
+    error = "UndefinedError: 'x' is undefined"
+    assert error in caplog_setup_text or error in caplog.text
 
 
 async def test_flow_preview(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update template select tests to use new test framework.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
