### PR TITLE
Update template switch tests to use new framework

### DIFF
--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -24,8 +24,10 @@ from homeassistant.setup import async_setup_component
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
+    assert_action,
     async_get_flow_preview_state,
     async_trigger,
+    make_test_action,
     make_test_trigger,
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
@@ -51,24 +53,9 @@ TEST_SWITCH = TemplatePlatformSetup(
     make_test_trigger(TEST_STATE_ENTITY_ID, TEST_SENSOR),
 )
 
-SWITCH_TURN_ON = {
-    "service": "test.automation",
-    "data_template": {
-        "action": "turn_on",
-        "caller": "{{ this.entity_id }}",
-    },
-}
-SWITCH_TURN_OFF = {
-    "service": "test.automation",
-    "data_template": {
-        "action": "turn_off",
-        "caller": "{{ this.entity_id }}",
-    },
-}
-SWITCH_ACTIONS = {
-    "turn_on": SWITCH_TURN_ON,
-    "turn_off": SWITCH_TURN_OFF,
-}
+TURN_ON_ACTION = make_test_action("turn_on")
+TURN_OFF_ACTION = make_test_action("turn_off")
+SWITCH_ACTIONS = {**TURN_ON_ACTION, **TURN_OFF_ACTION}
 
 
 @pytest.fixture
@@ -329,9 +316,7 @@ async def test_trigger_attributes_with_optimistic_state(
     assert state.state == STATE_ON
     assert state.attributes.get(attr) is None
 
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "turn_on"
-    assert calls[-1].data["caller"] == TEST_SWITCH.entity_id
+    assert_action(TEST_SWITCH, calls, 1, "turn_on")
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -344,9 +329,7 @@ async def test_trigger_attributes_with_optimistic_state(
     assert state.state == STATE_OFF
     assert state.attributes.get(attr) is None
 
-    assert len(calls) == 2
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_SWITCH.entity_id
+    assert_action(TEST_SWITCH, calls, 2, "turn_off")
 
     await async_trigger(hass, TEST_SENSOR, expected)
 
@@ -365,9 +348,7 @@ async def test_trigger_attributes_with_optimistic_state(
     assert state.state == STATE_ON
     assert state.attributes.get(attr) == expected
 
-    assert len(calls) == 3
-    assert calls[-1].data["action"] == "turn_on"
-    assert calls[-1].data["caller"] == TEST_SWITCH.entity_id
+    assert_action(TEST_SWITCH, calls, 3, "turn_on")
 
 
 @pytest.mark.parametrize(
@@ -513,12 +494,12 @@ async def test_no_switches_does_not_create(
     "config",
     [
         {
-            "not_on": SWITCH_TURN_ON,
-            "turn_off": SWITCH_TURN_OFF,
+            "not_on": [],
+            **TURN_OFF_ACTION,
         },
         {
-            "turn_on": SWITCH_TURN_ON,
-            "not_off": SWITCH_TURN_OFF,
+            **TURN_ON_ACTION,
+            "not_off": [],
         },
     ],
 )
@@ -553,9 +534,7 @@ async def test_on_action(
         blocking=True,
     )
 
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "turn_on"
-    assert calls[-1].data["caller"] == TEST_SWITCH.entity_id
+    assert_action(TEST_SWITCH, calls, 1, "turn_on")
 
 
 @pytest.mark.parametrize("count", [1])
@@ -584,9 +563,7 @@ async def test_on_action_optimistic(
     state = hass.states.get(TEST_SWITCH.entity_id)
     assert state.state == STATE_ON
 
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "turn_on"
-    assert calls[-1].data["caller"] == TEST_SWITCH.entity_id
+    assert_action(TEST_SWITCH, calls, 1, "turn_on")
 
 
 @pytest.mark.parametrize(
@@ -611,9 +588,7 @@ async def test_off_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None
         blocking=True,
     )
 
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_SWITCH.entity_id
+    assert_action(TEST_SWITCH, calls, 1, "turn_off")
 
 
 @pytest.mark.parametrize("count", [1])
@@ -642,9 +617,7 @@ async def test_off_action_optimistic(
     state = hass.states.get(TEST_SWITCH.entity_id)
     assert state.state == STATE_OFF
 
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "turn_off"
-    assert calls[-1].data["caller"] == TEST_SWITCH.entity_id
+    assert_action(TEST_SWITCH, calls, 1, "turn_off")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update template switch tests to use new test framework.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
