### PR TITLE
Update template vacuum tests to use new framework

### DIFF
--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -22,8 +22,10 @@ from homeassistant.helpers.typing import ConfigType
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
+    assert_action,
     async_get_flow_preview_state,
     async_trigger,
+    make_test_action,
     make_test_trigger,
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
@@ -34,82 +36,40 @@ from tests.common import MockConfigEntry
 from tests.components.vacuum import common
 from tests.typing import WebSocketGenerator
 
-TEST_STATE_SENSOR = "sensor.test_state"
-TEST_SPEED_SENSOR = "sensor.test_fan_speed"
-TEST_BATTERY_LEVEL_SENSOR = "sensor.test_battery_level"
-TEST_AVAILABILITY_ENTITY = "availability_state.state"
+TEST_STATE_ENTITY_ID = "sensor.test_state"
+TEST_ATTRIBUTE_ENTITY_ID = "sensor.test_attribute"
+TEST_AVAILABILITY_ENTITY = "binary_sensor.availability"
 
 TEST_VACUUM = TemplatePlatformSetup(
     vacuum.DOMAIN,
     "vacuums",
     "test_vacuum",
     make_test_trigger(
-        TEST_STATE_SENSOR,
-        TEST_SPEED_SENSOR,
-        TEST_BATTERY_LEVEL_SENSOR,
+        TEST_STATE_ENTITY_ID,
+        TEST_ATTRIBUTE_ENTITY_ID,
         TEST_AVAILABILITY_ENTITY,
     ),
 )
 
-START_ACTION = {
-    "start": {
-        "service": "test.automation",
-        "data": {
-            "caller": "{{ this.entity_id }}",
-            "action": "start",
-        },
-    },
-}
-
+CLEAN_SPOT_ACTION = make_test_action("clean_spot")
+LOCATE_ACTION = make_test_action("locate")
+PAUSE_ACTION = make_test_action("pause")
+RETURN_TO_BASE_ACTION = make_test_action("return_to_base")
+SET_FAN_SPEED_ACTION = make_test_action(
+    "set_fan_speed", {"fan_speed": "{{ fan_speed }}"}
+)
+START_ACTION = make_test_action("start")
+STOP_ACTION = make_test_action("stop")
 
 TEMPLATE_VACUUM_ACTIONS = {
     **START_ACTION,
-    "pause": {
-        "service": "test.automation",
-        "data": {
-            "caller": "{{ this.entity_id }}",
-            "action": "pause",
-        },
-    },
-    "stop": {
-        "service": "test.automation",
-        "data": {
-            "caller": "{{ this.entity_id }}",
-            "action": "stop",
-        },
-    },
-    "return_to_base": {
-        "service": "test.automation",
-        "data": {
-            "caller": "{{ this.entity_id }}",
-            "action": "return_to_base",
-        },
-    },
-    "clean_spot": {
-        "service": "test.automation",
-        "data": {
-            "caller": "{{ this.entity_id }}",
-            "action": "clean_spot",
-        },
-    },
-    "locate": {
-        "service": "test.automation",
-        "data": {
-            "caller": "{{ this.entity_id }}",
-            "action": "locate",
-        },
-    },
-    "set_fan_speed": {
-        "service": "test.automation",
-        "data": {
-            "caller": "{{ this.entity_id }}",
-            "action": "set_fan_speed",
-            "fan_speed": "{{ fan_speed }}",
-        },
-    },
+    **PAUSE_ACTION,
+    **STOP_ACTION,
+    **RETURN_TO_BASE_ACTION,
+    **CLEAN_SPOT_ACTION,
+    **LOCATE_ACTION,
+    **SET_FAN_SPEED_ACTION,
 }
-
-UNIQUE_ID_CONFIG = {"unique_id": "not-so-unique-anymore", **TEMPLATE_VACUUM_ACTIONS}
 
 
 def _verify(
@@ -344,7 +304,7 @@ async def test_valid_legacy_configs(hass: HomeAssistant, count, parm1, parm2) ->
     """Test: configs."""
 
     # Ensure trigger entity templates are rendered
-    hass.states.async_set(TEST_STATE_SENSOR, None)
+    hass.states.async_set(TEST_STATE_ENTITY_ID, None)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all("vacuum")) == count
@@ -396,7 +356,7 @@ async def test_battery_level_template(
     hass: HomeAssistant, expected: int | None
 ) -> None:
     """Test templates with values from other entities."""
-    await async_trigger(hass, TEST_STATE_SENSOR)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID)
     _verify(hass, STATE_UNKNOWN, expected)
 
 
@@ -420,7 +380,7 @@ async def test_battery_level_template_repair(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test battery_level template raises issue."""
-    await async_trigger(hass, TEST_STATE_SENSOR, VacuumActivity.DOCKED)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, VacuumActivity.DOCKED)
 
     assert len(issue_registry.issues) == issue_count
     issue = issue_registry.async_get_issue(
@@ -465,7 +425,7 @@ async def test_battery_level_template_repair(
 @pytest.mark.usefixtures("setup_single_attribute_state_vacuum")
 async def test_fan_speed_template(hass: HomeAssistant, expected: str | None) -> None:
     """Test templates with values from other entities."""
-    await async_trigger(hass, TEST_STATE_SENSOR)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID)
     _verify(hass, STATE_UNKNOWN, None, expected)
 
 
@@ -494,7 +454,7 @@ async def test_icon_template(hass: HomeAssistant, expected: int) -> None:
     state = hass.states.get(TEST_VACUUM.entity_id)
     assert state.attributes.get("icon") == expected
 
-    hass.states.async_set(TEST_STATE_SENSOR, STATE_ON)
+    hass.states.async_set(TEST_STATE_ENTITY_ID, STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_VACUUM.entity_id)
@@ -526,7 +486,7 @@ async def test_picture_template(hass: HomeAssistant, expected: int) -> None:
     state = hass.states.get(TEST_VACUUM.entity_id)
     assert state.attributes.get("entity_picture") == expected
 
-    hass.states.async_set(TEST_STATE_SENSOR, STATE_ON)
+    hass.states.async_set(TEST_STATE_ENTITY_ID, STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_VACUUM.entity_id)
@@ -540,7 +500,7 @@ async def test_picture_template(hass: HomeAssistant, expected: int) -> None:
         (
             1,
             None,
-            "{{ is_state('availability_state.state', 'on') }}",
+            "{{ is_state('binary_sensor.availability', 'on') }}",
         )
     ],
 )
@@ -595,7 +555,7 @@ async def test_invalid_availability_template_keeps_component_available(
     hass: HomeAssistant, caplog_setup_text, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that an invalid availability keeps the device available."""
-    await async_trigger(hass, TEST_STATE_SENSOR)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID)
     assert hass.states.get(TEST_VACUUM.entity_id) != STATE_UNAVAILABLE
     err = "'x' is undefined"
     assert err in caplog_setup_text or err in caplog.text
@@ -620,7 +580,7 @@ async def test_attribute_templates(hass: HomeAssistant) -> None:
     state = hass.states.get(TEST_VACUUM.entity_id)
     assert state.attributes["test_attribute"] == "It ."
 
-    hass.states.async_set(TEST_STATE_SENSOR, "Works")
+    hass.states.async_set(TEST_STATE_ENTITY_ID, "Works")
     await hass.async_block_till_done()
     await async_update_entity(hass, TEST_VACUUM.entity_id)
     state = hass.states.get(TEST_VACUUM.entity_id)
@@ -647,7 +607,7 @@ async def test_invalid_attribute_template(
 ) -> None:
     """Test that errors are logged if rendering template fails."""
 
-    hass.states.async_set(TEST_STATE_SENSOR, "Works")
+    hass.states.async_set(TEST_STATE_ENTITY_ID, "Works")
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all("vacuum")) == 1
@@ -760,9 +720,7 @@ async def test_state_services(
     await hass.async_block_till_done()
 
     # verify
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == action
-    assert calls[-1].data["caller"] == TEST_VACUUM.entity_id
+    assert_action(TEST_VACUUM, calls, 1, action)
 
 
 @pytest.mark.parametrize(
@@ -771,7 +729,7 @@ async def test_state_services(
         (
             1,
             "{{ states('sensor.test_state') }}",
-            "{{ states('sensor.test_fan_speed') }}",
+            "{{ states('sensor.test_attribute') }}",
             {
                 "fan_speeds": ["low", "medium", "high"],
             },
@@ -795,20 +753,14 @@ async def test_set_fan_speed(hass: HomeAssistant, calls: list[ServiceCall]) -> N
     await hass.async_block_till_done()
 
     # verify
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "set_fan_speed"
-    assert calls[-1].data["caller"] == TEST_VACUUM.entity_id
-    assert calls[-1].data["fan_speed"] == "high"
+    assert_action(TEST_VACUUM, calls, 1, "set_fan_speed", fan_speed="high")
 
     # Set fan's speed to medium
     await common.async_set_fan_speed(hass, "medium", TEST_VACUUM.entity_id)
     await hass.async_block_till_done()
 
     # verify
-    assert len(calls) == 2
-    assert calls[-1].data["action"] == "set_fan_speed"
-    assert calls[-1].data["caller"] == TEST_VACUUM.entity_id
-    assert calls[-1].data["fan_speed"] == "medium"
+    assert_action(TEST_VACUUM, calls, 2, "set_fan_speed", fan_speed="medium")
 
 
 @pytest.mark.parametrize(
@@ -825,7 +777,7 @@ async def test_set_fan_speed(hass: HomeAssistant, calls: list[ServiceCall]) -> N
         (
             1,
             "{{ states('sensor.test_state') }}",
-            "{{ states('sensor.test_fan_speed') }}",
+            "{{ states('sensor.test_attribute') }}",
         )
     ],
 )
@@ -848,20 +800,14 @@ async def test_set_invalid_fan_speed(
     await hass.async_block_till_done()
 
     # verify
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "set_fan_speed"
-    assert calls[-1].data["caller"] == TEST_VACUUM.entity_id
-    assert calls[-1].data["fan_speed"] == "high"
+    assert_action(TEST_VACUUM, calls, 1, "set_fan_speed", fan_speed="high")
 
     # Set vacuum's fan speed to 'invalid'
     await common.async_set_fan_speed(hass, "invalid", TEST_VACUUM.entity_id)
     await hass.async_block_till_done()
 
     # verify fan speed is unchanged
-    assert len(calls) == 1
-    assert calls[-1].data["action"] == "set_fan_speed"
-    assert calls[-1].data["caller"] == TEST_VACUUM.entity_id
-    assert calls[-1].data["fan_speed"] == "high"
+    assert_action(TEST_VACUUM, calls, 1, "set_fan_speed", fan_speed="high")
 
 
 @pytest.mark.parametrize(("count", "vacuum_config"), [(1, {"start": []})])
@@ -1006,7 +952,7 @@ async def test_optimistic_option(
     calls: list[ServiceCall],
 ) -> None:
     """Test optimistic yaml option."""
-    hass.states.async_set(TEST_STATE_SENSOR, VacuumActivity.DOCKED)
+    hass.states.async_set(TEST_STATE_ENTITY_ID, VacuumActivity.DOCKED)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_VACUUM.entity_id)
@@ -1023,10 +969,10 @@ async def test_optimistic_option(
     state = hass.states.get(TEST_VACUUM.entity_id)
     assert state.state == expected
 
-    hass.states.async_set(TEST_STATE_SENSOR, VacuumActivity.RETURNING)
+    hass.states.async_set(TEST_STATE_ENTITY_ID, VacuumActivity.RETURNING)
     await hass.async_block_till_done()
 
-    hass.states.async_set(TEST_STATE_SENSOR, VacuumActivity.DOCKED)
+    hass.states.async_set(TEST_STATE_ENTITY_ID, VacuumActivity.DOCKED)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_VACUUM.entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update template vacuum tests to use new test framework.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
