### PR TITLE
Fix Lyric sensor crash when next_period_time is None

### DIFF
--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -144,11 +144,13 @@ def get_setpoint_status(status: str, time: str) -> str | None:
     return LYRIC_SETPOINT_STATUS_NAMES.get(status)
 
 
-def get_datetime_from_future_time(time_str: str) -> datetime:
+def get_datetime_from_future_time(time_str: str | None) -> datetime | None:
     """Get datetime from future time provided."""
+    if time_str is None:
+        return None
     time = dt_util.parse_time(time_str)
     if time is None:
-        raise ValueError(f"Unable to parse time {time_str}")
+        return None
     now = dt_util.utcnow()
     if time <= now.time():
         now = now + timedelta(days=1)

--- a/tests/components/lyric/test_sensor.py
+++ b/tests/components/lyric/test_sensor.py
@@ -1,0 +1,23 @@
+"""Tests for the Honeywell Lyric sensor platform."""
+
+from datetime import datetime
+
+import pytest
+
+from homeassistant.components.lyric.sensor import get_datetime_from_future_time
+
+
+def test_get_datetime_from_future_time_none() -> None:
+    """Test that None input returns None instead of raising."""
+    assert get_datetime_from_future_time(None) is None
+
+
+def test_get_datetime_from_future_time_invalid() -> None:
+    """Test that an unparseable time string returns None."""
+    assert get_datetime_from_future_time("not_a_time") is None
+
+
+def test_get_datetime_from_future_time_valid() -> None:
+    """Test that a valid time string returns a datetime."""
+    result = get_datetime_from_future_time("13:30:00")
+    assert isinstance(result, datetime)

--- a/tests/components/lyric/test_sensor.py
+++ b/tests/components/lyric/test_sensor.py
@@ -2,8 +2,6 @@
 
 from datetime import datetime
 
-import pytest
-
 from homeassistant.components.lyric.sensor import get_datetime_from_future_time
 
 
@@ -13,7 +11,7 @@ def test_get_datetime_from_future_time_none() -> None:
 
 
 def test_get_datetime_from_future_time_invalid() -> None:
-    """Test that an unparseable time string returns None."""
+    """Test that an unparsable time string returns None."""
     assert get_datetime_from_future_time("not_a_time") is None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

N/A — this is a bugfix, not a breaking change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix `ValueError: Unable to parse time None` crash in the Lyric integration when the thermostat is in `PermanentHold` or `VacationHold` mode.

The `suitable_fn` guard for the `next_period_time` sensor only runs at entity setup time. If the sensor was created while a schedule was active (i.e. `next_period_time` was present), switching to `PermanentHold` later causes `get_datetime_from_future_time()` to receive `None` and raise `ValueError`. This crashes the coordinator refresh and breaks all thermostat controls (`set_temperature`, `set_preset_mode`).

The fix makes `get_datetime_from_future_time()` return `None` instead of raising, which causes the sensor to show as "unknown" — the correct state when there is no next period.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161030
- This PR is related to issue: #84952, #119384
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr