### PR TITLE
Extract setup_light helper for Govee local tests

### DIFF
--- a/tests/components/govee_light_local/conftest.py
+++ b/tests/components/govee_light_local/conftest.py
@@ -4,11 +4,15 @@ from asyncio import Event
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from govee_local_api import GoveeLightCapabilities, GoveeLightFeatures
+from govee_local_api import GoveeDevice, GoveeLightCapabilities, GoveeLightFeatures
 from govee_local_api.light_capabilities import COMMON_FEATURES, SCENE_CODES
 import pytest
 
+from homeassistant.components.govee_light_local.const import DOMAIN
 from homeassistant.components.govee_light_local.coordinator import GoveeController
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_govee_api")
@@ -56,3 +60,37 @@ SCENE_CAPABILITIES: GoveeLightCapabilities = GoveeLightCapabilities(
     segments=[],
     scenes=SCENE_CODES,
 )
+
+
+async def setup_light(
+    hass: HomeAssistant,
+    mock_govee_api: AsyncMock,
+    capabilities: GoveeLightCapabilities = DEFAULT_CAPABILITIES,
+    *,
+    ip: str = "192.168.1.100",
+    fingerprint: str = "asdawdqwdqwd",
+    sku: str = "H615A",
+) -> tuple[MockConfigEntry, GoveeDevice]:
+    """Set up a single mocked Govee light device and return its entry and device.
+
+    The returned tuple lets tests that need to mutate the device after setup
+    (e.g. ``device.update(...)`` in availability tests) access the underlying
+    ``GoveeDevice`` directly. Tests that only need the entry or neither can
+    discard the unused half with ``_``.
+    """
+    device = GoveeDevice(
+        controller=mock_govee_api,
+        ip=ip,
+        fingerprint=fingerprint,
+        sku=sku,
+        capabilities=capabilities,
+    )
+    mock_govee_api.devices = [device]
+
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    return entry, device

--- a/tests/components/govee_light_local/test_light.py
+++ b/tests/components/govee_light_local/test_light.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .conftest import DEFAULT_CAPABILITIES, SCENE_CAPABILITIES
+from .conftest import DEFAULT_CAPABILITIES, SCENE_CAPABILITIES, setup_light
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -45,22 +45,7 @@ async def test_light_known_device(
     hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test adding a known device."""
-
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=DEFAULT_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    entry, _ = await setup_light(hass, mock_govee_api)
 
     assert len(hass.states.async_all()) == 1
 
@@ -80,22 +65,14 @@ async def test_light_unknown_device(
     hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test adding an unknown device."""
-
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.101",
-            fingerprint="unkown_device",
-            sku="XYZK",
-            capabilities=ON_OFF_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    await setup_light(
+        hass,
+        mock_govee_api,
+        ON_OFF_CAPABILITIES,
+        ip="192.168.1.101",
+        fingerprint="unkown_device",
+        sku="XYZK",
+    )
 
     assert len(hass.states.async_all()) == 1
 
@@ -107,22 +84,8 @@ async def test_light_unknown_device(
 
 async def test_light_remove(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test remove device."""
+    entry, _ = await setup_light(hass, mock_govee_api, fingerprint="asdawdqwdqwd1")
 
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd1",
-            sku="H615A",
-            capabilities=DEFAULT_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
     assert hass.states.get("light.H615A") is not None
 
     # Remove 1
@@ -199,22 +162,7 @@ async def test_light_setup_error(
 
 async def test_light_on_off(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test light on and then off."""
-
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=DEFAULT_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api)
 
     assert len(hass.states.async_all()) == 1
 
@@ -233,7 +181,7 @@ async def test_light_on_off(hass: HomeAssistant, mock_govee_api: AsyncMock) -> N
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
+    mock_govee_api.turn_on_off.assert_awaited_with(device, True)
 
     # Turn off
     await hass.services.async_call(
@@ -247,7 +195,7 @@ async def test_light_on_off(hass: HomeAssistant, mock_govee_api: AsyncMock) -> N
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "off"
-    mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], False)
+    mock_govee_api.turn_on_off.assert_awaited_with(device, False)
 
 
 @pytest.mark.parametrize(
@@ -280,21 +228,7 @@ async def test_turn_on_call_order(
     mock_call_kwargs: dict[str, Any],
 ) -> None:
     """Test that turn_on is called after set_brightness/set_color/set_preset."""
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=SCENE_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api, SCENE_CAPABILITIES)
 
     assert len(hass.states.async_all()) == 1
 
@@ -312,32 +246,16 @@ async def test_turn_on_call_order(
 
     mock_govee_api.assert_has_calls(
         [
-            call.set_brightness(mock_govee_api.devices[0], 50),
-            getattr(call, mock_call)(
-                mock_govee_api.devices[0], *mock_call_args, **mock_call_kwargs
-            ),
-            call.turn_on_off(mock_govee_api.devices[0], True),
+            call.set_brightness(device, 50),
+            getattr(call, mock_call)(device, *mock_call_args, **mock_call_kwargs),
+            call.turn_on_off(device, True),
         ]
     )
 
 
 async def test_light_brightness(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test changing brightness."""
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=DEFAULT_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api)
 
     assert len(hass.states.async_all()) == 1
 
@@ -356,7 +274,7 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: AsyncMock) 
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    mock_govee_api.set_brightness.assert_awaited_with(mock_govee_api.devices[0], 50)
+    mock_govee_api.set_brightness.assert_awaited_with(device, 50)
     assert light.attributes[ATTR_BRIGHTNESS] == 127
 
     await hass.services.async_call(
@@ -371,7 +289,7 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: AsyncMock) 
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_BRIGHTNESS] == 255
-    mock_govee_api.set_brightness.assert_awaited_with(mock_govee_api.devices[0], 100)
+    mock_govee_api.set_brightness.assert_awaited_with(device, 100)
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -385,26 +303,12 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: AsyncMock) 
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_BRIGHTNESS] == 255
-    mock_govee_api.set_brightness.assert_awaited_with(mock_govee_api.devices[0], 100)
+    mock_govee_api.set_brightness.assert_awaited_with(device, 100)
 
 
 async def test_light_color(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test changing color."""
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=DEFAULT_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api)
 
     assert len(hass.states.async_all()) == 1
 
@@ -427,7 +331,7 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: AsyncMock) -> No
     assert light.attributes[ATTR_COLOR_MODE] == ColorMode.RGB
 
     mock_govee_api.set_color.assert_awaited_with(
-        mock_govee_api.devices[0], rgb=(100, 255, 50), temperature=None
+        device, rgb=(100, 255, 50), temperature=None
     )
 
     await hass.services.async_call(
@@ -444,29 +348,12 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: AsyncMock) -> No
     assert light.attributes[ATTR_COLOR_TEMP_KELVIN] == 4400
     assert light.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
 
-    mock_govee_api.set_color.assert_awaited_with(
-        mock_govee_api.devices[0], rgb=None, temperature=4400
-    )
+    mock_govee_api.set_color.assert_awaited_with(device, rgb=None, temperature=4400)
 
 
 async def test_scene_on(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test turning on scene."""
-
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=SCENE_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api, SCENE_CAPABILITIES)
 
     assert len(hass.states.async_all()) == 1
 
@@ -486,29 +373,14 @@ async def test_scene_on(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_EFFECT] == "sunrise"
-    mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
+    mock_govee_api.turn_on_off.assert_awaited_with(device, True)
 
 
 async def test_scene_restore_rgb(
     hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test restore rgb color."""
-
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=SCENE_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api, SCENE_CAPABILITIES)
 
     assert len(hass.states.async_all()) == 1
 
@@ -538,7 +410,7 @@ async def test_scene_restore_rgb(
     assert light.state == "on"
     assert light.attributes[ATTR_RGB_COLOR] == initial_color
     assert light.attributes[ATTR_BRIGHTNESS] == 255
-    mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
+    mock_govee_api.turn_on_off.assert_awaited_with(device, True)
 
     # Activate scene
     await hass.services.async_call(
@@ -553,7 +425,7 @@ async def test_scene_restore_rgb(
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_EFFECT] == "sunrise"
-    mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
+    mock_govee_api.turn_on_off.assert_awaited_with(device, True)
 
     # Deactivate scene
     await hass.services.async_call(
@@ -576,22 +448,7 @@ async def test_scene_restore_temperature(
     hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test restore color temperature."""
-
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=SCENE_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api, SCENE_CAPABILITIES)
 
     assert len(hass.states.async_all()) == 1
 
@@ -613,7 +470,7 @@ async def test_scene_restore_temperature(
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_COLOR_TEMP_KELVIN] == initial_color
-    mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
+    mock_govee_api.turn_on_off.assert_awaited_with(device, True)
 
     # Activate scene
     await hass.services.async_call(
@@ -628,7 +485,7 @@ async def test_scene_restore_temperature(
     assert light is not None
     assert light.state == "on"
     assert light.attributes[ATTR_EFFECT] == "sunrise"
-    mock_govee_api.set_scene.assert_awaited_with(mock_govee_api.devices[0], "sunrise")
+    mock_govee_api.set_scene.assert_awaited_with(device, "sunrise")
 
     # Deactivate scene
     await hass.services.async_call(
@@ -650,20 +507,7 @@ async def test_update_callback_registered_and_triggers_state_update(
     hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test that update callback is registered and triggers state update."""
-    device = GoveeDevice(
-        controller=mock_govee_api,
-        ip="192.168.1.100",
-        fingerprint="asdawdqwdqwd",
-        sku="H615A",
-        capabilities=DEFAULT_CAPABILITIES,
-    )
-    mock_govee_api.devices = [device]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api)
 
     assert device.update_callback is not None
 
@@ -685,20 +529,7 @@ async def test_update_callback_cleared_on_remove(
     hass: HomeAssistant, mock_govee_api: AsyncMock
 ) -> None:
     """Test that update callback is cleared when entity is removed."""
-    device = GoveeDevice(
-        controller=mock_govee_api,
-        ip="192.168.1.100",
-        fingerprint="asdawdqwdqwd",
-        sku="H615A",
-        capabilities=DEFAULT_CAPABILITIES,
-    )
-    mock_govee_api.devices = [device]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    entry, device = await setup_light(hass, mock_govee_api)
 
     assert device.update_callback is not None
 
@@ -710,22 +541,7 @@ async def test_update_callback_cleared_on_remove(
 
 async def test_scene_none(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
     """Test turn on 'none' scene."""
-
-    mock_govee_api.devices = [
-        GoveeDevice(
-            controller=mock_govee_api,
-            ip="192.168.1.100",
-            fingerprint="asdawdqwdqwd",
-            sku="H615A",
-            capabilities=SCENE_CAPABILITIES,
-        )
-    ]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api, SCENE_CAPABILITIES)
 
     assert len(hass.states.async_all()) == 1
 
@@ -755,7 +571,7 @@ async def test_scene_none(hass: HomeAssistant, mock_govee_api: AsyncMock) -> Non
     assert light.state == "on"
     assert light.attributes[ATTR_RGB_COLOR] == initial_color
     assert light.attributes[ATTR_BRIGHTNESS] == 255
-    mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
+    mock_govee_api.turn_on_off.assert_awaited_with(device, True)
 
     # Activate scene
     await hass.services.async_call(
@@ -808,20 +624,7 @@ async def test_device_availability(
     timeout, goes unavailable past it, and recovers when a status response
     refreshes ``lastseen``.
     """
-    device = GoveeDevice(
-        controller=mock_govee_api,
-        ip="192.168.1.100",
-        fingerprint="asdawdqwdqwd",
-        sku="H615A",
-        capabilities=DEFAULT_CAPABILITIES,
-    )
-    mock_govee_api.devices = [device]
-
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    _, device = await setup_light(hass, mock_govee_api)
 
     state = hass.states.get("light.H615A")
     assert state is not None


### PR DESCRIPTION
## Proposed change

A follow-up to https://github.com/home-assistant/core/pull/167702, as per @joostlek's request. 

Adds an async helper in conftest.py that constructs a single mocked GoveeDevice, registers it with the mock API, and sets up a config entry. Returns (entry, device) so tests that need the device reference (e.g. availability tests calling device.update) can access it; tests that don't can discard the unused half with `_`.

Migrates 14 of 18 tests in test_light.py to use the helper. Setup-failure tests (test_light_setup_retry, test_light_setup_retry_eaddrinuse, test_light_setup_error) and the multi-device test
(test_one_silent_device_does_not_affect_others) stay inline because they either expect setup to fail or need multiple distinct devices.

Pattern follows the dominant convention in HA platinum-tier integrations (tedee, litterrobot, acaia): module-level async helper rather than a callable-returning factory fixture.

Net: -159 lines.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
