### PR TITLE
Use runtime_data in sia integration

### DIFF
--- a/homeassistant/components/sia/__init__.py
+++ b/homeassistant/components/sia/__init__.py
@@ -13,7 +13,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SIAConfigEntry) -> bool:
     hub = SIAHub(hass, entry)
     hub.async_setup_hub()
 
-    entry.runtime_data = hub
     try:
         if hub.sia_client:
             await hub.sia_client.async_start(reuse_port=True)
@@ -21,6 +20,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SIAConfigEntry) -> bool:
         raise ConfigEntryNotReady(
             f"SIA Server at port {entry.data[CONF_PORT]} could not start."
         ) from exc
+
+    entry.runtime_data = hub
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/sia/__init__.py
+++ b/homeassistant/components/sia/__init__.py
@@ -1,14 +1,11 @@
 """The sia integration."""
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import PLATFORMS
-from .hub import SIAHub
-
-type SIAConfigEntry = ConfigEntry[SIAHub]
+from .hub import SIAConfigEntry, SIAHub
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SIAConfigEntry) -> bool:

--- a/homeassistant/components/sia/__init__.py
+++ b/homeassistant/components/sia/__init__.py
@@ -5,17 +5,18 @@ from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, PLATFORMS
+from .const import PLATFORMS
 from .hub import SIAHub
 
+type SIAConfigEntry = ConfigEntry[SIAHub]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+async def async_setup_entry(hass: HomeAssistant, entry: SIAConfigEntry) -> bool:
     """Set up sia from a config entry."""
-    hub: SIAHub = SIAHub(hass, entry)
+    hub = SIAHub(hass, entry)
     hub.async_setup_hub()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = hub
+    entry.runtime_data = hub
     try:
         if hub.sia_client:
             await hub.sia_client.async_start(reuse_port=True)
@@ -27,10 +28,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SIAConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hub: SIAHub = hass.data[DOMAIN].pop(entry.entry_id)
-        await hub.async_shutdown()
+        await entry.runtime_data.async_shutdown()
     return unload_ok

--- a/homeassistant/components/sia/config_flow.py
+++ b/homeassistant/components/sia/config_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from copy import deepcopy
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pysiaalarm import (
     InvalidAccountFormatError,
@@ -16,12 +16,7 @@ from pysiaalarm import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_PORT, CONF_PROTOCOL
 from homeassistant.core import callback
 
@@ -37,6 +32,9 @@ from .const import (
     TITLE,
 )
 from .hub import SIAHub
+
+if TYPE_CHECKING:
+    from . import SIAConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,7 +98,7 @@ class SIAConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: SIAConfigEntry,
     ) -> SIAOptionsFlowHandler:
         """Get the options flow for this handler."""
         return SIAOptionsFlowHandler(config_entry)
@@ -179,7 +177,9 @@ class SIAConfigFlow(ConfigFlow, domain=DOMAIN):
 class SIAOptionsFlowHandler(OptionsFlow):
     """Handle SIA options."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    config_entry: SIAConfigEntry
+
+    def __init__(self, config_entry: SIAConfigEntry) -> None:
         """Initialize SIA options flow."""
         self.options = deepcopy(dict(config_entry.options))
         self.hub: SIAHub | None = None
@@ -189,7 +189,7 @@ class SIAOptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the SIA options."""
-        self.hub = self.hass.data[DOMAIN][self.config_entry.entry_id]
+        self.hub = self.config_entry.runtime_data
         assert self.hub is not None
         assert self.hub.sia_accounts is not None
         self.accounts_todo = [a.account_id for a in self.hub.sia_accounts]

--- a/homeassistant/components/sia/config_flow.py
+++ b/homeassistant/components/sia/config_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from copy import deepcopy
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pysiaalarm import (
     InvalidAccountFormatError,
@@ -31,10 +31,7 @@ from .const import (
     DOMAIN,
     TITLE,
 )
-from .hub import SIAHub
-
-if TYPE_CHECKING:
-    from . import SIAConfigEntry
+from .hub import SIAConfigEntry, SIAHub
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sia/hub.py
+++ b/homeassistant/components/sia/hub.py
@@ -39,11 +39,11 @@ class SIAHub:
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: ConfigEntry,
+        entry: SIAConfigEntry,
     ) -> None:
         """Create the SIAHub."""
-        self._hass: HomeAssistant = hass
-        self._entry: ConfigEntry = entry
+        self._hass = hass
+        self._entry = entry
         self._port: int = entry.data[CONF_PORT]
         self._title: str = entry.title
         self._accounts: list[dict[str, Any]] = deepcopy(entry.data[CONF_ACCOUNTS])

--- a/homeassistant/components/sia/hub.py
+++ b/homeassistant/components/sia/hub.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pysiaalarm.aio import CommunicationsProtocol, SIAAccount, SIAClient, SIAEvent
 
@@ -26,10 +26,9 @@ from .const import (
 )
 from .utils import get_event_data_from_sia_event
 
-if TYPE_CHECKING:
-    from . import SIAConfigEntry
-
 _LOGGER = logging.getLogger(__name__)
+
+type SIAConfigEntry = ConfigEntry[SIAHub]
 
 DEFAULT_TIMEBAND = (80, 40)
 

--- a/homeassistant/components/sia/hub.py
+++ b/homeassistant/components/sia/hub.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from pysiaalarm.aio import CommunicationsProtocol, SIAAccount, SIAClient, SIAEvent
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_PORT, CONF_PROTOCOL, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -141,6 +141,8 @@ class SIAHub:
         Second, unload underlying platforms, and then setup platforms, this reflects any changes in number of zones.
 
         """
+        if config_entry.state != ConfigEntryState.LOADED:
+            return
         config_entry.runtime_data.update_accounts()
         await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
         await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/sia/hub.py
+++ b/homeassistant/components/sia/hub.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pysiaalarm.aio import CommunicationsProtocol, SIAAccount, SIAClient, SIAEvent
 
@@ -25,6 +25,9 @@ from .const import (
     SIA_EVENT,
 )
 from .utils import get_event_data_from_sia_event
+
+if TYPE_CHECKING:
+    from . import SIAConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -131,7 +134,7 @@ class SIAHub:
 
     @staticmethod
     async def async_config_entry_updated(
-        hass: HomeAssistant, config_entry: ConfigEntry
+        hass: HomeAssistant, config_entry: SIAConfigEntry
     ) -> None:
         """Handle signals of config entry being updated.
 
@@ -139,8 +142,6 @@ class SIAHub:
         Second, unload underlying platforms, and then setup platforms, this reflects any changes in number of zones.
 
         """
-        if not (hub := hass.data[DOMAIN].get(config_entry.entry_id)):
-            return
-        hub.update_accounts()
+        config_entry.runtime_data.update_accounts()
         await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
         await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)


### PR DESCRIPTION
## Proposed change

Migrate the `sia` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]` for storing the `SIAHub` instance.

- Add `SIAConfigEntry` type alias in `__init__.py`
- Store `SIAHub` in `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`
- Simplify `async_unload_entry` by accessing `entry.runtime_data` directly
- Update `config_flow.py` and `hub.py` to use the new typed config entry

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr