### PR TITLE
Use runtime_data in simplisafe integration

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -39,7 +39,7 @@ from simplipy.websocket import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_DEVICE_ID,
@@ -228,8 +228,10 @@ def _async_get_system_for_service_call(
     entry: SimpliSafeConfigEntry | None
     for entry_id in base_station_device_entry.config_entries:
         if (
-            entry := hass.config_entries.async_get_entry(entry_id)
-        ) is None or entry.domain != DOMAIN:
+            (entry := hass.config_entries.async_get_entry(entry_id)) is None
+            or entry.domain != DOMAIN
+            or entry.state != ConfigEntryState.LOADED
+        ):
             continue
         return entry.runtime_data.systems[system_id]
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine
-from typing import Any, cast
+from typing import Any
 
 from simplipy import API
 from simplipy.errors import (
@@ -87,6 +87,8 @@ from .const import (
 )
 from .coordinator import SimpliSafeDataUpdateCoordinator
 from .typing import SystemType
+
+type SimpliSafeConfigEntry = ConfigEntry[SimpliSafe]
 
 ATTR_CATEGORY = "category"
 ATTR_LAST_EVENT_CHANGED_BY = "last_event_changed_by"
@@ -224,9 +226,12 @@ def _async_get_system_for_service_call(
     system_id = int(system_id_str)
 
     for entry_id in base_station_device_entry.config_entries:
-        if (simplisafe := hass.data[DOMAIN].get(entry_id)) is None:
+        if not (entry := hass.config_entries.async_get_entry(entry_id)):
             continue
-        return cast(SystemType, simplisafe.systems[system_id])
+        if entry.domain != DOMAIN:
+            continue
+        simplisafe: SimpliSafe = entry.runtime_data
+        return simplisafe.systems[system_id]
 
     raise ValueError(f"No system for device ID: {device_id}")
 
@@ -286,7 +291,7 @@ def _async_standardize_config_entry(hass: HomeAssistant, entry: ConfigEntry) -> 
         hass.config_entries.async_update_entry(entry, **entry_updates)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SimpliSafeConfigEntry) -> bool:
     """Set up SimpliSafe as config entry."""
     _async_standardize_config_entry(hass, entry)
 
@@ -310,8 +315,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except SimplipyError as err:
         raise ConfigEntryNotReady from err
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = simplisafe
+    entry.runtime_data = simplisafe
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -396,11 +400,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SimpliSafeConfigEntry) -> bool:
     """Unload a SimpliSafe config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
 
     if not hass.config_entries.async_loaded_entries(DOMAIN):
         # If this is the last loaded instance of SimpliSafe, deregister any services

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -225,13 +225,13 @@ def _async_get_system_for_service_call(
     ]
     system_id = int(system_id_str)
 
+    entry: SimpliSafeConfigEntry | None
     for entry_id in base_station_device_entry.config_entries:
-        if not (entry := hass.config_entries.async_get_entry(entry_id)):
+        if (
+            entry := hass.config_entries.async_get_entry(entry_id)
+        ) is None or entry.domain != DOMAIN:
             continue
-        if entry.domain != DOMAIN:
-            continue
-        simplisafe: SimpliSafe = entry.runtime_data
-        return simplisafe.systems[system_id]
+        return entry.runtime_data.systems[system_id]
 
     raise ValueError(f"No system for device ID: {device_id}")
 

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -28,12 +28,11 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SimpliSafe
+from . import SimpliSafe, SimpliSafeConfigEntry
 from .const import (
     ATTR_ALARM_DURATION,
     ATTR_ALARM_VOLUME,
@@ -44,7 +43,6 @@ from .const import (
     ATTR_EXIT_DELAY_HOME,
     ATTR_LIGHT,
     ATTR_VOICE_PROMPT_VOLUME,
-    DOMAIN,
     LOGGER,
 )
 from .entity import SimpliSafeEntity
@@ -104,11 +102,11 @@ WEBSOCKET_EVENTS_TO_LISTEN_FOR = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SimpliSafeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a SimpliSafe alarm control panel based on a config entry."""
-    simplisafe = hass.data[DOMAIN][entry.entry_id]
+    simplisafe = entry.runtime_data
     async_add_entities(
         [SimpliSafeAlarm(simplisafe, system) for system in simplisafe.systems.values()],
         True,

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -11,13 +11,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SimpliSafe
-from .const import DOMAIN, LOGGER
+from . import SimpliSafe, SimpliSafeConfigEntry
+from .const import LOGGER
 from .entity import SimpliSafeEntity
 
 SUPPORTED_BATTERY_SENSOR_TYPES = [
@@ -59,11 +58,11 @@ TRIGGERED_SENSOR_TYPES = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SimpliSafeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up SimpliSafe binary sensors based on a config entry."""
-    simplisafe = hass.data[DOMAIN][entry.entry_id]
+    simplisafe = entry.runtime_data
 
     sensors: list[BatteryBinarySensor | TriggeredBinarySensor] = []
 
@@ -72,18 +71,19 @@ async def async_setup_entry(
             LOGGER.warning("Skipping sensor setup for V2 system: %s", system.system_id)
             continue
 
+        assert isinstance(system, SystemV3)
         for sensor in system.sensors.values():
             if sensor.type in TRIGGERED_SENSOR_TYPES:
                 sensors.append(
                     TriggeredBinarySensor(
                         simplisafe,
                         system,
-                        sensor,
+                        sensor,  # type: ignore[arg-type]
                         TRIGGERED_SENSOR_TYPES[sensor.type],
                     )
                 )
             if sensor.type in SUPPORTED_BATTERY_SENSOR_TYPES:
-                sensors.append(BatteryBinarySensor(simplisafe, system, sensor))
+                sensors.append(BatteryBinarySensor(simplisafe, system, sensor))  # type: ignore[arg-type]
 
         sensors.extend(
             BatteryBinarySensor(simplisafe, system, lock)

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 from simplipy.device import DeviceTypes, DeviceV3
 from simplipy.device.sensor.v3 import SensorV3
 from simplipy.system.v3 import SystemV3
@@ -71,19 +73,22 @@ async def async_setup_entry(
             LOGGER.warning("Skipping sensor setup for V2 system: %s", system.system_id)
             continue
 
-        assert isinstance(system, SystemV3)
+        if TYPE_CHECKING:
+            assert isinstance(system, SystemV3)
         for sensor in system.sensors.values():
             if sensor.type in TRIGGERED_SENSOR_TYPES:
                 sensors.append(
                     TriggeredBinarySensor(
                         simplisafe,
                         system,
-                        sensor,  # type: ignore[arg-type]
+                        cast(SensorV3, sensor),
                         TRIGGERED_SENSOR_TYPES[sensor.type],
                     )
                 )
             if sensor.type in SUPPORTED_BATTERY_SENSOR_TYPES:
-                sensors.append(BatteryBinarySensor(simplisafe, system, sensor))  # type: ignore[arg-type]
+                sensors.append(
+                    BatteryBinarySensor(simplisafe, system, cast(DeviceV3, sensor))
+                )
 
         sensors.extend(
             BatteryBinarySensor(simplisafe, system, lock)

--- a/homeassistant/components/simplisafe/button.py
+++ b/homeassistant/components/simplisafe/button.py
@@ -9,14 +9,12 @@ from simplipy.errors import SimplipyError
 from simplipy.system import System
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SimpliSafe
-from .const import DOMAIN
+from . import SimpliSafe, SimpliSafeConfigEntry
 from .entity import SimpliSafeEntity
 from .typing import SystemType
 
@@ -47,11 +45,11 @@ BUTTON_DESCRIPTIONS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SimpliSafeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up SimpliSafe buttons based on a config entry."""
-    simplisafe = hass.data[DOMAIN][entry.entry_id]
+    simplisafe = entry.runtime_data
 
     async_add_entities(
         [

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -14,16 +14,12 @@ from simplipy.util.auth import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_URL, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
+from . import SimpliSafeConfigEntry
 from .const import DOMAIN, LOGGER
 
 CONF_AUTH_CODE = "auth_code"
@@ -68,7 +64,7 @@ class SimpliSafeFlowHandler(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: SimpliSafeConfigEntry,
     ) -> SimpliSafeOptionsFlowHandler:
         """Define the config flow to handle options."""
         return SimpliSafeOptionsFlowHandler()

--- a/homeassistant/components/simplisafe/diagnostics.py
+++ b/homeassistant/components/simplisafe/diagnostics.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_CODE,
@@ -16,8 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import SimpliSafe
-from .const import DOMAIN
+from . import SimpliSafeConfigEntry
 
 CONF_CREDIT_CARD = "creditCard"
 CONF_EXPIRES = "expires"
@@ -53,10 +51,10 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: SimpliSafeConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    simplisafe: SimpliSafe = hass.data[DOMAIN][entry.entry_id]
+    simplisafe = entry.runtime_data
 
     return async_redact_data(
         {

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from simplipy.device.lock import Lock, LockStates
 from simplipy.errors import SimplipyError
@@ -43,7 +43,8 @@ async def async_setup_entry(
             LOGGER.warning("Skipping lock setup for V2 system: %s", system.system_id)
             continue
 
-        assert isinstance(system, SystemV3)
+        if TYPE_CHECKING:
+            assert isinstance(system, SystemV3)
         locks.extend(
             SimpliSafeLock(simplisafe, system, lock) for lock in system.locks.values()
         )

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -10,13 +10,12 @@ from simplipy.system.v3 import SystemV3
 from simplipy.websocket import EVENT_LOCK_LOCKED, EVENT_LOCK_UNLOCKED, WebsocketEvent
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SimpliSafe
-from .const import DOMAIN, LOGGER
+from . import SimpliSafe, SimpliSafeConfigEntry
+from .const import LOGGER
 from .entity import SimpliSafeEntity
 
 ATTR_LOCK_LOW_BATTERY = "lock_low_battery"
@@ -32,11 +31,11 @@ WEBSOCKET_EVENTS_TO_LISTEN_FOR = (EVENT_LOCK_LOCKED, EVENT_LOCK_UNLOCKED)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SimpliSafeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up SimpliSafe locks based on a config entry."""
-    simplisafe = hass.data[DOMAIN][entry.entry_id]
+    simplisafe = entry.runtime_data
     locks: list[SimpliSafeLock] = []
 
     for system in simplisafe.systems.values():
@@ -44,6 +43,7 @@ async def async_setup_entry(
             LOGGER.warning("Skipping lock setup for V2 system: %s", system.system_id)
             continue
 
+        assert isinstance(system, SystemV3)
         locks.extend(
             SimpliSafeLock(simplisafe, system, lock) for lock in system.locks.values()
         )

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 from simplipy.device import DeviceTypes
 from simplipy.device.sensor.v3 import SensorV3
 from simplipy.system.v3 import SystemV3
@@ -34,9 +36,10 @@ async def async_setup_entry(
             LOGGER.warning("Skipping sensor setup for V2 system: %s", system.system_id)
             continue
 
-        assert isinstance(system, SystemV3)
+        if TYPE_CHECKING:
+            assert isinstance(system, SystemV3)
         sensors.extend(
-            SimplisafeFreezeSensor(simplisafe, system, sensor)  # type: ignore[arg-type]
+            SimplisafeFreezeSensor(simplisafe, system, cast(SensorV3, sensor))
             for sensor in system.sensors.values()
             if sensor.type == DeviceTypes.TEMPERATURE
         )

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -11,23 +11,22 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SimpliSafe
-from .const import DOMAIN, LOGGER
+from . import SimpliSafe, SimpliSafeConfigEntry
+from .const import LOGGER
 from .entity import SimpliSafeEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SimpliSafeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up SimpliSafe freeze sensors based on a config entry."""
-    simplisafe = hass.data[DOMAIN][entry.entry_id]
+    simplisafe = entry.runtime_data
     sensors: list[SimplisafeFreezeSensor] = []
 
     for system in simplisafe.systems.values():
@@ -35,8 +34,9 @@ async def async_setup_entry(
             LOGGER.warning("Skipping sensor setup for V2 system: %s", system.system_id)
             continue
 
+        assert isinstance(system, SystemV3)
         sensors.extend(
-            SimplisafeFreezeSensor(simplisafe, system, sensor)
+            SimplisafeFreezeSensor(simplisafe, system, sensor)  # type: ignore[arg-type]
             for sensor in system.sensors.values()
             if sensor.type == DeviceTypes.TEMPERATURE
         )


### PR DESCRIPTION
## Proposed change

Migrate the `simplisafe` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]`.

- Add a `SimpliSafeConfigEntry` type alias in `__init__.py`.
- Update `__init__.py` to use `entry.runtime_data`, simplify `async_unload_entry`, and update the service call helper to use a config entry lookup.
- Update all five platform files (`alarm_control_panel.py`, `binary_sensor.py`, `button.py`, `lock.py`, `sensor.py`) to read from `entry.runtime_data`.
- Update `diagnostics.py` to use `entry.runtime_data`.
- Update `config_flow.async_get_options_flow` to use the typed config entry.
- Add `assert isinstance(system, SystemV3)` type narrowing in platform files where needed to satisfy mypy (pre-existing type issues exposed by proper typing).
- Remove a redundant `cast()` call in the service helper.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr