### PR TITLE
Use runtime_data in skybell integration

### DIFF
--- a/homeassistant/components/skybell/__init__.py
+++ b/homeassistant/components/skybell/__init__.py
@@ -7,14 +7,12 @@ import asyncio
 from aioskybell import Skybell
 from aioskybell.exceptions import SkybellAuthenticationException, SkybellException
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
-from .coordinator import SkybellDataUpdateCoordinator
+from .coordinator import SkybellConfigEntry, SkybellDataUpdateCoordinator
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -25,7 +23,7 @@ PLATFORMS = [
 ]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SkybellConfigEntry) -> bool:
     """Set up Skybell from a config entry."""
     email = entry.data[CONF_EMAIL]
     password = entry.data[CONF_PASSWORD]
@@ -53,14 +51,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for coordinator in device_coordinators
         ]
     )
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = device_coordinators
+    entry.runtime_data = device_coordinators
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SkybellConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/skybell/binary_sensor.py
+++ b/homeassistant/components/skybell/binary_sensor.py
@@ -9,12 +9,10 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN
-from .coordinator import SkybellDataUpdateCoordinator
+from .coordinator import SkybellConfigEntry, SkybellDataUpdateCoordinator
 from .entity import SkybellEntity
 
 BINARY_SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
@@ -32,14 +30,14 @@ BINARY_SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SkybellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Skybell binary sensor."""
     async_add_entities(
         SkybellBinarySensor(coordinator, sensor)
         for sensor in BINARY_SENSOR_TYPES
-        for coordinator in hass.data[DOMAIN][entry.entry_id]
+        for coordinator in entry.runtime_data
     )
 
 

--- a/homeassistant/components/skybell/camera.py
+++ b/homeassistant/components/skybell/camera.py
@@ -7,14 +7,12 @@ from haffmpeg.camera import CameraMjpeg
 
 from homeassistant.components.camera import Camera, CameraEntityDescription
 from homeassistant.components.ffmpeg import get_ffmpeg_manager
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import SkybellDataUpdateCoordinator
+from .coordinator import SkybellConfigEntry, SkybellDataUpdateCoordinator
 from .entity import SkybellEntity
 
 CAMERA_TYPES: tuple[CameraEntityDescription, ...] = (
@@ -31,13 +29,13 @@ CAMERA_TYPES: tuple[CameraEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SkybellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Skybell camera."""
     entities = []
     for description in CAMERA_TYPES:
-        for coordinator in hass.data[DOMAIN][entry.entry_id]:
+        for coordinator in entry.runtime_data:
             if description.key == "avatar":
                 entities.append(SkybellCamera(coordinator, description))
             else:

--- a/homeassistant/components/skybell/coordinator.py
+++ b/homeassistant/components/skybell/coordinator.py
@@ -10,14 +10,19 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import LOGGER
 
+type SkybellConfigEntry = ConfigEntry[list[SkybellDataUpdateCoordinator]]
+
 
 class SkybellDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Data update coordinator for the Skybell integration."""
 
-    config_entry: ConfigEntry
+    config_entry: SkybellConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, device: SkybellDevice
+        self,
+        hass: HomeAssistant,
+        config_entry: SkybellConfigEntry,
+        device: SkybellDevice,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(

--- a/homeassistant/components/skybell/light.py
+++ b/homeassistant/components/skybell/light.py
@@ -13,23 +13,22 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .coordinator import SkybellConfigEntry
 from .entity import SkybellEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SkybellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Skybell switch."""
     async_add_entities(
         SkybellLight(coordinator, LightEntityDescription(key="light"))
-        for coordinator in hass.data[DOMAIN][entry.entry_id]
+        for coordinator in entry.runtime_data
     )
 
 

--- a/homeassistant/components/skybell/sensor.py
+++ b/homeassistant/components/skybell/sensor.py
@@ -14,13 +14,13 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .entity import DOMAIN, SkybellEntity
+from .coordinator import SkybellConfigEntry
+from .entity import SkybellEntity
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -89,13 +89,13 @@ SENSOR_TYPES: tuple[SkybellSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SkybellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Skybell sensor."""
     async_add_entities(
         SkybellSensor(coordinator, description)
-        for coordinator in hass.data[DOMAIN][entry.entry_id]
+        for coordinator in entry.runtime_data
         for description in SENSOR_TYPES
         if coordinator.device.owner or description.key not in CONST.ATTR_OWNER_STATS
     )

--- a/homeassistant/components/skybell/switch.py
+++ b/homeassistant/components/skybell/switch.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from typing import Any, cast
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .coordinator import SkybellConfigEntry
 from .entity import SkybellEntity
 
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
@@ -30,13 +29,13 @@ SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SkybellConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SkyBell switch."""
     async_add_entities(
         SkybellSwitch(coordinator, description)
-        for coordinator in hass.data[DOMAIN][entry.entry_id]
+        for coordinator in entry.runtime_data
         for description in SWITCH_TYPES
     )
 


### PR DESCRIPTION
## Proposed change

Migrate the `skybell` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN]`.

- Added a `SkybellConfigEntry` type alias in `coordinator.py` (`ConfigEntry[list[SkybellDataUpdateCoordinator]]`).
- Updated `__init__.py` to store coordinators on `entry.runtime_data` and simplified `async_unload_entry`.
- Updated all 5 platform files (`binary_sensor.py`, `camera.py`, `light.py`, `sensor.py`, `switch.py`) to retrieve coordinators from `entry.runtime_data`.
- Cleaned up `DOMAIN` imports that are no longer needed in platform files (including fixing `sensor.py` which was importing `DOMAIN` via `.entity`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr