### PR TITLE
Use runtime_data in Slack

### DIFF
--- a/homeassistant/components/slack/__init__.py
+++ b/homeassistant/components/slack/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 
 from aiohttp.client_exceptions import ClientError
@@ -30,6 +31,17 @@ PLATFORMS = [Platform.NOTIFY, Platform.SENSOR]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
+type SlackConfigEntry = ConfigEntry[SlackData]
+
+
+@dataclass
+class SlackData:
+    """Runtime data for the Slack integration."""
+
+    client: AsyncWebClient
+    url: str
+    user_id: str
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Slack component."""
@@ -37,7 +49,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SlackConfigEntry) -> bool:
     """Set up Slack from a config entry."""
     session = aiohttp_client.async_get_clientsession(hass)
     slack = AsyncWebClient(
@@ -52,19 +64,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return False
         raise ConfigEntryNotReady("Error while setting up integration") from ex
 
-    data = {
-        DATA_CLIENT: slack,
-        ATTR_URL: res[ATTR_URL],
-        ATTR_USER_ID: res[ATTR_USER_ID],
-    }
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data | {SLACK_DATA: data}
+    entry.runtime_data = SlackData(
+        client=slack,
+        url=res[ATTR_URL],
+        user_id=res[ATTR_USER_ID],
+    )
 
     hass.async_create_task(
         discovery.async_load_platform(
             hass,
             Platform.NOTIFY,
             DOMAIN,
-            hass.data[DOMAIN][entry.entry_id],
+            entry.data
+            | {
+                SLACK_DATA: {
+                    DATA_CLIENT: slack,
+                    ATTR_URL: res[ATTR_URL],
+                    ATTR_USER_ID: res[ATTR_USER_ID],
+                }
+            },
             hass.data[DATA_HASS_CONFIG],
         )
     )

--- a/homeassistant/components/slack/entity.py
+++ b/homeassistant/components/slack/entity.py
@@ -6,6 +6,7 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 from . import SlackConfigEntry, SlackData
 from .const import DEFAULT_NAME, DOMAIN
 
+
 class SlackEntity(Entity):
     """Representation of a Slack entity."""
 

--- a/homeassistant/components/slack/entity.py
+++ b/homeassistant/components/slack/entity.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from slack_sdk.web.async_client import AsyncWebClient
+from typing import TYPE_CHECKING
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
-from .const import ATTR_URL, ATTR_USER_ID, DATA_CLIENT, DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_NAME, DOMAIN
+
+if TYPE_CHECKING:
+    from . import SlackConfigEntry, SlackData
 
 
 class SlackEntity(Entity):
@@ -16,16 +18,16 @@ class SlackEntity(Entity):
 
     def __init__(
         self,
-        data: dict[str, AsyncWebClient],
+        data: SlackData,
         description: EntityDescription,
-        entry: ConfigEntry,
+        entry: SlackConfigEntry,
     ) -> None:
         """Initialize a Slack entity."""
-        self._client: AsyncWebClient = data[DATA_CLIENT]
+        self._client = data.client
         self.entity_description = description
-        self._attr_unique_id = f"{data[ATTR_USER_ID]}_{description.key}"
+        self._attr_unique_id = f"{data.user_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
-            configuration_url=str(data[ATTR_URL]),
+            configuration_url=data.url,
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, entry.entry_id)},
             manufacturer=DEFAULT_NAME,

--- a/homeassistant/components/slack/entity.py
+++ b/homeassistant/components/slack/entity.py
@@ -1,17 +1,10 @@
 """The slack integration."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
+from . import SlackConfigEntry, SlackData
 from .const import DEFAULT_NAME, DOMAIN
-
-if TYPE_CHECKING:
-    from . import SlackConfigEntry, SlackData
-
 
 class SlackEntity(Entity):
     """Representation of a Slack entity."""

--- a/homeassistant/components/slack/sensor.py
+++ b/homeassistant/components/slack/sensor.py
@@ -9,25 +9,25 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import ATTR_SNOOZE, DOMAIN, SLACK_DATA
+from . import SlackConfigEntry
+from .const import ATTR_SNOOZE
 from .entity import SlackEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SlackConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Slack select."""
     async_add_entities(
         [
             SlackSensorEntity(
-                hass.data[DOMAIN][entry.entry_id][SLACK_DATA],
+                entry.runtime_data,
                 SensorEntityDescription(
                     key="do_not_disturb_until",
                     translation_key="do_not_disturb_until",

--- a/homeassistant/components/slack/sensor.py
+++ b/homeassistant/components/slack/sensor.py
@@ -23,7 +23,7 @@ async def async_setup_entry(
     entry: SlackConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Slack select."""
+    """Set up the Slack sensor."""
     async_add_entities(
         [
             SlackSensorEntity(


### PR DESCRIPTION
## Proposed change

Migrate the Slack integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]`.

- Add a `SlackConfigEntry` type alias and a `SlackData` dataclass (containing `client`, `url`, `user_id`) in `__init__.py`.
- Store a `SlackData` instance in `entry.runtime_data` instead of populating `hass.data[DOMAIN]`.
- The legacy `async_load_platform` discovery for the notify platform still passes a dict-based `discovery_info` since the notify platform is not a config entry platform.
- Update `SlackEntity` in `entity.py` to accept the `SlackData` dataclass instead of a dict and use its typed attributes.
- Update `sensor.py` to read from `entry.runtime_data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr