### PR TITLE
Use runtime_data in sleepiq integration

### DIFF
--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, IS_IN_BED, SLEEP_NUMBER
 from .coordinator import (
+    SleepIQConfigEntry,
     SleepIQData,
     SleepIQDataUpdateCoordinator,
     SleepIQPauseUpdateCoordinator,
@@ -64,7 +65,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SleepIQConfigEntry) -> bool:
     """Set up the SleepIQ config entry."""
     conf = entry.data
     email = conf[CONF_USERNAME]
@@ -104,7 +105,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await pause_coordinator.async_config_entry_first_refresh()
     await sleep_data_coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = SleepIQData(
+    entry.runtime_data = SleepIQData(
         data_coordinator=coordinator,
         pause_coordinator=pause_coordinator,
         sleep_data_coordinator=sleep_data_coordinator,
@@ -116,11 +117,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SleepIQConfigEntry) -> bool:
     """Unload the config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def _async_migrate_unique_ids(

--- a/homeassistant/components/sleepiq/binary_sensor.py
+++ b/homeassistant/components/sleepiq/binary_sensor.py
@@ -6,22 +6,21 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ICON_EMPTY, ICON_OCCUPIED, IS_IN_BED
-from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator
+from .const import ICON_EMPTY, ICON_OCCUPIED, IS_IN_BED
+from .coordinator import SleepIQConfigEntry, SleepIQDataUpdateCoordinator
 from .entity import SleepIQSleeperEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SleepIQConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed binary sensors."""
-    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
     async_add_entities(
         IsInBedBinarySensor(data.data_coordinator, bed, sleeper)
         for bed in data.client.beds.values()

--- a/homeassistant/components/sleepiq/button.py
+++ b/homeassistant/components/sleepiq/button.py
@@ -9,12 +9,10 @@ from typing import Any
 from asyncsleepiq import SleepIQBed
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import SleepIQData
+from .coordinator import SleepIQConfigEntry
 from .entity import SleepIQEntity
 
 
@@ -43,11 +41,11 @@ ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SleepIQConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sleep number buttons."""
-    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
         SleepNumberButton(bed, ed)

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -18,16 +18,18 @@ UPDATE_INTERVAL = timedelta(seconds=60)
 LONGER_UPDATE_INTERVAL = timedelta(minutes=5)
 SLEEP_DATA_UPDATE_INTERVAL = timedelta(hours=1)  # Sleep data doesn't change frequently
 
+type SleepIQConfigEntry = ConfigEntry[SleepIQData]
+
 
 class SleepIQDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """SleepIQ data update coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: SleepIQConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: SleepIQConfigEntry,
         client: AsyncSleepIQ,
     ) -> None:
         """Initialize coordinator."""
@@ -51,12 +53,12 @@ class SleepIQDataUpdateCoordinator(DataUpdateCoordinator[None]):
 class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
     """SleepIQ data update coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: SleepIQConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: SleepIQConfigEntry,
         client: AsyncSleepIQ,
     ) -> None:
         """Initialize coordinator."""
@@ -78,12 +80,12 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
 class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
     """SleepIQ sleep health data coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: SleepIQConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: SleepIQConfigEntry,
         client: AsyncSleepIQ,
     ) -> None:
         """Initialize coordinator."""

--- a/homeassistant/components/sleepiq/light.py
+++ b/homeassistant/components/sleepiq/light.py
@@ -6,12 +6,10 @@ from typing import Any
 from asyncsleepiq import SleepIQBed, SleepIQLight
 
 from homeassistant.components.light import ColorMode, LightEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator
+from .coordinator import SleepIQConfigEntry, SleepIQDataUpdateCoordinator
 from .entity import SleepIQBedEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,11 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SleepIQConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed lights."""
-    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
     async_add_entities(
         SleepIQLightEntity(data.data_coordinator, bed, light)
         for bed in data.client.beds.values()

--- a/homeassistant/components/sleepiq/number.py
+++ b/homeassistant/components/sleepiq/number.py
@@ -21,7 +21,6 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -29,13 +28,12 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .const import (
     ACTUATOR,
     CORE_CLIMATE_TIMER,
-    DOMAIN,
     ENTITY_TYPES,
     FIRMNESS,
     FOOT_WARMING_TIMER,
     ICON_OCCUPIED,
 )
-from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator
+from .coordinator import SleepIQConfigEntry, SleepIQDataUpdateCoordinator
 from .entity import SleepIQBedEntity, sleeper_for_side
 
 
@@ -180,11 +178,11 @@ NUMBER_DESCRIPTIONS: dict[str, SleepIQNumberEntityDescription] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SleepIQConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed sensors."""
-    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     entities: list[SleepIQNumberEntity] = []
     for bed in data.client.beds.values():

--- a/homeassistant/components/sleepiq/select.py
+++ b/homeassistant/components/sleepiq/select.py
@@ -13,22 +13,21 @@ from asyncsleepiq import (
 )
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CORE_CLIMATE, DOMAIN, FOOT_WARMER
-from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator
+from .const import CORE_CLIMATE, FOOT_WARMER
+from .coordinator import SleepIQConfigEntry, SleepIQDataUpdateCoordinator
 from .entity import SleepIQBedEntity, SleepIQSleeperEntity, sleeper_for_side
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SleepIQConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ foundation preset select entities."""
-    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
     entities: list[SleepIQBedEntity] = []
     for bed in data.client.beds.values():
         entities.extend(

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -13,13 +13,11 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
-    DOMAIN,
     HEART_RATE,
     HRV,
     PRESSURE,
@@ -29,7 +27,7 @@ from .const import (
     SLEEP_SCORE,
 )
 from .coordinator import (
-    SleepIQData,
+    SleepIQConfigEntry,
     SleepIQDataUpdateCoordinator,
     SleepIQSleepDataCoordinator,
 )
@@ -112,11 +110,11 @@ SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SleepIQConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed sensors."""
-    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     entities: list[SensorEntity] = []
 

--- a/homeassistant/components/sleepiq/switch.py
+++ b/homeassistant/components/sleepiq/switch.py
@@ -7,22 +7,20 @@ from typing import Any
 from asyncsleepiq import SleepIQBed
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import SleepIQData, SleepIQPauseUpdateCoordinator
+from .coordinator import SleepIQConfigEntry, SleepIQPauseUpdateCoordinator
 from .entity import SleepIQBedEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SleepIQConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sleep number switches."""
-    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
     async_add_entities(
         SleepNumberPrivateSwitch(data.pause_coordinator, bed)
         for bed in data.client.beds.values()


### PR DESCRIPTION
## Proposed change

Migrate the `sleepiq` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN]`.

- Add a `SleepIQConfigEntry` type alias in `coordinator.py` (typed as `ConfigEntry[SleepIQData]`).
- Update all three coordinators (`SleepIQDataUpdateCoordinator`, `SleepIQPauseUpdateCoordinator`, `SleepIQSleepDataCoordinator`) to use `SleepIQConfigEntry`.
- Update `__init__.py` to store `SleepIQData` in `entry.runtime_data` and simplify `async_unload_entry`.
- Update all 7 platform files (`binary_sensor.py`, `button.py`, `light.py`, `number.py`, `select.py`, `sensor.py`, `switch.py`) to read data from `entry.runtime_data`.
- Clean up unused `DOMAIN` and `SleepIQData` imports in platform files.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr