### PR TITLE
Use runtime_data in Snooz

### DIFF
--- a/homeassistant/components/snooz/__init__.py
+++ b/homeassistant/components/snooz/__init__.py
@@ -7,16 +7,15 @@ import logging
 from pysnooz.device import SnoozDevice
 
 from homeassistant.components.bluetooth import async_ble_device_from_address
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, PLATFORMS
-from .models import SnoozConfigurationData
+from .const import PLATFORMS
+from .models import SnoozConfigEntry, SnoozConfigurationData
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SnoozConfigEntry) -> bool:
     """Set up Snooz device from a config entry."""
     address: str = entry.data[CONF_ADDRESS]
     token: str = entry.data[CONF_TOKEN]
@@ -31,33 +30,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device = SnoozDevice(ble_device, token)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = SnoozConfigurationData(
-        ble_device, device, entry.title
-    )
+    entry.runtime_data = SnoozConfigurationData(ble_device, device, entry.title)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 
 
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_update_listener(hass: HomeAssistant, entry: SnoozConfigEntry) -> None:
     """Handle options update."""
-    data: SnoozConfigurationData = hass.data[DOMAIN][entry.entry_id]
-    if entry.title != data.title:
+    if entry.title != entry.runtime_data.title:
         await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SnoozConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        data: SnoozConfigurationData = hass.data[DOMAIN][entry.entry_id]
-
         # also called by fan entities, but do it here too for good measure
-        await data.device.async_disconnect()
-
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-        if not hass.config_entries.async_entries(DOMAIN):
-            hass.data.pop(DOMAIN)
+        await entry.runtime_data.device.async_disconnect()
 
     return unload_ok

--- a/homeassistant/components/snooz/fan.py
+++ b/homeassistant/components/snooz/fan.py
@@ -17,7 +17,6 @@ from pysnooz.commands import (
 import voluptuous as vol
 
 from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntity, FanEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -34,12 +33,12 @@ from .const import (
     SERVICE_TRANSITION_OFF,
     SERVICE_TRANSITION_ON,
 )
-from .models import SnoozConfigurationData
+from .models import SnoozConfigEntry, SnoozConfigurationData
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SnoozConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Snooz device from a config entry."""
@@ -67,9 +66,7 @@ async def async_setup_entry(
         "async_transition_off",
     )
 
-    data: SnoozConfigurationData = hass.data[DOMAIN][entry.entry_id]
-
-    async_add_entities([SnoozFan(data)])
+    async_add_entities([SnoozFan(entry.runtime_data)])
 
 
 class SnoozFan(FanEntity, RestoreEntity):

--- a/homeassistant/components/snooz/models.py
+++ b/homeassistant/components/snooz/models.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass
 from bleak.backends.device import BLEDevice
 from pysnooz.device import SnoozDevice
 
+from homeassistant.config_entries import ConfigEntry
+
+type SnoozConfigEntry = ConfigEntry[SnoozConfigurationData]
+
 
 @dataclass
 class SnoozConfigurationData:

--- a/tests/components/snooz/test_config_flow.py
+++ b/tests/components/snooz/test_config_flow.py
@@ -6,7 +6,7 @@ from asyncio import Event, sleep
 from unittest.mock import patch
 
 from homeassistant import config_entries
-from homeassistant.components.snooz import DOMAIN
+from homeassistant.components.snooz.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IGNORE
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TOKEN
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Proposed change

Migrate the `snooz` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]`.

- Added `SnoozConfigEntry` type alias in `models.py` (typed as `ConfigEntry[SnoozConfigurationData]`).
- Updated `__init__.py` to store `SnoozConfigurationData` in `entry.runtime_data`, simplifying `async_unload_entry` and `_async_update_listener`.
- Updated `fan.py` to get data from `entry.runtime_data`.
- Updated `tests/components/snooz/test_config_flow.py` to import `DOMAIN` from `.const` instead of `__init__`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr