### PR TITLE
Use runtime_data in soundtouch integration

### DIFF
--- a/homeassistant/components/soundtouch/__init__.py
+++ b/homeassistant/components/soundtouch/__init__.py
@@ -1,6 +1,9 @@
 """The soundtouch component."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from libsoundtouch import soundtouch_device
 from libsoundtouch.device import SoundTouchDevice
@@ -21,6 +24,11 @@ from .const import (
     SERVICE_PLAY_EVERYWHERE,
     SERVICE_REMOVE_ZONE_SLAVE,
 )
+
+if TYPE_CHECKING:
+    from .media_player import SoundTouchMediaPlayer
+
+type SoundTouchConfigEntry = ConfigEntry[SoundTouchData]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +63,7 @@ class SoundTouchData:
     def __init__(self, device: SoundTouchDevice) -> None:
         """Initialize the SoundTouch data object for a device."""
         self.device = device
-        self.media_player = None
+        self.media_player: SoundTouchMediaPlayer | None = None
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -65,20 +73,25 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Handle the applying of a service."""
         master_id = service.data.get("master")
         slaves_ids = service.data.get("slaves")
+        all_media_players = [
+            entry.runtime_data.media_player
+            for entry in hass.config_entries.async_loaded_entries(DOMAIN)
+            if entry.runtime_data.media_player is not None
+        ]
         slaves = []
         if slaves_ids:
             slaves = [
-                data.media_player
-                for data in hass.data[DOMAIN].values()
-                if data.media_player.entity_id in slaves_ids
+                media_player
+                for media_player in all_media_players
+                if media_player.entity_id in slaves_ids
             ]
 
         master = next(
             iter(
                 [
-                    data.media_player
-                    for data in hass.data[DOMAIN].values()
-                    if data.media_player.entity_id == master_id
+                    media_player
+                    for media_player in all_media_players
+                    if media_player.entity_id == master_id
                 ]
             ),
             None,
@@ -90,9 +103,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         if service.service == SERVICE_PLAY_EVERYWHERE:
             slaves = [
-                data.media_player
-                for data in hass.data[DOMAIN].values()
-                if data.media_player.entity_id != master_id
+                media_player
+                for media_player in all_media_players
+                if media_player.entity_id != master_id
             ]
             await hass.async_add_executor_job(master.create_zone, slaves)
         elif service.service == SERVICE_CREATE_ZONE:
@@ -130,7 +143,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SoundTouchConfigEntry) -> bool:
     """Set up Bose SoundTouch from a config entry."""
     try:
         device = await hass.async_add_executor_job(
@@ -141,14 +154,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Unable to connect to SoundTouch device at {entry.data[CONF_HOST]}"
         ) from err
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = SoundTouchData(device)
+    entry.runtime_data = SoundTouchData(device)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SoundTouchConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        del hass.data[DOMAIN][entry.entry_id]
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/soundtouch/__init__.py
+++ b/homeassistant/components/soundtouch/__init__.py
@@ -58,7 +58,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 class SoundTouchData:
-    """SoundTouch data stored in the Home Assistant data object."""
+    """SoundTouch data stored in the config entry runtime data."""
 
     def __init__(self, device: SoundTouchDevice) -> None:
         """Initialize the SoundTouch data object for a device."""

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -19,7 +19,6 @@ from homeassistant.components.media_player import (
     MediaType,
     async_process_play_media_url,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import (
@@ -29,6 +28,7 @@ from homeassistant.helpers.device_registry import (
 )
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import SoundTouchConfigEntry
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,16 +46,16 @@ ATTR_SOUNDTOUCH_ZONE = "soundtouch_zone"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SoundTouchConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Bose SoundTouch media player based on a config entry."""
-    device = hass.data[DOMAIN][entry.entry_id].device
+    device = entry.runtime_data.device
     media_player = SoundTouchMediaPlayer(device)
 
     async_add_entities([media_player], True)
 
-    hass.data[DOMAIN][entry.entry_id].media_player = media_player
+    entry.runtime_data.media_player = media_player
 
 
 class SoundTouchMediaPlayer(MediaPlayerEntity):
@@ -388,14 +388,16 @@ class SoundTouchMediaPlayer(MediaPlayerEntity):
 
     def _get_instance_by_ip(self, ip_address):
         """Search and return a SoundTouchDevice instance by it's IP address."""
-        for data in self.hass.data[DOMAIN].values():
+        for entry in self.hass.config_entries.async_loaded_entries(DOMAIN):
+            data = entry.runtime_data
             if data.device.config.device_ip == ip_address:
                 return data.media_player
         return None
 
     def _get_instance_by_id(self, instance_id):
         """Search and return a SoundTouchDevice instance by it's ID (aka MAC address)."""
-        for data in self.hass.data[DOMAIN].values():
+        for entry in self.hass.config_entries.async_loaded_entries(DOMAIN):
+            data = entry.runtime_data
             if data.device.config.device_id == instance_id:
                 return data.media_player
         return None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `soundtouch` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]`.

- Add a `SoundTouchConfigEntry` type alias (`ConfigEntry[SoundTouchData]`) in `__init__.py`.
- Store `SoundTouchData` in `entry.runtime_data` and simplify `async_unload_entry`.
- Annotate `SoundTouchData.media_player` as `SoundTouchMediaPlayer | None` using `TYPE_CHECKING` to avoid a circular import.
- Update the service handler to iterate `hass.config_entries.async_loaded_entries(DOMAIN)` instead of `hass.data[DOMAIN].values()`.
- Update `media_player.py`'s `async_setup_entry` to use `entry.runtime_data`.
- Update `_get_instance_by_ip` and `_get_instance_by_id` to iterate config entries via `async_loaded_entries(DOMAIN)`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr