### PR TITLE
Use runtime_data in srp_energy integration

### DIFF
--- a/homeassistant/components/srp_energy/__init__.py
+++ b/homeassistant/components/srp_energy/__init__.py
@@ -2,17 +2,16 @@
 
 from srpenergy.client import SrpEnergyClient
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, LOGGER
-from .coordinator import SRPEnergyDataUpdateCoordinator
+from .const import LOGGER
+from .coordinator import SRPEnergyConfigEntry, SRPEnergyDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SRPEnergyConfigEntry) -> bool:
     """Set up the SRP Energy component from a config entry."""
     api_account_id: str = entry.data[CONF_ID]
     api_username: str = entry.data[CONF_USERNAME]
@@ -30,17 +29,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SRPEnergyConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/srp_energy/coordinator.py
+++ b/homeassistant/components/srp_energy/coordinator.py
@@ -23,14 +23,19 @@ from .const import (
 TIMEOUT = 10
 PHOENIX_ZONE_INFO = dt_util.get_time_zone(PHOENIX_TIME_ZONE)
 
+type SRPEnergyConfigEntry = ConfigEntry[SRPEnergyDataUpdateCoordinator]
+
 
 class SRPEnergyDataUpdateCoordinator(DataUpdateCoordinator[float]):
     """A srp_energy Data Update Coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: SRPEnergyConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, client: SrpEnergyClient
+        self,
+        hass: HomeAssistant,
+        config_entry: SRPEnergyConfigEntry,
+        client: SrpEnergyClient,
     ) -> None:
         """Initialize the srp_energy data coordinator."""
         self._client = client

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -7,7 +7,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -15,19 +14,17 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import SRPEnergyDataUpdateCoordinator
 from .const import DEVICE_CONFIG_URL, DEVICE_MANUFACTURER, DEVICE_MODEL, DOMAIN
+from .coordinator import SRPEnergyConfigEntry, SRPEnergyDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SRPEnergyConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SRP Energy Usage sensor."""
-    coordinator: SRPEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    async_add_entities([SrpEntity(coordinator, entry)])
+    async_add_entities([SrpEntity(entry.runtime_data, entry)])
 
 
 class SrpEntity(CoordinatorEntity[SRPEnergyDataUpdateCoordinator], SensorEntity):
@@ -43,7 +40,7 @@ class SrpEntity(CoordinatorEntity[SRPEnergyDataUpdateCoordinator], SensorEntity)
     def __init__(
         self,
         coordinator: SRPEnergyDataUpdateCoordinator,
-        config_entry: ConfigEntry,
+        config_entry: SRPEnergyConfigEntry,
     ) -> None:
         """Initialize the SrpEntity class."""
         super().__init__(coordinator)


### PR DESCRIPTION
## Proposed change

Migrate the `srp_energy` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN]` for storing the coordinator.

- Added `SRPEnergyConfigEntry` type alias in `coordinator.py` (typed as `ConfigEntry[SRPEnergyDataUpdateCoordinator]`).
- Updated `__init__.py` to store the coordinator in `entry.runtime_data` and simplified `async_unload_entry`.
- Updated `sensor.py` to retrieve the coordinator from `entry.runtime_data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr