### PR TITLE
Use runtime_data in streamlabswater

### DIFF
--- a/homeassistant/components/streamlabswater/__init__.py
+++ b/homeassistant/components/streamlabswater/__init__.py
@@ -3,13 +3,12 @@
 from streamlabswater.streamlabswater import StreamlabsClient
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
-from .coordinator import StreamlabsCoordinator
+from .coordinator import StreamlabsConfigEntry, StreamlabsCoordinator
 
 ATTR_AWAY_MODE = "away_mode"
 SERVICE_SET_AWAY_MODE = "set_away_mode"
@@ -30,7 +29,7 @@ SET_AWAY_MODE_SCHEMA = vol.Schema(
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: StreamlabsConfigEntry) -> bool:
     """Set up StreamLabs from a config entry."""
 
     api_key = entry.data[CONF_API_KEY]
@@ -39,7 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     def set_away_mode(service: ServiceCall) -> None:
@@ -55,9 +54,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: StreamlabsConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/streamlabswater/binary_sensor.py
+++ b/homeassistant/components/streamlabswater/binary_sensor.py
@@ -3,22 +3,20 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import StreamlabsCoordinator
-from .const import DOMAIN
+from .coordinator import StreamlabsConfigEntry, StreamlabsCoordinator
 from .entity import StreamlabsWaterEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: StreamlabsConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Streamlabs water binary sensor from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         StreamlabsAwayMode(coordinator, location_id) for location_id in coordinator.data

--- a/homeassistant/components/streamlabswater/coordinator.py
+++ b/homeassistant/components/streamlabswater/coordinator.py
@@ -23,15 +23,18 @@ class StreamlabsData:
     yearly_usage: float
 
 
+type StreamlabsConfigEntry = ConfigEntry[StreamlabsCoordinator]
+
+
 class StreamlabsCoordinator(DataUpdateCoordinator[dict[str, StreamlabsData]]):
     """Coordinator for Streamlabs."""
 
-    config_entry: ConfigEntry
+    config_entry: StreamlabsConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: StreamlabsConfigEntry,
         client: StreamlabsClient,
     ) -> None:
         """Coordinator for Streamlabs."""

--- a/homeassistant/components/streamlabswater/sensor.py
+++ b/homeassistant/components/streamlabswater/sensor.py
@@ -10,15 +10,12 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import StreamlabsCoordinator
-from .const import DOMAIN
-from .coordinator import StreamlabsData
+from .coordinator import StreamlabsConfigEntry, StreamlabsCoordinator, StreamlabsData
 from .entity import StreamlabsWaterEntity
 
 
@@ -59,11 +56,11 @@ SENSORS: tuple[StreamlabsWaterSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: StreamlabsConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Streamlabs water sensor from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         StreamLabsSensor(coordinator, location_id, entity_description)


### PR DESCRIPTION
## Proposed change

Migrate the `streamlabswater` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]`:

- Added a `StreamlabsConfigEntry` type alias in `coordinator.py` (typed as `ConfigEntry[StreamlabsCoordinator]`).
- Updated `__init__.py` to store the coordinator in `entry.runtime_data` and simplified `async_unload_entry`.
- Updated `sensor.py` to retrieve the coordinator from `entry.runtime_data`.
- Updated `binary_sensor.py` to retrieve the coordinator from `entry.runtime_data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr