### PR TITLE
Add fabric index fields to Matter lock user and credential responses

### DIFF
--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -823,7 +823,8 @@ async def get_lock_credential_status(
 ) -> GetLockCredentialStatusResult:
     """Get the status of a credential slot on the lock.
 
-    Returns typed dict with credential_exists, user_index, next_credential_index.
+    Returns typed dict with credential_exists, user_index, creator_fabric_index,
+    last_modified_fabric_index, and next_credential_index.
     Raises HomeAssistantError on failure.
     """
     lock_endpoint = _get_lock_endpoint_or_raise(node)

--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -71,6 +71,8 @@ class LockUserData(TypedDict):
     user_type: str
     credential_rule: str
     credentials: list[LockUserCredentialData]
+    creator_fabric_index: int | None
+    last_modified_fabric_index: int | None
     next_user_index: int | None
 
 
@@ -115,6 +117,8 @@ class GetLockCredentialStatusResult(TypedDict):
 
     credential_exists: bool
     user_index: int | None
+    creator_fabric_index: int | None
+    last_modified_fabric_index: int | None
     next_credential_index: int | None
 
 
@@ -214,6 +218,8 @@ def _format_user_response(user_data: Any) -> LockUserData | None:
             _get_attr(user_data, "credentialRule"), "unknown"
         ),
         credentials=credentials,
+        creator_fabric_index=_get_attr(user_data, "creatorFabricIndex"),
+        last_modified_fabric_index=_get_attr(user_data, "lastModifiedFabricIndex"),
         next_user_index=_get_attr(user_data, "nextUserIndex"),
     )
 
@@ -839,5 +845,7 @@ async def get_lock_credential_status(
     return GetLockCredentialStatusResult(
         credential_exists=bool(_get_attr(response, "credentialExists")),
         user_index=_get_attr(response, "userIndex"),
+        creator_fabric_index=_get_attr(response, "creatorFabricIndex"),
+        last_modified_fabric_index=_get_attr(response, "lastModifiedFabricIndex"),
         next_credential_index=_get_attr(response, "nextCredentialIndex"),
     )

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -587,6 +587,8 @@ async def test_get_lock_users_service(
                 "user_type": "unrestricted_user",
                 "credential_rule": "single",
                 "credentials": [],
+                "creator_fabric_index": None,
+                "last_modified_fabric_index": None,
                 "next_user_index": None,
             }
         ],
@@ -745,6 +747,8 @@ async def test_get_lock_users_iterates_with_next_index(
                 "user_type": "unrestricted_user",
                 "credential_rule": "single",
                 "credentials": [],
+                "creator_fabric_index": None,
+                "last_modified_fabric_index": None,
                 "next_user_index": 5,
             },
             {
@@ -755,6 +759,8 @@ async def test_get_lock_users_iterates_with_next_index(
                 "user_type": "unrestricted_user",
                 "credential_rule": "single",
                 "credentials": [],
+                "creator_fabric_index": None,
+                "last_modified_fabric_index": None,
                 "next_user_index": None,
             },
         ],
@@ -889,6 +895,8 @@ async def test_get_lock_users_with_credentials(
                     {"type": "pin", "index": 1},
                     {"type": "pin", "index": 2},
                 ],
+                "creator_fabric_index": None,
+                "last_modified_fabric_index": None,
                 "next_user_index": None,
             }
         ],
@@ -1524,6 +1532,8 @@ async def test_get_lock_credential_status(
     assert result["lock.mock_door_lock"] == {
         "credential_exists": True,
         "user_index": 2,
+        "creator_fabric_index": None,
+        "last_modified_fabric_index": None,
         "next_credential_index": 3,
     }
 
@@ -1571,6 +1581,8 @@ async def test_get_lock_credential_status_empty_slot(
     assert result["lock.mock_door_lock"] == {
         "credential_exists": False,
         "user_index": None,
+        "creator_fabric_index": None,
+        "last_modified_fabric_index": None,
         "next_credential_index": None,
     }
 

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -970,6 +970,18 @@ async def test_get_lock_users_with_fabric_indices(
                 "credentials": None,
                 "creatorFabricIndex": 3,
                 "lastModifiedFabricIndex": NullValue,
+                "nextUserIndex": 2,
+            },
+            {
+                "userIndex": 2,
+                "userName": "External User",
+                "userUniqueID": None,
+                "userStatus": 1,
+                "userType": 0,
+                "credentialRule": 0,
+                "credentials": None,
+                "creatorFabricIndex": NullValue,
+                "lastModifiedFabricIndex": 5,
                 "nextUserIndex": None,
             },
         ]
@@ -984,9 +996,11 @@ async def test_get_lock_users_with_fabric_indices(
     )
 
     users = result["lock.mock_door_lock"]["users"]
-    assert len(users) == 1
+    assert len(users) == 2
     assert users[0]["creator_fabric_index"] == 3
     assert users[0]["last_modified_fabric_index"] is None
+    assert users[1]["creator_fabric_index"] is None
+    assert users[1]["last_modified_fabric_index"] == 5
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1628,18 +1642,29 @@ async def test_get_lock_credential_status_empty_slot(
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
 @pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
+@pytest.mark.parametrize(
+    ("creator", "last_modified", "expected_creator", "expected_last_modified"),
+    [
+        (3, NullValue, 3, None),
+        (NullValue, 2, None, 2),
+    ],
+)
 async def test_get_lock_credential_status_with_fabric_indices(
     hass: HomeAssistant,
     matter_client: MagicMock,
     matter_node: MatterNode,
+    creator: int,
+    last_modified: int,
+    expected_creator: int | None,
+    expected_last_modified: int | None,
 ) -> None:
     """Test get_lock_credential_status returns fabric indices and normalizes NullValue."""
     matter_client.send_device_command = AsyncMock(
         return_value={
             "credentialExists": True,
             "userIndex": 2,
-            "creatorFabricIndex": 1,
-            "lastModifiedFabricIndex": NullValue,
+            "creatorFabricIndex": creator,
+            "lastModifiedFabricIndex": last_modified,
             "nextCredentialIndex": 5,
         }
     )
@@ -1659,8 +1684,8 @@ async def test_get_lock_credential_status_with_fabric_indices(
     assert result["lock.mock_door_lock"] == {
         "credential_exists": True,
         "user_index": 2,
-        "creator_fabric_index": 1,
-        "last_modified_fabric_index": None,
+        "creator_fabric_index": expected_creator,
+        "last_modified_fabric_index": expected_last_modified,
         "next_credential_index": 5,
     }
 

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -952,6 +952,45 @@ async def test_get_lock_users_with_nullvalue_credentials(
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
 @pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
+async def test_get_lock_users_with_fabric_indices(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test get_lock_users returns fabric indices and normalizes NullValue."""
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {
+                "userIndex": 1,
+                "userName": "HA User",
+                "userUniqueID": None,
+                "userStatus": 1,
+                "userType": 0,
+                "credentialRule": 0,
+                "credentials": None,
+                "creatorFabricIndex": 3,
+                "lastModifiedFabricIndex": NullValue,
+                "nextUserIndex": None,
+            },
+        ]
+    )
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        "get_lock_users",
+        {ATTR_ENTITY_ID: "lock.mock_door_lock"},
+        blocking=True,
+        return_response=True,
+    )
+
+    users = result["lock.mock_door_lock"]["users"]
+    assert len(users) == 1
+    assert users[0]["creator_fabric_index"] == 3
+    assert users[0]["last_modified_fabric_index"] is None
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
 @pytest.mark.parametrize(
     ("service_name", "service_data", "return_response"),
     [
@@ -1584,6 +1623,45 @@ async def test_get_lock_credential_status_empty_slot(
         "creator_fabric_index": None,
         "last_modified_fabric_index": None,
         "next_credential_index": None,
+    }
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
+async def test_get_lock_credential_status_with_fabric_indices(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test get_lock_credential_status returns fabric indices and normalizes NullValue."""
+    matter_client.send_device_command = AsyncMock(
+        return_value={
+            "credentialExists": True,
+            "userIndex": 2,
+            "creatorFabricIndex": 1,
+            "lastModifiedFabricIndex": NullValue,
+            "nextCredentialIndex": 5,
+        }
+    )
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        "get_lock_credential_status",
+        {
+            ATTR_ENTITY_ID: "lock.mock_door_lock",
+            ATTR_CREDENTIAL_TYPE: "pin",
+            ATTR_CREDENTIAL_INDEX: 1,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert result["lock.mock_door_lock"] == {
+        "credential_exists": True,
+        "user_index": 2,
+        "creator_fabric_index": 1,
+        "last_modified_fabric_index": None,
+        "next_credential_index": 5,
     }
 
 


### PR DESCRIPTION
## Proposed change

Expose `creator_fabric_index` and `last_modified_fabric_index` from the Matter DoorLock spec in the `get_lock_users` and `get_lock_credential_status` service responses.

These fields indicate which Matter fabric (controller/app) created or last modified a user or credential. This is useful for identifying users and credentials created by other apps (e.g. Apple Home, Google Home, Nuki) especially when those apps don't set a `user_name`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
