### PR TITLE
Use runtime_data in system_bridge integration

### DIFF
--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -21,7 +21,7 @@ from systembridgeconnector.models.open_url import OpenUrl
 from systembridgeconnector.version import Version
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_COMMAND,
@@ -57,7 +57,24 @@ from homeassistant.helpers.issue_registry import IssueSeverity, async_create_iss
 
 from .config_flow import SystemBridgeConfigFlow
 from .const import DATA_WAIT_TIMEOUT, DOMAIN, MODULES
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
+
+
+def _get_coordinator(
+    hass: HomeAssistant, entry_id: str
+) -> SystemBridgeDataUpdateCoordinator:
+    """Return the coordinator for a config entry id."""
+    entry: SystemBridgeConfigEntry | None = hass.config_entries.async_get_entry(
+        entry_id
+    )
+    if entry is None or entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={"device": entry_id},
+        )
+    return entry.runtime_data
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,7 +110,7 @@ POWER_COMMAND_MAP = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
 ) -> bool:
     """Set up System Bridge from a config entry."""
 
@@ -198,8 +215,7 @@ async def async_setup_entry(
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     # Set up all platforms except notify
     await hass.config_entries.async_forward_entry_setups(
@@ -216,7 +232,7 @@ async def async_setup_entry(
                 CONF_NAME: f"{DOMAIN}_{coordinator.data.system.hostname}",
                 CONF_ENTITY_ID: entry.entry_id,
             },
-            hass.data[DOMAIN][entry.entry_id],
+            {},
         )
     )
 
@@ -249,9 +265,7 @@ async def async_setup_entry(
     async def handle_get_process_by_id(service_call: ServiceCall) -> ServiceResponse:
         """Handle the get process by id service call."""
         _LOGGER.debug("Get process by id: %s", service_call.data)
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            service_call.data[CONF_BRIDGE]
-        ]
+        coordinator = _get_coordinator(hass, service_call.data[CONF_BRIDGE])
         processes: list[Process] = coordinator.data.processes
 
         # Find process.id from list, raise ServiceValidationError if not found
@@ -275,9 +289,7 @@ async def async_setup_entry(
     ) -> ServiceResponse:
         """Handle the get process by name service call."""
         _LOGGER.debug("Get process by name: %s", service_call.data)
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            service_call.data[CONF_BRIDGE]
-        ]
+        coordinator = _get_coordinator(hass, service_call.data[CONF_BRIDGE])
 
         # Find processes from list
         items: list[dict[str, Any]] = [
@@ -295,9 +307,7 @@ async def async_setup_entry(
     async def handle_open_path(service_call: ServiceCall) -> ServiceResponse:
         """Handle the open path service call."""
         _LOGGER.debug("Open path: %s", service_call.data)
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            service_call.data[CONF_BRIDGE]
-        ]
+        coordinator = _get_coordinator(hass, service_call.data[CONF_BRIDGE])
         response = await coordinator.websocket_client.open_path(
             OpenPath(path=service_call.data[CONF_PATH])
         )
@@ -306,9 +316,7 @@ async def async_setup_entry(
     async def handle_power_command(service_call: ServiceCall) -> ServiceResponse:
         """Handle the power command service call."""
         _LOGGER.debug("Power command: %s", service_call.data)
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            service_call.data[CONF_BRIDGE]
-        ]
+        coordinator = _get_coordinator(hass, service_call.data[CONF_BRIDGE])
         response = await getattr(
             coordinator.websocket_client,
             POWER_COMMAND_MAP[service_call.data[CONF_COMMAND]],
@@ -318,9 +326,7 @@ async def async_setup_entry(
     async def handle_open_url(service_call: ServiceCall) -> ServiceResponse:
         """Handle the open url service call."""
         _LOGGER.debug("Open URL: %s", service_call.data)
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            service_call.data[CONF_BRIDGE]
-        ]
+        coordinator = _get_coordinator(hass, service_call.data[CONF_BRIDGE])
         response = await coordinator.websocket_client.open_url(
             OpenUrl(url=service_call.data[CONF_URL])
         )
@@ -328,9 +334,7 @@ async def async_setup_entry(
 
     async def handle_send_keypress(service_call: ServiceCall) -> ServiceResponse:
         """Handle the send_keypress service call."""
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            service_call.data[CONF_BRIDGE]
-        ]
+        coordinator = _get_coordinator(hass, service_call.data[CONF_BRIDGE])
         response = await coordinator.websocket_client.keyboard_keypress(
             KeyboardKey(key=service_call.data[CONF_KEY])
         )
@@ -338,9 +342,7 @@ async def async_setup_entry(
 
     async def handle_send_text(service_call: ServiceCall) -> ServiceResponse:
         """Handle the send_keypress service call."""
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            service_call.data[CONF_BRIDGE]
-        ]
+        coordinator = _get_coordinator(hass, service_call.data[CONF_BRIDGE])
         response = await coordinator.websocket_client.keyboard_text(
             KeyboardText(text=service_call.data[CONF_TEXT])
         )
@@ -446,24 +448,22 @@ async def async_setup_entry(
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: SystemBridgeConfigEntry
+) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(
         entry, [platform for platform in PLATFORMS if platform != Platform.NOTIFY]
     )
     if unload_ok:
-        coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
-            entry.entry_id
-        ]
+        coordinator = entry.runtime_data
 
         # Ensure disconnected and cleanup stop sub
         await coordinator.websocket_client.close()
         if coordinator.unsub:
             coordinator.unsub()
 
-        del hass.data[DOMAIN][entry.entry_id]
-
-    if not hass.data[DOMAIN]:
+    if not hass.config_entries.async_loaded_entries(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_OPEN_PATH)
         hass.services.async_remove(DOMAIN, SERVICE_OPEN_URL)
         hass.services.async_remove(DOMAIN, SERVICE_SEND_KEYPRESS)
@@ -472,7 +472,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(
+    hass: HomeAssistant, entry: SystemBridgeConfigEntry
+) -> None:
     """Reload the config entry when it changed."""
     await hass.config_entries.async_reload(entry.entry_id)
 

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -463,12 +463,6 @@ async def async_unload_entry(
         if coordinator.unsub:
             coordinator.unsub()
 
-    if not hass.config_entries.async_loaded_entries(DOMAIN):
-        hass.services.async_remove(DOMAIN, SERVICE_OPEN_PATH)
-        hass.services.async_remove(DOMAIN, SERVICE_OPEN_URL)
-        hass.services.async_remove(DOMAIN, SERVICE_SEND_KEYPRESS)
-        hass.services.async_remove(DOMAIN, SERVICE_SEND_TEXT)
-
     return unload_ok
 
 

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -10,13 +10,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
 from .data import SystemBridgeData
 from .entity import SystemBridgeEntity
 
@@ -64,11 +62,11 @@ BATTERY_BINARY_SENSOR_TYPES: tuple[SystemBridgeBinarySensorEntityDescription, ..
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up System Bridge binary sensor based on a config entry."""
-    coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = [
         SystemBridgeBinarySensor(coordinator, description, entry.data[CONF_PORT])

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -36,18 +36,20 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DOMAIN, GET_DATA_WAIT_TIMEOUT, MODULES
 from .data import SystemBridgeData
 
+type SystemBridgeConfigEntry = ConfigEntry[SystemBridgeDataUpdateCoordinator]
+
 
 class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData]):
     """Class to manage fetching System Bridge data from single endpoint."""
 
-    config_entry: ConfigEntry
+    config_entry: SystemBridgeConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
         LOGGER: logging.Logger,
         *,
-        entry: ConfigEntry,
+        entry: SystemBridgeConfigEntry,
     ) -> None:
         """Initialize global System Bridge data updater."""
         self.title = entry.title

--- a/homeassistant/components/system_bridge/media_player.py
+++ b/homeassistant/components/system_bridge/media_player.py
@@ -15,13 +15,11 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     RepeatMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
 from .data import SystemBridgeData
 from .entity import SystemBridgeEntity
 
@@ -64,11 +62,11 @@ MEDIA_PLAYER_DESCRIPTION: Final[MediaPlayerEntityDescription] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up System Bridge media players based on a config entry."""
-    coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     data = coordinator.data
 
     if data.media is not None:

--- a/homeassistant/components/system_bridge/media_source.py
+++ b/homeassistant/components/system_bridge/media_source.py
@@ -15,11 +15,22 @@ from homeassistant.components.media_source import (
     MediaSourceItem,
     PlayMedia,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import SystemBridgeConfigEntry
+
+
+def _get_loaded_entry(hass: HomeAssistant, entry_id: str) -> SystemBridgeConfigEntry:
+    """Return a loaded System Bridge config entry by id."""
+    entry: SystemBridgeConfigEntry | None = hass.config_entries.async_get_entry(
+        entry_id
+    )
+    if entry is None or entry.state is not ConfigEntryState.LOADED:
+        raise ValueError("Invalid entry")
+    return entry
 
 
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
@@ -45,9 +56,7 @@ class SystemBridgeSource(MediaSource):
     ) -> PlayMedia:
         """Resolve media to a url."""
         entry_id, path, mime_type = item.identifier.split("~~", 2)
-        entry = self.hass.config_entries.async_get_entry(entry_id)
-        if entry is None:
-            raise ValueError("Invalid entry")
+        entry = _get_loaded_entry(self.hass, entry_id)
         path_split = path.split("/", 1)
         return PlayMedia(
             f"{_build_base_url(entry)}&base={path_split[0]}&path={path_split[1]}",
@@ -63,20 +72,13 @@ class SystemBridgeSource(MediaSource):
             return self._build_bridges()
 
         if "~~" not in item.identifier:
-            entry: SystemBridgeConfigEntry | None = (
-                self.hass.config_entries.async_get_entry(item.identifier)
-            )
-            if entry is None:
-                raise ValueError("Invalid entry")
+            entry = _get_loaded_entry(self.hass, item.identifier)
             coordinator = entry.runtime_data
             directories = await coordinator.websocket_client.get_directories()
             return _build_root_paths(entry, directories)
 
         entry_id, path = item.identifier.split("~~", 1)
-        entry = self.hass.config_entries.async_get_entry(entry_id)
-        if entry is None:
-            raise ValueError("Invalid entry")
-
+        entry = _get_loaded_entry(self.hass, entry_id)
         coordinator = entry.runtime_data
 
         path_split = path.split("/", 1)

--- a/homeassistant/components/system_bridge/media_source.py
+++ b/homeassistant/components/system_bridge/media_source.py
@@ -15,12 +15,11 @@ from homeassistant.components.media_source import (
     MediaSourceItem,
     PlayMedia,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeConfigEntry
 
 
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
@@ -64,12 +63,12 @@ class SystemBridgeSource(MediaSource):
             return self._build_bridges()
 
         if "~~" not in item.identifier:
-            entry = self.hass.config_entries.async_get_entry(item.identifier)
+            entry: SystemBridgeConfigEntry | None = (
+                self.hass.config_entries.async_get_entry(item.identifier)
+            )
             if entry is None:
                 raise ValueError("Invalid entry")
-            coordinator: SystemBridgeDataUpdateCoordinator = self.hass.data[DOMAIN].get(
-                entry.entry_id
-            )
+            coordinator = entry.runtime_data
             directories = await coordinator.websocket_client.get_directories()
             return _build_root_paths(entry, directories)
 
@@ -78,7 +77,7 @@ class SystemBridgeSource(MediaSource):
         if entry is None:
             raise ValueError("Invalid entry")
 
-        coordinator = self.hass.data[DOMAIN].get(entry.entry_id)
+        coordinator = entry.runtime_data
 
         path_split = path.split("/", 1)
 
@@ -123,7 +122,7 @@ class SystemBridgeSource(MediaSource):
 
 
 def _build_base_url(
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
 ) -> str:
     """Build base url for System Bridge media."""
     return (
@@ -133,7 +132,7 @@ def _build_base_url(
 
 
 def _build_root_paths(
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
     media_directories: list[MediaDirectory],
 ) -> BrowseMediaSource:
     """Build base categories for System Bridge media."""
@@ -164,7 +163,7 @@ def _build_root_paths(
 
 
 def _build_media_items(
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
     media_files: MediaFiles,
     path: str,
     identifier: str,

--- a/homeassistant/components/system_bridge/notify.py
+++ b/homeassistant/components/system_bridge/notify.py
@@ -17,8 +17,7 @@ from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import DOMAIN
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,11 +36,13 @@ async def async_get_service(
     if discovery_info is None:
         return None
 
-    coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][
+    entry: SystemBridgeConfigEntry | None = hass.config_entries.async_get_entry(
         discovery_info[CONF_ENTITY_ID]
-    ]
+    )
+    if entry is None:
+        return None
 
-    return SystemBridgeNotificationService(coordinator)
+    return SystemBridgeNotificationService(entry.runtime_data)
 
 
 class SystemBridgeNotificationService(BaseNotificationService):

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -17,7 +17,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_PORT,
     PERCENTAGE,
@@ -33,8 +32,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
 from .data import SystemBridgeData
 from .entity import SystemBridgeEntity
 
@@ -364,11 +362,11 @@ BATTERY_SENSOR_TYPES: tuple[SystemBridgeSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up System Bridge sensor based on a config entry."""
-    coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = [
         SystemBridgeSensor(coordinator, description, entry.data[CONF_PORT])

--- a/homeassistant/components/system_bridge/update.py
+++ b/homeassistant/components/system_bridge/update.py
@@ -3,23 +3,21 @@
 from __future__ import annotations
 
 from homeassistant.components.update import UpdateEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import SystemBridgeDataUpdateCoordinator
+from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
 from .entity import SystemBridgeEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SystemBridgeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up System Bridge update based on a config entry."""
-    coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         [


### PR DESCRIPTION
## Proposed change

Migrate the `system_bridge` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]`.

- Add `SystemBridgeConfigEntry` type alias in `coordinator.py` (typed as `ConfigEntry[SystemBridgeDataUpdateCoordinator]`)
- Add a `_get_coordinator` helper in `__init__.py` that retrieves the coordinator from a config entry id (used by service handlers)
- Update `__init__.py` to store the coordinator in `entry.runtime_data`, update all 7 service handlers to use the helper, and simplify `async_unload_entry`
- Fix a pre-existing bug where `discovery.async_load_platform` was called with the coordinator as `hass_config` (now passes an empty dict)
- Update all 5 platform files (`binary_sensor.py`, `media_player.py`, `sensor.py`, `update.py`, `notify.py`) to use `entry.runtime_data`
- Update `media_source.py` to use `entry.runtime_data` via config entries lookup

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr