### PR TITLE
Add Preset button support for Bond cover devices

### DIFF
--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -258,13 +258,14 @@ BUTTONS: tuple[BondButtonEntityDescription, ...] = (
         mutually_exclusive=None,
         argument=None,
     ),
-    BondButtonEntityDescription(
-        key=Action.PRESET,
-        name="Preset",
-        translation_key="preset",
-        mutually_exclusive=None,
-        argument=None,
-    ),
+)
+
+PRESET_BUTTON = BondButtonEntityDescription(
+    key=Action.PRESET,
+    name="Preset",
+    translation_key="preset",
+    mutually_exclusive=None,
+    argument=None,
 )
 
 
@@ -287,17 +288,13 @@ async def async_setup_entry(
                 or not device.has_action(description.mutually_exclusive)
             )
         ]
-        if (
-            device_entities
-            and device.has_action(STOP_BUTTON.key)
-            and not device.has_action(Action.HOLD)
-        ):
+        if device_entities and device.has_action(STOP_BUTTON.key):
             # Most devices have the stop action available, but
             # we only add the stop action button if we add actions
-            # since its not so useful if there are no actions to stop.
-            # Devices with Hold (e.g. shades) already expose stop via
-            # the cover platform, so a separate Stop button is redundant.
+            # since its not so useful if there are no actions to stop
             device_entities.append(BondButtonEntity(data, device, STOP_BUTTON))
+        if device.has_action(PRESET_BUTTON.key):
+            device_entities.append(BondButtonEntity(data, device, PRESET_BUTTON))
         entities.extend(device_entities)
 
     async_add_entities(entities)

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -258,6 +258,13 @@ BUTTONS: tuple[BondButtonEntityDescription, ...] = (
         mutually_exclusive=None,
         argument=None,
     ),
+    BondButtonEntityDescription(
+        key=Action.PRESET,
+        name="Preset",
+        translation_key="preset",
+        mutually_exclusive=None,
+        argument=None,
+    ),
 )
 
 
@@ -280,10 +287,16 @@ async def async_setup_entry(
                 or not device.has_action(description.mutually_exclusive)
             )
         ]
-        if device_entities and device.has_action(STOP_BUTTON.key):
+        if (
+            device_entities
+            and device.has_action(STOP_BUTTON.key)
+            and not device.has_action(Action.HOLD)
+        ):
             # Most devices have the stop action available, but
             # we only add the stop action button if we add actions
-            # since its not so useful if there are no actions to stop
+            # since its not so useful if there are no actions to stop.
+            # Devices with Hold (e.g. shades) already expose stop via
+            # the cover platform, so a separate Stop button is redundant.
             device_entities.append(BondButtonEntity(data, device, STOP_BUTTON))
         entities.extend(device_entities)
 

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -66,6 +66,15 @@ def motorized_shade(name: str):
     }
 
 
+def motorized_shade_with_preset(name: str):
+    """Create a motorized shade with preset action."""
+    return {
+        "name": name,
+        "type": DeviceType.MOTORIZED_SHADES,
+        "actions": [Action.OPEN, Action.CLOSE, Action.HOLD, Action.PRESET, Action.STOP],
+    }
+
+
 async def test_entity_registry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -224,3 +233,45 @@ async def test_motorized_shade_actions(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     mock_action.assert_called_once_with("test-device-id", Action(Action.CLOSE_NEXT))
+
+
+async def test_preset_button(hass: HomeAssistant) -> None:
+    """Tests preset button is created and can be pressed."""
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        motorized_shade_with_preset("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    assert hass.states.get("button.name_1_preset")
+
+    with patch_bond_action() as mock_action, patch_bond_device_state():
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.name_1_preset"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_action.assert_called_once_with("test-device-id", Action(Action.PRESET))
+
+
+async def test_stop_not_created_when_device_has_hold(hass: HomeAssistant) -> None:
+    """Tests stop button is not created for devices with Hold (e.g. shades).
+
+    Devices with Hold already expose stop via the cover platform,
+    so a separate Stop Actions button would be redundant.
+    """
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        motorized_shade_with_preset("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    # Preset button should exist
+    assert hass.states.get("button.name_1_preset")
+    # Stop Actions should NOT exist - the cover's Hold already provides stop
+    assert not hass.states.get("button.name_1_stop_actions")

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -258,11 +258,12 @@ async def test_preset_button(hass: HomeAssistant) -> None:
     mock_action.assert_called_once_with("test-device-id", Action(Action.PRESET))
 
 
-async def test_stop_not_created_when_device_has_hold(hass: HomeAssistant) -> None:
-    """Tests stop button is not created for devices with Hold (e.g. shades).
+async def test_preset_does_not_trigger_stop_button(hass: HomeAssistant) -> None:
+    """Tests that Preset alone does not cause a Stop Actions button to appear.
 
-    Devices with Hold already expose stop via the cover platform,
-    so a separate Stop Actions button would be redundant.
+    Preset is added independently of the main button list, so it should
+    not trigger the Stop button logic (which only activates when there
+    are other button entities).
     """
     await setup_platform(
         hass,
@@ -273,5 +274,6 @@ async def test_stop_not_created_when_device_has_hold(hass: HomeAssistant) -> Non
 
     # Preset button should exist
     assert hass.states.get("button.name_1_preset")
-    # Stop Actions should NOT exist - the cover's Hold already provides stop
+    # Stop Actions should NOT exist - Preset is the only button and is
+    # added independently, so it does not trigger the Stop button logic
     assert not hass.states.get("button.name_1_stop_actions")

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -272,8 +272,5 @@ async def test_preset_does_not_trigger_stop_button(hass: HomeAssistant) -> None:
         bond_device_id="test-device-id",
     )
 
-    # Preset button should exist
     assert hass.states.get("button.name_1_preset")
-    # Stop Actions should NOT exist - Preset is the only button and is
-    # added independently, so it does not trigger the Stop button logic
     assert not hass.states.get("button.name_1_stop_actions")


### PR DESCRIPTION
## Proposed change

Bond-controlled motorized shades can have a Preset action that moves the cover to a saved position (configured via the Bond app or the device's physical remote). The `bond-async` library already supports `Action.PRESET` but the integration never exposed it.

This adds a Preset button entity for any Bond device that reports the Preset action.

Preset is handled independently of the main `BUTTONS` tuple (similar to how `STOP_BUTTON` is handled), so it does not trigger the Stop Actions button for devices that previously had no button entities. No existing behavior changes for any device type.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR is related to issue: #121916
- Link to documentation pull request: N/A (no user-facing configuration changes)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr