### PR TITLE
Use runtime_data in tesla_wall_connector

### DIFF
--- a/homeassistant/components/tesla_wall_connector/__init__.py
+++ b/homeassistant/components/tesla_wall_connector/__init__.py
@@ -5,21 +5,25 @@ from __future__ import annotations
 from tesla_wall_connector import WallConnector
 from tesla_wall_connector.exceptions import WallConnectorError
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
-from .coordinator import WallConnectorCoordinator, WallConnectorData, get_poll_interval
+from .coordinator import (
+    WallConnectorConfigEntry,
+    WallConnectorCoordinator,
+    WallConnectorData,
+    get_poll_interval,
+)
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: WallConnectorConfigEntry
+) -> bool:
     """Set up Tesla Wall Connector from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
     hostname = entry.data[CONF_HOST]
 
     wall_connector = WallConnector(host=hostname, session=async_get_clientsession(hass))
@@ -32,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = WallConnectorCoordinator(hass, entry, hostname, wall_connector)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = WallConnectorData(
+    entry.runtime_data = WallConnectorData(
         wall_connector_client=wall_connector,
         hostname=hostname,
         part_number=version_data.part_number,
@@ -48,15 +52,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def update_listener(hass: HomeAssistant, entry: WallConnectorConfigEntry) -> None:
     """Handle options update."""
-    wall_connector_data: WallConnectorData = hass.data[DOMAIN][entry.entry_id]
-    wall_connector_data.update_coordinator.update_interval = get_poll_interval(entry)
+    entry.runtime_data.update_coordinator.update_interval = get_poll_interval(entry)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: WallConnectorConfigEntry
+) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/tesla_wall_connector/binary_sensor.py
+++ b/homeassistant/components/tesla_wall_connector/binary_sensor.py
@@ -8,13 +8,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, WALLCONNECTOR_DATA_VITALS
-from .coordinator import WallConnectorData
+from .const import WALLCONNECTOR_DATA_VITALS
+from .coordinator import WallConnectorConfigEntry, WallConnectorData
 from .entity import WallConnectorEntity, WallConnectorLambdaValueGetterMixin
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,11 +46,11 @@ WALL_CONNECTOR_SENSORS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WallConnectorConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Create the Wall Connector sensor devices."""
-    wall_connector_data = hass.data[DOMAIN][config_entry.entry_id]
+    wall_connector_data = config_entry.runtime_data
 
     all_entities = [
         WallConnectorBinarySensorEntity(wall_connector_data, description)

--- a/homeassistant/components/tesla_wall_connector/coordinator.py
+++ b/homeassistant/components/tesla_wall_connector/coordinator.py
@@ -26,6 +26,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+type WallConnectorConfigEntry = ConfigEntry[WallConnectorData]
+
 
 @dataclass
 class WallConnectorData:
@@ -49,12 +51,12 @@ def get_poll_interval(entry: ConfigEntry) -> timedelta:
 class WallConnectorCoordinator(DataUpdateCoordinator[dict]):
     """Class to manage fetching Tesla Wall Connector data."""
 
-    config_entry: ConfigEntry
+    config_entry: WallConnectorConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: ConfigEntry,
+        entry: WallConnectorConfigEntry,
         hostname: str,
         wall_connector: WallConnector,
     ) -> None:

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EntityCategory,
     UnitOfElectricCurrent,
@@ -22,8 +21,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, WALLCONNECTOR_DATA_LIFETIME, WALLCONNECTOR_DATA_VITALS
-from .coordinator import WallConnectorData
+from .const import WALLCONNECTOR_DATA_LIFETIME, WALLCONNECTOR_DATA_VITALS
+from .coordinator import WallConnectorConfigEntry, WallConnectorData
 from .entity import WallConnectorEntity, WallConnectorLambdaValueGetterMixin
 
 _LOGGER = logging.getLogger(__name__)
@@ -196,11 +195,11 @@ WALL_CONNECTOR_SENSORS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WallConnectorConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Create the Wall Connector sensor devices."""
-    wall_connector_data = hass.data[DOMAIN][config_entry.entry_id]
+    wall_connector_data = config_entry.runtime_data
 
     all_entities = [
         WallConnectorSensorEntity(wall_connector_data, description)


### PR DESCRIPTION
## Proposed change

Migrate the `tesla_wall_connector` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN]`.

- Add `WallConnectorConfigEntry` type alias in `coordinator.py` (typed as `ConfigEntry[WallConnectorData]`)
- Update `__init__.py` to store `WallConnectorData` in `entry.runtime_data`, and simplify `async_unload_entry` and `update_listener`
- Update `sensor.py` and `binary_sensor.py` to use `entry.runtime_data`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr