### PR TITLE
Use runtime_data in tomorrowio

### DIFF
--- a/homeassistant/components/tomorrowio/__init__.py
+++ b/homeassistant/components/tomorrowio/__init__.py
@@ -6,31 +6,38 @@ from pytomorrowio import TomorrowioV4
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
-from .coordinator import TomorrowioDataUpdateCoordinator
+from .coordinator import (
+    TomorrowioConfigEntry,
+    TomorrowioDataUpdateCoordinator,
+    async_get_entries_by_api_key,
+)
 
 PLATFORMS = [SENSOR_DOMAIN, WEATHER_DOMAIN]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: TomorrowioConfigEntry) -> bool:
     """Set up Tomorrow.io API from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-
     api_key = entry.data[CONF_API_KEY]
-    # If coordinator already exists for this API key, we'll use that, otherwise
-    # we have to create a new one
-    if not (coordinator := hass.data[DOMAIN].get(api_key)):
+    # If another entry already has a coordinator for this API key, reuse it.
+    # Otherwise create a new one.
+    coordinator: TomorrowioDataUpdateCoordinator | None = None
+    for other_entry in async_get_entries_by_api_key(hass, api_key, exclude_entry=entry):
+        if hasattr(other_entry, "runtime_data"):
+            coordinator = other_entry.runtime_data
+            break
+
+    if coordinator is None:
         session = async_get_clientsession(hass)
         # we will not use the class's lat and long so we can pass in garbage
         # lats and longs
         api = TomorrowioV4(api_key, 361.0, 361.0, unit_system="metric", session=session)
         coordinator = TomorrowioDataUpdateCoordinator(hass, entry, api)
-        hass.data[DOMAIN][api_key] = coordinator
+
+    entry.runtime_data = coordinator
 
     await coordinator.async_setup_entry(entry)
 
@@ -39,18 +46,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, config_entry: TomorrowioConfigEntry
+) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     )
 
-    api_key = config_entry.data[CONF_API_KEY]
-    coordinator: TomorrowioDataUpdateCoordinator = hass.data[DOMAIN][api_key]
-    # If this is true, we can remove the coordinator
-    if await coordinator.async_unload_entry(config_entry):
-        hass.data[DOMAIN].pop(api_key)
-        if not hass.data[DOMAIN]:
-            hass.data.pop(DOMAIN)
+    await config_entry.runtime_data.async_unload_entry(config_entry)
 
     return unload_ok

--- a/homeassistant/components/tomorrowio/coordinator.py
+++ b/homeassistant/components/tomorrowio/coordinator.py
@@ -70,6 +70,8 @@ from .const import (
     TMRW_ATTR_WIND_SPEED,
 )
 
+type TomorrowioConfigEntry = ConfigEntry[TomorrowioDataUpdateCoordinator]
+
 
 @callback
 def async_get_entries_by_api_key(
@@ -116,10 +118,13 @@ def async_set_update_interval(
 class TomorrowioDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Define an object to hold Tomorrow.io data."""
 
-    config_entry: ConfigEntry
+    config_entry: TomorrowioConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, api: TomorrowioV4
+        self,
+        hass: HomeAssistant,
+        config_entry: TomorrowioConfigEntry,
+        api: TomorrowioV4,
     ) -> None:
         """Initialize."""
         self._api = api

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -25,7 +25,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
-    CONF_API_KEY,
     PERCENTAGE,
     UnitOfIrradiance,
     UnitOfLength,
@@ -39,7 +38,6 @@ from homeassistant.util.unit_conversion import DistanceConverter, SpeedConverter
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import (
-    DOMAIN,
     TMRW_ATTR_CARBON_MONOXIDE,
     TMRW_ATTR_CHINA_AQI,
     TMRW_ATTR_CHINA_HEALTH_CONCERN,
@@ -68,7 +66,7 @@ from .const import (
     TMRW_ATTR_UV_INDEX,
     TMRW_ATTR_WIND_GUST,
 )
-from .coordinator import TomorrowioDataUpdateCoordinator
+from .coordinator import TomorrowioConfigEntry, TomorrowioDataUpdateCoordinator
 from .entity import TomorrowioEntity
 
 
@@ -327,11 +325,11 @@ SENSOR_TYPES = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TomorrowioConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.data[CONF_API_KEY]]
+    coordinator = config_entry.runtime_data
     entities = [
         TomorrowioSensorEntity(hass, config_entry, coordinator, 4, description)
         for description in SENSOR_TYPES

--- a/homeassistant/components/tomorrowio/weather.py
+++ b/homeassistant/components/tomorrowio/weather.py
@@ -24,7 +24,6 @@ from homeassistant.components.weather import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_API_KEY,
     UnitOfLength,
     UnitOfPrecipitationDepth,
     UnitOfPressure,
@@ -59,17 +58,17 @@ from .const import (
     TMRW_ATTR_WIND_DIRECTION,
     TMRW_ATTR_WIND_SPEED,
 )
-from .coordinator import TomorrowioDataUpdateCoordinator
+from .coordinator import TomorrowioConfigEntry, TomorrowioDataUpdateCoordinator
 from .entity import TomorrowioEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TomorrowioConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.data[CONF_API_KEY]]
+    coordinator = config_entry.runtime_data
     entity_registry = er.async_get(hass)
 
     entities = [TomorrowioWeatherEntity(config_entry, coordinator, 4, DAILY)]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `tomorrowio` integration to use `ConfigEntry.runtime_data` instead of storing the coordinator in `hass.data[DOMAIN]`.

- Add a `TomorrowioConfigEntry` type alias in `coordinator.py` (typed as `ConfigEntry[TomorrowioDataUpdateCoordinator]`).
- Store the coordinator in `entry.runtime_data` in `async_setup_entry`. This integration shares one coordinator across multiple config entries with the same API key, so `async_setup_entry` now looks up other entries with the same API key and reuses their coordinator if one has already been assigned (detected via `hasattr(entry, "runtime_data")`).
- Simplify `async_unload_entry` — there is no longer a shared map in `hass.data` to clean up.
- Update `sensor.py` and `weather.py` to read the coordinator from `config_entry.runtime_data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr