### PR TITLE
Fix light on action for qbus integration

### DIFF
--- a/homeassistant/components/qbus/light.py
+++ b/homeassistant/components/qbus/light.py
@@ -79,8 +79,10 @@ class QbusLight(QbusEntity, LightEntity):
         await self._async_publish_output_state(state)
 
     async def _handle_state_received(self, state: QbusMqttAnalogState) -> None:
-        percentage = round(state.read_percentage() or 0)
-        self._set_state(percentage)
+        percentage = state.read_percentage()
+
+        if percentage is not None:
+            self._set_state(round(percentage))
 
     def _set_state(self, percentage: int) -> None:
         self._attr_is_on = percentage > 0

--- a/tests/components/qbus/test_light.py
+++ b/tests/components/qbus/test_light.py
@@ -20,6 +20,7 @@ _PAYLOAD_LIGHT_STATE_ON = '{"id":"UL15","properties":{"value":60},"type":"state"
 _PAYLOAD_LIGHT_STATE_BRIGHTNESS = (
     '{"id":"UL15","properties":{"value":' + str(_BRIGHTNESS_PCT) + '},"type":"state"}'
 )
+_PAYLOAD_LIGHT_STATE_EVENT = '{"id":"UL15","action":"on","type":"event"}'
 _PAYLOAD_LIGHT_STATE_OFF = '{"id":"UL15","properties":{"value":0},"type":"state"}'
 
 _PAYLOAD_LIGHT_SET_STATE_ON = '{"id": "UL15", "type": "action", "action": "on"}'
@@ -104,3 +105,37 @@ async def test_light(
     await hass.async_block_till_done()
 
     assert hass.states.get(_LIGHT_ENTITY_ID).state == STATE_OFF
+
+
+async def test_light_ignore_missing_percentage(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    setup_integration: None,
+) -> None:
+    """Test ignoring events without percentage."""
+
+    # Switch ON
+    mqtt_mock.reset_mock()
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: _LIGHT_ENTITY_ID},
+        blocking=True,
+    )
+
+    # Simulate response
+    async_fire_mqtt_message(hass, _TOPIC_LIGHT_STATE, _PAYLOAD_LIGHT_STATE_ON)
+    await hass.async_block_till_done()
+
+    entity = hass.states.get(_LIGHT_ENTITY_ID)
+    brightness = entity.attributes.get(ATTR_BRIGHTNESS)
+    assert entity.state == STATE_ON
+    assert brightness > 0
+
+    # Simulate additional event response
+    async_fire_mqtt_message(hass, _TOPIC_LIGHT_STATE, _PAYLOAD_LIGHT_STATE_EVENT)
+    await hass.async_block_till_done()
+
+    entity = hass.states.get(_LIGHT_ENTITY_ID)
+    assert entity.state == STATE_ON
+    assert entity.attributes.get(ATTR_BRIGHTNESS) == brightness


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Depending on the Qbus MQTT gateway version, the light (dimmer) on action might send multiple topics. Some of them do not include a percentage. Although the light is effectively on, HA still reported it as being off.

This PR only updates the state if percentage is available in the topic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
