### PR TITLE
Add Assist entity discovery search tool

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -7,9 +7,11 @@ from collections.abc import Callable
 from dataclasses import dataclass, field as dc_field
 from datetime import timedelta
 from decimal import Decimal
+from difflib import SequenceMatcher
 from enum import Enum
 from functools import cache, partial
 from operator import attrgetter
+import re
 from typing import Any, cast
 
 import slugify as unicode_slug
@@ -85,6 +87,10 @@ If the user asks about the CURRENT state, value, or mode (e.g., "Is the lock loc
     3.  Use the tool's response** to answer the user accurately (e.g., "The temperature outside is [value from tool].").
 For general knowledge questions not about the home: Answer truthfully from internal knowledge.
 """
+
+FIND_EXPOSED_ENTITIES_DEFAULT_LIMIT = 5
+FIND_EXPOSED_ENTITIES_MAX_LIMIT = 10
+_SEARCH_TEXT_SEPARATORS = re.compile(r"[\W_]+")
 
 
 @callback
@@ -595,6 +601,9 @@ class AssistAPI(API):
         tools.append(GetDateTimeTool())
 
         if exposed_entities:
+            if _has_exposed_entities(exposed_entities):
+                tools.append(FindExposedEntitiesTool())
+
             if exposed_entities[CALENDAR_DOMAIN]:
                 names = []
                 for info in exposed_entities[CALENDAR_DOMAIN].values():
@@ -724,6 +733,252 @@ def _get_exposed_entities(
 
     data["entities"] = entities
     return data
+
+
+@callback
+def _has_exposed_entities(exposed_entities: dict[str, dict[str, dict[str, Any]]]) -> bool:
+    """Return if any entities are exposed to the assistant."""
+    return any(exposed_entities.values())
+
+
+@callback
+def _get_searchable_exposed_entities(
+    hass: HomeAssistant, assistant: str
+) -> list[dict[str, Any]]:
+    """Return exposed entities in a shape tailored for discovery."""
+    area_registry = ar.async_get(hass)
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    entities: list[dict[str, Any]] = []
+
+    for state in sorted(hass.states.async_all(), key=attrgetter("name")):
+        if not async_should_expose(hass, assistant, state.entity_id):
+            continue
+
+        entity_entry = entity_registry.async_get(state.entity_id)
+        device_entry = (
+            device_registry.async_get(entity_entry.device_id)
+            if entity_entry is not None and entity_entry.device_id is not None
+            else None
+        )
+        primary_name = state.name.strip()
+        aliases = []
+
+        if entity_entry is not None:
+            aliases = [
+                alias
+                for alias in er.async_get_entity_aliases(
+                    hass, entity_entry, allow_empty=True
+                )
+                if alias and alias.strip() != primary_name
+            ]
+
+        area_names = []
+        if entity_entry is not None:
+            if (
+                entity_entry.area_id is not None
+                and (area_entry := area_registry.async_get_area(entity_entry.area_id))
+                is not None
+            ):
+                area_names.append(area_entry.name)
+                area_names.extend(area_entry.aliases)
+            elif device_entry is not None:
+                if (
+                    device_entry.area_id is not None
+                    and (
+                        area_entry := area_registry.async_get_area(device_entry.area_id)
+                    )
+                    is not None
+                ):
+                    area_names.append(area_entry.name)
+                    area_names.extend(area_entry.aliases)
+
+        entities.append(
+            {
+                "name": primary_name,
+                "aliases": aliases,
+                "domain": state.domain,
+                "areas": area_names,
+            }
+        )
+
+    return entities
+
+
+@callback
+def _normalize_search_text(text: str) -> str:
+    """Normalize search text for comparison."""
+    return " ".join(_SEARCH_TEXT_SEPARATORS.sub(" ", text).casefold().split())
+
+
+@callback
+def _score_search_match(query: str, candidate: str) -> float:
+    """Score how well a candidate name matches the search query."""
+    query_norm = _normalize_search_text(query)
+    candidate_norm = _normalize_search_text(candidate)
+
+    if not query_norm or not candidate_norm:
+        return 0
+
+    query_tokens = query_norm.split()
+    candidate_tokens = candidate_norm.split()
+
+    if candidate_norm == query_norm:
+        return 1_000
+
+    if candidate_norm.startswith(query_norm):
+        return 900 - len(candidate_norm)
+
+    if query_tokens and all(
+        any(candidate_token.startswith(query_token) for candidate_token in candidate_tokens)
+        for query_token in query_tokens
+    ):
+        return 700 - len(candidate_tokens)
+
+    fuzzy_scores: list[float] = []
+    for query_token in query_tokens:
+        fuzzy_score = max(
+            (
+                SequenceMatcher(None, query_token, candidate_token).ratio()
+                for candidate_token in candidate_tokens
+                if candidate_token[:1] == query_token[:1]
+            ),
+            default=0,
+        )
+        if fuzzy_score < 0.75:
+            return 0
+        fuzzy_scores.append(fuzzy_score)
+
+    if fuzzy_scores:
+        return 500 + sum(fuzzy_scores) * 100 / len(fuzzy_scores)
+
+    return 0
+
+
+class FindExposedEntitiesTool(Tool):
+    """Tool for searching exposed entities."""
+
+    name = "FindExposedEntities"
+    description = (
+        "Search for Home Assistant entities that are exposed to the assistant. "
+        "Use this to discover which entities exist and which name to pass to other Home Assistant tools. "
+        "Supports optional domain and area filters and returns concise matches."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Required(
+                "query",
+                description="Search text to match against exposed entity names and aliases",
+            ): cv.string,
+            vol.Optional(
+                "domain",
+                description="Limit results to one domain such as light, climate, or script",
+            ): cv.string,
+            vol.Optional(
+                "area",
+                description="Limit results to one area name or alias",
+            ): cv.string,
+            vol.Optional(
+                "limit",
+                description="Maximum number of matches to return",
+                default=FIND_EXPOSED_ENTITIES_DEFAULT_LIMIT,
+            ): vol.All(
+                vol.Coerce(int),
+                vol.Range(min=1, max=FIND_EXPOSED_ENTITIES_MAX_LIMIT),
+            ),
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: ToolInput,
+        llm_context: LLMContext,
+    ) -> JsonObjectType:
+        """Search exposed entities."""
+        if llm_context.assistant is None:
+            return {"success": False, "error": "No assistant configured"}
+
+        data = self.parameters(tool_input.tool_args)
+        query = data["query"].strip()
+        if not query:
+            return {"success": False, "error": "Query must not be empty"}
+
+        exposed_entities = _get_exposed_entities(
+            hass, llm_context.assistant, include_state=False
+        )
+
+        if not _has_exposed_entities(exposed_entities):
+            return {"success": False, "error": NO_ENTITIES_PROMPT}
+
+        searchable_entities = _get_searchable_exposed_entities(
+            hass, llm_context.assistant
+        )
+
+        domain_filter = data.get("domain")
+        if domain_filter is not None:
+            domain_filter = domain_filter.strip().casefold()
+            exposed_domains = {
+                info["domain"].casefold() for info in searchable_entities
+            }
+            if domain_filter not in exposed_domains:
+                return {"success": False, "error": "Domain not found"}
+
+        area_names: set[str] | None = None
+        if area_filter := data.get("area"):
+            area_registry = ar.async_get(hass)
+            matching_areas = list(intent.find_areas(area_filter, area_registry))
+            if not matching_areas:
+                return {"success": False, "error": "Area not found"}
+
+            area_names = {
+                _normalize_search_text(area_name)
+                for area in matching_areas
+                for area_name in (area.name, *area.aliases)
+            }
+
+        results: list[tuple[float, dict[str, Any]]] = []
+        for info in searchable_entities:
+            if domain_filter is not None and info["domain"].casefold() != domain_filter:
+                continue
+
+            candidate_areas = info["areas"]
+            if area_names is not None and (
+                not candidate_areas
+                or not {
+                    _normalize_search_text(area_name) for area_name in candidate_areas
+                }
+                & area_names
+            ):
+                continue
+
+            names = [info["name"], *info["aliases"]]
+            best_score = max((_score_search_match(query, name) for name in names), default=0)
+            if best_score <= 0:
+                continue
+
+            result: dict[str, Any] = {
+                "name": info["name"],
+                "domain": info["domain"],
+            }
+            if info["aliases"]:
+                result["aliases"] = info["aliases"]
+            if candidate_areas:
+                result["area"] = candidate_areas[0]
+
+            results.append((best_score, result))
+
+        results.sort(key=lambda item: (-item[0], item[1]["name"], item[1]["domain"]))
+
+        return {
+            "success": True,
+            "result": {
+                "matches": [
+                    result for _, result in results[: data["limit"]]
+                ],
+                "truncated": len(results) > data["limit"],
+            },
+        }
 
 
 def selector_serializer(schema: Any) -> Any:  # noqa: C901

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -909,16 +909,11 @@ class FindExposedEntitiesTool(Tool):
         if not query:
             return {"success": False, "error": "Query must not be empty"}
 
-        exposed_entities = _get_exposed_entities(
-            hass, llm_context.assistant, include_state=False
-        )
-
-        if not _has_exposed_entities(exposed_entities):
-            return {"success": False, "error": NO_ENTITIES_PROMPT}
-
         searchable_entities = _get_searchable_exposed_entities(
             hass, llm_context.assistant
         )
+        if not searchable_entities:
+            return {"success": False, "error": NO_ENTITIES_PROMPT}
 
         domain_filter = data.get("domain")
         if domain_filter is not None:

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -736,7 +736,9 @@ def _get_exposed_entities(
 
 
 @callback
-def _has_exposed_entities(exposed_entities: dict[str, dict[str, dict[str, Any]]]) -> bool:
+def _has_exposed_entities(
+    exposed_entities: dict[str, dict[str, dict[str, Any]]],
+) -> bool:
     """Return if any entities are exposed to the assistant."""
     return any(exposed_entities.values())
 
@@ -830,7 +832,10 @@ def _score_search_match(query: str, candidate: str) -> float:
         return 900 - len(candidate_norm)
 
     if query_tokens and all(
-        any(candidate_token.startswith(query_token) for candidate_token in candidate_tokens)
+        any(
+            candidate_token.startswith(query_token)
+            for candidate_token in candidate_tokens
+        )
         for query_token in query_tokens
     ):
         return 700 - len(candidate_tokens)
@@ -953,7 +958,9 @@ class FindExposedEntitiesTool(Tool):
                 continue
 
             names = [info["name"], *info["aliases"]]
-            best_score = max((_score_search_match(query, name) for name in names), default=0)
+            best_score = max(
+                (_score_search_match(query, name) for name in names), default=0
+            )
             if best_score <= 0:
                 continue
 
@@ -973,9 +980,7 @@ class FindExposedEntitiesTool(Tool):
         return {
             "success": True,
             "result": {
-                "matches": [
-                    result for _, result in results[: data["limit"]]
-                ],
+                "matches": [result for _, result in results[: data["limit"]]],
                 "truncated": len(results) > data["limit"],
             },
         }

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -141,6 +141,13 @@ async def sse_response_reader(
         yield event, data
 
 
+def _tool_payload(result: Any) -> dict[str, Any]:
+    """Decode the text payload returned by an MCP tool call."""
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    return json.loads(result.content[0].text)
+
+
 async def test_http_sse(
     hass: HomeAssistant,
     setup_integration: None,
@@ -388,6 +395,26 @@ async def test_mcp_tools_list(
     properties = tool.inputSchema.get("properties")
     assert properties.get("name") == {"type": "string"}
 
+    search_tool = next(
+        iter(tool for tool in result.tools if tool.name == "FindExposedEntities")
+    )
+    assert search_tool.description is not None
+    assert search_tool.inputSchema == {
+        "type": "object",
+        "properties": {
+            "query": {"description": "Search text to match against exposed entity names and aliases", "type": "string"},
+            "domain": {"description": "Limit results to one domain such as light, climate, or script", "type": "string"},
+            "area": {"description": "Limit results to one area name or alias", "type": "string"},
+            "limit": {
+                "description": "Maximum number of matches to return",
+                "default": 5,
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+            },
+        },
+    }
+
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
 async def test_mcp_tool_call(
@@ -410,10 +437,8 @@ async def test_mcp_tool_call(
         )
 
     assert not result.isError
-    assert len(result.content) == 1
-    assert result.content[0].type == "text"
     # The content is the raw tool call payload
-    content = json.loads(result.content[0].text)
+    content = _tool_payload(result)
     assert content.get("data", {}).get("success")
     assert not content.get("data", {}).get("failed")
 
@@ -442,6 +467,103 @@ async def test_mcp_tool_call_failed(
     assert len(result.content) == 1
     assert result.content[0].type == "text"
     assert "Error calling tool" in result.content[0].text
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_find_exposed_entities_tool_call(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test searching exposed entities through the MCP tool surface."""
+    kitchen = area_registry.async_get_area_by_name("Kitchen")
+    assert kitchen is not None
+    area_registry.async_update(kitchen.id, aliases={"Cooking Space"})
+
+    kitchen_counter = entity_registry.async_get_or_create(
+        LIGHT_DOMAIN,
+        "test",
+        "kitchen-counter-light",
+        suggested_object_id="kitchen_counter",
+        original_name="Kitchen Counter Light",
+    )
+    entity_registry.async_update_entity(kitchen_counter.entity_id, area_id=kitchen.id)
+    hass.states.async_set(
+        kitchen_counter.entity_id,
+        STATE_OFF,
+        {"friendly_name": "Kitchen Counter Light"},
+    )
+    async_expose_entity(hass, CONVERSATION_DOMAIN, kitchen_counter.entity_id, False)
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.call_tool(
+            name="FindExposedEntities",
+            arguments={"query": "kitch", "domain": "light", "area": "Cooking Space"},
+        )
+
+    assert not result.isError
+    payload = _tool_payload(result)
+    assert payload == {
+        "success": True,
+        "result": {
+            "matches": [
+                {
+                    "name": "Kitchen Light",
+                    "domain": "light",
+                    "area": "Kitchen",
+                }
+            ],
+            "truncated": False,
+        },
+    }
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_find_exposed_entities_tool_no_match(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test a no-match search result through MCP."""
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.call_tool(
+            name="FindExposedEntities",
+            arguments={"query": "garage fan"},
+        )
+
+    assert not result.isError
+    assert _tool_payload(result) == {
+        "success": True,
+        "result": {"matches": [], "truncated": False},
+    }
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_find_exposed_entities_tool_invalid_area(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test invalid area handling through MCP."""
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.call_tool(
+            name="FindExposedEntities",
+            arguments={"query": "kitchen", "area": "Unknown Area"},
+        )
+
+    assert not result.isError
+    assert _tool_payload(result) == {
+        "success": False,
+        "error": "Area not found",
+    }
 
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -402,9 +402,18 @@ async def test_mcp_tools_list(
     assert search_tool.inputSchema == {
         "type": "object",
         "properties": {
-            "query": {"description": "Search text to match against exposed entity names and aliases", "type": "string"},
-            "domain": {"description": "Limit results to one domain such as light, climate, or script", "type": "string"},
-            "area": {"description": "Limit results to one area name or alias", "type": "string"},
+            "query": {
+                "description": "Search text to match against exposed entity names and aliases",
+                "type": "string",
+            },
+            "domain": {
+                "description": "Limit results to one domain such as light, climate, or script",
+                "type": "string",
+            },
+            "area": {
+                "description": "Limit results to one area name or alias",
+                "type": "string",
+            },
             "limit": {
                 "description": "Maximum number of matches to return",
                 "default": 5,

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -183,7 +183,11 @@ async def test_assist_api(
 
     assert len(llm.async_get_apis(hass)) == 1
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert [tool.name for tool in api.tools] == ["GetDateTime", "GetLiveContext"]
+    assert [tool.name for tool in api.tools] == [
+        "GetDateTime",
+        "FindExposedEntities",
+        "GetLiveContext",
+    ]
 
     # Match all
     intent_handler.platforms = None
@@ -192,6 +196,7 @@ async def test_assist_api(
     assert [tool.name for tool in api.tools] == [
         "test_intent",
         "GetDateTime",
+        "FindExposedEntities",
         "GetLiveContext",
     ]
 
@@ -199,7 +204,7 @@ async def test_assist_api(
     intent_handler.platforms = {"light"}
 
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert len(api.tools) == 3
+    assert len(api.tools) == 4
     tool = api.tools[0]
     assert tool.name == "test_intent"
     assert tool.description == "Execute Home Assistant test_intent intent"
@@ -1489,6 +1494,164 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     assert calls[0].data == {
         "entity_id": ["todo.test_list"],
         "status": ["needs_action", "completed"],
+    }
+
+
+async def test_find_exposed_entities_tool(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test the exposed entity search tool."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    kitchen = area_registry.async_create("Kitchen", aliases={"Cooking Space"})
+
+    kitchen_light_entry = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "kitchen-ceiling",
+        suggested_object_id="kitchen_ceiling",
+        original_name="Kitchen Ceiling Light",
+    )
+    entity_registry.async_update_entity(
+        kitchen_light_entry.entity_id,
+        area_id=kitchen.id,
+        aliases=["Ceiling Lamp"],
+    )
+    coffee_machine_entry = entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "coffee-machine",
+        suggested_object_id="coffee_machine",
+        original_name="Coffee Machine",
+    )
+
+    hass.states.async_set(
+        kitchen_light_entry.entity_id,
+        "off",
+        {"friendly_name": "Kitchen Ceiling Light"},
+    )
+    hass.states.async_set(
+        coffee_machine_entry.entity_id,
+        "off",
+        {"friendly_name": "Coffee Machine"},
+    )
+
+    async_expose_entity(hass, "conversation", kitchen_light_entry.entity_id, True)
+    async_expose_entity(hass, "conversation", coffee_machine_entry.entity_id, False)
+
+    llm_context = llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+    api = await llm.async_get_api(hass, "assist", llm_context)
+
+    tool = next((tool for tool in api.tools if tool.name == "FindExposedEntities"), None)
+    assert tool is not None
+
+    result = await tool.async_call(
+        hass,
+        llm.ToolInput(
+            "FindExposedEntities",
+            {"query": "ceiling lamp", "domain": "light", "area": "Cooking Space"},
+        ),
+        llm_context,
+    )
+
+    assert result == {
+        "success": True,
+        "result": {
+            "matches": [
+                {
+                    "name": "Kitchen Ceiling Light",
+                    "domain": "light",
+                    "aliases": ["Ceiling Lamp"],
+                    "area": "Kitchen",
+                }
+            ],
+            "truncated": False,
+        },
+    }
+
+    no_match_result = await tool.async_call(
+        hass,
+        llm.ToolInput("FindExposedEntities", {"query": "garage fan"}),
+        llm_context,
+    )
+    assert no_match_result == {
+        "success": True,
+        "result": {"matches": [], "truncated": False},
+    }
+
+
+async def test_find_exposed_entities_tool_avoids_false_positive_substring_matches(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the search tool avoids unrelated substring matches."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    lamp_entry = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "desk-lamp",
+        suggested_object_id="desk_lamp",
+        original_name="Desk Lamp",
+    )
+    clamp_entry = entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "bench-clamp",
+        suggested_object_id="bench_clamp",
+        original_name="Bench Clamp",
+    )
+
+    hass.states.async_set(
+        lamp_entry.entity_id,
+        "off",
+        {"friendly_name": "Desk Lamp"},
+    )
+    hass.states.async_set(
+        clamp_entry.entity_id,
+        "off",
+        {"friendly_name": "Bench Clamp"},
+    )
+
+    async_expose_entity(hass, "conversation", lamp_entry.entity_id, True)
+    async_expose_entity(hass, "conversation", clamp_entry.entity_id, True)
+
+    llm_context = llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+    api = await llm.async_get_api(hass, "assist", llm_context)
+    tool = next((tool for tool in api.tools if tool.name == "FindExposedEntities"), None)
+    assert tool is not None
+
+    result = await tool.async_call(
+        hass,
+        llm.ToolInput("FindExposedEntities", {"query": "lamp"}),
+        llm_context,
+    )
+
+    assert result == {
+        "success": True,
+        "result": {
+            "matches": [
+                {
+                    "name": "Desk Lamp",
+                    "domain": "light",
+                }
+            ],
+            "truncated": False,
+        },
     }
 
 

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1550,7 +1550,9 @@ async def test_find_exposed_entities_tool(
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
 
-    tool = next((tool for tool in api.tools if tool.name == "FindExposedEntities"), None)
+    tool = next(
+        (tool for tool in api.tools if tool.name == "FindExposedEntities"), None
+    )
     assert tool is not None
 
     result = await tool.async_call(
@@ -1632,7 +1634,9 @@ async def test_find_exposed_entities_tool_avoids_false_positive_substring_matche
         device_id=None,
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
-    tool = next((tool for tool in api.tools if tool.name == "FindExposedEntities"), None)
+    tool = next(
+        (tool for tool in api.tools if tool.name == "FindExposedEntities"), None
+    )
     assert tool is not None
 
     result = await tool.async_call(


### PR DESCRIPTION
## Breaking change


## Proposed change
Add a small read-only `FindExposedEntities` tool to the Assist LLM API surface so models can discover exposed Home Assistant entities by query, with optional domain and area narrowing.

This keeps the change in the underlying Assist/LLM API surface instead of adding a custom `mcp_server`-only feature, which means the native MCP server exposes the new tool automatically through the configured LLM API.

The tool only searches entities already exposed to the assistant and returns concise structured matches intended to help a model refer to entities correctly in existing Assist intent tools. The PR also adds external MCP HTTP session coverage for tool listing, successful calls, exposed-entity filtering, and clean no-match / invalid-area handling.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr