### PR TITLE
Improve iaqualink reauthentication flow

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -93,6 +93,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
     try:
         systems = await aqualink.get_systems()
+    except AqualinkServiceUnauthorizedException as auth_exception:
+        await aqualink.close()
+        raise ConfigEntryAuthFailed(
+            "Invalid credentials for iAqualink"
+        ) from auth_exception
     except AqualinkServiceException as svc_exception:
         await aqualink.close()
         raise ConfigEntryNotReady(
@@ -120,6 +125,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
         try:
             devices = await system.get_devices()
+        except AqualinkServiceUnauthorizedException as auth_exception:
+            await aqualink.close()
+            raise ConfigEntryAuthFailed(
+                "Invalid credentials for iAqualink"
+            ) from auth_exception
         except AqualinkServiceException as svc_exception:
             await aqualink.close()
             raise ConfigEntryNotReady(

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -121,7 +121,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
     for system in systems_list:
         coordinator = AqualinkDataUpdateCoordinator(hass, entry, system)
         runtime_data.coordinators[system.serial] = coordinator
-        await coordinator.async_config_entry_first_refresh()
+        try:
+            await coordinator.async_config_entry_first_refresh()
+        except ConfigEntryAuthFailed:
+            await aqualink.close()
+            raise
 
         try:
             devices = await system.get_devices()

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import httpx
@@ -19,11 +20,45 @@ from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
 
 from .const import DOMAIN
 
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
 
 class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
     """Aqualink config flow."""
 
     VERSION = 1
+
+    async def _async_test_credentials(
+        self, user_input: dict[str, Any]
+    ) -> dict[str, str]:
+        """Validate credentials against iAqualink."""
+        try:
+            async with AqualinkClient(
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+                httpx_client=get_async_client(
+                    self.hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2
+                ),
+            ):
+                pass
+        except AqualinkServiceUnauthorizedException:
+            return {"base": "invalid_auth"}
+        except AqualinkServiceException, httpx.HTTPError:
+            return {"base": "cannot_connect"}
+
+        return {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -32,32 +67,44 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            username = user_input[CONF_USERNAME]
-            password = user_input[CONF_PASSWORD]
-
-            try:
-                async with AqualinkClient(
-                    username,
-                    password,
-                    httpx_client=get_async_client(
-                        self.hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2
-                    ),
-                ):
-                    pass
-            except AqualinkServiceUnauthorizedException:
-                errors["base"] = "invalid_auth"
-            except AqualinkServiceException, httpx.HTTPError:
-                errors["base"] = "cannot_connect"
-            else:
-                return self.async_create_entry(title=username, data=user_input)
+            errors = await self._async_test_credentials(user_input)
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_USERNAME], data=user_input
+                )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
-                }
-            ),
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle flow triggered by an authentication failure."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle confirmation of reauthentication."""
+        errors = {}
+
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            errors = await self._async_test_credentials(user_input)
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -90,6 +90,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
             if not errors:
                 return self.async_update_reload_and_abort(
                     reauth_entry,
+                    title=user_input[CONF_USERNAME],
                     data_updates={
                         CONF_USERNAME: user_input[CONF_USERNAME],
                         CONF_PASSWORD: user_input[CONF_PASSWORD],

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -20,14 +20,7 @@ from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
 
 from .const import DOMAIN
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
-    }
-)
-
-STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+CREDENTIALS_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
@@ -75,7 +68,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=CREDENTIALS_DATA_SCHEMA,
             errors=errors,
         )
 
@@ -105,6 +98,6 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            data_schema=CREDENTIALS_DATA_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -6,10 +6,14 @@ import logging
 from typing import Any
 
 import httpx
-from iaqualink.exception import AqualinkServiceException
+from iaqualink.exception import (
+    AqualinkServiceException,
+    AqualinkServiceUnauthorizedException,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, UPDATE_INTERVAL
@@ -37,6 +41,8 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
         """Refresh internal state for a system."""
         try:
             await self.system.update()
+        except AqualinkServiceUnauthorizedException as err:
+            raise ConfigEntryAuthFailed("Invalid credentials for iAqualink") from err
         except (AqualinkServiceException, httpx.HTTPError) as err:
             raise UpdateFailed(
                 f"Unable to update iAqualink system {self.system.serial}: {err}"

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -10,9 +10,10 @@
     "step": {
       "reauth_confirm": {
         "data": {
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
         },
-        "description": "Update your iAqualink password.",
+        "description": "Please enter the username and password for your iAqualink account.",
         "title": "Reauthenticate iAqualink"
       },
       "user": {

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -1,10 +1,20 @@
 {
   "config": {
+    "abort": {
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "description": "Update your iAqualink password.",
+        "title": "Reauthenticate iAqualink"
+      },
       "user": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -9,6 +9,7 @@ from iaqualink.exception import (
 
 from homeassistant.components.iaqualink import DOMAIN, config_flow
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -97,3 +98,81 @@ async def test_with_existing_config(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == config_data["username"]
     assert result["data"] == config_data
+
+
+async def test_reauth_success(hass: HomeAssistant, config_data) -> None:
+    """Test successful reauthentication."""
+    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_reload",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: config_data[CONF_USERNAME], CONF_PASSWORD: "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert dict(entry.data) == {
+        **config_data,
+        CONF_USERNAME: config_data[CONF_USERNAME],
+        CONF_PASSWORD: "new_password",
+    }
+
+
+async def test_reauth_invalid_auth(hass: HomeAssistant, config_data) -> None:
+    """Test reauthentication with invalid credentials."""
+    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        side_effect=AqualinkServiceUnauthorizedException,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: config_data[CONF_USERNAME], CONF_PASSWORD: "bad_password"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_reauth_cannot_connect(hass: HomeAssistant, config_data) -> None:
+    """Test reauthentication when the service cannot be reached."""
+    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        side_effect=AqualinkServiceException,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: config_data[CONF_USERNAME], CONF_PASSWORD: "new_password"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -100,7 +100,7 @@ async def test_with_existing_config(
     assert result["data"] == config_data
 
 
-async def test_reauth_success(hass: HomeAssistant, config_data) -> None:
+async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) -> None:
     """Test successful reauthentication."""
     entry = MockConfigEntry(domain=DOMAIN, data=config_data)
     entry.add_to_hass(hass)
@@ -136,7 +136,9 @@ async def test_reauth_success(hass: HomeAssistant, config_data) -> None:
     }
 
 
-async def test_reauth_invalid_auth(hass: HomeAssistant, config_data) -> None:
+async def test_reauth_invalid_auth(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
     """Test reauthentication with invalid credentials."""
     entry = MockConfigEntry(domain=DOMAIN, data=config_data)
     entry.add_to_hass(hass)
@@ -157,7 +159,9 @@ async def test_reauth_invalid_auth(hass: HomeAssistant, config_data) -> None:
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_reauth_cannot_connect(hass: HomeAssistant, config_data) -> None:
+async def test_reauth_cannot_connect(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
     """Test reauthentication when the service cannot be reached."""
     entry = MockConfigEntry(domain=DOMAIN, data=config_data)
     entry.add_to_hass(hass)

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -102,8 +102,14 @@ async def test_with_existing_config(
 
 async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) -> None:
     """Test successful reauthentication."""
-    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=config_data[CONF_USERNAME],
+        data=config_data,
+    )
     entry.add_to_hass(hass)
+
+    new_username = "updated@example.com"
 
     result = await entry.start_reauth_flow(hass)
 
@@ -123,15 +129,16 @@ async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) 
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_USERNAME: config_data[CONF_USERNAME], CONF_PASSWORD: "new_password"},
+            {CONF_USERNAME: new_username, CONF_PASSWORD: "new_password"},
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+    assert entry.title == new_username
     assert dict(entry.data) == {
         **config_data,
-        CONF_USERNAME: config_data[CONF_USERNAME],
+        CONF_USERNAME: new_username,
         CONF_PASSWORD: "new_password",
     }
 

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -23,7 +23,7 @@ from homeassistant.components.iaqualink.const import UPDATE_INTERVAL
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
@@ -195,6 +195,10 @@ async def test_setup_login_unauthorized(hass: HomeAssistant, config_entry) -> No
 
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+
 
 async def test_setup_login_timeout(
     hass: HomeAssistant, config_entry: MockConfigEntry
@@ -232,6 +236,32 @@ async def test_setup_systems_exception(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_systems_unauthorized(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test setup encountering an unauthorized exception while retrieving systems."""
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            side_effect=AqualinkServiceUnauthorizedException,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
 
 
 async def test_setup_no_systems_recognized(
@@ -587,3 +617,47 @@ async def test_entity_assumed_and_available(
     state = hass.states.get(name)
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_ASSUMED_STATE) is None
+
+
+async def test_system_refresh_unauthorized_triggers_reauth(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an unauthorized refresh starts reauthentication."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
+    systems = {system.serial: system}
+
+    light = get_aqualink_device(
+        system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
+    )
+    system.get_devices = AsyncMock(return_value={light.name: light})
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    system.update = AsyncMock(side_effect=AqualinkServiceUnauthorizedException)
+
+    await _advance_coordinator_time(hass, freezer)
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    assert flows[0]["context"]["entry_id"] == config_entry.entry_id

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -182,7 +182,9 @@ async def test_setup_login_exception(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_login_unauthorized(hass: HomeAssistant, config_entry) -> None:
+async def test_setup_login_unauthorized(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test setup encountering an unauthorized exception during login."""
     config_entry.add_to_hass(hass)
 
@@ -258,6 +260,41 @@ async def test_setup_systems_unauthorized(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+
+
+async def test_setup_first_refresh_unauthorized_closes_client(
+    hass: HomeAssistant, config_entry: MockConfigEntry, client: AqualinkClient
+) -> None:
+    """Test setup closes the client when first refresh triggers reauthentication."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.update = AsyncMock(side_effect=AqualinkServiceUnauthorizedException)
+    systems = {system.serial: system}
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.close",
+            new_callable=AsyncMock,
+        ) as mock_close,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    mock_close.assert_awaited_once()
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Prompt for the username and password during iAqualink reauthentication instead of
reusing the stored username.

Also trigger a Home Assistant reauthentication flow when iAqualink rejects
credentials during setup or coordinator refresh, so expired or changed
credentials surface as a repair flow instead of a generic setup or update
failure.

Tests cover the reauthentication flow and auth failures during setup and
coordinator updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging the code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
