### PR TITLE
Allow removing devices that are no longer available in fjaraskupan

### DIFF
--- a/homeassistant/components/fjaraskupan/__init__.py
+++ b/homeassistant/components/fjaraskupan/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.components.bluetooth import (
     BluetoothChange,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
+    async_discovered_service_info,
     async_rediscover_address,
     async_register_callback,
 )
@@ -131,3 +132,17 @@ async def async_unload_entry(
                     async_rediscover_address(hass, conn[1])
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: FjaraskupanConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Remove a config entry from a device."""
+    for service_info in async_discovered_service_info(hass, False):
+        if (DOMAIN, service_info.address) in device_entry.identifiers:
+            return False
+
+    # No matching service info, so allow removal.
+    return True

--- a/tests/components/fjaraskupan/test_init.py
+++ b/tests/components/fjaraskupan/test_init.py
@@ -1,0 +1,90 @@
+"""Test the Fjäråskupan integration init."""
+
+from fjaraskupan import ANNOUNCE_MANUFACTURER, DEVICE_NAME
+from habluetooth import BluetoothServiceInfo
+
+from homeassistant.components.fjaraskupan.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import (
+    inject_bluetooth_service_info,
+    patch_discovered_devices,
+)
+from tests.typing import WebSocketGenerator
+
+MOCK_SERVICE_INFO = BluetoothServiceInfo(
+    address="11:11:11:11:11:11",
+    name=DEVICE_NAME,
+    service_uuids=[],
+    rssi=-60,
+    manufacturer_data={ANNOUNCE_MANUFACTURER: b"ODFJAR\x01\x02\x00\x00\x00\x30\x04"},
+    service_data={},
+    source="local",
+)
+
+
+async def test_setup(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test setup creates expected device."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id) is True
+
+    inject_bluetooth_service_info(
+        hass,
+        MOCK_SERVICE_INFO,
+    )
+
+    await hass.async_block_till_done()
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, MOCK_SERVICE_INFO.address)}
+    )
+    assert device_entry is not None
+    assert device_entry.manufacturer == "Fjäråskupan"
+    assert device_entry.name == "Fjäråskupan"
+
+
+async def test_remove_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test we can remove devices that are not available."""
+    assert await async_setup_component(hass, "config", {})
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id) is True
+
+    inject_bluetooth_service_info(hass, MOCK_SERVICE_INFO)
+
+    await hass.async_block_till_done()
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, MOCK_SERVICE_INFO.address)}
+    )
+    assert device_entry
+
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+    await hass.async_block_till_done()
+    assert device_registry.async_get(device_entry.id)
+
+    with patch_discovered_devices([]):
+        response = await client.remove_device(device_entry.id, config_entry.entry_id)
+        assert response["success"]
+
+        await hass.async_block_till_done()
+        assert not device_registry.async_get(device_entry.id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow removing no longer available devices in fjaraskupan


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
