### PR TITLE
Use model info from API for Maximum tokens in Anthropic config flow

### DIFF
--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -65,6 +65,7 @@ from .const import (
     DEFAULT_AI_TASK_NAME,
     DEFAULT_CONVERSATION_NAME,
     DOMAIN,
+    MIN_THINKING_BUDGET,
     NON_ADAPTIVE_THINKING_MODELS,
     NON_THINKING_MODELS,
     TOOL_SEARCH_UNSUPPORTED_MODELS,
@@ -486,9 +487,12 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
             user_input = {}  # pragma: no cover
 
         if user_input is not None:
-            if user_input.get(
-                CONF_THINKING_BUDGET, DEFAULT[CONF_THINKING_BUDGET]
-            ) >= user_input.get(CONF_MAX_TOKENS, DEFAULT[CONF_MAX_TOKENS]):
+            if (
+                CONF_THINKING_BUDGET in user_input
+                and user_input[CONF_THINKING_BUDGET] >= MIN_THINKING_BUDGET
+                and user_input[CONF_THINKING_BUDGET]
+                >= user_input.get(CONF_MAX_TOKENS, DEFAULT[CONF_MAX_TOKENS])
+            ):
                 errors[CONF_THINKING_BUDGET] = "thinking_budget_too_large"
 
             if user_input.get(CONF_WEB_SEARCH, DEFAULT[CONF_WEB_SEARCH]) and not errors:

--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import llm
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.selector import (
     NumberSelector,
@@ -325,10 +326,6 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
                 SelectSelectorConfig(options=self._get_model_list(), custom_value=True)
             ),
             vol.Optional(
-                CONF_MAX_TOKENS,
-                default=DEFAULT[CONF_MAX_TOKENS],
-            ): int,
-            vol.Optional(
                 CONF_TEMPERATURE,
                 default=DEFAULT[CONF_TEMPERATURE],
             ): NumberSelector(NumberSelectorConfig(min=0, max=1, step=0.05)),
@@ -384,7 +381,19 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
         """Manage model-specific options."""
         errors: dict[str, str] = {}
 
-        step_schema: VolDictType = {}
+        step_schema: VolDictType = {
+            vol.Optional(
+                CONF_MAX_TOKENS,
+                default=DEFAULT[CONF_MAX_TOKENS],
+            ): vol.All(
+                NumberSelector(
+                    NumberSelectorConfig(min=0, max=self.model_info.max_tokens)
+                ),
+                vol.Coerce(int),
+            )
+            if self.model_info.max_tokens
+            else cv.positive_int,
+        }
 
         model = self.options[CONF_CHAT_MODEL]
 
@@ -395,14 +404,15 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
                 vol.Optional(
                     CONF_THINKING_BUDGET, default=DEFAULT[CONF_THINKING_BUDGET]
                 )
-            ] = vol.All(
-                NumberSelector(
-                    NumberSelectorConfig(
-                        min=0,
-                        max=self.options.get(CONF_MAX_TOKENS, DEFAULT[CONF_MAX_TOKENS]),
-                    )
-                ),
-                vol.Coerce(int),
+            ] = (
+                vol.All(
+                    NumberSelector(
+                        NumberSelectorConfig(min=0, max=self.model_info.max_tokens)
+                    ),
+                    vol.Coerce(int),
+                )
+                if self.model_info.max_tokens
+                else cv.positive_int
             )
         else:
             self.options.pop(CONF_THINKING_BUDGET, None)
@@ -471,9 +481,16 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
             self.options.pop(CONF_TOOL_SEARCH, None)
 
         if not step_schema:
-            user_input = {}
+            # Currently our schema is always present, but if one day it becomes empty,
+            # then the below line is needed to skip this step
+            user_input = {}  # pragma: no cover
 
         if user_input is not None:
+            if user_input.get(
+                CONF_THINKING_BUDGET, DEFAULT[CONF_THINKING_BUDGET]
+            ) >= user_input.get(CONF_MAX_TOKENS, DEFAULT[CONF_MAX_TOKENS]):
+                errors[CONF_THINKING_BUDGET] = "thinking_budget_too_large"
+
             if user_input.get(CONF_WEB_SEARCH, DEFAULT[CONF_WEB_SEARCH]) and not errors:
                 if user_input.get(
                     CONF_WEB_SEARCH_USER_LOCATION,

--- a/homeassistant/components/anthropic/strings.json
+++ b/homeassistant/components/anthropic/strings.json
@@ -51,13 +51,11 @@
         "advanced": {
           "data": {
             "chat_model": "[%key:common::generic::model%]",
-            "max_tokens": "[%key:component::anthropic::config_subentries::conversation::step::advanced::data::max_tokens%]",
             "prompt_caching": "[%key:component::anthropic::config_subentries::conversation::step::advanced::data::prompt_caching%]",
             "temperature": "[%key:component::anthropic::config_subentries::conversation::step::advanced::data::temperature%]"
           },
           "data_description": {
             "chat_model": "[%key:component::anthropic::config_subentries::conversation::step::advanced::data_description::chat_model%]",
-            "max_tokens": "[%key:component::anthropic::config_subentries::conversation::step::advanced::data_description::max_tokens%]",
             "prompt_caching": "[%key:component::anthropic::config_subentries::conversation::step::advanced::data_description::prompt_caching%]",
             "temperature": "[%key:component::anthropic::config_subentries::conversation::step::advanced::data_description::temperature%]"
           },
@@ -77,6 +75,7 @@
         "model": {
           "data": {
             "code_execution": "[%key:component::anthropic::config_subentries::conversation::step::model::data::code_execution%]",
+            "max_tokens": "[%key:component::anthropic::config_subentries::conversation::step::model::data::max_tokens%]",
             "thinking_budget": "[%key:component::anthropic::config_subentries::conversation::step::model::data::thinking_budget%]",
             "thinking_effort": "[%key:component::anthropic::config_subentries::conversation::step::model::data::thinking_effort%]",
             "tool_search": "[%key:component::anthropic::config_subentries::conversation::step::model::data::tool_search%]",
@@ -86,6 +85,7 @@
           },
           "data_description": {
             "code_execution": "[%key:component::anthropic::config_subentries::conversation::step::model::data_description::code_execution%]",
+            "max_tokens": "[%key:component::anthropic::config_subentries::conversation::step::model::data_description::max_tokens%]",
             "thinking_budget": "[%key:component::anthropic::config_subentries::conversation::step::model::data_description::thinking_budget%]",
             "thinking_effort": "[%key:component::anthropic::config_subentries::conversation::step::model::data_description::thinking_effort%]",
             "tool_search": "[%key:component::anthropic::config_subentries::conversation::step::model::data_description::tool_search%]",
@@ -116,13 +116,11 @@
         "advanced": {
           "data": {
             "chat_model": "[%key:common::generic::model%]",
-            "max_tokens": "Maximum tokens to return in response",
             "prompt_caching": "Caching strategy",
             "temperature": "Temperature"
           },
           "data_description": {
             "chat_model": "The model to serve the responses.",
-            "max_tokens": "Limit the number of response tokens.",
             "prompt_caching": "Optimize your API cost and response times based on your usage.",
             "temperature": "Control the randomness of the response, trading off between creativity and coherence."
           },
@@ -146,6 +144,7 @@
         "model": {
           "data": {
             "code_execution": "Code execution",
+            "max_tokens": "Maximum tokens to return in response",
             "thinking_budget": "Thinking budget",
             "thinking_effort": "Thinking effort",
             "tool_search": "Enable tool search tool",
@@ -155,6 +154,7 @@
           },
           "data_description": {
             "code_execution": "Allow the model to execute code in a secure sandbox environment, enabling it to analyze data and perform complex calculations.",
+            "max_tokens": "Limit the number of response tokens.",
             "thinking_budget": "The number of tokens the model can use to think about the response out of the total maximum number of tokens. Set to 1024 or greater to enable extended thinking.",
             "thinking_effort": "Control how many tokens Claude uses when responding, trading off between response thoroughness and token efficiency",
             "tool_search": "Enable dynamic tool discovery instead of preloading all tools into the context",

--- a/homeassistant/components/anthropic/strings.json
+++ b/homeassistant/components/anthropic/strings.json
@@ -40,7 +40,8 @@
       "entry_type": "AI task",
       "error": {
         "api_error": "[%key:component::anthropic::config_subentries::conversation::error::api_error%]",
-        "model_not_found": "[%key:component::anthropic::config_subentries::conversation::error::model_not_found%]"
+        "model_not_found": "[%key:component::anthropic::config_subentries::conversation::error::model_not_found%]",
+        "thinking_budget_too_large": "[%key:component::anthropic::config_subentries::conversation::error::thinking_budget_too_large%]"
       },
       "initiate_flow": {
         "reconfigure": "Reconfigure AI task",
@@ -104,7 +105,8 @@
       "entry_type": "Conversation agent",
       "error": {
         "api_error": "Unable to get model info: {message}",
-        "model_not_found": "Model not found"
+        "model_not_found": "Model not found",
+        "thinking_budget_too_large": "Thinking budget must be less than the Maximum tokens."
       },
       "initiate_flow": {
         "reconfigure": "Reconfigure conversation agent",

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -253,6 +253,64 @@ async def test_api_error(hass: HomeAssistant, side_effect, error) -> None:
     }
 
 
+async def test_subentry_options_thinking_budget_more_than_max(
+    hass: HomeAssistant, mock_config_entry, mock_init_component
+) -> None:
+    """Test error about thinking budget being more than max tokens."""
+    subentry = next(iter(mock_config_entry.subentries.values()))
+    options = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, subentry.subentry_id
+    )
+
+    # Configure initial step
+    options = await hass.config_entries.subentries.async_configure(
+        options["flow_id"],
+        {
+            "prompt": "Speak like a pirate",
+            "recommended": False,
+        },
+    )
+    assert options["type"] is FlowResultType.FORM
+    assert options["step_id"] == "advanced"
+
+    # Configure advanced step
+    options = await hass.config_entries.subentries.async_configure(
+        options["flow_id"],
+        {
+            "chat_model": "claude-sonnet-4-5",
+            "temperature": 1,
+        },
+    )
+    assert options["type"] is FlowResultType.FORM
+    assert options["step_id"] == "model"
+
+    # Configure model step
+    options = await hass.config_entries.subentries.async_configure(
+        options["flow_id"],
+        {
+            "max_tokens": 8192,
+            "thinking_budget": 16384,
+        },
+    )
+    await hass.async_block_till_done()
+    assert options["type"] is FlowResultType.FORM
+    assert options["errors"] == {"thinking_budget": "thinking_budget_too_large"}
+
+    # Try again
+    options = await hass.config_entries.subentries.async_configure(
+        options["flow_id"],
+        {
+            "max_tokens": 16384,
+            "thinking_budget": 8192,
+        },
+    )
+    await hass.async_block_till_done()
+    assert options["type"] is FlowResultType.ABORT
+    assert options["reason"] == "reconfigure_successful"
+    assert subentry.data["max_tokens"] == 16384
+    assert subentry.data["thinking_budget"] == 8192
+
+
 async def test_subentry_web_search_user_location(
     hass: HomeAssistant, mock_config_entry, mock_init_component
 ) -> None:
@@ -277,7 +335,6 @@ async def test_subentry_web_search_user_location(
     options = await hass.config_entries.subentries.async_configure(
         options["flow_id"],
         {
-            "max_tokens": 8192,
             "chat_model": "claude-sonnet-4-5",
         },
     )
@@ -311,6 +368,7 @@ async def test_subentry_web_search_user_location(
         options = await hass.config_entries.subentries.async_configure(
             options["flow_id"],
             {
+                "max_tokens": 8192,
                 "web_search": True,
                 "web_search_max_uses": 5,
                 "user_location": True,
@@ -493,32 +551,6 @@ async def test_invalid_model(
                 CONF_LLM_HASS_API: ["assist"],
             },
         ),
-        (  # Model with no model-specific options
-            {
-                CONF_RECOMMENDED: True,
-                CONF_PROMPT: "bla",
-                CONF_LLM_HASS_API: ["assist"],
-            },
-            (
-                {
-                    CONF_RECOMMENDED: False,
-                    CONF_PROMPT: "Speak like a pirate",
-                },
-                {
-                    CONF_CHAT_MODEL: "claude-3-haiku-20240307",
-                    CONF_TEMPERATURE: 1.0,
-                    CONF_PROMPT_CACHING: "prompt",
-                },
-            ),
-            {
-                CONF_RECOMMENDED: False,
-                CONF_PROMPT: "Speak like a pirate",
-                CONF_TEMPERATURE: 1.0,
-                CONF_CHAT_MODEL: "claude-3-haiku-20240307",
-                CONF_MAX_TOKENS: DEFAULT[CONF_MAX_TOKENS],
-                CONF_PROMPT_CACHING: "prompt",
-            },
-        ),
         (  # Model with web search options
             {
                 CONF_RECOMMENDED: False,
@@ -571,6 +603,7 @@ async def test_invalid_model(
                 CONF_RECOMMENDED: False,
                 CONF_CHAT_MODEL: "claude-sonnet-4-5",
                 CONF_PROMPT: "bla",
+                CONF_LLM_HASS_API: ["assist"],
                 CONF_PROMPT_CACHING: "off",
                 CONF_TOOL_SEARCH: False,
                 CONF_WEB_SEARCH: False,
@@ -583,7 +616,6 @@ async def test_invalid_model(
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like a pirate",
-                    CONF_LLM_HASS_API: [],
                 },
                 {
                     CONF_CHAT_MODEL: "claude-sonnet-4-5",
@@ -674,6 +706,7 @@ async def test_invalid_model(
                     CONF_LLM_HASS_API: [],
                 },
                 {
+                    CONF_CHAT_MODEL: "claude-3-haiku-20240307",
                     CONF_TEMPERATURE: 0.3,
                     CONF_PROMPT_CACHING: "automatic",
                 },
@@ -684,13 +717,8 @@ async def test_invalid_model(
                 CONF_PROMPT: "Speak like a pirate",
                 CONF_PROMPT_CACHING: "automatic",
                 CONF_TEMPERATURE: 0.3,
-                CONF_CHAT_MODEL: DEFAULT[CONF_CHAT_MODEL],
+                CONF_CHAT_MODEL: "claude-3-haiku-20240307",
                 CONF_MAX_TOKENS: DEFAULT[CONF_MAX_TOKENS],
-                CONF_THINKING_BUDGET: DEFAULT[CONF_THINKING_BUDGET],
-                CONF_WEB_SEARCH: False,
-                CONF_WEB_SEARCH_MAX_USES: 5,
-                CONF_WEB_SEARCH_USER_LOCATION: False,
-                CONF_CODE_EXECUTION: False,
             },
         ),
         (  # Test switching from custom to recommended options
@@ -860,7 +888,6 @@ async def test_creating_ai_task_subentry_advanced(
         result["flow_id"],
         {
             CONF_CHAT_MODEL: "claude-sonnet-4-5",
-            CONF_MAX_TOKENS: 1200,
             CONF_TEMPERATURE: 0.5,
         },
     )
@@ -872,6 +899,7 @@ async def test_creating_ai_task_subentry_advanced(
     result4 = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
+            CONF_MAX_TOKENS: 1200,
             CONF_WEB_SEARCH: False,
         },
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Anthropic API now returns the max tokens value for a model.
This PR uses it in the config flow to set the limit for Maximum tokens and Thinking budget values, allowing users to see how far they are from the max.
For this to work, the Maximum tokens settings has been moved to the last screen.
<img width="572" height="440" alt="image" src="https://github.com/user-attachments/assets/cb132061-0e27-4faf-a2a5-ddc48334359f" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
