### PR TITLE
Add support for away mode in ESPHome water heater

### DIFF
--- a/homeassistant/components/esphome/water_heater.py
+++ b/homeassistant/components/esphome/water_heater.py
@@ -11,6 +11,7 @@ from aioesphomeapi import (
     WaterHeaterInfo,
     WaterHeaterMode,
     WaterHeaterState,
+    WaterHeaterStateFlag,
 )
 
 from homeassistant.components.water_heater import (
@@ -72,6 +73,8 @@ class EsphomeWaterHeater(
             self._attr_operation_list = None
         if static_info.supported_features & WaterHeaterFeature.SUPPORTS_ON_OFF:
             features |= WaterHeaterEntityFeature.ON_OFF
+        if static_info.supported_features & WaterHeaterFeature.SUPPORTS_AWAY_MODE:
+            features |= WaterHeaterEntityFeature.AWAY_MODE
         self._attr_supported_features = features
 
     @property
@@ -125,6 +128,30 @@ class EsphomeWaterHeater(
         self._client.water_heater_command(
             key=self._key,
             on=False,
+            device_id=self._static_info.device_id,
+        )
+
+    @property
+    @esphome_state_property
+    def is_away_mode_on(self) -> bool | None:
+        """Return true if away mode is on."""
+        return bool(self._state.state & WaterHeaterStateFlag.AWAY)
+
+    @convert_api_error_ha_error
+    async def async_turn_away_mode_on(self) -> None:
+        """Turn away mode on."""
+        self._client.water_heater_command(
+            key=self._key,
+            away=True,
+            device_id=self._static_info.device_id,
+        )
+
+    @convert_api_error_ha_error
+    async def async_turn_away_mode_off(self) -> None:
+        """Turn away mode off."""
+        self._client.water_heater_command(
+            key=self._key,
+            away=False,
             device_id=self._static_info.device_id,
         )
 

--- a/homeassistant/components/esphome/water_heater.py
+++ b/homeassistant/components/esphome/water_heater.py
@@ -97,7 +97,7 @@ class EsphomeWaterHeater(
 
     @property
     @esphome_state_property
-    def is_away_mode_on(self) -> bool:
+    def is_away_mode_on(self) -> bool | None:
         """Return true if away mode is on."""
         return bool(self._state.state & WaterHeaterStateFlag.AWAY)
 

--- a/homeassistant/components/esphome/water_heater.py
+++ b/homeassistant/components/esphome/water_heater.py
@@ -95,6 +95,12 @@ class EsphomeWaterHeater(
         """Return current operation mode."""
         return _WATER_HEATER_MODES.from_esphome(self._state.mode)
 
+    @property
+    @esphome_state_property
+    def is_away_mode_on(self) -> bool:
+        """Return true if away mode is on."""
+        return bool(self._state.state & WaterHeaterStateFlag.AWAY)
+
     @convert_api_error_ha_error
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -130,12 +136,6 @@ class EsphomeWaterHeater(
             on=False,
             device_id=self._static_info.device_id,
         )
-
-    @property
-    @esphome_state_property
-    def is_away_mode_on(self) -> bool | None:
-        """Return true if away mode is on."""
-        return bool(self._state.state & WaterHeaterStateFlag.AWAY)
 
     @convert_api_error_ha_error
     async def async_turn_away_mode_on(self) -> None:

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -23,7 +23,11 @@ from homeassistant.components.water_heater import (
     SERVICE_TURN_ON,
     WaterHeaterEntityFeature,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_TEMPERATURE,
+)
 from homeassistant.core import HomeAssistant
 
 from .conftest import MockGenericDeviceEntryType
@@ -362,7 +366,8 @@ async def test_water_heater_away_mode_feature_flag(
     assert state is not None
     assert (
         bool(
-            state.attributes[ATTR_SUPPORTED_FEATURES] & WaterHeaterEntityFeature.AWAY_MODE
+            state.attributes[ATTR_SUPPORTED_FEATURES]
+            & WaterHeaterEntityFeature.AWAY_MODE
         )
         is has_away_mode
     )

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -409,7 +409,7 @@ async def test_water_heater_away_mode_state(
 
     state = hass.states.get("water_heater.test_my_boiler")
     assert state is not None
-    assert state.attributes.get(ATTR_AWAY_MODE) == expected_away_mode
+    assert state.attributes[ATTR_AWAY_MODE] == expected_away_mode
 
 
 @pytest.mark.parametrize("away_mode", [True, False])

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -362,7 +362,7 @@ async def test_water_heater_away_mode_feature_flag(
     assert state is not None
     assert (
         bool(
-            state.attributes["supported_features"] & WaterHeaterEntityFeature.AWAY_MODE
+            state.attributes[ATTR_SUPPORTED_FEATURES] & WaterHeaterEntityFeature.AWAY_MODE
         )
         is has_away_mode
     )

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -12,6 +12,7 @@ from aioesphomeapi import (
 )
 
 from homeassistant.components.water_heater import (
+    ATTR_AWAY_MODE,
     ATTR_OPERATION_LIST,
     DOMAIN as WATER_HEATER_DOMAIN,
     SERVICE_SET_AWAY_MODE,
@@ -497,7 +498,7 @@ async def test_water_heater_turn_away_mode_on(
         SERVICE_SET_AWAY_MODE,
         {
             ATTR_ENTITY_ID: "water_heater.test_my_boiler",
-            "away_mode": True,
+            ATTR_AWAY_MODE: True,
         },
         blocking=True,
     )
@@ -542,7 +543,7 @@ async def test_water_heater_turn_away_mode_off(
         SERVICE_SET_AWAY_MODE,
         {
             ATTR_ENTITY_ID: "water_heater.test_my_boiler",
-            "away_mode": False,
+            ATTR_AWAY_MODE: False,
         },
         blocking=True,
     )

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -10,6 +10,7 @@ from aioesphomeapi import (
     WaterHeaterState,
     WaterHeaterStateFlag,
 )
+import pytest
 
 from homeassistant.components.water_heater import (
     ATTR_AWAY_MODE,
@@ -324,12 +325,64 @@ async def test_water_heater_no_on_off_without_feature(
     )
 
 
+@pytest.mark.parametrize(
+    ("supported_features", "has_away_mode"),
+    [
+        (WaterHeaterFeature.SUPPORTS_AWAY_MODE, True),
+        (WaterHeaterFeature(0), False),
+    ],
+)
 async def test_water_heater_away_mode_feature_flag(
     hass: HomeAssistant,
     mock_client: APIClient,
     mock_generic_device_entry: MockGenericDeviceEntryType,
+    supported_features: WaterHeaterFeature,
+    has_away_mode: bool,
 ) -> None:
-    """Test AWAY_MODE feature flag is advertised when ESPHome reports SUPPORTS_AWAY_MODE."""
+    """Test AWAY_MODE feature flag tracks the ESPHome SUPPORTS_AWAY_MODE flag."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            supported_features=supported_features,
+        )
+    ]
+    states = [WaterHeaterState(key=1, target_temperature=50.0)]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert (
+        bool(
+            state.attributes["supported_features"] & WaterHeaterEntityFeature.AWAY_MODE
+        )
+        is has_away_mode
+    )
+
+
+@pytest.mark.parametrize(
+    ("state_flag", "expected_away_mode"),
+    [
+        (WaterHeaterStateFlag(0), "off"),
+        (WaterHeaterStateFlag.AWAY, "on"),
+    ],
+)
+async def test_water_heater_away_mode_state(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+    state_flag: WaterHeaterStateFlag,
+    expected_away_mode: str,
+) -> None:
+    """Test is_away_mode_on reflects the AWAY state flag."""
     entity_info = [
         WaterHeaterInfo(
             object_id="my_boiler",
@@ -344,6 +397,7 @@ async def test_water_heater_away_mode_feature_flag(
         WaterHeaterState(
             key=1,
             target_temperature=50.0,
+            state=state_flag,
         )
     ]
 
@@ -355,50 +409,17 @@ async def test_water_heater_away_mode_feature_flag(
 
     state = hass.states.get("water_heater.test_my_boiler")
     assert state is not None
-    assert state.attributes["supported_features"] & WaterHeaterEntityFeature.AWAY_MODE
+    assert state.attributes.get("away_mode") == expected_away_mode
 
 
-async def test_water_heater_no_away_mode_without_feature(
+@pytest.mark.parametrize("away_mode", [True, False])
+async def test_water_heater_set_away_mode(
     hass: HomeAssistant,
     mock_client: APIClient,
     mock_generic_device_entry: MockGenericDeviceEntryType,
+    away_mode: bool,
 ) -> None:
-    """Test AWAY_MODE feature is not set when not supported by ESPHome device."""
-    entity_info = [
-        WaterHeaterInfo(
-            object_id="my_boiler",
-            key=1,
-            name="My Boiler",
-            min_temperature=10.0,
-            max_temperature=85.0,
-        )
-    ]
-    states = [
-        WaterHeaterState(
-            key=1,
-            target_temperature=50.0,
-        )
-    ]
-
-    await mock_generic_device_entry(
-        mock_client=mock_client,
-        entity_info=entity_info,
-        states=states,
-    )
-
-    state = hass.states.get("water_heater.test_my_boiler")
-    assert state is not None
-    assert not (
-        state.attributes["supported_features"] & WaterHeaterEntityFeature.AWAY_MODE
-    )
-
-
-async def test_water_heater_away_mode_state_off(
-    hass: HomeAssistant,
-    mock_client: APIClient,
-    mock_generic_device_entry: MockGenericDeviceEntryType,
-) -> None:
-    """Test is_away_mode_on is off when AWAY bit is clear."""
+    """Test the set_away_mode service forwards the value to ESPHome."""
     entity_info = [
         WaterHeaterInfo(
             object_id="my_boiler",
@@ -413,77 +434,7 @@ async def test_water_heater_away_mode_state_off(
         WaterHeaterState(
             key=1,
             target_temperature=50.0,
-            state=0,
-        )
-    ]
-
-    await mock_generic_device_entry(
-        mock_client=mock_client,
-        entity_info=entity_info,
-        states=states,
-    )
-
-    state = hass.states.get("water_heater.test_my_boiler")
-    assert state is not None
-    assert state.attributes.get("away_mode") == "off"
-
-
-async def test_water_heater_away_mode_state_on(
-    hass: HomeAssistant,
-    mock_client: APIClient,
-    mock_generic_device_entry: MockGenericDeviceEntryType,
-) -> None:
-    """Test is_away_mode_on is on when AWAY bit is set."""
-    entity_info = [
-        WaterHeaterInfo(
-            object_id="my_boiler",
-            key=1,
-            name="My Boiler",
-            min_temperature=10.0,
-            max_temperature=85.0,
-            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
-        )
-    ]
-    states = [
-        WaterHeaterState(
-            key=1,
-            target_temperature=50.0,
-            state=WaterHeaterStateFlag.AWAY,
-        )
-    ]
-
-    await mock_generic_device_entry(
-        mock_client=mock_client,
-        entity_info=entity_info,
-        states=states,
-    )
-
-    state = hass.states.get("water_heater.test_my_boiler")
-    assert state is not None
-    assert state.attributes.get("away_mode") == "on"
-
-
-async def test_water_heater_turn_away_mode_on(
-    hass: HomeAssistant,
-    mock_client: APIClient,
-    mock_generic_device_entry: MockGenericDeviceEntryType,
-) -> None:
-    """Test turning away mode on sends away=True to ESPHome."""
-    entity_info = [
-        WaterHeaterInfo(
-            object_id="my_boiler",
-            key=1,
-            name="My Boiler",
-            min_temperature=10.0,
-            max_temperature=85.0,
-            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
-        )
-    ]
-    states = [
-        WaterHeaterState(
-            key=1,
-            target_temperature=50.0,
-            state=0,
+            state=WaterHeaterStateFlag(0),
         )
     ]
 
@@ -498,56 +449,11 @@ async def test_water_heater_turn_away_mode_on(
         SERVICE_SET_AWAY_MODE,
         {
             ATTR_ENTITY_ID: "water_heater.test_my_boiler",
-            ATTR_AWAY_MODE: True,
+            ATTR_AWAY_MODE: away_mode,
         },
         blocking=True,
     )
 
     mock_client.water_heater_command.assert_has_calls(
-        [call(key=1, away=True, device_id=0)]
-    )
-
-
-async def test_water_heater_turn_away_mode_off(
-    hass: HomeAssistant,
-    mock_client: APIClient,
-    mock_generic_device_entry: MockGenericDeviceEntryType,
-) -> None:
-    """Test turning away mode off sends away=False to ESPHome."""
-    entity_info = [
-        WaterHeaterInfo(
-            object_id="my_boiler",
-            key=1,
-            name="My Boiler",
-            min_temperature=10.0,
-            max_temperature=85.0,
-            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
-        )
-    ]
-    states = [
-        WaterHeaterState(
-            key=1,
-            target_temperature=50.0,
-            state=WaterHeaterStateFlag.AWAY,
-        )
-    ]
-
-    await mock_generic_device_entry(
-        mock_client=mock_client,
-        entity_info=entity_info,
-        states=states,
-    )
-
-    await hass.services.async_call(
-        WATER_HEATER_DOMAIN,
-        SERVICE_SET_AWAY_MODE,
-        {
-            ATTR_ENTITY_ID: "water_heater.test_my_boiler",
-            ATTR_AWAY_MODE: False,
-        },
-        blocking=True,
-    )
-
-    mock_client.water_heater_command.assert_has_calls(
-        [call(key=1, away=False, device_id=0)]
+        [call(key=1, away=away_mode, device_id=0)]
     )

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -8,11 +8,13 @@ from aioesphomeapi import (
     WaterHeaterInfo,
     WaterHeaterMode,
     WaterHeaterState,
+    WaterHeaterStateFlag,
 )
 
 from homeassistant.components.water_heater import (
     ATTR_OPERATION_LIST,
     DOMAIN as WATER_HEATER_DOMAIN,
+    SERVICE_SET_AWAY_MODE,
     SERVICE_SET_OPERATION_MODE,
     SERVICE_SET_TEMPERATURE,
     SERVICE_TURN_OFF,
@@ -318,4 +320,233 @@ async def test_water_heater_no_on_off_without_feature(
     assert state is not None
     assert not (
         state.attributes["supported_features"] & WaterHeaterEntityFeature.ON_OFF
+    )
+
+
+async def test_water_heater_away_mode_feature_flag(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test AWAY_MODE feature flag is advertised when ESPHome reports SUPPORTS_AWAY_MODE."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert state.attributes["supported_features"] & WaterHeaterEntityFeature.AWAY_MODE
+
+
+async def test_water_heater_no_away_mode_without_feature(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test AWAY_MODE feature is not set when not supported by ESPHome device."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert not (
+        state.attributes["supported_features"] & WaterHeaterEntityFeature.AWAY_MODE
+    )
+
+
+async def test_water_heater_away_mode_state_off(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test is_away_mode_on is off when AWAY bit is clear."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+            state=0,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert state.attributes.get("away_mode") == "off"
+
+
+async def test_water_heater_away_mode_state_on(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test is_away_mode_on is on when AWAY bit is set."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+            state=WaterHeaterStateFlag.AWAY,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert state.attributes.get("away_mode") == "on"
+
+
+async def test_water_heater_turn_away_mode_on(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test turning away mode on sends away=True to ESPHome."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+            state=0,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    await hass.services.async_call(
+        WATER_HEATER_DOMAIN,
+        SERVICE_SET_AWAY_MODE,
+        {
+            ATTR_ENTITY_ID: "water_heater.test_my_boiler",
+            "away_mode": True,
+        },
+        blocking=True,
+    )
+
+    mock_client.water_heater_command.assert_has_calls(
+        [call(key=1, away=True, device_id=0)]
+    )
+
+
+async def test_water_heater_turn_away_mode_off(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test turning away mode off sends away=False to ESPHome."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            supported_features=WaterHeaterFeature.SUPPORTS_AWAY_MODE,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+            state=WaterHeaterStateFlag.AWAY,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    await hass.services.async_call(
+        WATER_HEATER_DOMAIN,
+        SERVICE_SET_AWAY_MODE,
+        {
+            ATTR_ENTITY_ID: "water_heater.test_my_boiler",
+            "away_mode": False,
+        },
+        blocking=True,
+    )
+
+    mock_client.water_heater_command.assert_has_calls(
+        [call(key=1, away=False, device_id=0)]
     )

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -409,7 +409,7 @@ async def test_water_heater_away_mode_state(
 
     state = hass.states.get("water_heater.test_my_boiler")
     assert state is not None
-    assert state.attributes.get("away_mode") == expected_away_mode
+    assert state.attributes.get(ATTR_AWAY_MODE) == expected_away_mode
 
 
 @pytest.mark.parametrize("away_mode", [True, False])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for away mode in ESPHome water heater

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
