### PR TITLE
Recover Whisker coordinator when session loop is closed

### DIFF
--- a/homeassistant/components/litterrobot/coordinator.py
+++ b/homeassistant/components/litterrobot/coordinator.py
@@ -56,14 +56,83 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 if domain == DOMAIN:
                     self.previous_members.add(identifier)
 
+    def _account_session_is_usable(self) -> bool:
+        """Check whether the underlying aiohttp session is still usable."""
+        session = getattr(self.account, "session", None)
+        websession = getattr(session, "websession", None)
+
+        if websession is None:
+            return True
+
+        if websession.closed:
+            return False
+
+        loop = getattr(websession, "loop", None)
+        if loop is not None and loop.is_closed():
+            return False
+
+        return True
+
+    async def _reconnect_account(self, reason: str) -> None:
+        """Reconnect account after session/loop issues."""
+        _LOGGER.warning("Resetting Litter-Robot account connection: %s", reason)
+
+        try:
+            await self.account.disconnect()
+        except (LitterRobotException, RuntimeError):
+            _LOGGER.debug(
+                "Ignoring disconnect failure during account reset", exc_info=True
+            )
+
+        self.account = Account(websession=async_get_clientsession(self.hass))
+        await self.account.connect(
+            username=self.config_entry.data[CONF_USERNAME],
+            password=self.config_entry.data[CONF_PASSWORD],
+            load_robots=True,
+            subscribe_for_updates=True,
+            load_pets=True,
+        )
+
     async def _async_update_data(self) -> None:
         """Update all device states from the Litter-Robot API."""
+        if not self._account_session_is_usable():
+            try:
+                await self._reconnect_account(
+                    "detected closed session/loop before refresh"
+                )
+            except LitterRobotLoginException as ex:
+                raise ConfigEntryAuthFailed(
+                    translation_domain=DOMAIN, translation_key="invalid_credentials"
+                ) from ex
+            except LitterRobotException as ex:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="cannot_connect",
+                    translation_placeholders={"error": str(ex)},
+                ) from ex
+
         try:
             await self.account.load_robots(subscribe_for_updates=True)
             await self.account.load_pets()
             for pet in self.account.pets:
                 # Need to fetch weight history for `get_visits_since`
                 await pet.fetch_weight_history()
+        except RuntimeError as ex:
+            if "event loop is closed" not in str(ex).lower():
+                raise
+
+            try:
+                await self._reconnect_account("runtime error from closed event loop")
+            except LitterRobotLoginException as reconnect_ex:
+                raise ConfigEntryAuthFailed(
+                    translation_domain=DOMAIN, translation_key="invalid_credentials"
+                ) from reconnect_ex
+            except LitterRobotException as reconnect_ex:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="cannot_connect",
+                    translation_placeholders={"error": str(reconnect_ex)},
+                ) from reconnect_ex
         except LitterRobotLoginException as ex:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN, translation_key="invalid_credentials"
@@ -93,6 +162,9 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
+        if not self._account_session_is_usable():
+            self.account = Account(websession=async_get_clientsession(self.hass))
+
         try:
             await self.account.connect(
                 username=self.config_entry.data[CONF_USERNAME],
@@ -101,6 +173,11 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 subscribe_for_updates=True,
                 load_pets=True,
             )
+        except RuntimeError as ex:
+            if "event loop is closed" not in str(ex).lower():
+                raise
+
+            await self._reconnect_account("setup hit closed event loop")
         except LitterRobotLoginException as ex:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN, translation_key="invalid_credentials"

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from pylitterbot import LitterRobot4
@@ -293,3 +293,41 @@ async def test_dynamic_devices(
 
     # Fourth check -> removed 1 device after reload
     assert len(dr.async_entries_for_config_entry(device_registry, entry.entry_id)) == 0
+
+
+async def test_update_reconnects_if_account_session_unusable(
+    hass: HomeAssistant,
+    mock_account: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test update reconnect when account session/loop is stale."""
+    entry = await setup_integration(hass, mock_account, VACUUM_DOMAIN)
+    coordinator = entry.runtime_data
+
+    with (
+        patch.object(coordinator, "_account_session_is_usable", return_value=False),
+        patch.object(coordinator, "_reconnect_account", new_callable=AsyncMock) as reconnect,
+    ):
+        freezer.tick(UPDATE_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    reconnect.assert_awaited_once()
+
+
+async def test_update_reconnects_on_event_loop_closed_runtime_error(
+    hass: HomeAssistant,
+    mock_account: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test update recovery when load_robots raises event loop closed."""
+    entry = await setup_integration(hass, mock_account, VACUUM_DOMAIN)
+    coordinator = entry.runtime_data
+    mock_account.load_robots.side_effect = RuntimeError("Event loop is closed")
+
+    with patch.object(coordinator, "_reconnect_account", new_callable=AsyncMock) as reconnect:
+        freezer.tick(UPDATE_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    reconnect.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This draft PR adds a narrow recovery path for the Whisker coordinator when the underlying `pylitterbot` session is no longer usable and refreshes start failing with errors like `Event loop is closed`.

I hit repeated errors of this form during coordinator refresh:

- `Failed to fetch LitterRobot3: Event loop is closed`
- `Failed to fetch LitterRobot4: Event loop is closed`
- `Failed to fetch LitterRobot5: Event loop is closed`
- `Failed to fetch FeederRobot: Event loop is closed`

I was able to reproduce successful direct access outside Home Assistant using the same `pylitterbot` version, which suggested a coordinator/session lifecycle recovery gap rather than a basic API or authentication failure.

This change:
- checks whether the underlying `pylitterbot` web session is still usable before refresh
- recreates and reconnects the account if the session/loop is no longer usable
- recovers when refresh hits `RuntimeError: Event loop is closed`
- adds regression tests for both recovery paths

This keeps the normal happy path unchanged and only adds guarded recovery behavior for a broken session state.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr