### PR TITLE
Add duration sensor to Home Connect

### DIFF
--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -707,7 +707,7 @@ class HomeConnectProgramDurationSensor(HomeConnectProgramSensor):
     def available(self) -> bool:
         """Return true if the sensor is available."""
         # We need to override the available property for the duration sensor,
-        # because it should only be available when a program is running, paused or finished,
+        # because it should only be available when a program is not running,
         # unlike the HomeConnectProgramSensor.
         return HomeConnectEntity.available.__get__(self) and not self.program_running
 

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import cast
+from typing import Any, cast
 
 from aiohomeconnect.model import EventKey, StatusKey
 
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfVolume
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTime, UnitOfVolume
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util, slugify
@@ -70,6 +70,24 @@ BSH_PROGRAM_SENSORS = (
         native_unit_of_measurement=PERCENTAGE,
         translation_key="program_progress",
         appliance_types=APPLIANCES_WITH_PROGRAMS,
+    ),
+)
+
+PROGRAM_DURATION_SENSOR = HomeConnectSensorEntityDescription(
+    key=EventKey.BSH_COMMON_OPTION_REMAINING_PROGRAM_TIME,
+    device_class=SensorDeviceClass.DURATION,
+    native_unit_of_measurement=UnitOfTime.SECONDS,
+    translation_key="program_duration",
+    appliance_types=(
+        "CoffeeMaker",
+        "CookProcessor",
+        "Dishwasher",
+        "Dryer",
+        "Microwave",
+        "Hood",
+        "Oven",
+        "Washer",
+        "WasherDryer",
     ),
 )
 
@@ -527,6 +545,17 @@ def _get_entities_for_appliance(
             if desc.appliance_types
             and appliance_coordinator.data.info.type in desc.appliance_types
         ],
+        *(
+            [
+                HomeConnectProgramDurationSensor(
+                    appliance_coordinator, PROGRAM_DURATION_SENSOR
+                )
+            ]
+            if PROGRAM_DURATION_SENSOR.appliance_types
+            and appliance_coordinator.data.info.type
+            in PROGRAM_DURATION_SENSOR.appliance_types
+            else []
+        ),
         *[
             HomeConnectSensor(appliance_coordinator, description)
             for description in SENSORS
@@ -643,6 +672,44 @@ class HomeConnectProgramSensor(HomeConnectSensor):
         event = self.appliance.events.get(cast(EventKey, self.bsh_key))
         if event:
             self._update_native_value(event.value)
+
+
+class HomeConnectProgramDurationSensor(HomeConnectProgramSensor):
+    """Sensor class for Home Connect sensors that reports the duration program."""
+
+    def __init__(
+        self,
+        appliance_coordinator: HomeConnectApplianceCoordinator,
+        desc: HomeConnectSensorEntityDescription,
+        context_override: Any | None = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(appliance_coordinator, desc, context_override)
+        # Because this sensor uses `EventKey.BSH_COMMON_OPTION_REMAINING_PROGRAM_TIME`
+        # as its key the unique id will collide with the finish time sensor,
+        # so we append "_duration" to make it unique.
+        assert self._attr_unique_id
+        self._attr_unique_id += "_duration"
+
+    def _update_native_value(self, status: str | float | None) -> None:
+        """Set the value of the sensor based on the given value."""
+        self._attr_native_value = cast(float | None, status)
+
+    @callback
+    def _handle_operation_state_event(self) -> None:
+        """Update status when an event for the entity is received."""
+        if self.program_running:
+            # reset the value when the program is running, paused or finished
+            self._attr_native_value = None
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return true if the sensor is available."""
+        # We need to override the available property for the duration sensor,
+        # because it should only be available when a program is running, paused or finished,
+        # unlike the HomeConnectProgramSensor.
+        return HomeConnectEntity.available.__get__(self) and not self.program_running
 
 
 class HomeConnectEventSensor(HomeConnectSensor):

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -691,10 +691,6 @@ class HomeConnectProgramDurationSensor(HomeConnectProgramSensor):
         assert self._attr_unique_id
         self._attr_unique_id += "_duration"
 
-    def _update_native_value(self, status: str | float | None) -> None:
-        """Set the value of the sensor based on the given value."""
-        self._attr_native_value = cast(float | None, status)
-
     @callback
     def _handle_operation_state_event(self) -> None:
         """Update status when an event for the entity is received."""

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -675,7 +675,7 @@ class HomeConnectProgramSensor(HomeConnectSensor):
 
 
 class HomeConnectProgramDurationSensor(HomeConnectProgramSensor):
-    """Sensor class for Home Connect sensors that reports the duration program."""
+    """Sensor class for Home Connect sensors that reports the program duration."""
 
     def __init__(
         self,

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1157,6 +1157,9 @@
           "present": "[%key:component::home_connect::common::present%]"
         }
       },
+      "program_duration": {
+        "name": "Program duration"
+      },
       "program_finish_time": {
         "name": "Program finish time"
       },

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -94,6 +94,10 @@ EVENT_PROG_END = {
     EventType.STATUS: {
         EventKey.BSH_COMMON_STATUS_OPERATION_STATE: "BSH.Common.EnumType.OperationState.Ready",
     },
+    EventType.EVENT: {
+        EventKey.BSH_COMMON_OPTION_REMAINING_PROGRAM_TIME: 25,
+        EventKey.BSH_COMMON_OPTION_PROGRAM_PROGRESS: 0,
+    },
 }
 
 
@@ -310,6 +314,14 @@ ENTITY_ID_STATES = {
         "99",
         "99",
         STATE_UNAVAILABLE,
+    ),
+    "sensor.dishwasher_program_duration": (
+        STATE_UNAVAILABLE,
+        STATE_UNAVAILABLE,
+        STATE_UNAVAILABLE,
+        STATE_UNAVAILABLE,
+        STATE_UNAVAILABLE,
+        "25",
     ),
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We currently support showing to the user at what time does it finish the program, but when the user hasn't selected yet a program, there isn't any information about how long it takes, so this PR adds a sensor that reads the values from the remaining time key to show the value but only when the program is **not** running, as the value will change at the same time the program advances on time and we don't want that.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
