### PR TITLE
Portainer fix fetching swarm stacks

### DIFF
--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -263,12 +263,6 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
                     # Now assign stats to the containers
                     for container_name, stats in container_stats.items():
                         container_map[container_name].stats = stats
-            except PortainerTimeoutError as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="timeout_connect",
-                    translation_placeholders={"error": repr(err)},
-                ) from err
             except PortainerConnectionError as err:
                 _LOGGER.exception("Connection error")
                 raise UpdateFailed(

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -170,14 +170,33 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
                     docker_version,
                     docker_info,
                     docker_system_df,
-                    stacks,
                 ) = await asyncio.gather(
                     self.portainer.get_containers(endpoint.id),
                     self.portainer.docker_version(endpoint.id),
                     self.portainer.docker_info(endpoint.id),
                     self.portainer.docker_system_df(endpoint.id),
-                    self.portainer.get_stacks(endpoint.id),
                 )
+
+                stack_requests = [self.portainer.get_stacks(endpoint_id=endpoint.id)]
+                swarm_id = (
+                    docker_info.swarm.cluster.get("ID")
+                    if docker_info.swarm
+                    and docker_info.swarm.control_available
+                    and docker_info.swarm.cluster
+                    else None
+                )
+                if swarm_id:
+                    stack_requests.append(
+                        self.portainer.get_stacks(
+                            endpoint_id=endpoint.id, swarm_id=swarm_id
+                        )
+                    )
+
+                stacks = [
+                    stack
+                    for result in await asyncio.gather(*stack_requests)
+                    for stack in result
+                ]
 
                 prev_endpoint = self.data.get(endpoint.id) if self.data else None
                 container_map: dict[str, PortainerContainerData] = {}
@@ -244,6 +263,12 @@ class PortainerCoordinator(DataUpdateCoordinator[dict[int, PortainerCoordinatorD
                     # Now assign stats to the containers
                     for container_name, stats in container_stats.items():
                         container_map[container_name].stats = stats
+            except PortainerTimeoutError as err:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="timeout_connect",
+                    translation_placeholders={"error": repr(err)},
+                ) from err
             except PortainerConnectionError as err:
                 _LOGGER.exception("Connection error")
                 raise UpdateFailed(

--- a/tests/components/portainer/fixtures/docker_info.json
+++ b/tests/components/portainer/fixtures/docker_info.json
@@ -76,7 +76,9 @@
     "RemoteManagers": [],
     "Nodes": 4,
     "Managers": 3,
-    "Cluster": {}
+    "Cluster": {
+      "ID": "swarm-cluster-id"
+    }
   },
   "LiveRestoreEnabled": false,
   "Isolation": "default",

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -363,6 +363,21 @@ async def test_new_container_callback(
     ) > len(entities)
 
 
+async def test_swarm_stacks_fetched_by_swarm_id(
+    hass: HomeAssistant,
+    mock_portainer_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that on a Swarm manager get_stacks is called with both endpoint_id and swarm_id."""
+    await setup_integration(hass, mock_config_entry)
+
+    calls = mock_portainer_client.get_stacks.call_args_list
+    # Expect exactly two calls: one by endpoint_id, one by swarm_id
+    assert len(calls) == 2
+    assert calls[0].kwargs == {"endpoint_id": 1}
+    assert calls[1].kwargs == {"endpoint_id": 1, "swarm_id": "swarm-cluster-id"}
+
+
 async def test_new_stack_callback(
     hass: HomeAssistant,
     mock_portainer_client: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Should resolve reported issue: https://github.com/home-assistant/core/issues/167575

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/167575
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
