### PR TITLE
Fix gardena entity categories and percentage values

### DIFF
--- a/homeassistant/components/gardena_bluetooth/number.py
+++ b/homeassistant/components/gardena_bluetooth/number.py
@@ -142,6 +142,7 @@ DESCRIPTIONS = (
         native_min_value=0.0,
         native_max_value=359.0,
         native_step=1.0,
+        entity_category=EntityCategory.CONFIG,
         char=Spray.sector,
     ),
     GardenaBluetoothNumberEntityDescription(
@@ -153,6 +154,7 @@ DESCRIPTIONS = (
         native_max_value=100.0,
         native_step=0.1,
         char=Spray.distance,
+        entity_category=EntityCategory.CONFIG,
         scale=10.0,
     ),
 )

--- a/homeassistant/components/gardena_bluetooth/select.py
+++ b/homeassistant/components/gardena_bluetooth/select.py
@@ -13,6 +13,7 @@ from gardena_bluetooth.const import (
 from gardena_bluetooth.parse import CharacteristicInt
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -61,6 +62,7 @@ DESCRIPTIONS = (
         translation_key="operation_mode",
         char=AquaContour.operation_mode,
         option_to_number=_enum_to_int(AquaContour.operation_mode.enum),
+        entity_category=EntityCategory.CONFIG,
     ),
     GardenaBluetoothSelectEntityDescription(
         translation_key="active_position",

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 from gardena_bluetooth.const import (
     AquaContourBattery,
@@ -38,7 +39,7 @@ from homeassistant.util import dt as dt_util
 from .coordinator import GardenaBluetoothConfigEntry, GardenaBluetoothCoordinator
 from .entity import GardenaBluetoothDescriptorEntity, GardenaBluetoothEntity
 
-type SensorRawType = StateType | datetime
+type SensorRawType = StateType | datetime | Decimal
 
 
 def _get_timestamp(value: datetime | None):
@@ -47,10 +48,10 @@ def _get_timestamp(value: datetime | None):
     return value.replace(tzinfo=dt_util.get_default_time_zone())
 
 
-def _get_distance_ratio(value: int | None):
+def _get_distance_percentage(value: int | None) -> Decimal | None:
     if value is None:
         return None
-    return value / 1000
+    return Decimal(value) / 10
 
 
 @dataclass(frozen=True)
@@ -169,7 +170,7 @@ DESCRIPTIONS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=PERCENTAGE,
         char=Spray.current_distance,
-        get=_get_distance_ratio,
+        get=_get_distance_percentage,
     ),
     GardenaBluetoothSensorEntityDescription(
         key=Spray.current_sector.unique_id,

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from decimal import Decimal
 
 from gardena_bluetooth.const import (
     AquaContourBattery,
@@ -39,7 +38,7 @@ from homeassistant.util import dt as dt_util
 from .coordinator import GardenaBluetoothConfigEntry, GardenaBluetoothCoordinator
 from .entity import GardenaBluetoothDescriptorEntity, GardenaBluetoothEntity
 
-type SensorRawType = StateType | datetime | Decimal
+type SensorRawType = StateType | datetime
 
 
 def _get_timestamp(value: datetime | None):
@@ -48,10 +47,10 @@ def _get_timestamp(value: datetime | None):
     return value.replace(tzinfo=dt_util.get_default_time_zone())
 
 
-def _get_distance_percentage(value: int | None) -> Decimal | None:
+def _get_distance_percentage(value: int | None) -> float | None:
     if value is None:
         return None
-    return Decimal(value) / 10
+    return value / 10
 
 
 @dataclass(frozen=True)

--- a/tests/components/gardena_bluetooth/snapshots/test_number.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_number.ambr
@@ -358,3 +358,75 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_setup[service_info5-98bd0112-0b0e-421a-84e5-ddbf75dc6de4-raw5-number.mock_title_sector]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Sector',
+      'max': 359.0,
+      'min': 0.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_sector',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '359.0',
+  })
+# ---
+# name: test_setup[service_info5-98bd0112-0b0e-421a-84e5-ddbf75dc6de4-raw5-number.mock_title_sector].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Sector',
+      'max': 359.0,
+      'min': 0.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_sector',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.0',
+  })
+# ---
+# name: test_setup[service_info6-98bd0111-0b0e-421a-84e5-ddbf75dc6de4-raw6-number.mock_title_distance]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Distance',
+      'max': 100.0,
+      'min': 0.0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 0.1,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_distance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_setup[service_info6-98bd0111-0b0e-421a-84e5-ddbf75dc6de4-raw6-number.mock_title_distance].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Distance',
+      'max': 100.0,
+      'min': 0.0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 0.1,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_distance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.0',
+  })
+# ---

--- a/tests/components/gardena_bluetooth/snapshots/test_select.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_select.ambr
@@ -84,7 +84,7 @@
     'device_id': <ANY>,
     'disabled_by': None,
     'domain': 'select',
-    'entity_category': None,
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
     'entity_id': 'select.mock_title_operation_mode',
     'has_entity_name': True,
     'hidden_by': None,

--- a/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
@@ -134,7 +134,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.333',
+    'state': '33.3',
   })
 # ---
 # name: test_sensors[aqua_contour][sensor.mock_title_current_flow-entry]

--- a/tests/components/gardena_bluetooth/test_number.py
+++ b/tests/components/gardena_bluetooth/test_number.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import Mock, call
 
-from gardena_bluetooth.const import AquaContourWatering, Sensor, Valve
+from gardena_bluetooth.const import AquaContourWatering, Sensor, Spray, Valve
 from gardena_bluetooth.exceptions import (
     CharacteristicNoAccess,
     GardenaBluetoothException,
@@ -75,6 +75,24 @@ from tests.common import MockConfigEntry
                 GardenaBluetoothException("Test for errors on bluetooth"),
             ],
             "number.mock_title_remaining_watering_time",
+        ),
+        (
+            AQUA_CONTOUR_SERVICE_INFO,
+            Spray.sector.uuid,
+            [
+                Spray.sector.encode(359),
+                Spray.sector.encode(10),
+            ],
+            "number.mock_title_sector",
+        ),
+        (
+            AQUA_CONTOUR_SERVICE_INFO,
+            Spray.distance.uuid,
+            [
+                Spray.distance.encode(1000),
+                Spray.distance.encode(10),
+            ],
+            "number.mock_title_distance",
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Corrected entity category of a few entities that are config not control
- Corrected scaling of distance sensor to show correct percentage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
