### PR TITLE
iaqualink: add system selection options flow

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -25,18 +25,13 @@ from iaqualink.exception import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryError,
-    ConfigEntryNotReady,
-)
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
 
-from .const import DOMAIN
+from .const import CONF_SYSTEMS, DOMAIN
 from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
+from .utils import async_get_aqualink_client
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +55,7 @@ class AqualinkRuntimeData:
 
     client: AqualinkClient
     coordinators: dict[str, AqualinkDataUpdateCoordinator]
+    platforms_loaded: bool
     # These will contain the initialized devices
     binary_sensors: list[AqualinkBinarySensor]
     lights: list[AqualinkLight]
@@ -73,11 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
 
-    aqualink = AqualinkClient(
-        username,
-        password,
-        httpx_client=get_async_client(hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2),
-    )
+    aqualink = await async_get_aqualink_client(hass, username, password)
     try:
         await aqualink.login()
     except AqualinkServiceUnauthorizedException as auth_exception:
@@ -104,20 +96,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
             f"Error while attempting to retrieve systems list: {svc_exception}"
         ) from svc_exception
 
-    systems_list = list(systems.values())
-    if not systems_list:
-        await aqualink.close()
-        raise ConfigEntryError("No systems detected or supported")
-
     runtime_data = AqualinkRuntimeData(
         aqualink,
         coordinators={},
+        platforms_loaded=False,
         binary_sensors=[],
         lights=[],
         sensors=[],
         switches=[],
         thermostats=[],
     )
+
+    systems_list = list(systems.values())
+    if not systems_list:
+        entry.runtime_data = runtime_data
+        _LOGGER.warning("No systems detected or supported")
+        return True
+
+    # Filter to only selected systems (default to all if options not set yet)
+    selected_systems = entry.options.get(
+        CONF_SYSTEMS, [sys.serial for sys in systems_list]
+    )
+
+    entry.runtime_data = runtime_data
+
+    if not selected_systems:
+        _LOGGER.warning("No systems selected")
+        return True
+
+    systems_list = [sys for sys in systems_list if sys.serial in selected_systems]
+
+    if not systems_list:
+        _LOGGER.warning("No selected systems detected or supported")
+        return True
+
     for system in systems_list:
         coordinator = AqualinkDataUpdateCoordinator(hass, entry, system)
         runtime_data.coordinators[system.serial] = coordinator
@@ -177,9 +189,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
         runtime_data.thermostats,
     )
 
-    entry.runtime_data = runtime_data
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    runtime_data.platforms_loaded = True
 
     return True
 
@@ -187,6 +198,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 async def async_unload_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> bool:
     """Unload a config entry."""
     await entry.runtime_data.client.close()
+    if not entry.runtime_data.platforms_loaded:
+        return True
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -100,6 +100,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
             f"Error while attempting to retrieve systems list: {svc_exception}"
         ) from svc_exception
 
+    systems = systems or {}
+
     runtime_data = AqualinkRuntimeData(
         aqualink,
         coordinators={},
@@ -114,6 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
     systems_list = list(systems.values())
     if not systems_list:
         entry.runtime_data = runtime_data
+        await aqualink.close()
         _LOGGER.warning("No systems detected or supported")
         return True
 
@@ -125,12 +128,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
     entry.runtime_data = runtime_data
 
     if not selected_systems:
+        await aqualink.close()
         _LOGGER.warning("No systems selected")
         return True
 
     systems_list = [sys for sys in systems_list if sys.serial in selected_systems]
 
     if not systems_list:
+        await aqualink.close()
         _LOGGER.warning("No selected systems detected or supported")
         return True
 
@@ -150,7 +155,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
             raise ConfigEntryAuthFailed(
                 "Invalid credentials for iAqualink"
             ) from auth_exception
-        except AqualinkServiceException as svc_exception:
+        except (
+            AqualinkServiceException,
+            TimeoutError,
+            httpx.HTTPError,
+        ) as svc_exception:
             await aqualink.close()
             raise ConfigEntryNotReady(
                 f"Error while attempting to retrieve devices list: {svc_exception}"
@@ -209,6 +218,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) ->
         await entry.runtime_data.client.close()
 
     return unload_ok
+
+
 def refresh_system[_AqualinkEntityT: AqualinkEntity, **_P](
     func: Callable[Concatenate[_AqualinkEntityT, _P], Awaitable[Any]],
 ) -> Callable[Concatenate[_AqualinkEntityT, _P], Coroutine[Any, Any, None]]:

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
 
-    aqualink = await async_get_aqualink_client(hass, username, password)
+    aqualink = async_get_aqualink_client(hass, username, password)
     try:
         await aqualink.login()
     except AqualinkServiceUnauthorizedException as auth_exception:

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -90,7 +90,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
         raise ConfigEntryAuthFailed(
             "Invalid credentials for iAqualink"
         ) from auth_exception
-    except AqualinkServiceException as svc_exception:
+    except (
+        AqualinkServiceException,
+        TimeoutError,
+        httpx.HTTPError,
+    ) as svc_exception:
         await aqualink.close()
         raise ConfigEntryNotReady(
             f"Error while attempting to retrieve systems list: {svc_exception}"

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -201,12 +201,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
 async def async_unload_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> bool:
     """Unload a config entry."""
-    await entry.runtime_data.client.close()
     if not entry.runtime_data.platforms_loaded:
         return True
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        await entry.runtime_data.client.close()
 
+    return unload_ok
 def refresh_system[_AqualinkEntityT: AqualinkEntity, **_P](
     func: Callable[Concatenate[_AqualinkEntityT, _P], Awaitable[Any]],
 ) -> Callable[Concatenate[_AqualinkEntityT, _P], Coroutine[Any, Any, None]]:

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.config_entries import (
     OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 
 from .const import CONF_SYSTEMS, DOMAIN
@@ -38,9 +38,7 @@ async def async_get_systems(
 ) -> tuple[dict[str, Any] | None, str | None]:
     """Fetch systems from iAqualink and map failures to flow error reasons."""
     try:
-        async with await async_get_aqualink_client(
-            hass, username, password
-        ) as aqualink:
+        async with async_get_aqualink_client(hass, username, password) as aqualink:
             systems = await aqualink.get_systems()
     except AqualinkServiceUnauthorizedException:
         return None, "invalid_auth"
@@ -82,7 +80,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> dict[str, str]:
         """Validate credentials against iAqualink."""
         try:
-            async with await async_get_aqualink_client(
+            async with async_get_aqualink_client(
                 self.hass, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             ):
                 pass
@@ -176,6 +174,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @callback
     @staticmethod
     def async_get_options_flow(config_entry: ConfigEntry) -> AqualinkOptionsFlowHandler:
         """Create the options flow."""

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -6,19 +6,24 @@ from collections.abc import Mapping
 from typing import Any
 
 import httpx
-from iaqualink.client import AqualinkClient
 from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN
+from .const import CONF_SYSTEMS, DOMAIN
+from .utils import async_get_aqualink_client
 
 CREDENTIALS_DATA_SCHEMA = vol.Schema(
     {
@@ -28,22 +33,57 @@ CREDENTIALS_DATA_SCHEMA = vol.Schema(
 )
 
 
+async def async_get_systems(
+    hass: HomeAssistant, username: str, password: str
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Fetch systems from iAqualink and map failures to flow error reasons."""
+    try:
+        async with await async_get_aqualink_client(
+            hass, username, password
+        ) as aqualink:
+            systems = await aqualink.get_systems()
+    except AqualinkServiceUnauthorizedException:
+        return None, "invalid_auth"
+    except AqualinkServiceException, httpx.HTTPError:
+        return None, "cannot_connect"
+
+    if not systems:
+        return None, "no_systems"
+
+    return systems, None
+
+
+def _build_systems_schema(
+    system_keys: dict[str, str], selected_systems: list[str]
+) -> vol.Schema:
+    """Build the schema used by both config and options flow system selection."""
+    return vol.Schema(
+        {
+            vol.Optional(
+                CONF_SYSTEMS,
+                default=selected_systems,
+            ): cv.multi_select(system_keys),
+        }
+    )
+
+
 class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
     """Aqualink config flow."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize flow state."""
+        self._pending_user_input: dict[str, Any] | None = None
+        self._system_keys: dict[str, str] | None = None
 
     async def _async_test_credentials(
         self, user_input: dict[str, Any]
     ) -> dict[str, str]:
         """Validate credentials against iAqualink."""
         try:
-            async with AqualinkClient(
-                user_input[CONF_USERNAME],
-                user_input[CONF_PASSWORD],
-                httpx_client=get_async_client(
-                    self.hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2
-                ),
+            async with await async_get_aqualink_client(
+                self.hass, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             ):
                 pass
         except AqualinkServiceUnauthorizedException:
@@ -57,19 +97,52 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow start."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             errors = await self._async_test_credentials(user_input)
             if not errors:
-                return self.async_create_entry(
-                    title=user_input[CONF_USERNAME], data=user_input
+                systems, systems_error = await async_get_systems(
+                    self.hass,
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
                 )
+                if systems is None:
+                    assert systems_error is not None
+                    errors = {"base": systems_error}
+                else:
+                    self._pending_user_input = user_input
+                    self._system_keys = {
+                        system.serial: system.name for system in systems.values()
+                    }
+                    return await self.async_step_systems()
 
         return self.async_show_form(
             step_id="user",
             data_schema=CREDENTIALS_DATA_SCHEMA,
             errors=errors,
+        )
+
+    async def async_step_systems(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle selecting which systems to include."""
+        if self._pending_user_input is None or self._system_keys is None:
+            return await self.async_step_user()
+
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._pending_user_input[CONF_USERNAME],
+                data=self._pending_user_input,
+                options=user_input,
+            )
+
+        return self.async_show_form(
+            step_id="systems",
+            data_schema=_build_systems_schema(
+                self._system_keys,
+                list(self._system_keys.keys()),
+            ),
         )
 
     async def async_step_reauth(
@@ -101,4 +174,54 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=CREDENTIALS_DATA_SCHEMA,
             errors=errors,
+        )
+
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> AqualinkOptionsFlowHandler:
+        """Create the options flow."""
+        return AqualinkOptionsFlowHandler()
+
+
+class AqualinkOptionsFlowHandler(OptionsFlowWithReload):
+    """Options flow for Aqualink."""
+
+    def __init__(self) -> None:
+        """Initialize the options flow state."""
+        self._system_keys: dict[str, str] | None = None
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage options."""
+        if user_input is not None and self._system_keys is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        # Fetch systems from API
+        username = self.config_entry.data[CONF_USERNAME]
+        password = self.config_entry.data[CONF_PASSWORD]
+
+        systems, error_reason = await async_get_systems(self.hass, username, password)
+
+        if systems is None:
+            assert error_reason is not None
+            return self.async_show_form(
+                step_id="init",
+                data_schema=_build_systems_schema({}, []),
+                errors={"base": error_reason},
+            )
+
+        # Build schema with all systems as selectable checkboxes
+        self._system_keys = {system.serial: system.name for system in systems.values()}
+
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        # Get currently selected systems from options (or default to all)
+        current_systems = self.config_entry.options.get(
+            CONF_SYSTEMS, list(self._system_keys.keys())
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_build_systems_schema(self._system_keys, current_systems),
         )

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -174,8 +174,8 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    @callback
     @staticmethod
+    @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> AqualinkOptionsFlowHandler:
         """Create the options flow."""
         return AqualinkOptionsFlowHandler()
@@ -196,10 +196,7 @@ class AqualinkOptionsFlowHandler(OptionsFlowWithReload):
             return self.async_create_entry(title="", data=user_input)
 
         # Fetch systems from API
-        username = self.config_entry.data[CONF_USERNAME]
-        password = self.config_entry.data[CONF_PASSWORD]
-
-        systems, error_reason = await async_get_systems(self.hass, username, password)
+        systems, error_reason = await async_get_systems(self.hass, self.config_entry.data[CONF_USERNAME], self.config_entry.data[CONF_PASSWORD])
 
         if systems is None:
             assert error_reason is not None

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import httpx
 from iaqualink.exception import (
@@ -32,20 +33,39 @@ CREDENTIALS_DATA_SCHEMA = vol.Schema(
     }
 )
 
+type SystemsError = Literal["invalid_auth", "cannot_connect"]
+
+
+@dataclass(slots=True, frozen=True)
+class SystemsSuccess:
+    """Successful systems fetch result."""
+
+    systems: dict[str, Any]
+
+
+@dataclass(slots=True, frozen=True)
+class SystemsFailure:
+    """Failed systems fetch result."""
+
+    error: SystemsError
+
+
+type SystemsResult = SystemsSuccess | SystemsFailure
+
 
 async def async_get_systems(
     hass: HomeAssistant, username: str, password: str
-) -> tuple[dict[str, Any] | None, str | None]:
+) -> SystemsResult:
     """Fetch systems from iAqualink and map failures to flow error reasons."""
     try:
         async with async_get_aqualink_client(hass, username, password) as aqualink:
             systems = await aqualink.get_systems()
     except AqualinkServiceUnauthorizedException:
-        return None, "invalid_auth"
+        return SystemsFailure("invalid_auth")
     except AqualinkServiceException, TimeoutError, httpx.HTTPError:
-        return None, "cannot_connect"
+        return SystemsFailure("cannot_connect")
 
-    return systems or {}, None
+    return SystemsSuccess(systems or {})
 
 
 class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -81,18 +101,18 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            systems, systems_error = await async_get_systems(
+            systems_result = await async_get_systems(
                 self.hass,
                 user_input[CONF_USERNAME],
                 user_input[CONF_PASSWORD],
             )
-            if systems is None:
-                assert systems_error is not None
-                errors = {"base": systems_error}
+            if isinstance(systems_result, SystemsFailure):
+                errors = {"base": systems_result.error}
             else:
                 self._pending_user_input = user_input
                 self._system_keys = {
-                    system.serial: system.name for system in systems.values()
+                    system.serial: system.name
+                    for system in systems_result.systems.values()
                 }
                 return await self.async_step_systems()
 
@@ -181,14 +201,13 @@ class AqualinkOptionsFlowHandler(OptionsFlowWithReload):
             return self.async_create_entry(title="", data=user_input)
 
         # Fetch systems from API
-        systems, error_reason = await async_get_systems(
+        systems_result = await async_get_systems(
             self.hass,
             self.config_entry.data[CONF_USERNAME],
             self.config_entry.data[CONF_PASSWORD],
         )
 
-        if systems is None:
-            assert error_reason is not None
+        if isinstance(systems_result, SystemsFailure):
             return self.async_show_form(
                 step_id="init",
                 data_schema=vol.Schema(
@@ -199,11 +218,13 @@ class AqualinkOptionsFlowHandler(OptionsFlowWithReload):
                         ): cv.multi_select({}),
                     }
                 ),
-                errors={"base": error_reason},
+                errors={"base": systems_result.error},
             )
 
         # Build schema with all systems as selectable checkboxes
-        self._system_keys = {system.serial: system.name for system in systems.values()}
+        self._system_keys = {
+            system.serial: system.name for system in systems_result.systems.values()
+        }
 
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -45,21 +45,7 @@ async def async_get_systems(
     except AqualinkServiceException, TimeoutError, httpx.HTTPError:
         return None, "cannot_connect"
 
-    return systems, None
-
-
-def _build_systems_schema(
-    system_keys: dict[str, str], selected_systems: list[str]
-) -> vol.Schema:
-    """Build the schema used by both config and options flow system selection."""
-    return vol.Schema(
-        {
-            vol.Optional(
-                CONF_SYSTEMS,
-                default=selected_systems,
-            ): cv.multi_select(system_keys),
-        }
-    )
+    return systems or {}, None
 
 
 class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -95,22 +81,20 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            errors = await self._async_test_credentials(user_input)
-            if not errors:
-                systems, systems_error = await async_get_systems(
-                    self.hass,
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PASSWORD],
-                )
-                if systems is None:
-                    assert systems_error is not None
-                    errors = {"base": systems_error}
-                else:
-                    self._pending_user_input = user_input
-                    self._system_keys = {
-                        system.serial: system.name for system in systems.values()
-                    }
-                    return await self.async_step_systems()
+            systems, systems_error = await async_get_systems(
+                self.hass,
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+            )
+            if systems is None:
+                assert systems_error is not None
+                errors = {"base": systems_error}
+            else:
+                self._pending_user_input = user_input
+                self._system_keys = {
+                    system.serial: system.name for system in systems.values()
+                }
+                return await self.async_step_systems()
 
         return self.async_show_form(
             step_id="user",
@@ -134,9 +118,13 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="systems",
-            data_schema=_build_systems_schema(
-                self._system_keys,
-                list(self._system_keys.keys()),
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SYSTEMS,
+                        default=list(self._system_keys.keys()),
+                    ): cv.multi_select(self._system_keys),
+                }
             ),
         )
 
@@ -203,7 +191,14 @@ class AqualinkOptionsFlowHandler(OptionsFlowWithReload):
             assert error_reason is not None
             return self.async_show_form(
                 step_id="init",
-                data_schema=_build_systems_schema({}, []),
+                data_schema=vol.Schema(
+                    {
+                        vol.Optional(
+                            CONF_SYSTEMS,
+                            default=[],
+                        ): cv.multi_select({}),
+                    }
+                ),
                 errors={"base": error_reason},
             )
 
@@ -214,11 +209,23 @@ class AqualinkOptionsFlowHandler(OptionsFlowWithReload):
             return self.async_create_entry(title="", data=user_input)
 
         # Get currently selected systems from options (or default to all)
-        current_systems = self.config_entry.options.get(
-            CONF_SYSTEMS, list(self._system_keys.keys())
-        )
+        if CONF_SYSTEMS in self.config_entry.options:
+            current_systems = [
+                system_id
+                for system_id in self.config_entry.options[CONF_SYSTEMS]
+                if system_id in self._system_keys
+            ]
+        else:
+            current_systems = list(self._system_keys.keys())
 
         return self.async_show_form(
             step_id="init",
-            data_schema=_build_systems_schema(self._system_keys, current_systems),
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SYSTEMS,
+                        default=current_systems,
+                    ): cv.multi_select(self._system_keys),
+                }
+            ),
         )

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -45,9 +45,6 @@ async def async_get_systems(
     except AqualinkServiceException, TimeoutError, httpx.HTTPError:
         return None, "cannot_connect"
 
-    if not systems:
-        return None, "no_systems"
-
     return systems, None
 
 
@@ -196,7 +193,11 @@ class AqualinkOptionsFlowHandler(OptionsFlowWithReload):
             return self.async_create_entry(title="", data=user_input)
 
         # Fetch systems from API
-        systems, error_reason = await async_get_systems(self.hass, self.config_entry.data[CONF_USERNAME], self.config_entry.data[CONF_PASSWORD])
+        systems, error_reason = await async_get_systems(
+            self.hass,
+            self.config_entry.data[CONF_USERNAME],
+            self.config_entry.data[CONF_PASSWORD],
+        )
 
         if systems is None:
             assert error_reason is not None

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -44,7 +44,7 @@ async def async_get_systems(
             systems = await aqualink.get_systems()
     except AqualinkServiceUnauthorizedException:
         return None, "invalid_auth"
-    except AqualinkServiceException, httpx.HTTPError:
+    except AqualinkServiceException, TimeoutError, httpx.HTTPError:
         return None, "cannot_connect"
 
     if not systems:
@@ -88,7 +88,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
                 pass
         except AqualinkServiceUnauthorizedException:
             return {"base": "invalid_auth"}
-        except AqualinkServiceException, httpx.HTTPError:
+        except AqualinkServiceException, TimeoutError, httpx.HTTPError:
             return {"base": "cannot_connect"}
 
         return {}

--- a/homeassistant/components/iaqualink/const.py
+++ b/homeassistant/components/iaqualink/const.py
@@ -2,5 +2,6 @@
 
 from datetime import timedelta
 
+CONF_SYSTEMS = "systems"
 DOMAIN = "iaqualink"
 UPDATE_INTERVAL = timedelta(seconds=15)

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -5,8 +5,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "no_systems": "No systems found on account"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {
       "reauth_confirm": {
@@ -21,7 +20,7 @@
         "data": {
           "systems": "Systems to include"
         },
-        "description": "Select which iAqualink systems you want to add to Home Assistant."
+        "description": "Select which iAqualink systems you want to add to Home Assistant. If no systems are listed, none were detected and you can continue without selecting any."
       },
       "user": {
         "data": {
@@ -36,15 +35,14 @@
   "options": {
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "no_systems": "No systems found on account"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {
       "init": {
         "data": {
           "systems": "Systems to include"
         },
-        "description": "Select which iAqualink systems you want to add to Home Assistant."
+        "description": "Select which iAqualink systems you want to add to Home Assistant. If no systems are listed, none were detected and you can continue without selecting any."
       }
     }
   }

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -5,7 +5,8 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "no_systems": "No systems found on account"
     },
     "step": {
       "reauth_confirm": {
@@ -16,6 +17,12 @@
         "description": "Please enter the username and password for your iAqualink account.",
         "title": "Reauthenticate iAqualink"
       },
+      "systems": {
+        "data": {
+          "systems": "Systems to include"
+        },
+        "description": "Select which iAqualink systems you want to add to Home Assistant."
+      },
       "user": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",
@@ -23,6 +30,21 @@
         },
         "description": "Please enter the username and password for your iAqualink account.",
         "title": "Connect to iAqualink"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "no_systems": "No systems found on account"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "systems": "Systems to include"
+        },
+        "description": "Select which iAqualink systems you want to add to Home Assistant."
       }
     }
   }

--- a/homeassistant/components/iaqualink/utils.py
+++ b/homeassistant/components/iaqualink/utils.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
 
 
-async def async_get_aqualink_client(
+def async_get_aqualink_client(
     hass: HomeAssistant, username: str, password: str
 ) -> AqualinkClient:
     """Create an Aqualink client configured with Home Assistant's HTTP client."""

--- a/homeassistant/components/iaqualink/utils.py
+++ b/homeassistant/components/iaqualink/utils.py
@@ -5,9 +5,24 @@ from __future__ import annotations
 from collections.abc import Awaitable
 
 import httpx
+from iaqualink.client import AqualinkClient
 from iaqualink.exception import AqualinkServiceException
 
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
+
+
+async def async_get_aqualink_client(
+    hass: HomeAssistant, username: str, password: str
+) -> AqualinkClient:
+    """Create an Aqualink client configured with Home Assistant's HTTP client."""
+    return AqualinkClient(
+        username,
+        password,
+        httpx_client=get_async_client(hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2),
+    )
 
 
 async def await_or_reraise(awaitable: Awaitable) -> None:

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -149,7 +149,7 @@ async def test_with_existing_config(
 async def test_with_no_systems(
     hass: HomeAssistant, config_data: dict[str, str]
 ) -> None:
-    """Test config flow when the account returns no systems."""
+    """Test config flow shows the systems step when the account returns no systems."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
@@ -166,8 +166,14 @@ async def test_with_no_systems(
         result = await flow.async_step_user(config_data)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "no_systems"}
+    assert result["step_id"] == "systems"
+
+    result = await flow.async_step_systems({CONF_SYSTEMS: []})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == config_data[CONF_USERNAME]
+    assert result["data"] == config_data
+    assert result["options"] == {CONF_SYSTEMS: []}
 
 
 async def test_timeout_during_system_fetch(
@@ -220,6 +226,31 @@ async def test_async_get_systems_success(
         )
 
     assert systems == {"SN001": mock_system}
+    assert error_reason is None
+
+
+async def test_async_get_systems_no_systems(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+) -> None:
+    """Test async_get_systems treats no systems as a valid result."""
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            return_value={},
+        ),
+    ):
+        systems, error_reason = await config_flow.async_get_systems(
+            hass,
+            config_data[CONF_USERNAME],
+            config_data[CONF_PASSWORD],
+        )
+
+    assert systems == {}
     assert error_reason is None
 
 
@@ -431,7 +462,6 @@ async def test_options_flow_submit_systems_direct_init_call(
     [
         (AqualinkServiceUnauthorizedException, "invalid_auth"),
         (AqualinkServiceException, "cannot_connect"),
-        ({}, "no_systems"),
     ],
 )
 async def test_options_flow_init_abort_reasons(
@@ -466,3 +496,27 @@ async def test_options_flow_init_abort_reasons(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {"base": reason}
+
+
+async def test_options_flow_init_no_systems(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test options flow shows an empty systems form when no systems are detected."""
+    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            return_value={},
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result.get("errors") in (None, {})

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -194,6 +194,35 @@ async def test_timeout_during_system_fetch(
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_async_get_systems_success(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+) -> None:
+    """Test async_get_systems returns systems on success."""
+    mock_system = MagicMock()
+    mock_system.serial = "SN001"
+    mock_system.name = "Pool System 1"
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            return_value={"SN001": mock_system},
+        ),
+    ):
+        systems, error_reason = await config_flow.async_get_systems(
+            hass,
+            config_data[CONF_USERNAME],
+            config_data[CONF_PASSWORD],
+        )
+
+    assert systems == {"SN001": mock_system}
+    assert error_reason is None
+
+
 async def test_systems_step_without_pending_user_input(
     hass: HomeAssistant,
 ) -> None:
@@ -370,6 +399,31 @@ async def test_options_flow_submit_systems(
         )
 
     assert entry.options[CONF_SYSTEMS] == ["SN001"]
+
+
+async def test_options_flow_submit_systems_direct_init_call(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test options flow can submit directly when started with user input."""
+    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry.add_to_hass(hass)
+
+    flow = config_flow.AqualinkOptionsFlowHandler()
+    flow.hass = hass
+    flow.handler = entry.entry_id
+
+    mock_system = MagicMock()
+    mock_system.serial = "SN001"
+    mock_system.name = "Pool System 1"
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.async_get_systems",
+        return_value=({"SN001": mock_system}, None),
+    ):
+        result = await flow.async_step_init({CONF_SYSTEMS: ["SN001"]})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_SYSTEMS: ["SN001"]}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -101,12 +101,11 @@ async def test_with_existing_config(
         ),
         patch(
             "homeassistant.components.iaqualink.config_flow.async_get_systems",
-            return_value=(
+            return_value=config_flow.SystemsSuccess(
                 {
                     "SN001": mock_system1,
                     "SN002": mock_system2,
-                },
-                None,
+                }
             ),
         ),
     ):
@@ -142,7 +141,7 @@ async def test_user_step_relies_on_async_get_systems(
         ),
         patch(
             "homeassistant.components.iaqualink.config_flow.async_get_systems",
-            return_value=({"SN001": mock_system}, None),
+            return_value=config_flow.SystemsSuccess({"SN001": mock_system}),
         ),
     ):
         result = await flow.async_step_user(config_data)
@@ -236,14 +235,14 @@ async def test_async_get_systems_success(
             return_value={"SN001": mock_system},
         ),
     ):
-        systems, error_reason = await config_flow.async_get_systems(
+        systems_result = await config_flow.async_get_systems(
             hass,
             config_data[CONF_USERNAME],
             config_data[CONF_PASSWORD],
         )
 
-    assert systems == {"SN001": mock_system}
-    assert error_reason is None
+    assert isinstance(systems_result, config_flow.SystemsSuccess)
+    assert systems_result.systems == {"SN001": mock_system}
 
 
 async def test_async_get_systems_no_systems(
@@ -261,14 +260,14 @@ async def test_async_get_systems_no_systems(
             return_value={},
         ),
     ):
-        systems, error_reason = await config_flow.async_get_systems(
+        systems_result = await config_flow.async_get_systems(
             hass,
             config_data[CONF_USERNAME],
             config_data[CONF_PASSWORD],
         )
 
-    assert systems == {}
-    assert error_reason is None
+    assert isinstance(systems_result, config_flow.SystemsSuccess)
+    assert systems_result.systems == {}
 
 
 async def test_async_get_systems_none_systems(
@@ -286,14 +285,14 @@ async def test_async_get_systems_none_systems(
             return_value=None,
         ),
     ):
-        systems, error_reason = await config_flow.async_get_systems(
+        systems_result = await config_flow.async_get_systems(
             hass,
             config_data[CONF_USERNAME],
             config_data[CONF_PASSWORD],
         )
 
-    assert systems == {}
-    assert error_reason is None
+    assert isinstance(systems_result, config_flow.SystemsSuccess)
+    assert systems_result.systems == {}
 
 
 async def test_systems_step_without_pending_user_input(
@@ -407,12 +406,11 @@ async def test_options_flow_init_success(
 
     with patch(
         "homeassistant.components.iaqualink.config_flow.async_get_systems",
-        return_value=(
+        return_value=config_flow.SystemsSuccess(
             {
                 "SN001": mock_system1,
                 "SN002": mock_system2,
-            },
-            None,
+            }
         ),
     ):
         result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -444,12 +442,11 @@ async def test_options_flow_submit_systems(
 
     with patch(
         "homeassistant.components.iaqualink.config_flow.async_get_systems",
-        return_value=(
+        return_value=config_flow.SystemsSuccess(
             {
                 "SN001": mock_system1,
                 "SN002": mock_system2,
-            },
-            None,
+            }
         ),
     ):
         result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -480,7 +477,7 @@ async def test_options_flow_submit_systems_direct_init_call(
 
     with patch(
         "homeassistant.components.iaqualink.config_flow.async_get_systems",
-        return_value=({"SN001": mock_system}, None),
+        return_value=config_flow.SystemsSuccess({"SN001": mock_system}),
     ):
         result = await flow.async_step_init({CONF_SYSTEMS: ["SN001"]})
 
@@ -509,12 +506,11 @@ async def test_options_flow_filters_stale_selected_systems(
 
     with patch(
         "homeassistant.components.iaqualink.config_flow.async_get_systems",
-        return_value=(
+        return_value=config_flow.SystemsSuccess(
             {
                 "SN001": mock_system1,
                 "SN002": mock_system2,
-            },
-            None,
+            }
         ),
     ):
         result = await hass.config_entries.options.async_init(entry.entry_id)

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -146,6 +146,34 @@ async def test_with_existing_config(
     assert result["options"] == {"systems": ["SN001"]}
 
 
+async def test_user_step_relies_on_async_get_systems(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test the initial user step does not separately validate credentials."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+
+    mock_system = MagicMock()
+    mock_system.serial = "SN001"
+    mock_system.name = "Pool System 1"
+
+    with (
+        patch.object(
+            config_flow.AqualinkFlowHandler,
+            "_async_test_credentials",
+            side_effect=AssertionError("should not be called"),
+        ),
+        patch(
+            "homeassistant.components.iaqualink.config_flow.async_get_systems",
+            return_value=({"SN001": mock_system}, None),
+        ),
+    ):
+        result = await flow.async_step_user(config_data)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "systems"
+
+
 async def test_with_no_systems(
     hass: HomeAssistant, config_data: dict[str, str]
 ) -> None:
@@ -242,6 +270,31 @@ async def test_async_get_systems_no_systems(
         patch(
             "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
             return_value={},
+        ),
+    ):
+        systems, error_reason = await config_flow.async_get_systems(
+            hass,
+            config_data[CONF_USERNAME],
+            config_data[CONF_PASSWORD],
+        )
+
+    assert systems == {}
+    assert error_reason is None
+
+
+async def test_async_get_systems_none_systems(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+) -> None:
+    """Test async_get_systems normalizes a missing systems payload."""
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            return_value=None,
         ),
     ):
         systems, error_reason = await config_flow.async_get_systems(
@@ -455,6 +508,41 @@ async def test_options_flow_submit_systems_direct_init_call(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_SYSTEMS: ["SN001"]}
+
+
+async def test_options_flow_filters_stale_selected_systems(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test options flow excludes saved systems that are no longer available."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        options={CONF_SYSTEMS: ["SN001", "STALE_SYSTEM"]},
+    )
+    entry.add_to_hass(hass)
+
+    mock_system1 = MagicMock()
+    mock_system1.serial = "SN001"
+    mock_system1.name = "Pool System 1"
+
+    mock_system2 = MagicMock()
+    mock_system2.serial = "SN002"
+    mock_system2.name = "Pool System 2"
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.async_get_systems",
+        return_value=(
+            {
+                "SN001": mock_system1,
+                "SN002": mock_system2,
+            },
+            None,
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["data_schema"]({}) == {CONF_SYSTEMS: ["SN001"]}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -83,6 +83,24 @@ async def test_service_exception(
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_timeout_during_credential_check(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test config flow maps login timeout to cannot_connect."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+
+    with patch(
+        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+        side_effect=TimeoutError,
+    ):
+        result = await flow.async_step_user(config_data)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
 async def test_with_existing_config(
     hass: HomeAssistant, config_data: dict[str, str]
 ) -> None:
@@ -150,6 +168,30 @@ async def test_with_no_systems(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "no_systems"}
+
+
+async def test_timeout_during_system_fetch(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test config flow maps system fetch timeout to cannot_connect."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            side_effect=TimeoutError,
+        ),
+    ):
+        result = await flow.async_step_user(config_data)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_systems_step_without_pending_user_input(

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
@@ -47,58 +48,34 @@ async def test_without_config(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
 
-async def test_with_invalid_credentials(
-    hass: HomeAssistant, config_data: dict[str, str]
+@pytest.mark.parametrize(
+    ("exception", "error_reason"),
+    [
+        (AqualinkServiceUnauthorizedException(), "invalid_auth"),
+        (AqualinkServiceException(), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
+        (httpx.HTTPError("request failed"), "cannot_connect"),
+    ],
+)
+async def test_user_step_exception_handling(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+    exception: Exception,
+    error_reason: str,
 ) -> None:
-    """Test config flow with invalid username and/or password."""
+    """Test config flow maps login exceptions to the expected error."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
     with patch(
         "homeassistant.components.iaqualink.utils.AqualinkClient.login",
-        side_effect=AqualinkServiceUnauthorizedException,
+        side_effect=exception,
     ):
         result = await flow.async_step_user(config_data)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "invalid_auth"}
-
-
-async def test_service_exception(
-    hass: HomeAssistant, config_data: dict[str, str]
-) -> None:
-    """Test config flow encountering service exception."""
-    flow = config_flow.AqualinkFlowHandler()
-    flow.hass = hass
-
-    with patch(
-        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
-        side_effect=AqualinkServiceException,
-    ):
-        result = await flow.async_step_user(config_data)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_timeout_during_credential_check(
-    hass: HomeAssistant, config_data: dict[str, str]
-) -> None:
-    """Test config flow maps login timeout to cannot_connect."""
-    flow = config_flow.AqualinkFlowHandler()
-    flow.hass = hass
-
-    with patch(
-        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
-        side_effect=TimeoutError,
-    ):
-        result = await flow.async_step_user(config_data)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": error_reason}
 
 
 async def test_with_existing_config(
@@ -204,10 +181,22 @@ async def test_with_no_systems(
     assert result["options"] == {CONF_SYSTEMS: []}
 
 
-async def test_timeout_during_system_fetch(
-    hass: HomeAssistant, config_data: dict[str, str]
+@pytest.mark.parametrize(
+    ("exception", "error_reason"),
+    [
+        (AqualinkServiceUnauthorizedException(), "invalid_auth"),
+        (AqualinkServiceException(), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
+        (httpx.HTTPError("request failed"), "cannot_connect"),
+    ],
+)
+async def test_system_fetch_exception_handling(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+    exception: Exception,
+    error_reason: str,
 ) -> None:
-    """Test config flow maps system fetch timeout to cannot_connect."""
+    """Test config flow maps system fetch exceptions to the expected error."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
@@ -218,14 +207,14 @@ async def test_timeout_during_system_fetch(
         ),
         patch(
             "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
-            side_effect=TimeoutError,
+            side_effect=exception,
         ),
     ):
         result = await flow.async_step_user(config_data)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": error_reason}
 
 
 async def test_async_get_systems_success(
@@ -365,10 +354,22 @@ async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) 
     }
 
 
-async def test_reauth_invalid_auth(
-    hass: HomeAssistant, config_data: dict[str, str]
+@pytest.mark.parametrize(
+    ("exception", "error_reason"),
+    [
+        (AqualinkServiceUnauthorizedException(), "invalid_auth"),
+        (AqualinkServiceException(), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
+        (httpx.HTTPError("request failed"), "cannot_connect"),
+    ],
+)
+async def test_reauth_exception_handling(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+    exception: Exception,
+    error_reason: str,
 ) -> None:
-    """Test reauthentication with invalid credentials."""
+    """Test reauthentication maps exceptions to the expected flow errors."""
     entry = MockConfigEntry(domain=DOMAIN, data=config_data)
     entry.add_to_hass(hass)
 
@@ -376,7 +377,7 @@ async def test_reauth_invalid_auth(
 
     with patch(
         "homeassistant.components.iaqualink.utils.AqualinkClient.login",
-        side_effect=AqualinkServiceUnauthorizedException,
+        side_effect=exception,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -385,30 +386,7 @@ async def test_reauth_invalid_auth(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
-    assert result["errors"] == {"base": "invalid_auth"}
-
-
-async def test_reauth_cannot_connect(
-    hass: HomeAssistant, config_data: dict[str, str]
-) -> None:
-    """Test reauthentication when the service cannot be reached."""
-    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
-    entry.add_to_hass(hass)
-
-    result = await entry.start_reauth_flow(hass)
-
-    with patch(
-        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
-        side_effect=AqualinkServiceException,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_USERNAME: config_data[CONF_USERNAME], CONF_PASSWORD: "new_password"},
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reauth_confirm"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": error_reason}
 
 
 async def test_options_flow_init_success(
@@ -546,38 +524,33 @@ async def test_options_flow_filters_stale_selected_systems(
 
 
 @pytest.mark.parametrize(
-    ("get_systems_result", "reason"),
+    ("exception", "reason"),
     [
-        (AqualinkServiceUnauthorizedException, "invalid_auth"),
-        (AqualinkServiceException, "cannot_connect"),
+        (AqualinkServiceUnauthorizedException(), "invalid_auth"),
+        (AqualinkServiceException(), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
+        (httpx.HTTPError("request failed"), "cannot_connect"),
     ],
 )
 async def test_options_flow_init_abort_reasons(
     hass: HomeAssistant,
     config_data: dict[str, str],
-    get_systems_result: type[Exception] | dict[str, str],
+    exception: Exception,
     reason: str,
 ) -> None:
     """Test options flow displays errors when systems cannot be loaded."""
     entry = MockConfigEntry(domain=DOMAIN, data=config_data)
     entry.add_to_hass(hass)
 
-    get_systems_patch = patch(
-        "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
-        side_effect=get_systems_result,
-    )
-    if isinstance(get_systems_result, dict):
-        get_systems_patch = patch(
-            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
-            return_value=get_systems_result,
-        )
-
     with (
         patch(
             "homeassistant.components.iaqualink.utils.AqualinkClient.login",
             return_value=None,
         ),
-        get_systems_patch,
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            side_effect=exception,
+        ),
     ):
         result = await hass.config_entries.options.async_init(entry.entry_id)
 

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -1,13 +1,15 @@
 """Tests for iAqualink config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
 )
+import pytest
 
 from homeassistant.components.iaqualink import DOMAIN, config_flow
+from homeassistant.components.iaqualink.const import CONF_SYSTEMS
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -53,7 +55,7 @@ async def test_with_invalid_credentials(
     flow.hass = hass
 
     with patch(
-        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
         side_effect=AqualinkServiceUnauthorizedException,
     ):
         result = await flow.async_step_user(config_data)
@@ -71,7 +73,7 @@ async def test_service_exception(
     flow.hass = hass
 
     with patch(
-        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
         side_effect=AqualinkServiceException,
     ):
         result = await flow.async_step_user(config_data)
@@ -89,15 +91,80 @@ async def test_with_existing_config(
     flow.hass = hass
     flow.context = {}
 
-    with patch(
-        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
-        return_value=None,
+    mock_system1 = MagicMock()
+    mock_system1.serial = "SN001"
+    mock_system1.name = "Pool System 1"
+
+    mock_system2 = MagicMock()
+    mock_system2.serial = "SN002"
+    mock_system2.name = "Pool System 2"
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.config_flow.async_get_systems",
+            return_value=(
+                {
+                    "SN001": mock_system1,
+                    "SN002": mock_system2,
+                },
+                None,
+            ),
+        ),
     ):
         result = await flow.async_step_user(config_data)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "systems"
+
+    result = await flow.async_step_systems({"systems": ["SN001"]})
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == config_data["username"]
     assert result["data"] == config_data
+    assert result["options"] == {"systems": ["SN001"]}
+
+
+async def test_with_no_systems(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test config flow when the account returns no systems."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            return_value={},
+        ),
+    ):
+        result = await flow.async_step_user(config_data)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "no_systems"}
+
+
+async def test_systems_step_without_pending_user_input(
+    hass: HomeAssistant,
+) -> None:
+    """Test systems step falls back to the initial form without saved state."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+    flow.context = {}
+
+    result = await flow.async_step_systems()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
 
 
 async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) -> None:
@@ -119,7 +186,7 @@ async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) 
 
     with (
         patch(
-            "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
             return_value=None,
         ),
         patch(
@@ -153,7 +220,7 @@ async def test_reauth_invalid_auth(
     result = await entry.start_reauth_flow(hass)
 
     with patch(
-        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
         side_effect=AqualinkServiceUnauthorizedException,
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -176,7 +243,7 @@ async def test_reauth_cannot_connect(
     result = await entry.start_reauth_flow(hass)
 
     with patch(
-        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        "homeassistant.components.iaqualink.utils.AqualinkClient.login",
         side_effect=AqualinkServiceException,
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -187,3 +254,119 @@ async def test_reauth_cannot_connect(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_options_flow_init_success(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test options flow initializes and displays systems."""
+    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry.add_to_hass(hass)
+
+    # Mock systems
+    mock_system1 = MagicMock()
+    mock_system1.serial = "SN001"
+    mock_system1.name = "Pool System 1"
+
+    mock_system2 = MagicMock()
+    mock_system2.serial = "SN002"
+    mock_system2.name = "Pool System 2"
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.async_get_systems",
+        return_value=(
+            {
+                "SN001": mock_system1,
+                "SN002": mock_system2,
+            },
+            None,
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+
+async def test_options_flow_submit_systems(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test options flow submits selected systems."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    # Mock systems
+    mock_system1 = MagicMock()
+    mock_system1.serial = "SN001"
+    mock_system1.name = "Pool System 1"
+
+    mock_system2 = MagicMock()
+    mock_system2.serial = "SN002"
+    mock_system2.name = "Pool System 2"
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.async_get_systems",
+        return_value=(
+            {
+                "SN001": mock_system1,
+                "SN002": mock_system2,
+            },
+            None,
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+        # Submit form with only SN001 selected
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_SYSTEMS: ["SN001"]},
+        )
+
+    assert entry.options[CONF_SYSTEMS] == ["SN001"]
+
+
+@pytest.mark.parametrize(
+    ("get_systems_result", "reason"),
+    [
+        (AqualinkServiceUnauthorizedException, "invalid_auth"),
+        (AqualinkServiceException, "cannot_connect"),
+        ({}, "no_systems"),
+    ],
+)
+async def test_options_flow_init_abort_reasons(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+    get_systems_result: type[Exception] | dict[str, str],
+    reason: str,
+) -> None:
+    """Test options flow displays errors when systems cannot be loaded."""
+    entry = MockConfigEntry(domain=DOMAIN, data=config_data)
+    entry.add_to_hass(hass)
+
+    get_systems_patch = patch(
+        "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+        side_effect=get_systems_result,
+    )
+    if isinstance(get_systems_result, dict):
+        get_systems_patch = patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.get_systems",
+            return_value=get_systems_result,
+        )
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.utils.AqualinkClient.login",
+            return_value=None,
+        ),
+        get_systems_patch,
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {"base": reason}

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
+import httpx
 from iaqualink.client import AqualinkClient
 from iaqualink.exception import (
     AqualinkServiceException,
@@ -243,6 +244,50 @@ async def test_setup_systems_exception(
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
             side_effect=AqualinkServiceException,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_systems_timeout(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test setup encountering a timeout while retrieving systems."""
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            side_effect=TimeoutError,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_systems_http_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test setup encountering an HTTP error while retrieving systems."""
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            side_effect=httpx.HTTPError("boom"),
         ),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -17,6 +17,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaThermostat,
 )
 from iaqualink.systems.iaqua.system import IaquaSystem
+import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -178,84 +179,59 @@ async def test_light_service_calls_update_entity_state(
     assert state.state == STATE_ON
 
 
-async def test_setup_login_exception(
-    hass: HomeAssistant, config_entry: MockConfigEntry
+@pytest.mark.parametrize(
+    ("exception", "expected_state", "reauth_expected"),
+    [
+        (AqualinkServiceException(), ConfigEntryState.SETUP_RETRY, False),
+        (AqualinkServiceUnauthorizedException(), ConfigEntryState.SETUP_ERROR, True),
+        (TimeoutError(), ConfigEntryState.SETUP_RETRY, False),
+        (httpx.HTTPError("boom"), ConfigEntryState.SETUP_RETRY, False),
+    ],
+)
+async def test_setup_login_exception_handling(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    exception: Exception,
+    expected_state: ConfigEntryState,
+    reauth_expected: bool,
 ) -> None:
-    """Test setup encountering a login exception."""
+    """Test setup maps login exceptions to the expected config entry state."""
     config_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.iaqualink.AqualinkClient.login",
-        side_effect=AqualinkServiceException,
+        side_effect=exception,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_login_unauthorized(
-    hass: HomeAssistant, config_entry: MockConfigEntry
-) -> None:
-    """Test setup encountering an unauthorized exception during login."""
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login",
-        side_effect=AqualinkServiceUnauthorizedException,
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is expected_state
 
     flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    if reauth_expected:
+        assert len(flows) == 1
+        assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    else:
+        assert flows == []
 
 
-async def test_setup_login_timeout(
-    hass: HomeAssistant, config_entry: MockConfigEntry
+@pytest.mark.parametrize(
+    ("exception", "expected_state", "reauth_expected"),
+    [
+        (AqualinkServiceException(), ConfigEntryState.SETUP_RETRY, False),
+        (TimeoutError(), ConfigEntryState.SETUP_RETRY, False),
+        (httpx.HTTPError("boom"), ConfigEntryState.SETUP_RETRY, False),
+        (AqualinkServiceUnauthorizedException(), ConfigEntryState.SETUP_ERROR, True),
+    ],
+)
+async def test_setup_systems_exception_handling(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    exception: Exception,
+    expected_state: ConfigEntryState,
+    reauth_expected: bool,
 ) -> None:
-    """Test setup encountering a timeout while logging in."""
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login",
-        side_effect=TimeoutError,
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_systems_exception(
-    hass: HomeAssistant, config_entry: MockConfigEntry
-) -> None:
-    """Test setup encountering an exception while retrieving systems."""
-    config_entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
-        ),
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
-            side_effect=AqualinkServiceException,
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_systems_timeout(
-    hass: HomeAssistant, config_entry: MockConfigEntry
-) -> None:
-    """Test setup encountering a timeout while retrieving systems."""
+    """Test setup maps system fetch exceptions to the expected config entry state."""
     config_entry.add_to_hass(hass)
 
     with (
@@ -265,61 +241,20 @@ async def test_setup_systems_timeout(
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
-            side_effect=TimeoutError,
+            side_effect=exception,
         ),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_systems_http_error(
-    hass: HomeAssistant, config_entry: MockConfigEntry
-) -> None:
-    """Test setup encountering an HTTP error while retrieving systems."""
-    config_entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
-        ),
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
-            side_effect=httpx.HTTPError("boom"),
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_systems_unauthorized(
-    hass: HomeAssistant, config_entry: MockConfigEntry
-) -> None:
-    """Test setup encountering an unauthorized exception while retrieving systems."""
-    config_entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
-        ),
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
-            side_effect=AqualinkServiceUnauthorizedException,
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is expected_state
 
     flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    if reauth_expected:
+        assert len(flows) == 1
+        assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    else:
+        assert flows == []
 
 
 async def test_setup_first_refresh_unauthorized_closes_client(
@@ -372,17 +307,56 @@ async def test_setup_no_systems_recognized_supports_reload_and_unload(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
             return_value={},
         ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.close",
+            new_callable=AsyncMock,
+        ) as mock_close,
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.runtime_data.platforms_loaded is False
+        assert mock_close.await_count == 1
 
         assert await hass.config_entries.async_reload(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.runtime_data.platforms_loaded is False
+        assert mock_close.await_count == 2
 
         assert await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
+        assert mock_close.await_count == 2
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_none_systems_recognized_supports_reload_and_unload(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test setup treats a None systems payload as an empty supported state."""
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.close",
+            new_callable=AsyncMock,
+        ) as mock_close,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.runtime_data.platforms_loaded is False
+        assert mock_close.await_count == 1
+
+        assert await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert mock_close.await_count == 1
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
@@ -412,17 +386,24 @@ async def test_setup_no_systems_selected_supports_reload_and_unload(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
             return_value=systems,
         ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.close",
+            new_callable=AsyncMock,
+        ) as mock_close,
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.runtime_data.platforms_loaded is False
+        assert mock_close.await_count == 1
 
         assert await hass.config_entries.async_reload(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.runtime_data.platforms_loaded is False
+        assert mock_close.await_count == 2
 
         assert await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
+        assert mock_close.await_count == 2
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
@@ -452,17 +433,24 @@ async def test_setup_selected_systems_not_found_supports_reload_and_unload(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
             return_value=systems,
         ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.close",
+            new_callable=AsyncMock,
+        ) as mock_close,
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.runtime_data.platforms_loaded is False
+        assert mock_close.await_count == 1
 
         assert await hass.config_entries.async_reload(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.runtime_data.platforms_loaded is False
+        assert mock_close.await_count == 2
 
         assert await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
+        assert mock_close.await_count == 2
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
@@ -497,15 +485,28 @@ async def test_setup_with_systems_marks_platforms_loaded(
     assert config_entry.runtime_data.platforms_loaded is True
 
 
-async def test_setup_devices_exception(
+@pytest.mark.parametrize(
+    ("exception", "expected_state", "reauth_expected"),
+    [
+        (AqualinkServiceException(), ConfigEntryState.SETUP_RETRY, False),
+        (TimeoutError(), ConfigEntryState.SETUP_RETRY, False),
+        (httpx.HTTPError("boom"), ConfigEntryState.SETUP_RETRY, False),
+        (AqualinkServiceUnauthorizedException(), ConfigEntryState.SETUP_ERROR, True),
+    ],
+)
+async def test_setup_devices_exception_handling(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     client: AqualinkClient,
+    exception: Exception,
+    expected_state: ConfigEntryState,
+    reauth_expected: bool,
 ) -> None:
-    """Test setup encountering an exception while retrieving devices."""
+    """Test setup maps device retrieval exceptions to the expected config entry state."""
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
     system.update = AsyncMock()
     systems = {system.serial: system}
 
@@ -521,79 +522,20 @@ async def test_setup_devices_exception(
         patch.object(
             system,
             "get_devices",
-        ) as mock_get_devices,
-    ):
-        mock_get_devices.side_effect = AqualinkServiceException
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_devices_unauthorized(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    client: AqualinkClient,
-) -> None:
-    """Test setup handles unauthorized errors while retrieving devices."""
-    config_entry.add_to_hass(hass)
-
-    system = get_aqualink_system(client, cls=IaquaSystem)
-    system.online = True
-    system.update = AsyncMock()
-    systems = {system.serial: system}
-
-    with (
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
-        ),
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
-            return_value=systems,
-        ),
-        patch.object(
-            system, "get_devices", side_effect=AqualinkServiceUnauthorizedException
+            side_effect=exception,
         ),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is expected_state
 
     flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == SOURCE_REAUTH
-
-
-async def test_setup_devices_service_exception_with_online_system(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    client: AqualinkClient,
-) -> None:
-    """Test setup retries when device retrieval fails for an online system."""
-    config_entry.add_to_hass(hass)
-
-    system = get_aqualink_system(client, cls=IaquaSystem)
-    system.online = True
-    system.update = AsyncMock()
-    systems = {system.serial: system}
-
-    with (
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
-        ),
-        patch(
-            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
-            return_value=systems,
-        ),
-        patch.object(system, "get_devices", side_effect=AqualinkServiceException),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    if reauth_expected:
+        assert len(flows) == 1
+        assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    else:
+        assert flows == []
 
 
 async def test_setup_all_good_no_recognized_devices(

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -382,6 +382,46 @@ async def test_setup_no_systems_selected_supports_reload_and_unload(
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
+async def test_setup_selected_systems_not_found_supports_reload_and_unload(
+    hass: HomeAssistant,
+    client: AqualinkClient,
+    config_data: dict[str, str],
+) -> None:
+    """Test setup supports options containing systems no longer returned by the API."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        options={CONF_SYSTEMS: ["MISSING"]},
+    )
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    systems = {system.serial: system}
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.runtime_data.platforms_loaded is False
+
+        assert await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.runtime_data.platforms_loaded is False
+
+        assert await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
 async def test_setup_with_systems_marks_platforms_loaded(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
@@ -439,6 +479,72 @@ async def test_setup_devices_exception(
         ) as mock_get_devices,
     ):
         mock_get_devices.side_effect = AqualinkServiceException
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_devices_unauthorized(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+) -> None:
+    """Test setup handles unauthorized errors while retrieving devices."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
+    systems = {system.serial: system}
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+        patch.object(
+            system, "get_devices", side_effect=AqualinkServiceUnauthorizedException
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+
+
+async def test_setup_devices_service_exception_with_online_system(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+) -> None:
+    """Test setup retries when device retrieval fails for an online system."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
+    systems = {system.serial: system}
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+        patch.object(system, "get_devices", side_effect=AqualinkServiceException),
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -19,7 +19,11 @@ from iaqualink.systems.iaqua.system import IaquaSystem
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.iaqualink.const import UPDATE_INTERVAL
+from homeassistant.components.iaqualink.const import (
+    CONF_SYSTEMS,
+    DOMAIN,
+    UPDATE_INTERVAL,
+)
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -308,10 +312,10 @@ async def test_setup_first_refresh_unauthorized_closes_client(
     assert flows[0]["context"]["source"] == SOURCE_REAUTH
 
 
-async def test_setup_no_systems_recognized(
+async def test_setup_no_systems_recognized_supports_reload_and_unload(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test setup ending in no systems recognized."""
+    """Test setup supports accounts with no detected systems."""
     config_entry.add_to_hass(hass)
 
     with (
@@ -324,10 +328,88 @@ async def test_setup_no_systems_recognized(
             return_value={},
         ),
     ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.runtime_data.platforms_loaded is False
+
+        assert await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.runtime_data.platforms_loaded is False
+
+        assert await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_no_systems_selected_supports_reload_and_unload(
+    hass: HomeAssistant,
+    client: AqualinkClient,
+    config_data: dict[str, str],
+) -> None:
+    """Test setup supports an empty selected-systems list."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        options={CONF_SYSTEMS: []},
+    )
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    systems = {system.serial: system}
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.runtime_data.platforms_loaded is False
+
+        assert await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.runtime_data.platforms_loaded is False
+
+        assert await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_with_systems_marks_platforms_loaded(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+) -> None:
+    """Test setup marks platforms as loaded when entry setups are forwarded."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
+    systems = {system.serial: system}
+    system.get_devices = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.runtime_data.platforms_loaded is True
 
 
 async def test_setup_devices_exception(


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add system selection during config entry setup and expose the same selection through an options flow.

Refactor system loading into shared helpers, surface flow errors consistently, and keep entries loadable when no systems are active or selected.

Update config flow and setup tests to cover the new options flow, error handling, and no-active-systems lifecycle.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
