### PR TITLE
Extract entity template functions into an entity Jinja2 extension

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -1289,26 +1289,6 @@ def distance(hass: HomeAssistant, *args: Any) -> float | None:
     )
 
 
-def entity_name(hass: HomeAssistant, entity_id: str) -> str | None:
-    """Get the name of an entity from its entity ID."""
-    ent_reg = er.async_get(hass)
-    if (entry := ent_reg.async_get(entity_id)) is not None:
-        return er.async_get_unprefixed_name(hass, entry)
-
-    # Fall back to state for entities without a unique_id (not in the registry)
-    if (state := hass.states.get(entity_id)) is not None:
-        return state.name
-
-    return None
-
-
-def is_hidden_entity(hass: HomeAssistant, entity_id: str) -> bool:
-    """Test if an entity is hidden."""
-    entity_reg = er.async_get(hass)
-    entry = entity_reg.async_get(entity_id)
-    return entry is not None and entry.hidden
-
-
 def is_state(hass: HomeAssistant, entity_id: str, state: str | list[str]) -> bool:
     """Test if a state is a specific value."""
     state_obj = _get_state(hass, entity_id)
@@ -1482,6 +1462,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
             "homeassistant.helpers.template.extensions.DateTimeExtension"
         )
         self.add_extension("homeassistant.helpers.template.extensions.DeviceExtension")
+        self.add_extension("homeassistant.helpers.template.extensions.EntityExtension")
         self.add_extension("homeassistant.helpers.template.extensions.FloorExtension")
         self.add_extension(
             "homeassistant.helpers.template.extensions.FunctionalExtension"
@@ -1537,10 +1518,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
             hass_globals = [
                 "closest",
                 "distance",
-                "entity_name",
                 "expand",
                 "has_value",
-                "is_hidden_entity",
                 "is_state_attr",
                 "is_state",
                 "state_attr",
@@ -1550,7 +1529,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
             ]
             hass_filters = [
                 "closest",
-                "entity_name",
                 "expand",
                 "has_value",
                 "state_attr",
@@ -1560,7 +1538,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
             ]
             hass_tests = [
                 "has_value",
-                "is_hidden_entity",
                 "is_state_attr",
                 "is_state",
             ]
@@ -1582,15 +1559,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["has_value"] = self.globals["has_value"]
 
         self.tests["has_value"] = hassfunction(has_value, pass_eval_context)
-
-        # Entity extensions
-
-        self.globals["entity_name"] = hassfunction(entity_name)
-        self.filters["entity_name"] = self.globals["entity_name"]
-        self.globals["is_hidden_entity"] = hassfunction(is_hidden_entity)
-        self.tests["is_hidden_entity"] = hassfunction(
-            is_hidden_entity, pass_eval_context
-        )
 
         # State extensions
 

--- a/homeassistant/helpers/template/extensions/__init__.py
+++ b/homeassistant/helpers/template/extensions/__init__.py
@@ -7,6 +7,7 @@ from .config_entries import ConfigEntryExtension
 from .crypto import CryptoExtension
 from .datetime import DateTimeExtension
 from .devices import DeviceExtension
+from .entities import EntityExtension
 from .floors import FloorExtension
 from .functional import FunctionalExtension
 from .issues import IssuesExtension
@@ -26,6 +27,7 @@ __all__ = [
     "CryptoExtension",
     "DateTimeExtension",
     "DeviceExtension",
+    "EntityExtension",
     "FloorExtension",
     "FunctionalExtension",
     "IssuesExtension",

--- a/homeassistant/helpers/template/extensions/entities.py
+++ b/homeassistant/helpers/template/extensions/entities.py
@@ -1,0 +1,58 @@
+"""Entity functions for Home Assistant templates."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import entity_registry as er
+
+from .base import BaseTemplateExtension, TemplateFunction
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.template import TemplateEnvironment
+
+
+class EntityExtension(BaseTemplateExtension):
+    """Jinja2 extension for entity functions."""
+
+    def __init__(self, environment: TemplateEnvironment) -> None:
+        """Initialize the entity extension."""
+        super().__init__(
+            environment,
+            functions=[
+                TemplateFunction(
+                    "entity_name",
+                    self.entity_name,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                    limited_ok=False,
+                ),
+                TemplateFunction(
+                    "is_hidden_entity",
+                    self.is_hidden_entity,
+                    as_global=True,
+                    as_test=True,
+                    requires_hass=True,
+                    limited_ok=False,
+                ),
+            ],
+        )
+
+    def entity_name(self, entity_id: str) -> str | None:
+        """Get the name of an entity from its entity ID."""
+        ent_reg = er.async_get(self.hass)
+        if (entry := ent_reg.async_get(entity_id)) is not None:
+            return er.async_get_unprefixed_name(self.hass, entry)
+
+        # Fall back to state for entities without a unique_id (not in the registry)
+        if (state := self.hass.states.get(entity_id)) is not None:
+            return state.name
+
+        return None
+
+    def is_hidden_entity(self, entity_id: str) -> bool:
+        """Test if an entity is hidden."""
+        entity_reg = er.async_get(self.hass)
+        entry = entity_reg.async_get(entity_id)
+        return entry is not None and entry.hidden

--- a/tests/helpers/template/extensions/test_entities.py
+++ b/tests/helpers/template/extensions/test_entities.py
@@ -1,0 +1,88 @@
+"""Test entity functions for Home Assistant templates."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+from tests.helpers.template.helpers import render
+
+
+def test_entity_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test entity_name method."""
+    assert render(hass, "{{ entity_name('sensor.fake') }}") is None
+
+    entry = entity_registry.async_get_or_create(
+        "sensor", "test", "unique_1", original_name="Registry Sensor"
+    )
+    assert render(hass, f"{{{{ entity_name('{entry.entity_id}') }}}}") == (
+        "Registry Sensor"
+    )
+    assert render(hass, f"{{{{ '{entry.entity_id}' | entity_name }}}}") == (
+        "Registry Sensor"
+    )
+
+    entity_registry.async_update_entity(entry.entity_id, name="My Custom Sensor")
+    assert render(hass, f"{{{{ entity_name('{entry.entity_id}') }}}}") == (
+        "My Custom Sensor"
+    )
+
+    # Falls back to state for entities not in the registry
+    hass.states.async_set(
+        "light.no_unique_id", "on", {"friendly_name": "No Unique ID Light"}
+    )
+    assert render(hass, "{{ entity_name('light.no_unique_id') }}") == (
+        "No Unique ID Light"
+    )
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        name="My Device",
+    )
+    entry2 = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "unique_2",
+        config_entry=config_entry,
+        device_id=device_entry.id,
+        has_entity_name=True,
+        original_name="Temperature",
+    )
+    assert render(hass, f"{{{{ entity_name('{entry2.entity_id}') }}}}") == (
+        "Temperature"
+    )
+
+    # Strips device name prefix
+    entity_registry.async_update_entity(
+        entry2.entity_id, name="My Device Custom Sensor"
+    )
+    assert render(hass, f"{{{{ entity_name('{entry2.entity_id}') }}}}") == (
+        "Custom Sensor"
+    )
+
+
+def test_is_hidden_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test is_hidden_entity method."""
+    hidden_entity = entity_registry.async_get_or_create(
+        "sensor", "mock", "hidden", hidden_by=er.RegistryEntryHider.USER
+    )
+    visible_entity = entity_registry.async_get_or_create("sensor", "mock", "visible")
+    assert render(hass, f"{{{{ is_hidden_entity('{hidden_entity.entity_id}') }}}}")
+
+    assert not render(hass, f"{{{{ is_hidden_entity('{visible_entity.entity_id}') }}}}")
+
+    assert not render(
+        hass,
+        f"{{{{ ['{visible_entity.entity_id}'] | select('is_hidden_entity') | first }}}}",
+    )

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -26,12 +26,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-    template,
-    translation,
-)
+from homeassistant.helpers import entity_registry as er, template, translation
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.template.render_info import (
     ALL_STATES_RATE_LIMIT,
@@ -401,85 +396,6 @@ def test_if_state_exists(hass: HomeAssistant) -> None:
         hass, "{% if states.test.object %}exists{% else %}not exists{% endif %}"
     )
     assert result == "exists"
-
-
-def test_entity_name(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test entity_name method."""
-    assert render(hass, "{{ entity_name('sensor.fake') }}") is None
-
-    entry = entity_registry.async_get_or_create(
-        "sensor", "test", "unique_1", original_name="Registry Sensor"
-    )
-    assert render(hass, f"{{{{ entity_name('{entry.entity_id}') }}}}") == (
-        "Registry Sensor"
-    )
-    assert render(hass, f"{{{{ '{entry.entity_id}' | entity_name }}}}") == (
-        "Registry Sensor"
-    )
-
-    entity_registry.async_update_entity(entry.entity_id, name="My Custom Sensor")
-    assert render(hass, f"{{{{ entity_name('{entry.entity_id}') }}}}") == (
-        "My Custom Sensor"
-    )
-
-    # Falls back to state for entities not in the registry
-    hass.states.async_set(
-        "light.no_unique_id", "on", {"friendly_name": "No Unique ID Light"}
-    )
-    assert render(hass, "{{ entity_name('light.no_unique_id') }}") == (
-        "No Unique ID Light"
-    )
-
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
-        name="My Device",
-    )
-    entry2 = entity_registry.async_get_or_create(
-        "sensor",
-        "test",
-        "unique_2",
-        config_entry=config_entry,
-        device_id=device_entry.id,
-        has_entity_name=True,
-        original_name="Temperature",
-    )
-    assert render(hass, f"{{{{ entity_name('{entry2.entity_id}') }}}}") == (
-        "Temperature"
-    )
-
-    # Strips device name prefix
-    entity_registry.async_update_entity(
-        entry2.entity_id, name="My Device Custom Sensor"
-    )
-    assert render(hass, f"{{{{ entity_name('{entry2.entity_id}') }}}}") == (
-        "Custom Sensor"
-    )
-
-
-def test_is_hidden_entity(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test is_hidden_entity method."""
-    hidden_entity = entity_registry.async_get_or_create(
-        "sensor", "mock", "hidden", hidden_by=er.RegistryEntryHider.USER
-    )
-    visible_entity = entity_registry.async_get_or_create("sensor", "mock", "visible")
-    assert render(hass, f"{{{{ is_hidden_entity('{hidden_entity.entity_id}') }}}}")
-
-    assert not render(hass, f"{{{{ is_hidden_entity('{visible_entity.entity_id}') }}}}")
-
-    assert not render(
-        hass,
-        f"{{{{ ['{visible_entity.entity_id}'] | select('is_hidden_entity') | first }}}}",
-    )
 
 
 def test_is_state(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is part of the ongoing effort to refactor our huge single template monolith into something more maintainable. In previous PRs I've moved many categories of template methods out of the monolith template file into their own Jinja2 extension.

This PR moves the **entity** template functions (`entity_name`, `is_hidden_entity`) into their own Jinja2 extension. Moves all tests as well.

There is no functional change in this PR, it is only moving these methods and tests into an extension.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
