### PR TITLE
Move template state infrastructure into a dedicated states module

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -35,7 +35,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State, callback, valid_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import entity_registry as er, location as loc_helper
+from homeassistant.helpers import location as loc_helper
 from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.util import convert, location as location_util

--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from ast import literal_eval
 import asyncio
 import collections.abc
-from collections.abc import Callable, Generator, Iterable
-from datetime import datetime, timedelta
-from enum import Enum
-from functools import cache, lru_cache, partial, wraps
+from collections.abc import Callable, Iterable
+from datetime import timedelta
+from functools import lru_cache, partial, wraps
 import logging
 import pathlib
 import re
@@ -22,42 +21,27 @@ from jinja2 import pass_context, pass_eval_context
 from jinja2.runtime import AsyncLoopContext, LoopContext
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
-from lru import LRU
-from propcache.api import under_cached_property
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
     ATTR_PERSONS,
-    ATTR_UNIT_OF_MEASUREMENT,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfLength,
 )
-from homeassistant.core import (
-    Context,
-    HomeAssistant,
-    State,
-    callback,
-    valid_domain,
-    valid_entity_id,
-)
+from homeassistant.core import HomeAssistant, State, callback, valid_entity_id
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import entity_registry as er, location as loc_helper
 from homeassistant.helpers.singleton import singleton
-from homeassistant.helpers.translation import (
-    async_translate_state,
-    async_translate_state_attr,
-)
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.util import convert, location as location_util
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.json import JSON_DECODE_EXCEPTIONS, json_loads
-from homeassistant.util.read_only_dict import ReadOnlyDict
 from homeassistant.util.thread import ThreadWithException
 
 from .context import (
@@ -68,6 +52,20 @@ from .context import (
 )
 from .helpers import result_as_boolean as result_as_boolean
 from .render_info import RenderInfo, render_info_cv
+from .states import (
+    CACHED_TEMPLATE_LRU,
+    CACHED_TEMPLATE_NO_COLLECT_LRU,
+    ENTITY_COUNT_GROWTH_FACTOR,
+    AllStates,
+    DomainStates,
+    StateAttrTranslated,
+    StateTranslated,
+    TemplateState as TemplateState,
+    TemplateStateFromEntityId as TemplateStateFromEntityId,
+    _collect_state,
+    _get_state,
+    _resolve_state,
+)
 
 if TYPE_CHECKING:
     from _typeshed import OptExcInfo
@@ -90,67 +88,10 @@ _HASS_LOADER = "template.hass_loader"
 # Match "simple" ints and floats. -1.0, 1, +5, 5.0
 _IS_NUMERIC = re.compile(r"^[+-]?(?!0\d)\d*(?:\.\d*)?$")
 
-_RESERVED_NAMES = {
-    "contextfunction",
-    "evalcontextfunction",
-    "environmentfunction",
-    "jinja_pass_arg",
-}
-
-_COLLECTABLE_STATE_ATTRIBUTES = {
-    "state",
-    "attributes",
-    "last_changed",
-    "last_updated",
-    "context",
-    "domain",
-    "object_id",
-    "name",
-}
-
-
-#
-# CACHED_TEMPLATE_STATES is a rough estimate of the number of entities
-# on a typical system. It is used as the initial size of the LRU cache
-# for TemplateState objects.
-#
-# If the cache is too small we will end up creating and destroying
-# TemplateState objects too often which will cause a lot of GC activity
-# and slow down the system. For systems with a lot of entities and
-# templates, this can reach 100000s of object creations and destructions
-# per minute.
-#
-# Since entity counts may grow over time, we will increase
-# the size if the number of entities grows via _async_adjust_lru_sizes
-# at the start of the system and every 10 minutes if needed.
-#
-CACHED_TEMPLATE_STATES = 512
 EVAL_CACHE_SIZE = 512
 
 MAX_CUSTOM_TEMPLATE_SIZE = 5 * 1024 * 1024
 MAX_TEMPLATE_OUTPUT = 256 * 1024  # 256KiB
-
-CACHED_TEMPLATE_LRU: LRU[State, TemplateState] = LRU(CACHED_TEMPLATE_STATES)
-CACHED_TEMPLATE_NO_COLLECT_LRU: LRU[State, TemplateState] = LRU(CACHED_TEMPLATE_STATES)
-ENTITY_COUNT_GROWTH_FACTOR = 1.2
-
-
-def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
-    """Return a TemplateState for a state without collecting."""
-    if template_state := CACHED_TEMPLATE_NO_COLLECT_LRU.get(state):
-        return template_state
-    template_state = _create_template_state_no_collect(hass, state)
-    CACHED_TEMPLATE_NO_COLLECT_LRU[state] = template_state
-    return template_state
-
-
-def _template_state(hass: HomeAssistant, state: State) -> TemplateState:
-    """Return a TemplateState for a state that collects."""
-    if template_state := CACHED_TEMPLATE_LRU.get(state):
-        return template_state
-    template_state = TemplateState(hass, state)
-    CACHED_TEMPLATE_LRU[state] = template_state
-    return template_state
 
 
 def async_setup(hass: HomeAssistant) -> bool:
@@ -688,429 +629,6 @@ class Template:
     def __repr__(self) -> str:
         """Representation of Template."""
         return f"Template<template=({self.template}) renders={self._renders}>"
-
-
-@cache
-def _domain_states(hass: HomeAssistant, name: str) -> DomainStates:
-    return DomainStates(hass, name)
-
-
-def _readonly(*args: Any, **kwargs: Any) -> Any:
-    """Raise an exception when a states object is modified."""
-    raise RuntimeError(f"Cannot modify template States object: {args} {kwargs}")
-
-
-class AllStates:
-    """Class to expose all HA states as attributes."""
-
-    __setitem__ = _readonly
-    __delitem__ = _readonly
-    __slots__ = ("_hass",)
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize all states."""
-        self._hass = hass
-
-    def __getattr__(self, name):
-        """Return the domain state."""
-        if "." in name:
-            return _get_state_if_valid(self._hass, name)
-
-        if name in _RESERVED_NAMES:
-            return None
-
-        if not valid_domain(name):
-            raise TemplateError(f"Invalid domain name '{name}'")
-
-        return _domain_states(self._hass, name)
-
-    # Jinja will try __getitem__ first and it avoids the need
-    # to call is_safe_attribute
-    __getitem__ = __getattr__
-
-    def _collect_all(self) -> None:
-        if (render_info := render_info_cv.get()) is not None:
-            render_info.all_states = True
-
-    def _collect_all_lifecycle(self) -> None:
-        if (render_info := render_info_cv.get()) is not None:
-            render_info.all_states_lifecycle = True
-
-    def __iter__(self) -> Generator[TemplateState]:
-        """Return all states."""
-        self._collect_all()
-        return _state_generator(self._hass, None)
-
-    def __len__(self) -> int:
-        """Return number of states."""
-        self._collect_all_lifecycle()
-        return self._hass.states.async_entity_ids_count()
-
-    def __call__(
-        self,
-        entity_id: str,
-        rounded: bool | object = _SENTINEL,
-        with_unit: bool = False,
-    ) -> str:
-        """Return the states."""
-        state = _get_state(self._hass, entity_id)
-        if state is None:
-            return STATE_UNKNOWN
-        if rounded is _SENTINEL:
-            rounded = with_unit
-        if rounded or with_unit:
-            return state.format_state(rounded, with_unit)  # type: ignore[arg-type]
-        return state.state
-
-    def __repr__(self) -> str:
-        """Representation of All States."""
-        return "<template AllStates>"
-
-
-class StateTranslated:
-    """Class to represent a translated state in a template."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize all states."""
-        self._hass = hass
-
-    def __call__(self, entity_id: str) -> str | None:
-        """Retrieve translated state if available."""
-        state = _get_state_if_valid(self._hass, entity_id)
-
-        if state is None:
-            return STATE_UNKNOWN
-
-        state_value = state.state
-        domain = state.domain
-        device_class = state.attributes.get("device_class")
-        entry = er.async_get(self._hass).async_get(entity_id)
-        platform = None if entry is None else entry.platform
-        translation_key = None if entry is None else entry.translation_key
-
-        return async_translate_state(
-            self._hass, state_value, domain, platform, translation_key, device_class
-        )
-
-    def __repr__(self) -> str:
-        """Representation of Translated state."""
-        return "<template StateTranslated>"
-
-
-class StateAttrTranslated:
-    """Class to represent a translated state attribute value in a template."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize."""
-        self._hass = hass
-
-    def __call__(self, entity_id: str, attribute: str) -> Any:
-        """Retrieve translated state attribute value if available."""
-        state = _get_state_if_valid(self._hass, entity_id)
-
-        if state is None:
-            return None
-
-        attr_value = state.attributes.get(attribute)
-        if attr_value is None:
-            return None
-
-        if not isinstance(attr_value, str | Enum):
-            return attr_value
-
-        domain = state.domain
-        device_class = state.attributes.get("device_class")
-        entry = er.async_get(self._hass).async_get(entity_id)
-        platform = None if entry is None else entry.platform
-        translation_key = None if entry is None else entry.translation_key
-
-        return async_translate_state_attr(
-            self._hass,
-            str(attr_value),
-            domain,
-            platform,
-            translation_key,
-            device_class,
-            attribute,
-        )
-
-    def __repr__(self) -> str:
-        """Representation of Translated state attribute."""
-        return "<template StateAttrTranslated>"
-
-
-class DomainStates:
-    """Class to expose a specific HA domain as attributes."""
-
-    __slots__ = ("_domain", "_hass")
-
-    __setitem__ = _readonly
-    __delitem__ = _readonly
-
-    def __init__(self, hass: HomeAssistant, domain: str) -> None:
-        """Initialize the domain states."""
-        self._hass = hass
-        self._domain = domain
-
-    def __getattr__(self, name: str) -> TemplateState | None:
-        """Return the states."""
-        return _get_state_if_valid(self._hass, f"{self._domain}.{name}")
-
-    # Jinja will try __getitem__ first and it avoids the need
-    # to call is_safe_attribute
-    __getitem__ = __getattr__
-
-    def _collect_domain(self) -> None:
-        if (entity_collect := render_info_cv.get()) is not None:
-            entity_collect.domains.add(self._domain)  # type: ignore[attr-defined]
-
-    def _collect_domain_lifecycle(self) -> None:
-        if (entity_collect := render_info_cv.get()) is not None:
-            entity_collect.domains_lifecycle.add(self._domain)  # type: ignore[attr-defined]
-
-    def __iter__(self) -> Generator[TemplateState]:
-        """Return the iteration over all the states."""
-        self._collect_domain()
-        return _state_generator(self._hass, self._domain)
-
-    def __len__(self) -> int:
-        """Return number of states."""
-        self._collect_domain_lifecycle()
-        return self._hass.states.async_entity_ids_count(self._domain)
-
-    def __repr__(self) -> str:
-        """Representation of Domain States."""
-        return f"<template DomainStates('{self._domain}')>"
-
-
-class TemplateStateBase(State):
-    """Class to represent a state object in a template."""
-
-    __slots__ = ("_collect", "_entity_id", "_hass", "_state")
-
-    _state: State
-
-    __setitem__ = _readonly
-    __delitem__ = _readonly
-
-    # Inheritance is done so functions that check against State keep working
-    # pylint: disable-next=super-init-not-called
-    def __init__(self, hass: HomeAssistant, collect: bool, entity_id: str) -> None:
-        """Initialize template state."""
-        self._hass = hass
-        self._collect = collect
-        self._entity_id = entity_id
-        self._cache: dict[str, Any] = {}
-
-    def _collect_state(self) -> None:
-        if self._collect and (render_info := render_info_cv.get()):
-            render_info.entities.add(self._entity_id)  # type: ignore[attr-defined]
-
-    # Jinja will try __getitem__ first and it avoids the need
-    # to call is_safe_attribute
-    def __getitem__(self, item: str) -> Any:
-        """Return a property as an attribute for jinja."""
-        if item in _COLLECTABLE_STATE_ATTRIBUTES:
-            # _collect_state inlined here for performance
-            if self._collect and (render_info := render_info_cv.get()):
-                render_info.entities.add(self._entity_id)  # type: ignore[attr-defined]
-            return getattr(self._state, item)
-        if item == "entity_id":
-            return self._entity_id
-        if item == "state_with_unit":
-            return self.state_with_unit
-        raise KeyError
-
-    @under_cached_property
-    def entity_id(self) -> str:
-        """Wrap State.entity_id.
-
-        Intentionally does not collect state
-        """
-        return self._entity_id
-
-    @property
-    def state(self) -> str:  # type: ignore[override]
-        """Wrap State.state."""
-        self._collect_state()
-        return self._state.state
-
-    @property
-    def attributes(self) -> ReadOnlyDict[str, Any]:  # type: ignore[override]
-        """Wrap State.attributes."""
-        self._collect_state()
-        return self._state.attributes
-
-    @property
-    def last_changed(self) -> datetime:  # type: ignore[override]
-        """Wrap State.last_changed."""
-        self._collect_state()
-        return self._state.last_changed
-
-    @property
-    def last_reported(self) -> datetime:  # type: ignore[override]
-        """Wrap State.last_reported."""
-        self._collect_state()
-        return self._state.last_reported
-
-    @property
-    def last_updated(self) -> datetime:  # type: ignore[override]
-        """Wrap State.last_updated."""
-        self._collect_state()
-        return self._state.last_updated
-
-    @property
-    def context(self) -> Context:  # type: ignore[override]
-        """Wrap State.context."""
-        self._collect_state()
-        return self._state.context
-
-    @property
-    def domain(self) -> str:  # type: ignore[override]
-        """Wrap State.domain."""
-        self._collect_state()
-        return self._state.domain
-
-    @property
-    def object_id(self) -> str:  # type: ignore[override]
-        """Wrap State.object_id."""
-        self._collect_state()
-        return self._state.object_id
-
-    @property
-    def name(self) -> str:
-        """Wrap State.name."""
-        self._collect_state()
-        return self._state.name
-
-    @property
-    def state_with_unit(self) -> str:
-        """Return the state concatenated with the unit if available."""
-        return self.format_state(rounded=True, with_unit=True)
-
-    def format_state(self, rounded: bool, with_unit: bool) -> str:
-        """Return a formatted version of the state."""
-        # Import here, not at top-level, to avoid circular import
-        from homeassistant.components.sensor import (  # noqa: PLC0415
-            DOMAIN as SENSOR_DOMAIN,
-            async_rounded_state,
-        )
-
-        self._collect_state()
-        if rounded and self._state.domain == SENSOR_DOMAIN:
-            state = async_rounded_state(self._hass, self._entity_id, self._state)
-        else:
-            state = self._state.state
-        if with_unit and (unit := self._state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
-            return f"{state} {unit}"
-        return state
-
-    def __eq__(self, other: object) -> bool:
-        """Ensure we collect on equality check."""
-        self._collect_state()
-        return self._state.__eq__(other)
-
-
-class TemplateState(TemplateStateBase):
-    """Class to represent a state object in a template."""
-
-    __slots__ = ()
-
-    # Inheritance is done so functions that check against State keep working
-    def __init__(self, hass: HomeAssistant, state: State, collect: bool = True) -> None:
-        """Initialize template state."""
-        super().__init__(hass, collect, state.entity_id)
-        self._state = state
-
-    def __repr__(self) -> str:
-        """Representation of Template State."""
-        return f"<template TemplateState({self._state!r})>"
-
-
-class TemplateStateFromEntityId(TemplateStateBase):
-    """Class to represent a state object in a template."""
-
-    __slots__ = ()
-
-    def __init__(
-        self, hass: HomeAssistant, entity_id: str, collect: bool = True
-    ) -> None:
-        """Initialize template state."""
-        super().__init__(hass, collect, entity_id)
-
-    @property
-    def _state(self) -> State:  # type: ignore[override]
-        state = self._hass.states.get(self._entity_id)
-        if not state:
-            state = State(self._entity_id, STATE_UNKNOWN)
-        return state
-
-    def __repr__(self) -> str:
-        """Representation of Template State."""
-        return f"<template TemplateStateFromEntityId({self._entity_id})>"
-
-
-_create_template_state_no_collect = partial(TemplateState, collect=False)
-
-
-def _collect_state(hass: HomeAssistant, entity_id: str) -> None:
-    if (entity_collect := render_info_cv.get()) is not None:
-        entity_collect.entities.add(entity_id)  # type: ignore[attr-defined]
-
-
-def _state_generator(
-    hass: HomeAssistant, domain: str | None
-) -> Generator[TemplateState]:
-    """State generator for a domain or all states."""
-    states = hass.states
-    # If domain is None, we want to iterate over all states, but making
-    # a copy of the dict is expensive. So we iterate over the protected
-    # _states dict instead. This is safe because we're not modifying it
-    # and everything is happening in the same thread (MainThread).
-    #
-    # We do not want to expose this method in the public API though to
-    # ensure it does not get misused.
-    #
-    container: Iterable[State]
-    if domain is None:
-        container = states._states.values()  # noqa: SLF001
-    else:
-        container = states.async_all(domain)
-    for state in container:
-        yield _template_state_no_collect(hass, state)
-
-
-def _get_state_if_valid(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
-    state = hass.states.get(entity_id)
-    if state is None and not valid_entity_id(entity_id):
-        raise TemplateError(f"Invalid entity ID '{entity_id}'")
-    return _get_template_state_from_state(hass, entity_id, state)
-
-
-def _get_state(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
-    return _get_template_state_from_state(hass, entity_id, hass.states.get(entity_id))
-
-
-def _get_template_state_from_state(
-    hass: HomeAssistant, entity_id: str, state: State | None
-) -> TemplateState | None:
-    if state is None:
-        # Only need to collect if none, if not none collect first actual
-        # access to the state properties in the state wrapper.
-        _collect_state(hass, entity_id)
-        return None
-    return _template_state(hass, state)
-
-
-def _resolve_state(
-    hass: HomeAssistant, entity_id_or_state: Any
-) -> State | TemplateState | None:
-    """Return state or entity_id if given."""
-    if isinstance(entity_id_or_state, State):
-        return entity_id_or_state
-    if isinstance(entity_id_or_state, str):
-        return _get_state(hass, entity_id_or_state)
-    return None
 
 
 def expand(hass: HomeAssistant, *args: Any) -> Iterable[State]:

--- a/homeassistant/helpers/template/states.py
+++ b/homeassistant/helpers/template/states.py
@@ -1,0 +1,513 @@
+"""State wrapper classes and helpers for Home Assistant templates."""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Iterable
+from datetime import datetime
+from enum import Enum
+from functools import cache, partial
+from typing import Any
+
+from lru import LRU
+from propcache.api import under_cached_property
+
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN
+from homeassistant.core import (
+    Context,
+    HomeAssistant,
+    State,
+    valid_domain,
+    valid_entity_id,
+)
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.translation import (
+    async_translate_state,
+    async_translate_state_attr,
+)
+from homeassistant.util.read_only_dict import ReadOnlyDict
+
+from .render_info import render_info_cv
+
+_SENTINEL = object()
+
+_RESERVED_NAMES = {
+    "contextfunction",
+    "evalcontextfunction",
+    "environmentfunction",
+    "jinja_pass_arg",
+}
+
+_COLLECTABLE_STATE_ATTRIBUTES = {
+    "state",
+    "attributes",
+    "last_changed",
+    "last_updated",
+    "context",
+    "domain",
+    "object_id",
+    "name",
+}
+
+
+#
+# CACHED_TEMPLATE_STATES is a rough estimate of the number of entities
+# on a typical system. It is used as the initial size of the LRU cache
+# for TemplateState objects.
+#
+# If the cache is too small we will end up creating and destroying
+# TemplateState objects too often which will cause a lot of GC activity
+# and slow down the system. For systems with a lot of entities and
+# templates, this can reach 100000s of object creations and destructions
+# per minute.
+#
+# Since entity counts may grow over time, we will increase
+# the size if the number of entities grows via _async_adjust_lru_sizes
+# at the start of the system and every 10 minutes if needed.
+#
+CACHED_TEMPLATE_STATES = 512
+
+CACHED_TEMPLATE_LRU: LRU[State, TemplateState] = LRU(CACHED_TEMPLATE_STATES)
+CACHED_TEMPLATE_NO_COLLECT_LRU: LRU[State, TemplateState] = LRU(CACHED_TEMPLATE_STATES)
+ENTITY_COUNT_GROWTH_FACTOR = 1.2
+
+
+def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
+    """Return a TemplateState for a state without collecting."""
+    if template_state := CACHED_TEMPLATE_NO_COLLECT_LRU.get(state):
+        return template_state
+    template_state = _create_template_state_no_collect(hass, state)
+    CACHED_TEMPLATE_NO_COLLECT_LRU[state] = template_state
+    return template_state
+
+
+def _template_state(hass: HomeAssistant, state: State) -> TemplateState:
+    """Return a TemplateState for a state that collects."""
+    if template_state := CACHED_TEMPLATE_LRU.get(state):
+        return template_state
+    template_state = TemplateState(hass, state)
+    CACHED_TEMPLATE_LRU[state] = template_state
+    return template_state
+
+
+@cache
+def _domain_states(hass: HomeAssistant, name: str) -> DomainStates:
+    return DomainStates(hass, name)
+
+
+def _readonly(*args: Any, **kwargs: Any) -> Any:
+    """Raise an exception when a states object is modified."""
+    raise RuntimeError(f"Cannot modify template States object: {args} {kwargs}")
+
+
+class AllStates:
+    """Class to expose all HA states as attributes."""
+
+    __setitem__ = _readonly
+    __delitem__ = _readonly
+    __slots__ = ("_hass",)
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize all states."""
+        self._hass = hass
+
+    def __getattr__(self, name: str) -> Any:
+        """Return the domain state."""
+        if "." in name:
+            return _get_state_if_valid(self._hass, name)
+
+        if name in _RESERVED_NAMES:
+            return None
+
+        if not valid_domain(name):
+            raise TemplateError(f"Invalid domain name '{name}'")
+
+        return _domain_states(self._hass, name)
+
+    # Jinja will try __getitem__ first and it avoids the need
+    # to call is_safe_attribute
+    __getitem__ = __getattr__
+
+    def _collect_all(self) -> None:
+        if (render_info := render_info_cv.get()) is not None:
+            render_info.all_states = True
+
+    def _collect_all_lifecycle(self) -> None:
+        if (render_info := render_info_cv.get()) is not None:
+            render_info.all_states_lifecycle = True
+
+    def __iter__(self) -> Generator[TemplateState]:
+        """Return all states."""
+        self._collect_all()
+        return _state_generator(self._hass, None)
+
+    def __len__(self) -> int:
+        """Return number of states."""
+        self._collect_all_lifecycle()
+        return self._hass.states.async_entity_ids_count()
+
+    def __call__(
+        self,
+        entity_id: str,
+        rounded: bool | object = _SENTINEL,
+        with_unit: bool = False,
+    ) -> str:
+        """Return the states."""
+        state = _get_state(self._hass, entity_id)
+        if state is None:
+            return STATE_UNKNOWN
+        if rounded is _SENTINEL:
+            rounded = with_unit
+        if rounded or with_unit:
+            return state.format_state(rounded, with_unit)  # type: ignore[arg-type]
+        return state.state
+
+    def __repr__(self) -> str:
+        """Representation of All States."""
+        return "<template AllStates>"
+
+
+class StateTranslated:
+    """Class to represent a translated state in a template."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize all states."""
+        self._hass = hass
+
+    def __call__(self, entity_id: str) -> str | None:
+        """Retrieve translated state if available."""
+        state = _get_state_if_valid(self._hass, entity_id)
+
+        if state is None:
+            return STATE_UNKNOWN
+
+        state_value = state.state
+        domain = state.domain
+        device_class = state.attributes.get("device_class")
+        entry = er.async_get(self._hass).async_get(entity_id)
+        platform = None if entry is None else entry.platform
+        translation_key = None if entry is None else entry.translation_key
+
+        return async_translate_state(
+            self._hass, state_value, domain, platform, translation_key, device_class
+        )
+
+    def __repr__(self) -> str:
+        """Representation of Translated state."""
+        return "<template StateTranslated>"
+
+
+class StateAttrTranslated:
+    """Class to represent a translated state attribute value in a template."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize."""
+        self._hass = hass
+
+    def __call__(self, entity_id: str, attribute: str) -> Any:
+        """Retrieve translated state attribute value if available."""
+        state = _get_state_if_valid(self._hass, entity_id)
+
+        if state is None:
+            return None
+
+        attr_value = state.attributes.get(attribute)
+        if attr_value is None:
+            return None
+
+        if not isinstance(attr_value, str | Enum):
+            return attr_value
+
+        domain = state.domain
+        device_class = state.attributes.get("device_class")
+        entry = er.async_get(self._hass).async_get(entity_id)
+        platform = None if entry is None else entry.platform
+        translation_key = None if entry is None else entry.translation_key
+
+        return async_translate_state_attr(
+            self._hass,
+            str(attr_value),
+            domain,
+            platform,
+            translation_key,
+            device_class,
+            attribute,
+        )
+
+    def __repr__(self) -> str:
+        """Representation of Translated state attribute."""
+        return "<template StateAttrTranslated>"
+
+
+class DomainStates:
+    """Class to expose a specific HA domain as attributes."""
+
+    __slots__ = ("_domain", "_hass")
+
+    __setitem__ = _readonly
+    __delitem__ = _readonly
+
+    def __init__(self, hass: HomeAssistant, domain: str) -> None:
+        """Initialize the domain states."""
+        self._hass = hass
+        self._domain = domain
+
+    def __getattr__(self, name: str) -> TemplateState | None:
+        """Return the states."""
+        return _get_state_if_valid(self._hass, f"{self._domain}.{name}")
+
+    # Jinja will try __getitem__ first and it avoids the need
+    # to call is_safe_attribute
+    __getitem__ = __getattr__
+
+    def _collect_domain(self) -> None:
+        if (entity_collect := render_info_cv.get()) is not None:
+            entity_collect.domains.add(self._domain)  # type: ignore[attr-defined]
+
+    def _collect_domain_lifecycle(self) -> None:
+        if (entity_collect := render_info_cv.get()) is not None:
+            entity_collect.domains_lifecycle.add(self._domain)  # type: ignore[attr-defined]
+
+    def __iter__(self) -> Generator[TemplateState]:
+        """Return the iteration over all the states."""
+        self._collect_domain()
+        return _state_generator(self._hass, self._domain)
+
+    def __len__(self) -> int:
+        """Return number of states."""
+        self._collect_domain_lifecycle()
+        return self._hass.states.async_entity_ids_count(self._domain)
+
+    def __repr__(self) -> str:
+        """Representation of Domain States."""
+        return f"<template DomainStates('{self._domain}')>"
+
+
+class TemplateStateBase(State):
+    """Class to represent a state object in a template."""
+
+    __slots__ = ("_collect", "_entity_id", "_hass", "_state")
+
+    _state: State
+
+    __setitem__ = _readonly
+    __delitem__ = _readonly
+
+    # Inheritance is done so functions that check against State keep working
+    # pylint: disable-next=super-init-not-called
+    def __init__(self, hass: HomeAssistant, collect: bool, entity_id: str) -> None:
+        """Initialize template state."""
+        self._hass = hass
+        self._collect = collect
+        self._entity_id = entity_id
+        self._cache: dict[str, Any] = {}
+
+    def _collect_state(self) -> None:
+        if self._collect and (render_info := render_info_cv.get()):
+            render_info.entities.add(self._entity_id)  # type: ignore[attr-defined]
+
+    # Jinja will try __getitem__ first and it avoids the need
+    # to call is_safe_attribute
+    def __getitem__(self, item: str) -> Any:
+        """Return a property as an attribute for jinja."""
+        if item in _COLLECTABLE_STATE_ATTRIBUTES:
+            # _collect_state inlined here for performance
+            if self._collect and (render_info := render_info_cv.get()):
+                render_info.entities.add(self._entity_id)  # type: ignore[attr-defined]
+            return getattr(self._state, item)
+        if item == "entity_id":
+            return self._entity_id
+        if item == "state_with_unit":
+            return self.state_with_unit
+        raise KeyError
+
+    @under_cached_property
+    def entity_id(self) -> str:
+        """Wrap State.entity_id.
+
+        Intentionally does not collect state
+        """
+        return self._entity_id
+
+    @property
+    def state(self) -> str:  # type: ignore[override]
+        """Wrap State.state."""
+        self._collect_state()
+        return self._state.state
+
+    @property
+    def attributes(self) -> ReadOnlyDict[str, Any]:  # type: ignore[override]
+        """Wrap State.attributes."""
+        self._collect_state()
+        return self._state.attributes
+
+    @property
+    def last_changed(self) -> datetime:  # type: ignore[override]
+        """Wrap State.last_changed."""
+        self._collect_state()
+        return self._state.last_changed
+
+    @property
+    def last_reported(self) -> datetime:  # type: ignore[override]
+        """Wrap State.last_reported."""
+        self._collect_state()
+        return self._state.last_reported
+
+    @property
+    def last_updated(self) -> datetime:  # type: ignore[override]
+        """Wrap State.last_updated."""
+        self._collect_state()
+        return self._state.last_updated
+
+    @property
+    def context(self) -> Context:  # type: ignore[override]
+        """Wrap State.context."""
+        self._collect_state()
+        return self._state.context
+
+    @property
+    def domain(self) -> str:  # type: ignore[override]
+        """Wrap State.domain."""
+        self._collect_state()
+        return self._state.domain
+
+    @property
+    def object_id(self) -> str:  # type: ignore[override]
+        """Wrap State.object_id."""
+        self._collect_state()
+        return self._state.object_id
+
+    @property
+    def name(self) -> str:
+        """Wrap State.name."""
+        self._collect_state()
+        return self._state.name
+
+    @property
+    def state_with_unit(self) -> str:
+        """Return the state concatenated with the unit if available."""
+        return self.format_state(rounded=True, with_unit=True)
+
+    def format_state(self, rounded: bool, with_unit: bool) -> str:
+        """Return a formatted version of the state."""
+        # Import here, not at top-level, to avoid circular import
+        from homeassistant.components.sensor import (  # noqa: PLC0415
+            DOMAIN as SENSOR_DOMAIN,
+            async_rounded_state,
+        )
+
+        self._collect_state()
+        if rounded and self._state.domain == SENSOR_DOMAIN:
+            state = async_rounded_state(self._hass, self._entity_id, self._state)
+        else:
+            state = self._state.state
+        if with_unit and (unit := self._state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+            return f"{state} {unit}"
+        return state
+
+    def __eq__(self, other: object) -> bool:
+        """Ensure we collect on equality check."""
+        self._collect_state()
+        return self._state.__eq__(other)
+
+
+class TemplateState(TemplateStateBase):
+    """Class to represent a state object in a template."""
+
+    __slots__ = ()
+
+    # Inheritance is done so functions that check against State keep working
+    def __init__(self, hass: HomeAssistant, state: State, collect: bool = True) -> None:
+        """Initialize template state."""
+        super().__init__(hass, collect, state.entity_id)
+        self._state = state
+
+    def __repr__(self) -> str:
+        """Representation of Template State."""
+        return f"<template TemplateState({self._state!r})>"
+
+
+class TemplateStateFromEntityId(TemplateStateBase):
+    """Class to represent a state object in a template."""
+
+    __slots__ = ()
+
+    def __init__(
+        self, hass: HomeAssistant, entity_id: str, collect: bool = True
+    ) -> None:
+        """Initialize template state."""
+        super().__init__(hass, collect, entity_id)
+
+    @property
+    def _state(self) -> State:  # type: ignore[override]
+        state = self._hass.states.get(self._entity_id)
+        if not state:
+            state = State(self._entity_id, STATE_UNKNOWN)
+        return state
+
+    def __repr__(self) -> str:
+        """Representation of Template State."""
+        return f"<template TemplateStateFromEntityId({self._entity_id})>"
+
+
+_create_template_state_no_collect = partial(TemplateState, collect=False)
+
+
+def _collect_state(hass: HomeAssistant, entity_id: str) -> None:
+    if (entity_collect := render_info_cv.get()) is not None:
+        entity_collect.entities.add(entity_id)  # type: ignore[attr-defined]
+
+
+def _state_generator(
+    hass: HomeAssistant, domain: str | None
+) -> Generator[TemplateState]:
+    """State generator for a domain or all states."""
+    states = hass.states
+    # If domain is None, we want to iterate over all states, but making
+    # a copy of the dict is expensive. So we iterate over the protected
+    # _states dict instead. This is safe because we're not modifying it
+    # and everything is happening in the same thread (MainThread).
+    #
+    # We do not want to expose this method in the public API though to
+    # ensure it does not get misused.
+    #
+    container: Iterable[State]
+    if domain is None:
+        container = states._states.values()  # noqa: SLF001
+    else:
+        container = states.async_all(domain)
+    for state in container:
+        yield _template_state_no_collect(hass, state)
+
+
+def _get_state_if_valid(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
+    state = hass.states.get(entity_id)
+    if state is None and not valid_entity_id(entity_id):
+        raise TemplateError(f"Invalid entity ID '{entity_id}'")
+    return _get_template_state_from_state(hass, entity_id, state)
+
+
+def _get_state(hass: HomeAssistant, entity_id: str) -> TemplateState | None:
+    return _get_template_state_from_state(hass, entity_id, hass.states.get(entity_id))
+
+
+def _get_template_state_from_state(
+    hass: HomeAssistant, entity_id: str, state: State | None
+) -> TemplateState | None:
+    if state is None:
+        # Only need to collect if none, if not none collect first actual
+        # access to the state properties in the state wrapper.
+        _collect_state(hass, entity_id)
+        return None
+    return _template_state(hass, state)
+
+
+def _resolve_state(
+    hass: HomeAssistant, entity_id_or_state: Any
+) -> State | TemplateState | None:
+    """Return state or entity_id if given."""
+    if isinstance(entity_id_or_state, State):
+        return entity_id_or_state
+    if isinstance(entity_id_or_state, str):
+        return _get_state(hass, entity_id_or_state)
+    return None

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -13,7 +13,6 @@ import voluptuous as vol
 from homeassistant.components import group
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
-    STATE_ON,
     STATE_UNAVAILABLE,
     UnitOfArea,
     UnitOfLength,
@@ -27,7 +26,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import entity_registry as er, template, translation
-from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.template.render_info import (
     ALL_STATES_RATE_LIMIT,
     DOMAIN_STATES_RATE_LIMIT,
@@ -38,7 +36,7 @@ from homeassistant.util.unit_system import UnitSystem
 
 from .helpers import assert_result_info, render, render_to_info
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 
 def _set_up_units(hass: HomeAssistant) -> None:
@@ -2259,24 +2257,6 @@ async def test_undefined_symbol_warnings(
     )
 
 
-async def test_template_states_blocks_setitem(hass: HomeAssistant) -> None:
-    """Test we cannot setitem on TemplateStates."""
-    hass.states.async_set("light.new", STATE_ON)
-    state = hass.states.get("light.new")
-    template_state = template.TemplateState(hass, state, True)
-    with pytest.raises(RuntimeError):
-        template_state["any"] = "any"
-
-
-async def test_template_states_can_serialize(hass: HomeAssistant) -> None:
-    """Test TemplateState is serializable."""
-    hass.states.async_set("light.new", STATE_ON)
-    state = hass.states.get("light.new")
-    template_state = template.TemplateState(hass, state, True)
-    assert template_state.as_dict() is template_state.as_dict()
-    assert json_dumps(template_state) == json_dumps(template_state)
-
-
 async def test_render_to_info_with_exception(hass: HomeAssistant) -> None:
     """Test info is still available if the template has an exception."""
     hass.states.async_set("test_domain.object", "dog")
@@ -2286,49 +2266,6 @@ async def test_render_to_info_with_exception(hass: HomeAssistant) -> None:
 
     assert info.all_states is False
     assert info.entities == {"test_domain.object"}
-
-
-async def test_lru_increases_with_many_entities(hass: HomeAssistant) -> None:
-    """Test that the template internal LRU cache increases with many entities."""
-    # We do not actually want to record 4096 entities so we mock the entity count
-    mock_entity_count = 16
-
-    assert template.CACHED_TEMPLATE_LRU.get_size() == template.CACHED_TEMPLATE_STATES
-    assert (
-        template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size()
-        == template.CACHED_TEMPLATE_STATES
-    )
-    template.CACHED_TEMPLATE_LRU.set_size(8)
-    template.CACHED_TEMPLATE_NO_COLLECT_LRU.set_size(8)
-
-    template.async_setup(hass)
-    for i in range(mock_entity_count):
-        hass.states.async_set(f"sensor.sensor{i}", "on")
-
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
-    await hass.async_block_till_done()
-
-    assert template.CACHED_TEMPLATE_LRU.get_size() == int(
-        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
-    )
-    assert template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
-        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
-    )
-
-    await hass.async_stop()
-
-    for i in range(mock_entity_count):
-        hass.states.async_set(f"sensor.sensor_add_{i}", "on")
-
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=20))
-    await hass.async_block_till_done()
-
-    assert template.CACHED_TEMPLATE_LRU.get_size() == int(
-        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
-    )
-    assert template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
-        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
-    )
 
 
 async def test_template_thread_safety_checks(hass: HomeAssistant) -> None:

--- a/tests/helpers/template/test_states.py
+++ b/tests/helpers/template/test_states.py
@@ -1,0 +1,80 @@
+"""Test state wrapper classes and helpers for Home Assistant templates."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import template
+from homeassistant.helpers.json import json_dumps
+from homeassistant.helpers.template import states as template_states
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed
+
+
+async def test_template_states_blocks_setitem(hass: HomeAssistant) -> None:
+    """Test we cannot setitem on TemplateStates."""
+    hass.states.async_set("light.new", STATE_ON)
+    state = hass.states.get("light.new")
+    template_state = template.TemplateState(hass, state, True)
+    with pytest.raises(RuntimeError):
+        template_state["any"] = "any"
+
+
+async def test_template_states_can_serialize(hass: HomeAssistant) -> None:
+    """Test TemplateState is serializable."""
+    hass.states.async_set("light.new", STATE_ON)
+    state = hass.states.get("light.new")
+    template_state = template.TemplateState(hass, state, True)
+    assert template_state.as_dict() is template_state.as_dict()
+    assert json_dumps(template_state) == json_dumps(template_state)
+
+
+async def test_lru_increases_with_many_entities(hass: HomeAssistant) -> None:
+    """Test that the template internal LRU cache increases with many entities."""
+    # We do not actually want to record 4096 entities so we mock the entity count
+    mock_entity_count = 16
+
+    assert (
+        template_states.CACHED_TEMPLATE_LRU.get_size()
+        == template_states.CACHED_TEMPLATE_STATES
+    )
+    assert (
+        template_states.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size()
+        == template_states.CACHED_TEMPLATE_STATES
+    )
+    template_states.CACHED_TEMPLATE_LRU.set_size(8)
+    template_states.CACHED_TEMPLATE_NO_COLLECT_LRU.set_size(8)
+
+    template.async_setup(hass)
+    for i in range(mock_entity_count):
+        hass.states.async_set(f"sensor.sensor{i}", "on")
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
+    await hass.async_block_till_done()
+
+    assert template_states.CACHED_TEMPLATE_LRU.get_size() == int(
+        round(mock_entity_count * template_states.ENTITY_COUNT_GROWTH_FACTOR)
+    )
+    assert template_states.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
+        round(mock_entity_count * template_states.ENTITY_COUNT_GROWTH_FACTOR)
+    )
+
+    await hass.async_stop()
+
+    for i in range(mock_entity_count):
+        hass.states.async_set(f"sensor.sensor_add_{i}", "on")
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=20))
+    await hass.async_block_till_done()
+
+    assert template_states.CACHED_TEMPLATE_LRU.get_size() == int(
+        round(mock_entity_count * template_states.ENTITY_COUNT_GROWTH_FACTOR)
+    )
+    assert template_states.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
+        round(mock_entity_count * template_states.ENTITY_COUNT_GROWTH_FACTOR)
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is part of the ongoing effort to refactor our huge single template monolith into something more maintainable. In previous PRs I've moved many categories of template methods out of the monolith template file into their own Jinja2 extension.

This PR is a preparation step for the upcoming state Jinja2 extension. It moves the **state wrapper classes and helpers** out of the monolith into a dedicated `states` module. These are infrastructure classes (not Jinja2 functions), so they belong in their own module rather than a Jinja2 extension. Moves all tests as well.

Moved into `homeassistant/helpers/template/states.py`:

- Classes: `AllStates`, `StateTranslated`, `StateAttrTranslated`, `DomainStates`, `TemplateStateBase`, `TemplateState`, `TemplateStateFromEntityId`
- Helpers: `_domain_states`, `_readonly`, `_template_state`, `_template_state_no_collect`, `_create_template_state_no_collect`, `_collect_state`, `_state_generator`, `_get_state_if_valid`, `_get_state`, `_get_template_state_from_state`, `_resolve_state`
- Constants: `_RESERVED_NAMES`, `_COLLECTABLE_STATE_ATTRIBUTES`, `CACHED_TEMPLATE_STATES`, `CACHED_TEMPLATE_LRU`, `CACHED_TEMPLATE_NO_COLLECT_LRU`, `ENTITY_COUNT_GROWTH_FACTOR`

`TemplateStateFromEntityId` is re-exported from `homeassistant.helpers.template` for backwards compatibility with existing external consumers.

There is no functional change in this PR, it is only moving these classes, helpers, and tests into a dedicated module.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
