### PR TITLE
Mark exception-translations rule as done for Peblar

### DIFF
--- a/homeassistant/components/peblar/quality_scale.yaml
+++ b/homeassistant/components/peblar/quality_scale.yaml
@@ -61,10 +61,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations:
-    status: exempt
-    comment: |
-      The coordinator needs translation when the update failed.
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
   repair-issues:


### PR DESCRIPTION
## Proposed change

Correct the quality scale status for the `exception-translations` rule in the Peblar integration.

The rule was marked as `exempt` with a comment that read more like a rule description than an exemption reason ("The coordinator needs translation when the update failed."). In reality, the integration already fully implements exception translations:

- `coordinator.py` raises `ConfigEntryAuthFailed` and `UpdateFailed` with `translation_domain` / `translation_key` for authentication, communication, and unknown errors.
- `helpers.py` does the same for `HomeAssistantError` raised from the entity service-action decorator.
- `strings.json` defines the matching `authentication_error`, `communication_error`, and `unknown_error` keys under `exceptions`.

So the rule should simply be `done`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
