### PR TITLE
Handle connection errors in Peblar zeroconf confirm step

### DIFF
--- a/homeassistant/components/peblar/config_flow.py
+++ b/homeassistant/components/peblar/config_flow.py
@@ -165,6 +165,8 @@ class PeblarFlowHandler(ConfigFlow, domain=DOMAIN):
                 await peblar.login(password=user_input[CONF_PASSWORD])
             except PeblarAuthenticationError:
                 errors[CONF_PASSWORD] = "invalid_auth"
+            except PeblarConnectionError:
+                errors["base"] = "cannot_connect"
             except Exception:  # noqa: BLE001
                 LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"

--- a/tests/components/peblar/test_config_flow.py
+++ b/tests/components/peblar/test_config_flow.py
@@ -291,7 +291,7 @@ async def test_zeroconf_flow_abort_no_serial(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("side_effect", "expected_error"),
     [
-        (PeblarConnectionError, {"base": "unknown"}),
+        (PeblarConnectionError, {"base": "cannot_connect"}),
         (PeblarAuthenticationError, {CONF_PASSWORD: "invalid_auth"}),
         (Exception, {"base": "unknown"}),
     ],


### PR DESCRIPTION
## Proposed change

The `async_step_zeroconf_confirm` step in the Peblar config flow caught `PeblarAuthenticationError` and a bare `Exception` fallback, but not `PeblarConnectionError`. As a result, a connection error during the zeroconf confirm step fell through to the generic `"unknown"` error, which is inconsistent with the other steps in this flow (`user`, `reconfigure`, `reauth_confirm`), all of which map connection errors to `"cannot_connect"`.

This PR adds explicit handling for `PeblarConnectionError` in the zeroconf confirm step so the user gets the correct `"cannot_connect"` error message, matching the behavior of the other steps.

The existing parametrized `test_zeroconf_flow_errors` test already covered the `PeblarConnectionError` side effect; its expected error has been updated from `{"base": "unknown"}` to `{"base": "cannot_connect"}` to reflect the corrected behavior.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
