### PR TITLE
Add Kodi screensaver binary sensor

### DIFF
--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 import logging
 
+from jsonrpc_base.jsonrpc import ProtocolError, TransportError
 from pykodi import CannotConnectError, InvalidAuthError, Kodi, get_kodi_connection
 from pykodi.kodi import KodiHTTPConnection, KodiWSConnection
 
@@ -27,7 +28,7 @@ from .services import async_setup_services
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR]
 
 type KodiConfigEntry = ConfigEntry[KodiRuntimeData]
 
@@ -38,6 +39,30 @@ class KodiRuntimeData:
 
     connection: KodiHTTPConnection | KodiWSConnection
     kodi: Kodi
+    screensaver_active: bool | None = None
+
+    def set_screensaver_state(self, screensaver_active: bool | None) -> bool:
+        """Set the current screensaver state."""
+        changed = self.screensaver_active != screensaver_active
+        self.screensaver_active = screensaver_active
+        return changed
+
+    async def async_update_screensaver_state(self) -> bool:
+        """Refresh the Kodi screensaver state."""
+        if not self.connection.connected:
+            return self.set_screensaver_state(None)
+
+        try:
+            display_status = await self.kodi.call_method(
+                "XBMC.GetInfoBooleans",
+                booleans=["System.ScreenSaverActive"],
+            )
+        except (ProtocolError, TransportError):
+            return self.set_screensaver_state(None)
+
+        return self.set_screensaver_state(
+            display_status.get("System.ScreenSaverActive")
+        )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass
 import logging
 
-from jsonrpc_base.jsonrpc import ProtocolError, TransportError
 from pykodi import CannotConnectError, InvalidAuthError, Kodi, get_kodi_connection
 from pykodi.kodi import KodiHTTPConnection, KodiWSConnection
 
@@ -23,6 +22,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_WS_PORT, DOMAIN
+from .screensaver import KodiScreensaver
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,30 +39,7 @@ class KodiRuntimeData:
 
     connection: KodiHTTPConnection | KodiWSConnection
     kodi: Kodi
-    screensaver_active: bool | None = None
-
-    def set_screensaver_state(self, screensaver_active: bool | None) -> bool:
-        """Set the current screensaver state."""
-        changed = self.screensaver_active != screensaver_active
-        self.screensaver_active = screensaver_active
-        return changed
-
-    async def async_update_screensaver_state(self) -> bool:
-        """Refresh the Kodi screensaver state."""
-        if not self.connection.connected:
-            return self.set_screensaver_state(None)
-
-        try:
-            display_status = await self.kodi.call_method(
-                "XBMC.GetInfoBooleans",
-                booleans=["System.ScreenSaverActive"],
-            )
-        except (ProtocolError, TransportError):
-            return self.set_screensaver_state(None)
-
-        return self.set_screensaver_state(
-            display_status.get("System.ScreenSaverActive")
-        )
+    screensaver: KodiScreensaver
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -102,7 +79,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: KodiConfigEntry) -> bool
 
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
 
-    entry.runtime_data = KodiRuntimeData(connection=conn, kodi=kodi)
+    entry.runtime_data = KodiRuntimeData(
+        connection=conn,
+        kodi=kodi,
+        screensaver=KodiScreensaver(entry.entry_id, conn, kodi),
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -28,7 +28,7 @@ from .services import async_setup_services
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.MEDIA_PLAYER]
 
 type KodiConfigEntry = ConfigEntry[KodiRuntimeData]
 

--- a/homeassistant/components/kodi/binary_sensor.py
+++ b/homeassistant/components/kodi/binary_sensor.py
@@ -1,0 +1,82 @@
+"""Binary sensor support for Kodi."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import KodiConfigEntry, KodiRuntimeData
+from .const import DOMAIN, async_signal_screensaver_update
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: KodiConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Kodi binary sensor entities."""
+    data = config_entry.runtime_data
+    if (uid := config_entry.unique_id) is None:
+        uid = config_entry.entry_id
+
+    await data.async_update_screensaver_state()
+
+    async_add_entities(
+        [
+            KodiScreensaverBinarySensor(
+                data,
+                config_entry.data[CONF_NAME],
+                uid,
+                config_entry.entry_id,
+            )
+        ]
+    )
+
+
+class KodiScreensaverBinarySensor(BinarySensorEntity):
+    """Representation of the Kodi screensaver state."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_should_poll = False
+    _attr_translation_key = "screensaver"
+
+    def __init__(
+        self, runtime_data: KodiRuntimeData, name: str, uid: str, entry_id: str
+    ) -> None:
+        """Initialize the binary sensor."""
+        self._runtime_data = runtime_data
+        self._attr_unique_id = f"{uid}_screensaver"
+        self._signal = async_signal_screensaver_update(entry_id)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, uid)},
+            manufacturer="Kodi",
+            name=name,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to screensaver state updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self._signal, self._handle_screensaver_update
+            )
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if the entity is available."""
+        return self._runtime_data.connection.connected
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the Kodi screensaver state."""
+        return self._runtime_data.screensaver_active
+
+    @callback
+    def _handle_screensaver_update(self) -> None:
+        """Handle shared screensaver state updates."""
+        self.async_write_ha_state()

--- a/homeassistant/components/kodi/binary_sensor.py
+++ b/homeassistant/components/kodi/binary_sensor.py
@@ -41,7 +41,6 @@ class KodiScreensaverBinarySensor(BinarySensorEntity):
     """Representation of the Kodi screensaver state."""
 
     _attr_has_entity_name = True
-    _attr_name = None
     _attr_should_poll = False
     _attr_translation_key = "screensaver"
 

--- a/homeassistant/components/kodi/binary_sensor.py
+++ b/homeassistant/components/kodi/binary_sensor.py
@@ -9,8 +9,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import KodiConfigEntry, KodiRuntimeData
-from .const import DOMAIN, async_signal_screensaver_update
+from . import KodiConfigEntry
+from .const import DOMAIN
 
 
 async def async_setup_entry(
@@ -23,15 +23,15 @@ async def async_setup_entry(
     if (uid := config_entry.unique_id) is None:
         uid = config_entry.entry_id
 
-    await data.async_update_screensaver_state()
+    data.screensaver.set_hass(hass)
+    await data.screensaver.async_update()
 
     async_add_entities(
         [
             KodiScreensaverBinarySensor(
-                data,
+                data.screensaver,
                 config_entry.data[CONF_NAME],
                 uid,
-                config_entry.entry_id,
             )
         ]
     )
@@ -45,13 +45,10 @@ class KodiScreensaverBinarySensor(BinarySensorEntity):
     _attr_should_poll = False
     _attr_translation_key = "screensaver"
 
-    def __init__(
-        self, runtime_data: KodiRuntimeData, name: str, uid: str, entry_id: str
-    ) -> None:
+    def __init__(self, screensaver, name: str, uid: str) -> None:
         """Initialize the binary sensor."""
-        self._runtime_data = runtime_data
+        self._screensaver = screensaver
         self._attr_unique_id = f"{uid}_screensaver"
-        self._signal = async_signal_screensaver_update(entry_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, uid)},
             manufacturer="Kodi",
@@ -60,21 +57,22 @@ class KodiScreensaverBinarySensor(BinarySensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to screensaver state updates."""
+        self._screensaver.set_hass(self.hass)
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass, self._signal, self._handle_screensaver_update
+                self.hass, self._screensaver.signal, self._handle_screensaver_update
             )
         )
 
     @property
     def available(self) -> bool:
         """Return if the entity is available."""
-        return self._runtime_data.connection.connected
+        return self._screensaver.available
 
     @property
     def is_on(self) -> bool | None:
         """Return the Kodi screensaver state."""
-        return self._runtime_data.screensaver_active
+        return self._screensaver.is_on
 
     @callback
     def _handle_screensaver_update(self) -> None:

--- a/homeassistant/components/kodi/binary_sensor.py
+++ b/homeassistant/components/kodi/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import KodiConfigEntry
 from .const import DOMAIN
+from .screensaver import KodiScreensaver
 
 
 async def async_setup_entry(
@@ -44,7 +45,7 @@ class KodiScreensaverBinarySensor(BinarySensorEntity):
     _attr_should_poll = False
     _attr_translation_key = "screensaver"
 
-    def __init__(self, screensaver, name: str, uid: str) -> None:
+    def __init__(self, screensaver: KodiScreensaver, name: str, uid: str) -> None:
         """Initialize the binary sensor."""
         self._screensaver = screensaver
         self._attr_unique_id = f"{uid}_screensaver"

--- a/homeassistant/components/kodi/const.py
+++ b/homeassistant/components/kodi/const.py
@@ -11,3 +11,8 @@ DEFAULT_WS_PORT = 9090
 
 EVENT_TURN_OFF = "kodi.turn_off"
 EVENT_TURN_ON = "kodi.turn_on"
+
+
+def async_signal_screensaver_update(entry_id: str) -> str:
+    """Generate a dispatcher signal for Kodi screensaver updates."""
+    return f"{DOMAIN}_{entry_id}_screensaver_update"

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -152,9 +152,9 @@ class KodiEntity(MediaPlayerEntity):
         self._attr_unique_id = uid
         self._device_id = None
         self._players = None
-        self._properties = {}
-        self._item = {}
-        self._app_properties = {}
+        self._properties: dict[str, Any] = {}
+        self._item: dict[str, Any] = {}
+        self._app_properties: dict[str, Any] = {}
         self._media_position_updated_at = None
         self._media_position = None
         self._connect_error = False

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -32,7 +32,6 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.network import is_internal_request
@@ -45,12 +44,7 @@ from .browse_media import (
     library_payload,
     media_source_content_filter,
 )
-from .const import (
-    DOMAIN,
-    EVENT_TURN_OFF,
-    EVENT_TURN_ON,
-    async_signal_screensaver_update,
-)
+from .const import DOMAIN, EVENT_TURN_OFF, EVENT_TURN_ON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +90,7 @@ async def async_setup_entry(
     if (uid := config_entry.unique_id) is None:
         uid = config_entry.entry_id
 
-    entity = KodiEntity(data, name, uid, config_entry.entry_id)
+    entity = KodiEntity(data, name, uid)
     async_add_entities([entity])
 
 
@@ -149,14 +143,12 @@ class KodiEntity(MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_STEP
     )
 
-    def __init__(
-        self, runtime_data: KodiRuntimeData, name: str, uid: str, entry_id: str
-    ) -> None:
+    def __init__(self, runtime_data: KodiRuntimeData, name: str, uid: str) -> None:
         """Initialize the Kodi entity."""
         self._runtime_data = runtime_data
         self._connection = runtime_data.connection
         self._kodi = runtime_data.kodi
-        self._screensaver_signal = async_signal_screensaver_update(entry_id)
+        self._screensaver = runtime_data.screensaver
         self._attr_unique_id = uid
         self._device_id = None
         self._players = None
@@ -234,37 +226,16 @@ class KodiEntity(MediaPlayerEntity):
             },
         )
 
-    @callback
-    def _set_screensaver_state(self, is_on: bool | None) -> None:
-        """Update shared screensaver state."""
-        if self._runtime_data.set_screensaver_state(is_on):
-            async_dispatcher_send(self.hass, self._screensaver_signal)
-
-    @callback
-    def _clear_screensaver_state(self) -> None:
-        """Clear shared screensaver state."""
-        self._set_screensaver_state(None)
-
-    @callback
-    def async_on_screensaver_on(self, sender, data) -> None:
-        """Handle screensaver activation."""
-        self._set_screensaver_state(True)
-
-    @callback
-    def async_on_screensaver_off(self, sender, data) -> None:
-        """Handle screensaver deactivation."""
-        self._set_screensaver_state(False)
-
     async def async_on_quit(self, sender, data):
         """Reset the player state on quit action."""
         await self._clear_connection()
 
     async def _clear_connection(self, close=True):
         self._reset_state()
-        self._clear_screensaver_state()
-        self.async_write_ha_state()
         if close:
             await self._connection.close()
+        self._screensaver.async_clear()
+        self.async_write_ha_state()
 
     @property
     def state(self) -> MediaPlayerState:
@@ -282,6 +253,8 @@ class KodiEntity(MediaPlayerEntity):
 
     async def async_added_to_hass(self) -> None:
         """Connect the websocket if needed."""
+        self._screensaver.set_hass(self.hass)
+
         if not self._connection.can_subscribe:
             return
 
@@ -310,6 +283,7 @@ class KodiEntity(MediaPlayerEntity):
         """Call after ws is connected."""
         self._connect_error = False
         self._register_ws_callbacks()
+        await self._screensaver.async_update()
 
         version = (await self._kodi.get_application_properties(["version"]))["version"]
         sw_version = f"{version['major']}.{version['minor']}"
@@ -364,10 +338,7 @@ class KodiEntity(MediaPlayerEntity):
         self._connection.server.Application.OnVolumeChanged = (
             self.async_on_volume_changed
         )
-        self._connection.server.GUI.OnScreensaverActivated = self.async_on_screensaver_on
-        self._connection.server.GUI.OnScreensaverDeactivated = (
-            self.async_on_screensaver_off
-        )
+        self._screensaver.async_register_ws_callbacks()
         self._connection.server.Other.OnKeyPress = self.async_on_key_press
         self._connection.server.System.OnQuit = self.async_on_quit
         self._connection.server.System.OnRestart = self.async_on_quit
@@ -378,24 +349,23 @@ class KodiEntity(MediaPlayerEntity):
         """Retrieve latest state."""
         if not self._connection.connected:
             self._reset_state()
-            self._clear_screensaver_state()
+            self._screensaver.async_clear()
             return
 
-        if await self._runtime_data.async_update_screensaver_state():
-            async_dispatcher_send(self.hass, self._screensaver_signal)
+        await self._screensaver.async_update()
 
         try:
             self._players = await self._kodi.get_players()
         except TransportError, ProtocolError:
             if not self._connection.can_subscribe:
                 self._reset_state()
-                self._clear_screensaver_state()
+                self._screensaver.async_clear()
                 return
             raise
 
         if self._kodi_is_off:
             self._reset_state()
-            self._clear_screensaver_state()
+            self._screensaver.async_clear()
             return
 
         if self._players:

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -32,19 +32,25 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.network import is_internal_request
 from homeassistant.util import dt as dt_util
 
-from . import KodiConfigEntry
+from . import KodiConfigEntry, KodiRuntimeData
 from .browse_media import (
     build_item_response,
     get_media_info,
     library_payload,
     media_source_content_filter,
 )
-from .const import DOMAIN, EVENT_TURN_OFF, EVENT_TURN_ON
+from .const import (
+    DOMAIN,
+    EVENT_TURN_OFF,
+    EVENT_TURN_ON,
+    async_signal_screensaver_update,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,7 +96,7 @@ async def async_setup_entry(
     if (uid := config_entry.unique_id) is None:
         uid = config_entry.entry_id
 
-    entity = KodiEntity(data.connection, data.kodi, name, uid)
+    entity = KodiEntity(data, name, uid, config_entry.entry_id)
     async_add_entities([entity])
 
 
@@ -143,10 +149,14 @@ class KodiEntity(MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_STEP
     )
 
-    def __init__(self, connection, kodi, name, uid):
+    def __init__(
+        self, runtime_data: KodiRuntimeData, name: str, uid: str, entry_id: str
+    ) -> None:
         """Initialize the Kodi entity."""
-        self._connection = connection
-        self._kodi = kodi
+        self._runtime_data = runtime_data
+        self._connection = runtime_data.connection
+        self._kodi = runtime_data.kodi
+        self._screensaver_signal = async_signal_screensaver_update(entry_id)
         self._attr_unique_id = uid
         self._device_id = None
         self._players = None
@@ -224,12 +234,34 @@ class KodiEntity(MediaPlayerEntity):
             },
         )
 
+    @callback
+    def _set_screensaver_state(self, is_on: bool | None) -> None:
+        """Update shared screensaver state."""
+        if self._runtime_data.set_screensaver_state(is_on):
+            async_dispatcher_send(self.hass, self._screensaver_signal)
+
+    @callback
+    def _clear_screensaver_state(self) -> None:
+        """Clear shared screensaver state."""
+        self._set_screensaver_state(None)
+
+    @callback
+    def async_on_screensaver_on(self, sender, data) -> None:
+        """Handle screensaver activation."""
+        self._set_screensaver_state(True)
+
+    @callback
+    def async_on_screensaver_off(self, sender, data) -> None:
+        """Handle screensaver deactivation."""
+        self._set_screensaver_state(False)
+
     async def async_on_quit(self, sender, data):
         """Reset the player state on quit action."""
         await self._clear_connection()
 
     async def _clear_connection(self, close=True):
         self._reset_state()
+        self._clear_screensaver_state()
         self.async_write_ha_state()
         if close:
             await self._connection.close()
@@ -332,6 +364,10 @@ class KodiEntity(MediaPlayerEntity):
         self._connection.server.Application.OnVolumeChanged = (
             self.async_on_volume_changed
         )
+        self._connection.server.GUI.OnScreensaverActivated = self.async_on_screensaver_on
+        self._connection.server.GUI.OnScreensaverDeactivated = (
+            self.async_on_screensaver_off
+        )
         self._connection.server.Other.OnKeyPress = self.async_on_key_press
         self._connection.server.System.OnQuit = self.async_on_quit
         self._connection.server.System.OnRestart = self.async_on_quit
@@ -342,18 +378,24 @@ class KodiEntity(MediaPlayerEntity):
         """Retrieve latest state."""
         if not self._connection.connected:
             self._reset_state()
+            self._clear_screensaver_state()
             return
+
+        if await self._runtime_data.async_update_screensaver_state():
+            async_dispatcher_send(self.hass, self._screensaver_signal)
 
         try:
             self._players = await self._kodi.get_players()
         except TransportError, ProtocolError:
             if not self._connection.can_subscribe:
                 self._reset_state()
+                self._clear_screensaver_state()
                 return
             raise
 
         if self._kodi_is_off:
             self._reset_state()
+            self._clear_screensaver_state()
             return
 
         if self._players:

--- a/homeassistant/components/kodi/screensaver.py
+++ b/homeassistant/components/kodi/screensaver.py
@@ -59,6 +59,9 @@ class KodiScreensaver:
             self._set_state(None)
             return
 
+        if self._connection.can_subscribe and self.is_on is not None:
+            return
+
         try:
             display_status = await self._kodi.call_method(
                 "XBMC.GetInfoBooleans",

--- a/homeassistant/components/kodi/screensaver.py
+++ b/homeassistant/components/kodi/screensaver.py
@@ -1,0 +1,96 @@
+"""Shared Kodi screensaver state."""
+
+from __future__ import annotations
+
+from jsonrpc_base.jsonrpc import ProtocolError, TransportError
+from pykodi import Kodi
+from pykodi.kodi import KodiHTTPConnection, KodiWSConnection
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import async_signal_screensaver_update
+
+
+class KodiScreensaver:
+    """Shared Kodi screensaver state and events."""
+
+    def __init__(
+        self,
+        entry_id: str,
+        connection: KodiHTTPConnection | KodiWSConnection,
+        kodi: Kodi,
+    ) -> None:
+        """Initialize the shared screensaver state."""
+        self._connection = connection
+        self._kodi = kodi
+        self._signal = async_signal_screensaver_update(entry_id)
+        self._hass: HomeAssistant | None = None
+        self.is_on: bool | None = None
+
+    @property
+    def available(self) -> bool:
+        """Return if the underlying Kodi connection is available."""
+        return self._connection.connected
+
+    @property
+    def signal(self) -> str:
+        """Return the dispatcher signal for screensaver updates."""
+        return self._signal
+
+    @callback
+    def set_hass(self, hass: HomeAssistant) -> None:
+        """Store the Home Assistant instance for dispatching updates."""
+        self._hass = hass
+
+    @callback
+    def _set_state(self, is_on: bool | None) -> None:
+        """Set the current screensaver state and notify listeners."""
+        if self.is_on == is_on:
+            return
+
+        self.is_on = is_on
+        if self._hass is not None:
+            async_dispatcher_send(self._hass, self._signal)
+
+    async def async_update(self) -> None:
+        """Refresh the Kodi screensaver state."""
+        if not self._connection.connected:
+            self._set_state(None)
+            return
+
+        try:
+            display_status = await self._kodi.call_method(
+                "XBMC.GetInfoBooleans",
+                booleans=["System.ScreenSaverActive"],
+            )
+        except ProtocolError, TransportError:
+            self._set_state(None)
+            return
+
+        self._set_state(display_status.get("System.ScreenSaverActive"))
+
+    @callback
+    def async_clear(self) -> None:
+        """Clear the current screensaver state."""
+        self._set_state(None)
+
+    @callback
+    def async_on_screensaver_on(self, sender, data) -> None:
+        """Handle screensaver activation."""
+        self._set_state(True)
+
+    @callback
+    def async_on_screensaver_off(self, sender, data) -> None:
+        """Handle screensaver deactivation."""
+        self._set_state(False)
+
+    @callback
+    def async_register_ws_callbacks(self) -> None:
+        """Register Kodi websocket callbacks."""
+        self._connection.server.GUI.OnScreensaverActivated = (
+            self.async_on_screensaver_on
+        )
+        self._connection.server.GUI.OnScreensaverDeactivated = (
+            self.async_on_screensaver_off
+        )

--- a/homeassistant/components/kodi/screensaver.py
+++ b/homeassistant/components/kodi/screensaver.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from jsonrpc_base.jsonrpc import ProtocolError, TransportError
 from pykodi import Kodi
 from pykodi.kodi import KodiHTTPConnection, KodiWSConnection
@@ -27,6 +29,7 @@ class KodiScreensaver:
         self._signal = async_signal_screensaver_update(entry_id)
         self._hass: HomeAssistant | None = None
         self.is_on: bool | None = None
+        self._update_lock = asyncio.Lock()
 
     @property
     def available(self) -> bool:
@@ -59,19 +62,24 @@ class KodiScreensaver:
             self._set_state(None)
             return
 
-        if self._connection.can_subscribe and self.is_on is not None:
-            return
+        async with self._update_lock:
+            if not self._connection.connected:
+                self._set_state(None)
+                return
 
-        try:
-            display_status = await self._kodi.call_method(
-                "XBMC.GetInfoBooleans",
-                booleans=["System.ScreenSaverActive"],
-            )
-        except ProtocolError, TransportError:
-            self._set_state(None)
-            return
+            if self._connection.can_subscribe and self.is_on is not None:
+                return
 
-        self._set_state(display_status.get("System.ScreenSaverActive"))
+            try:
+                display_status = await self._kodi.call_method(
+                    "XBMC.GetInfoBooleans",
+                    booleans=["System.ScreenSaverActive"],
+                )
+            except ProtocolError, TransportError:
+                self._set_state(None)
+                return
+
+            self._set_state(display_status.get("System.ScreenSaverActive"))
 
     @callback
     def async_clear(self) -> None:

--- a/homeassistant/components/kodi/strings.json
+++ b/homeassistant/components/kodi/strings.json
@@ -51,6 +51,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "screensaver": {
+        "name": "Screensaver"
+      }
+    },
     "media_player": {
       "media_player": {
         "state_attributes": {

--- a/tests/components/kodi/__init__.py
+++ b/tests/components/kodi/__init__.py
@@ -18,7 +18,11 @@ from .util import MockConnection
 from tests.common import MockConfigEntry
 
 
-async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
+async def init_integration(
+    hass: HomeAssistant,
+    *,
+    call_method_return_value: dict[str, bool] | None = None,
+) -> MockConfigEntry:
     """Set up the Kodi integration in Home Assistant."""
     entry_data = {
         CONF_NAME: "name",
@@ -31,9 +35,15 @@ async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     }
     entry = MockConfigEntry(domain=DOMAIN, data=entry_data, title="name")
     entry.add_to_hass(hass)
+    if call_method_return_value is None:
+        call_method_return_value = {"System.ScreenSaverActive": False}
 
     with (
         patch("homeassistant.components.kodi.Kodi.ping", return_value=True),
+        patch(
+            "homeassistant.components.kodi.Kodi.call_method",
+            return_value=call_method_return_value,
+        ),
         patch(
             "homeassistant.components.kodi.Kodi.get_application_properties",
             return_value={"version": {"major": 1, "minor": 1}},

--- a/tests/components/kodi/__init__.py
+++ b/tests/components/kodi/__init__.py
@@ -1,5 +1,6 @@
 """Tests for the Kodi integration."""
 
+from collections.abc import Sequence
 from unittest.mock import patch
 
 from homeassistant.components.kodi.const import CONF_WS_PORT, DOMAIN
@@ -13,7 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .util import MockConnection
+from .util import MockConnection, MockWSConnection
 
 from tests.common import MockConfigEntry
 
@@ -22,6 +23,8 @@ async def init_integration(
     hass: HomeAssistant,
     *,
     call_method_return_value: dict[str, bool] | None = None,
+    call_method_side_effect: Sequence[dict[str, bool]] | None = None,
+    connection: MockConnection | MockWSConnection | None = None,
 ) -> MockConfigEntry:
     """Set up the Kodi integration in Home Assistant."""
     entry_data = {
@@ -37,12 +40,23 @@ async def init_integration(
     entry.add_to_hass(hass)
     if call_method_return_value is None:
         call_method_return_value = {"System.ScreenSaverActive": False}
+    if connection is None:
+        connection = MockConnection()
+    call_method_patch_kwargs: dict[str, object]
+    if call_method_side_effect is None:
+        call_method_patch_kwargs = {"return_value": call_method_return_value}
+    else:
+        call_method_patch_kwargs = {"side_effect": call_method_side_effect}
 
     with (
         patch("homeassistant.components.kodi.Kodi.ping", return_value=True),
         patch(
             "homeassistant.components.kodi.Kodi.call_method",
-            return_value=call_method_return_value,
+            **call_method_patch_kwargs,
+        ),
+        patch(
+            "homeassistant.components.kodi.Kodi.get_players",
+            return_value=[],
         ),
         patch(
             "homeassistant.components.kodi.Kodi.get_application_properties",
@@ -50,7 +64,7 @@ async def init_integration(
         ),
         patch(
             "homeassistant.components.kodi.get_kodi_connection",
-            return_value=MockConnection(),
+            return_value=connection,
         ),
     ):
         await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/kodi/test_binary_sensor.py
+++ b/tests/components/kodi/test_binary_sensor.py
@@ -1,0 +1,29 @@
+"""Tests for Kodi binary sensors."""
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from . import init_integration
+
+
+async def test_screensaver_binary_sensor_defaults_off(hass: HomeAssistant) -> None:
+    """Test the Kodi screensaver binary sensor is created."""
+    await init_integration(hass)
+
+    state = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.name_screensaver")
+
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_screensaver_binary_sensor_can_be_on(hass: HomeAssistant) -> None:
+    """Test the Kodi screensaver binary sensor reports the Kodi state."""
+    await init_integration(
+        hass,
+        call_method_return_value={"System.ScreenSaverActive": True},
+    )
+
+    state = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.name_screensaver")
+
+    assert state is not None
+    assert state.state == "on"

--- a/tests/components/kodi/test_binary_sensor.py
+++ b/tests/components/kodi/test_binary_sensor.py
@@ -3,9 +3,7 @@
 from unittest.mock import patch
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.homeassistant import DOMAIN as HOMEASSISTANT_DOMAIN
 from homeassistant.components.kodi.const import CONF_WS_PORT, DOMAIN
-from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -16,6 +14,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_component import async_update_entity
 
 from . import init_integration
 from .util import MockConnection, MockWSConnection
@@ -118,12 +117,7 @@ async def test_screensaver_binary_sensor_updates_via_media_player_polling(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        await hass.services.async_call(
-            HOMEASSISTANT_DOMAIN,
-            "update_entity",
-            {"entity_id": f"{MEDIA_PLAYER_DOMAIN}.name"},
-            blocking=True,
-        )
+        await async_update_entity(hass, "media_player.name")
         await hass.async_block_till_done()
 
         state = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.name_screensaver")

--- a/tests/components/kodi/test_binary_sensor.py
+++ b/tests/components/kodi/test_binary_sensor.py
@@ -124,3 +124,50 @@ async def test_screensaver_binary_sensor_updates_via_media_player_polling(
 
         assert state is not None
         assert state.state == "on"
+
+
+async def test_screensaver_binary_sensor_skips_extra_ws_refresh(
+    hass: HomeAssistant,
+) -> None:
+    """Test websocket setups do not re-query a known screensaver state."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "name",
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 8080,
+            CONF_WS_PORT: 9090,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_SSL: False,
+        },
+        title="name",
+    )
+    entry.add_to_hass(hass)
+    connection = MockWSConnection()
+
+    with (
+        patch("homeassistant.components.kodi.Kodi.ping", return_value=True),
+        patch(
+            "homeassistant.components.kodi.Kodi.call_method",
+            return_value={"System.ScreenSaverActive": False},
+        ) as call_method,
+        patch("homeassistant.components.kodi.Kodi.get_players", return_value=[]),
+        patch(
+            "homeassistant.components.kodi.Kodi.get_application_properties",
+            return_value={"version": {"major": 1, "minor": 1}},
+        ),
+        patch(
+            "homeassistant.components.kodi.get_kodi_connection",
+            return_value=connection,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert call_method.call_count == 1
+
+        await async_update_entity(hass, "media_player.name")
+        await hass.async_block_till_done()
+
+        assert call_method.call_count == 1

--- a/tests/components/kodi/test_binary_sensor.py
+++ b/tests/components/kodi/test_binary_sensor.py
@@ -1,9 +1,26 @@
 """Tests for Kodi binary sensors."""
 
+from unittest.mock import patch
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.homeassistant import DOMAIN as HOMEASSISTANT_DOMAIN
+from homeassistant.components.kodi.const import CONF_WS_PORT, DOMAIN
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 
 from . import init_integration
+from .util import MockConnection, MockWSConnection
+
+from tests.common import MockConfigEntry
 
 
 async def test_screensaver_binary_sensor_defaults_off(hass: HomeAssistant) -> None:
@@ -16,14 +33,100 @@ async def test_screensaver_binary_sensor_defaults_off(hass: HomeAssistant) -> No
     assert state.state == "off"
 
 
-async def test_screensaver_binary_sensor_can_be_on(hass: HomeAssistant) -> None:
-    """Test the Kodi screensaver binary sensor reports the Kodi state."""
-    await init_integration(
-        hass,
-        call_method_return_value={"System.ScreenSaverActive": True},
-    )
+async def test_screensaver_binary_sensor_updates_from_websocket(
+    hass: HomeAssistant,
+) -> None:
+    """Test the Kodi screensaver binary sensor updates from websocket events."""
+    connection = MockWSConnection()
+    await init_integration(hass, connection=connection)
+
+    connection.server.GUI.OnScreensaverActivated(None, None)
+    await hass.async_block_till_done()
 
     state = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.name_screensaver")
 
     assert state is not None
     assert state.state == "on"
+
+    connection.server.GUI.OnScreensaverDeactivated(None, None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.name_screensaver")
+
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_screensaver_binary_sensor_clears_on_disconnect(
+    hass: HomeAssistant,
+) -> None:
+    """Test the Kodi screensaver binary sensor clears on disconnect."""
+    connection = MockWSConnection()
+    await init_integration(
+        hass,
+        call_method_return_value={"System.ScreenSaverActive": True},
+        connection=connection,
+    )
+
+    await connection.server.System.OnQuit(None, None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.name_screensaver")
+
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_screensaver_binary_sensor_updates_via_media_player_polling(
+    hass: HomeAssistant,
+) -> None:
+    """Test the Kodi screensaver binary sensor updates via media player polling."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "name",
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 8080,
+            CONF_WS_PORT: 9090,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_SSL: False,
+        },
+        title="name",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.kodi.Kodi.ping", return_value=True),
+        patch(
+            "homeassistant.components.kodi.Kodi.call_method",
+            side_effect=[
+                {"System.ScreenSaverActive": False},
+                {"System.ScreenSaverActive": True},
+            ],
+        ),
+        patch("homeassistant.components.kodi.Kodi.get_players", return_value=[]),
+        patch(
+            "homeassistant.components.kodi.Kodi.get_application_properties",
+            return_value={"version": {"major": 1, "minor": 1}},
+        ),
+        patch(
+            "homeassistant.components.kodi.get_kodi_connection",
+            return_value=MockConnection(),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            HOMEASSISTANT_DOMAIN,
+            "update_entity",
+            {"entity_id": f"{MEDIA_PLAYER_DOMAIN}.name"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get(f"{BINARY_SENSOR_DOMAIN}.name_screensaver")
+
+        assert state is not None
+        assert state.state == "on"

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -1,6 +1,7 @@
 """Test the Kodi config flow."""
 
 from ipaddress import ip_address
+from types import SimpleNamespace
 
 from homeassistant.components.kodi.const import DEFAULT_SSL
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -69,6 +70,7 @@ class MockConnection:
 
     async def connect(self):
         """Mock connect."""
+        self._connected = True
 
     @property
     def connected(self):
@@ -82,6 +84,7 @@ class MockConnection:
 
     async def close(self):
         """Mock close."""
+        self._connected = False
 
     @property
     def server(self):
@@ -95,9 +98,17 @@ class MockWSConnection:
     def __init__(self, connected=True) -> None:
         """Mock the websocket connection."""
         self._connected = connected
+        self._server = SimpleNamespace(
+            Application=SimpleNamespace(),
+            GUI=SimpleNamespace(),
+            Other=SimpleNamespace(),
+            Player=SimpleNamespace(),
+            System=SimpleNamespace(),
+        )
 
     async def connect(self):
         """Mock connect."""
+        self._connected = True
 
     @property
     def connected(self):
@@ -107,12 +118,13 @@ class MockWSConnection:
     @property
     def can_subscribe(self):
         """Mock can_subscribe."""
-        return False
+        return True
 
     async def close(self):
         """Mock close."""
+        self._connected = False
 
     @property
     def server(self):
         """Mock server."""
-        return None
+        return self._server


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a separate Kodi `binary_sensor` for screensaver state.

This keeps the existing `media_player` focused on playback state and exposes the screensaver as its own boolean entity instead of a media player attribute.

The screensaver sensor uses shared integration state, updates from Kodi websocket screensaver events when available, and also refreshes through the existing update path so polling/non-websocket setups stay in sync.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/57655
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44681
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

