### PR TITLE
Mark entity-translations rule as done for Twente Milieu

### DIFF
--- a/homeassistant/components/twentemilieu/calendar.py
+++ b/homeassistant/components/twentemilieu/calendar.py
@@ -27,7 +27,6 @@ async def async_setup_entry(
 class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEntity):
     """Defines a Twente Milieu calendar."""
 
-    _attr_has_entity_name = True
     _attr_name = None
     _attr_translation_key = "calendar"
 

--- a/homeassistant/components/twentemilieu/quality_scale.yaml
+++ b/homeassistant/components/twentemilieu/quality_scale.yaml
@@ -55,10 +55,7 @@ rules:
       This integration does not have an options flow.
 
   # Gold
-  entity-translations:
-    status: todo
-    comment: |
-      The calendar entity name isn't translated yet.
+  entity-translations: done
   entity-device-class: done
   devices: done
   entity-category: done


### PR DESCRIPTION
## Proposed change

The `entity-translations` rule was marked as `todo` in the Twente Milieu quality scale with the comment "The calendar entity name isn't translated yet".

In practice, the calendar entity uses `_attr_name = None`, meaning it inherits the device name; there is no separate entity name that needs translating. The sensor entities all already have `translation_key`s with matching entries in `strings.json`.

This PR flips the rule to `done`.

While there, this PR also removes the now-redundant `_attr_has_entity_name = True` from the calendar entity, it is already set on the `TwenteMilieuEntity` base class.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
