### PR TITLE
Translate coordinator exceptions for Twente Milieu

### DIFF
--- a/homeassistant/components/twentemilieu/coordinator.py
+++ b/homeassistant/components/twentemilieu/coordinator.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from datetime import date
 
-from twentemilieu import TwenteMilieu, WasteType
+from twentemilieu import (
+    TwenteMilieu,
+    TwenteMilieuConnectionError,
+    TwenteMilieuError,
+    WasteType,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     CONF_HOUSE_LETTER,
@@ -46,4 +51,15 @@ class TwenteMilieuDataUpdateCoordinator(
 
     async def _async_update_data(self) -> dict[WasteType, list[date]]:
         """Fetch Twente Milieu data."""
-        return await self.twentemilieu.update()
+        try:
+            return await self.twentemilieu.update()
+        except TwenteMilieuConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from err
+        except TwenteMilieuError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+            ) from err

--- a/homeassistant/components/twentemilieu/quality_scale.yaml
+++ b/homeassistant/components/twentemilieu/quality_scale.yaml
@@ -70,10 +70,7 @@ rules:
     comment: |
       This integration has a fixed single device which represents the service.
   diagnostics: done
-  exception-translations:
-    status: todo
-    comment: |
-      The coordinator raises, and currently, doesn't provide a translation for it.
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: todo
   dynamic-devices:

--- a/homeassistant/components/twentemilieu/strings.json
+++ b/homeassistant/components/twentemilieu/strings.json
@@ -41,5 +41,13 @@
         "name": "Paper waste pickup"
       }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Twente Milieu service."
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the Twente Milieu service."
+    }
   }
 }

--- a/tests/components/twentemilieu/test_init.py
+++ b/tests/components/twentemilieu/test_init.py
@@ -1,8 +1,9 @@
 """Tests for the Twente Milieu integration."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
+from twentemilieu import TwenteMilieuConnectionError, TwenteMilieuError
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -28,19 +29,21 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@patch(
-    "homeassistant.components.twentemilieu.coordinator.TwenteMilieu.update",
-    side_effect=RuntimeError,
+@pytest.mark.parametrize(
+    "side_effect", [TwenteMilieuConnectionError, TwenteMilieuError]
 )
 async def test_config_entry_not_ready(
-    mock_request: MagicMock,
     hass: HomeAssistant,
+    mock_twentemilieu: MagicMock,
     mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
 ) -> None:
     """Test the Twente Milieu configuration entry not ready."""
+    mock_twentemilieu.update.side_effect = side_effect
+
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_request.call_count == 1
+    assert mock_twentemilieu.update.call_count == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change

The Twente Milieu coordinator's `_async_update_data` called `twentemilieu.update()` directly and let any library exception bubble up as a raw, untranslated error. This PR add handling + translations for it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
