### PR TITLE
Improve setup exception handling in ruckus_unleashed

### DIFF
--- a/homeassistant/components/ruckus_unleashed/__init__.py
+++ b/homeassistant/components/ruckus_unleashed/__init__.py
@@ -47,12 +47,16 @@ async def async_setup_entry(
 
     coordinator = RuckusDataUpdateCoordinator(hass, entry, ruckus)
 
-    await coordinator.async_config_entry_first_refresh()
+    try:
+        await coordinator.async_config_entry_first_refresh()
 
-    system_info = await ruckus.api.get_system_info()
+        system_info = await ruckus.api.get_system_info()
+        aps = await ruckus.api.get_aps()
+    except (ConnectionError, SchemaError) as err:
+        await ruckus.close()
+        raise ConfigEntryNotReady from err
 
     registry = dr.async_get(hass)
-    aps = await ruckus.api.get_aps()
     for access_point in aps:
         _LOGGER.debug("AP [%s] %s", access_point[API_AP_MAC], entry.entry_id)
         registry.async_get_or_create(

--- a/homeassistant/components/ruckus_unleashed/__init__.py
+++ b/homeassistant/components/ruckus_unleashed/__init__.py
@@ -47,9 +47,9 @@ async def async_setup_entry(
 
     coordinator = RuckusDataUpdateCoordinator(hass, entry, ruckus)
 
-    try:
-        await coordinator.async_config_entry_first_refresh()
+    await coordinator.async_config_entry_first_refresh()
 
+    try:
         system_info = await ruckus.api.get_system_info()
         aps = await ruckus.api.get_aps()
     except (ConnectionError, SchemaError) as err:

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -1,9 +1,10 @@
 """Test the Ruckus config flow."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
+from aioruckus import RuckusAjaxApi
 from aioruckus.const import ERROR_CONNECT_TIMEOUT, ERROR_LOGIN_INCORRECT
-from aioruckus.exceptions import AuthenticationError
+from aioruckus.exceptions import AuthenticationError, SchemaError
 
 from homeassistant.components.ruckus_unleashed.const import (
     API_AP_DEVNAME,
@@ -90,3 +91,43 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_entry_connection_error_post_login(
+    hass: HomeAssistant,
+) -> None:
+    """Test entry setup retries when get_system_info raises ConnectionError."""
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    with (
+        RuckusAjaxApiPatchContext(),
+        patch.object(
+            RuckusAjaxApi,
+            "get_system_info",
+            new=AsyncMock(side_effect=ConnectionError("connection lost")),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_schema_error_post_login(
+    hass: HomeAssistant,
+) -> None:
+    """Test entry setup retries when get_aps raises SchemaError."""
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    with (
+        RuckusAjaxApiPatchContext(),
+        patch.object(
+            RuckusAjaxApi,
+            "get_aps",
+            new=AsyncMock(side_effect=SchemaError("unexpected schema")),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from aioruckus import RuckusAjaxApi
 from aioruckus.const import ERROR_CONNECT_TIMEOUT, ERROR_LOGIN_INCORRECT
 from aioruckus.exceptions import AuthenticationError, SchemaError
+import pytest
 
 from homeassistant.components.ruckus_unleashed.const import (
     API_AP_DEVNAME,
@@ -93,38 +94,25 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_setup_entry_connection_error_post_login(
-    hass: HomeAssistant,
+@pytest.mark.parametrize(
+    ("method", "error"),
+    [
+        ("get_system_info", ConnectionError("connection lost")),
+        ("get_aps", SchemaError("unexpected schema")),
+    ],
+)
+async def test_setup_entry_error_post_login(
+    hass: HomeAssistant, method: str, error: Exception
 ) -> None:
-    """Test entry setup retries when get_system_info raises ConnectionError."""
+    """Test entry setup retries on post-login API errors."""
     entry = mock_config_entry()
     entry.add_to_hass(hass)
     with (
         RuckusAjaxApiPatchContext(),
         patch.object(
             RuckusAjaxApi,
-            "get_system_info",
-            new=AsyncMock(side_effect=ConnectionError("connection lost")),
-        ),
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_entry_schema_error_post_login(
-    hass: HomeAssistant,
-) -> None:
-    """Test entry setup retries when get_aps raises SchemaError."""
-    entry = mock_config_entry()
-    entry.add_to_hass(hass)
-    with (
-        RuckusAjaxApiPatchContext(),
-        patch.object(
-            RuckusAjaxApi,
-            "get_aps",
-            new=AsyncMock(side_effect=SchemaError("unexpected schema")),
+            method,
+            new=AsyncMock(side_effect=error),
         ),
     ):
         await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Wrap post-login API calls (first refresh, system info, AP list) in try-except to catch ConnectionError/SchemaError and re-raise as ConfigEntryNotReady.

Addresses: https://github.com/home-assistant/core/pull/164706#discussion_r3060477853

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #164706
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
