### PR TITLE
Fix missing kWh unit for dlq ADD_ELE energy sensor

### DIFF
--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -379,6 +379,8 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             translation_key="total_energy",
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
+            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+            suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.FORWARD_ENERGY_TOTAL,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -380,7 +380,6 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.FORWARD_ENERGY_TOTAL,

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -6549,8 +6549,11 @@
     'name': None,
     'object_id_base': 'Total energy',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
     'original_name': 'Total energy',
     'platform': 'tuya',
@@ -6559,15 +6562,16 @@
     'supported_features': 0,
     'translation_key': 'total_energy',
     'unique_id': 'tuya.a3qtb7pulkcc6jdjqldadd_ele',
-    'unit_of_measurement': '',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.eau_chaude_total_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'energy',
       'friendly_name': 'Eau Chaude Total energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': '',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.eau_chaude_total_energy',
@@ -25764,8 +25768,11 @@
     'name': None,
     'object_id_base': 'Total energy',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
     'original_name': 'Total energy',
     'platform': 'tuya',
@@ -25774,14 +25781,16 @@
     'supported_features': 0,
     'translation_key': 'total_energy',
     'unique_id': 'tuya.fcdadqsiax2gvnt0qldadd_ele',
-    'unit_of_measurement': None,
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.yi_lu_dai_ji_liang_ci_bao_chi_tong_duan_qi_total_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'energy',
       'friendly_name': '一路带计量磁保持通断器 Total energy',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.yi_lu_dai_ji_liang_ci_bao_chi_tong_duan_qi_total_energy',


### PR DESCRIPTION
## Proposed change

Set the native and suggested unit of measurement for the `dlq`
`DPCode.ADD_ELE` sensor to `UnitOfEnergy.KILO_WATT_HOUR`.

At the moment, `DeviceCategory.DLQ` exposes `ADD_ELE` as an energy
sensor with `SensorStateClass.TOTAL_INCREASING`, but it does not assign
a unit. For some `dlq` devices, Tuya reports an empty unit for this
datapoint, so the resulting Home Assistant entity has no usable unit of
measurement and cannot be used in the Energy dashboard.

This change fixes that by explicitly setting the unit to kWh.

## Why this is correct

`add_ele` is Tuya's cumulative energy datapoint for these metering
devices, and it is documented in kWh. This also matches the existing
handling of `DPCode.ADD_ELE` for `DeviceCategory.KG`, which already sets
the unit to `UnitOfEnergy.KILO_WATT_HOUR`.

## Additional information

`dlq` sensor support was added in #63519, including the total energy
sensor, but the unit was not set there.

This is a narrow change that only affects `DeviceCategory.DLQ` /
`DPCode.ADD_ELE`.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`is_allowed_path` guards against `thepath.resolve()` throwing a `FileNotFoundError`. This, however, no longer happens on Python 3.6+ [unless `strict=True` is passed](https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve). Without this fix, `is_allowed_path` could return `True` for broken symlinks.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [ ] Tests have been added to verify that the new code works.