### PR TITLE
Set parallel updates for Tailwind platforms

### DIFF
--- a/homeassistant/components/tailwind/binary_sensor.py
+++ b/homeassistant/components/tailwind/binary_sensor.py
@@ -19,6 +19,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import TailwindConfigEntry
 from .entity import TailwindDoorEntity
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(kw_only=True, frozen=True)
 class TailwindDoorBinarySensorEntityDescription(BinarySensorEntityDescription):

--- a/homeassistant/components/tailwind/button.py
+++ b/homeassistant/components/tailwind/button.py
@@ -22,6 +22,8 @@ from .const import DOMAIN
 from .coordinator import TailwindConfigEntry
 from .entity import TailwindEntity
 
+PARALLEL_UPDATES = 1
+
 
 @dataclass(frozen=True, kw_only=True)
 class TailwindButtonEntityDescription(ButtonEntityDescription):

--- a/homeassistant/components/tailwind/cover.py
+++ b/homeassistant/components/tailwind/cover.py
@@ -26,6 +26,8 @@ from .const import DOMAIN, LOGGER
 from .coordinator import TailwindConfigEntry
 from .entity import TailwindDoorEntity
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tailwind/number.py
+++ b/homeassistant/components/tailwind/number.py
@@ -18,6 +18,8 @@ from .const import DOMAIN
 from .coordinator import TailwindConfigEntry
 from .entity import TailwindEntity
 
+PARALLEL_UPDATES = 1
+
 
 @dataclass(frozen=True, kw_only=True)
 class TailwindNumberEntityDescription(NumberEntityDescription):

--- a/homeassistant/components/tailwind/quality_scale.yaml
+++ b/homeassistant/components/tailwind/quality_scale.yaml
@@ -32,7 +32,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: done
   # Gold


### PR DESCRIPTION
## Proposed change

Explicitly declare `PARALLEL_UPDATES` on all Tailwind entity platforms.

Flips the `parallel-updates` quality scale rule to `done`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
