### PR TITLE
Translate coordinator exceptions for Tailwind

### DIFF
--- a/homeassistant/components/tailwind/coordinator.py
+++ b/homeassistant/components/tailwind/coordinator.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from gotailwind import (
     Tailwind,
     TailwindAuthenticationError,
+    TailwindConnectionError,
     TailwindDeviceStatus,
     TailwindError,
 )
@@ -45,5 +46,13 @@ class TailwindDataUpdateCoordinator(DataUpdateCoordinator[TailwindDeviceStatus])
             return await self.tailwind.status()
         except TailwindAuthenticationError as err:
             raise ConfigEntryAuthFailed from err
+        except TailwindConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from err
         except TailwindError as err:
-            raise UpdateFailed(err) from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+            ) from err

--- a/homeassistant/components/tailwind/quality_scale.yaml
+++ b/homeassistant/components/tailwind/quality_scale.yaml
@@ -55,10 +55,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations:
-    status: exempt
-    comment: |
-      The coordinator needs translation when the update failed.
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues:

--- a/homeassistant/components/tailwind/strings.json
+++ b/homeassistant/components/tailwind/strings.json
@@ -70,6 +70,9 @@
     },
     "door_locked_out": {
       "message": "The door is locked out and cannot be operated."
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the Tailwind device."
     }
   }
 }

--- a/tests/components/tailwind/test_init.py
+++ b/tests/components/tailwind/test_init.py
@@ -12,6 +12,7 @@ import pytest
 from homeassistant.components.tailwind.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from tests.common import MockConfigEntry
 
@@ -36,12 +37,19 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.parametrize("side_effect", [TailwindConnectionError, TailwindError])
+@pytest.mark.parametrize(
+    ("side_effect", "expected_translation_key"),
+    [
+        (TailwindConnectionError, "communication_error"),
+        (TailwindError, "unknown_error"),
+    ],
+)
 async def test_config_entry_not_ready(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_tailwind: MagicMock,
     side_effect: type[Exception],
+    expected_translation_key: str,
 ) -> None:
     """Test the Tailwind configuration entry not ready."""
     mock_tailwind.status.side_effect = side_effect
@@ -52,6 +60,35 @@ async def test_config_entry_not_ready(
 
     assert len(mock_tailwind.status.mock_calls) == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_translation_key"),
+    [
+        (TailwindConnectionError, "communication_error"),
+        (TailwindError, "unknown_error"),
+    ],
+)
+async def test_coordinator_update_failed_translation(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_tailwind: MagicMock,
+    side_effect: type[Exception],
+    expected_translation_key: str,
+) -> None:
+    """Test the coordinator raises UpdateFailed with the correct translation key."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    mock_tailwind.status.side_effect = side_effect
+
+    with pytest.raises(UpdateFailed) as exc_info:
+        await coordinator._async_update_data()
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == expected_translation_key
 
 
 async def test_config_entry_authentication_failed(

--- a/tests/components/tailwind/test_init.py
+++ b/tests/components/tailwind/test_init.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import MagicMock
 
-from gotailwind import TailwindAuthenticationError, TailwindConnectionError
+from gotailwind import (
+    TailwindAuthenticationError,
+    TailwindConnectionError,
+    TailwindError,
+)
+import pytest
 
 from homeassistant.components.tailwind.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
@@ -31,13 +36,15 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
+@pytest.mark.parametrize("side_effect", [TailwindConnectionError, TailwindError])
 async def test_config_entry_not_ready(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_tailwind: MagicMock,
+    side_effect: type[Exception],
 ) -> None:
     """Test the Tailwind configuration entry not ready."""
-    mock_tailwind.status.side_effect = TailwindConnectionError
+    mock_tailwind.status.side_effect = side_effect
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/tailwind/test_init.py
+++ b/tests/components/tailwind/test_init.py
@@ -12,7 +12,6 @@ import pytest
 from homeassistant.components.tailwind.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from tests.common import MockConfigEntry
 
@@ -60,35 +59,6 @@ async def test_config_entry_not_ready(
 
     assert len(mock_tailwind.status.mock_calls) == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-@pytest.mark.parametrize(
-    ("side_effect", "expected_translation_key"),
-    [
-        (TailwindConnectionError, "communication_error"),
-        (TailwindError, "unknown_error"),
-    ],
-)
-async def test_coordinator_update_failed_translation(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_tailwind: MagicMock,
-    side_effect: type[Exception],
-    expected_translation_key: str,
-) -> None:
-    """Test the coordinator raises UpdateFailed with the correct translation key."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    mock_tailwind.status.side_effect = side_effect
-
-    with pytest.raises(UpdateFailed) as exc_info:
-        await coordinator._async_update_data()
-
-    assert exc_info.value.translation_domain == DOMAIN
-    assert exc_info.value.translation_key == expected_translation_key
 
 
 async def test_config_entry_authentication_failed(


### PR DESCRIPTION
## Proposed change

This PR splits the catch into `TailwindConnectionError` → `communication_error` and the generic `TailwindError` → `unknown_error`, both raised as `UpdateFailed` with `translation_domain` and `translation_key`.

The `communication_error` key already existed in `strings.json` (used by entity actions); this PR adds the `unknown_error` key alongside it.

The `exception-translations` rule was incorrectly marked as `exempt` with a comment that described the gap rather than an exemption reason. Flipped to `done`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
