### PR TITLE
Add unifi_discovery integration, migrate unifiprotect discovery

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1828,6 +1828,8 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/unifi_access/ @imhotep @RaHehl
 /tests/components/unifi_access/ @imhotep @RaHehl
 /homeassistant/components/unifi_direct/ @tofuSCHNITZEL
+/homeassistant/components/unifi_discovery/ @RaHehl
+/tests/components/unifi_discovery/ @RaHehl
 /homeassistant/components/unifiled/ @florisvdk
 /homeassistant/components/unifiprotect/ @RaHehl
 /tests/components/unifiprotect/ @RaHehl

--- a/homeassistant/brands/ubiquiti.json
+++ b/homeassistant/brands/ubiquiti.json
@@ -6,6 +6,7 @@
     "unifi",
     "unifi_access",
     "unifi_direct",
+    "unifi_discovery",
     "unifiled",
     "unifiprotect"
   ]

--- a/homeassistant/components/unifi_discovery/__init__.py
+++ b/homeassistant/components/unifi_discovery/__init__.py
@@ -1,0 +1,18 @@
+"""The UniFi Discovery integration."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+from .discovery import async_start_discovery
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up UniFi Discovery."""
+    async_start_discovery(hass)
+    return True

--- a/homeassistant/components/unifi_discovery/config_flow.py
+++ b/homeassistant/components/unifi_discovery/config_flow.py
@@ -30,7 +30,8 @@ class UnifiDiscoveryFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle discovery via DHCP."""
         _LOGGER.debug("Starting discovery via DHCP: %s", discovery_info)
-        await self.async_set_unique_id(DOMAIN)
+        if self._async_in_progress():
+            return self.async_abort(reason="already_in_progress")
         async_start_discovery(self.hass)
         return self.async_abort(reason="discovery_started")
 
@@ -39,6 +40,7 @@ class UnifiDiscoveryFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle discovery via SSDP."""
         _LOGGER.debug("Starting discovery via SSDP: %s", discovery_info)
-        await self.async_set_unique_id(DOMAIN)
+        if self._async_in_progress():
+            return self.async_abort(reason="already_in_progress")
         async_start_discovery(self.hass)
         return self.async_abort(reason="discovery_started")

--- a/homeassistant/components/unifi_discovery/config_flow.py
+++ b/homeassistant/components/unifi_discovery/config_flow.py
@@ -1,0 +1,43 @@
+"""Config flow for UniFi Discovery."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+
+from .const import DOMAIN
+from .discovery import async_start_discovery
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class UnifiDiscoveryFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for UniFi Discovery."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a user-initiated flow."""
+        return self.async_abort(reason="discovery_started")
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle discovery via DHCP."""
+        _LOGGER.debug("Starting discovery via DHCP: %s", discovery_info)
+        await self.async_set_unique_id(DOMAIN)
+        async_start_discovery(self.hass)
+        return self.async_abort(reason="discovery_started")
+
+    async def async_step_ssdp(
+        self, discovery_info: SsdpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle discovery via SSDP."""
+        _LOGGER.debug("Starting discovery via SSDP: %s", discovery_info)
+        await self.async_set_unique_id(DOMAIN)
+        async_start_discovery(self.hass)
+        return self.async_abort(reason="discovery_started")

--- a/homeassistant/components/unifi_discovery/config_flow.py
+++ b/homeassistant/components/unifi_discovery/config_flow.py
@@ -22,6 +22,7 @@ class UnifiDiscoveryFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a user-initiated flow."""
+        async_start_discovery(self.hass)
         return self.async_abort(reason="discovery_started")
 
     async def async_step_dhcp(

--- a/homeassistant/components/unifi_discovery/const.py
+++ b/homeassistant/components/unifi_discovery/const.py
@@ -1,0 +1,12 @@
+"""Constants for the UniFi Discovery integration."""
+
+from unifi_discovery import UnifiService
+
+DOMAIN = "unifi_discovery"
+
+# Static mapping of UniFi service types to their Home Assistant integration domains.
+# This must be static (not a runtime registry) because consumers may not be loaded
+# when initial discovery runs — the same pattern DHCP/SSDP use with manifest matchers.
+CONSUMER_MAPPING: dict[UnifiService, str] = {
+    UnifiService.Protect: "unifiprotect",
+}

--- a/homeassistant/components/unifi_discovery/discovery.py
+++ b/homeassistant/components/unifi_discovery/discovery.py
@@ -1,13 +1,13 @@
-"""The unifiprotect integration discovery."""
+"""UniFi network device discovery."""
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict
 from datetime import timedelta
 import logging
 from typing import Any
 
-from unifi_discovery import AIOUnifiScanner, UnifiDevice, UnifiService
+from unifi_discovery import AIOUnifiScanner, UnifiDevice
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
@@ -15,32 +15,21 @@ from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.hass_dict import HassKey
 
-from .const import DOMAIN
+from .const import CONSUMER_MAPPING, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-
-@dataclass
-class UniFiProtectRuntimeData:
-    """Runtime data stored in hass.data[DOMAIN]."""
-
-    auth_retries: dict[str, int] = field(default_factory=dict)
-    discovery_started: bool = False
-
-
-# Typed key for hass.data access at DOMAIN level
-DATA_UNIFIPROTECT: HassKey[UniFiProtectRuntimeData] = HassKey(DOMAIN)
-
 DISCOVERY_INTERVAL = timedelta(minutes=60)
+
+DATA_DISCOVERY_STARTED: HassKey[bool] = HassKey(f"{DOMAIN}_started")
 
 
 @callback
 def async_start_discovery(hass: HomeAssistant) -> None:
-    """Start discovery."""
-    domain_data = hass.data.setdefault(DATA_UNIFIPROTECT, UniFiProtectRuntimeData())
-    if domain_data.discovery_started:
+    """Start discovery of UniFi devices."""
+    if hass.data.get(DATA_DISCOVERY_STARTED):
         return
-    domain_data.discovery_started = True
+    hass.data[DATA_DISCOVERY_STARTED] = True
 
     async def _async_discovery() -> None:
         async_trigger_discovery(hass, await async_discover_devices())
@@ -48,7 +37,9 @@ def async_start_discovery(hass: HomeAssistant) -> None:
     @callback
     def _async_start_background_discovery(*_: Any) -> None:
         """Run discovery in the background."""
-        hass.async_create_background_task(_async_discovery(), "unifiprotect-discovery")
+        hass.async_create_background_task(
+            _async_discovery(), "unifi_discovery-discovery"
+        )
 
     # Do not block startup since discovery takes 31s or more
     _async_start_background_discovery()
@@ -61,7 +52,7 @@ def async_start_discovery(hass: HomeAssistant) -> None:
 
 
 async def async_discover_devices() -> list[UnifiDevice]:
-    """Discover devices."""
+    """Discover UniFi devices on the network."""
     scanner = AIOUnifiScanner()
     devices = await scanner.async_scan()
     _LOGGER.debug("Found devices: %s", devices)
@@ -75,10 +66,13 @@ def async_trigger_discovery(
 ) -> None:
     """Trigger config flows for discovered devices."""
     for device in discovered_devices:
-        if device.services[UnifiService.Protect] and device.hw_addr:
-            discovery_flow.async_create_flow(
-                hass,
-                DOMAIN,
-                context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-                data=asdict(device),
-            )
+        if not device.hw_addr:
+            continue
+        for service, domain in CONSUMER_MAPPING.items():
+            if device.services.get(service):
+                discovery_flow.async_create_flow(
+                    hass,
+                    domain,
+                    context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+                    data=asdict(device),
+                )

--- a/homeassistant/components/unifi_discovery/discovery.py
+++ b/homeassistant/components/unifi_discovery/discovery.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DISCOVERY_INTERVAL = timedelta(minutes=60)
 
-DATA_DISCOVERY_STARTED: HassKey[bool] = HassKey(f"{DOMAIN}_started")
+DATA_DISCOVERY_STARTED: HassKey[bool] = HassKey(DOMAIN)
 
 
 @callback

--- a/homeassistant/components/unifi_discovery/manifest.json
+++ b/homeassistant/components/unifi_discovery/manifest.json
@@ -1,0 +1,63 @@
+{
+  "domain": "unifi_discovery",
+  "name": "UniFi Discovery",
+  "codeowners": ["@RaHehl"],
+  "config_flow": true,
+  "dhcp": [
+    {
+      "macaddress": "B4FBE4*"
+    },
+    {
+      "macaddress": "802AA8*"
+    },
+    {
+      "macaddress": "F09FC2*"
+    },
+    {
+      "macaddress": "68D79A*"
+    },
+    {
+      "macaddress": "18E829*"
+    },
+    {
+      "macaddress": "245A4C*"
+    },
+    {
+      "macaddress": "784558*"
+    },
+    {
+      "macaddress": "E063DA*"
+    },
+    {
+      "macaddress": "265A4C*"
+    },
+    {
+      "macaddress": "74ACB9*"
+    }
+  ],
+  "documentation": "https://www.home-assistant.io/integrations/unifi_discovery",
+  "integration_type": "system",
+  "iot_class": "local_polling",
+  "loggers": ["unifi_discovery"],
+  "quality_scale": "internal",
+  "requirements": ["unifi-discovery==1.4.0"],
+  "single_config_entry": true,
+  "ssdp": [
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine Pro"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine SE"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine Pro Max"
+    }
+  ]
+}

--- a/homeassistant/components/unifi_discovery/strings.json
+++ b/homeassistant/components/unifi_discovery/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "discovery_started": "Discovery started"
     },
     "step": {

--- a/homeassistant/components/unifi_discovery/strings.json
+++ b/homeassistant/components/unifi_discovery/strings.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "abort": {
+      "discovery_started": "Discovery started"
+    },
+    "step": {
+      "user": {
+        "description": "UniFi Discovery is set up automatically."
+      }
+    }
+  }
+}

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -39,12 +39,7 @@ from .const import (
     MIN_REQUIRED_PROTECT_V,
     PLATFORMS,
 )
-from .data import (
-    DATA_UNIFIPROTECT,
-    ProtectData,
-    UFPConfigEntry,
-    UniFiProtectRuntimeData,
-)
+from .data import DATA_AUTH_RETRIES, ProtectData, UFPConfigEntry
 from .migrate import async_migrate_data
 from .services import async_setup_services
 from .utils import (
@@ -68,7 +63,6 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the UniFi Protect."""
-    hass.data.setdefault(DATA_UNIFIPROTECT, UniFiProtectRuntimeData())
     async_setup_services(hass)
     return True
 
@@ -82,11 +76,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: UFPConfigEntry) -> bool:
     try:
         await protect.update()
     except NotAuthorized as err:
-        domain_data = hass.data.setdefault(DATA_UNIFIPROTECT, UniFiProtectRuntimeData())
-        retries = domain_data.auth_retries.get(entry.entry_id, 0)
+        auth_retries = hass.data.setdefault(DATA_AUTH_RETRIES, {})
+        retries = auth_retries.get(entry.entry_id, 0)
         if retries < AUTH_RETRIES:
             retries += 1
-            domain_data.auth_retries[entry.entry_id] = retries
+            auth_retries[entry.entry_id] = retries
             raise ConfigEntryNotReady from err
         raise ConfigEntryAuthFailed(err) from err
     except (TimeoutError, ClientError, ServerDisconnectedError) as err:

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -140,7 +140,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: UFPConfigEntry) -> bool:
     if entry.unique_id is None:
         hass.config_entries.async_update_entry(entry, unique_id=nvr_info.mac)
 
-    entry.runtime_data = data_service
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, data_service.async_stop)
     )

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -39,8 +39,12 @@ from .const import (
     MIN_REQUIRED_PROTECT_V,
     PLATFORMS,
 )
-from .data import ProtectData, UFPConfigEntry
-from .discovery import DATA_UNIFIPROTECT, UniFiProtectRuntimeData, async_start_discovery
+from .data import (
+    DATA_UNIFIPROTECT,
+    ProtectData,
+    UFPConfigEntry,
+    UniFiProtectRuntimeData,
+)
 from .migrate import async_migrate_data
 from .services import async_setup_services
 from .utils import (
@@ -64,11 +68,8 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the UniFi Protect."""
-    # Initialize domain data structure (setdefault in case discovery already started)
     hass.data.setdefault(DATA_UNIFIPROTECT, UniFiProtectRuntimeData())
-    # Only start discovery once regardless of how many entries they have
     async_setup_services(hass)
-    async_start_discovery(hass)
     return True
 
 

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -39,7 +39,7 @@ from .const import (
     MIN_REQUIRED_PROTECT_V,
     PLATFORMS,
 )
-from .data import DATA_AUTH_RETRIES, ProtectData, UFPConfigEntry
+from .data import ProtectData, UFPConfigEntry
 from .migrate import async_migrate_data
 from .services import async_setup_services
 from .utils import (
@@ -73,20 +73,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: UFPConfigEntry) -> bool:
     protect = async_create_api_client(hass, entry)
     _LOGGER.debug("Connect to UniFi Protect")
 
+    # Reuse ProtectData from previous retry or create new
+    if hasattr(entry, "runtime_data"):
+        data_service = entry.runtime_data
+        data_service.api = protect
+    else:
+        data_service = ProtectData(hass, protect, SCAN_INTERVAL, entry)
+        entry.runtime_data = data_service
+
     try:
         await protect.update()
     except NotAuthorized as err:
-        auth_retries = hass.data.setdefault(DATA_AUTH_RETRIES, {})
-        retries = auth_retries.get(entry.entry_id, 0)
-        if retries < AUTH_RETRIES:
-            retries += 1
-            auth_retries[entry.entry_id] = retries
-            raise ConfigEntryNotReady from err
-        raise ConfigEntryAuthFailed(err) from err
+        data_service.auth_retries += 1
+        if data_service.auth_retries > AUTH_RETRIES:
+            raise ConfigEntryAuthFailed(err) from err
+        raise ConfigEntryNotReady from err
     except (TimeoutError, ClientError, ServerDisconnectedError) as err:
         raise ConfigEntryNotReady from err
-
-    data_service = ProtectData(hass, protect, SCAN_INTERVAL, entry)
     bootstrap = protect.bootstrap
     nvr_info = bootstrap.nvr
     auth_user = bootstrap.users.get(bootstrap.auth_user_id)

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -36,8 +36,6 @@ from homeassistant.helpers.aiohttp_client import (
     async_create_clientsession,
     async_get_clientsession,
 )
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
-from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.loader import async_get_integration
@@ -56,7 +54,6 @@ from .const import (
     OUTDATED_LOG_MESSAGE,
 )
 from .data import UFPConfigEntry, async_last_update_was_successful
-from .discovery import async_start_discovery
 from .utils import (
     _async_resolve,
     _async_short_mac,
@@ -204,28 +201,6 @@ class ProtectFlowHandler(ConfigFlow, domain=DOMAIN):
         """Init the config flow."""
         super().__init__()
         self._discovered_device: dict[str, str] = {}
-
-    async def async_step_dhcp(
-        self, discovery_info: DhcpServiceInfo
-    ) -> ConfigFlowResult:
-        """Handle discovery via dhcp."""
-        _LOGGER.debug("Starting discovery via: %s", discovery_info)
-        return await self._async_discovery_handoff()
-
-    async def async_step_ssdp(
-        self, discovery_info: SsdpServiceInfo
-    ) -> ConfigFlowResult:
-        """Handle a discovered UniFi device."""
-        _LOGGER.debug("Starting discovery via: %s", discovery_info)
-        return await self._async_discovery_handoff()
-
-    async def _async_discovery_handoff(self) -> ConfigFlowResult:
-        """Ensure discovery is active."""
-        # Discovery requires an additional check so we use
-        # SSDP and DHCP to tell us to start it so it only
-        # runs on networks where unifi devices are present.
-        async_start_discovery(self.hass)
-        return self.async_abort(reason="discovery_started")
 
     async def async_step_integration_discovery(
         self, discovery_info: DiscoveryInfoType

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import partial
 import logging
@@ -33,6 +34,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     AUTH_RETRIES,
@@ -50,6 +52,17 @@ from .utils import async_get_devices_by_type
 _LOGGER = logging.getLogger(__name__)
 type ProtectDeviceType = ProtectAdoptableDeviceModel | NVR
 type UFPConfigEntry = ConfigEntry[ProtectData]
+
+
+@dataclass
+class UniFiProtectRuntimeData:
+    """Runtime data stored in hass.data[DOMAIN]."""
+
+    auth_retries: dict[str, int] = field(default_factory=dict)
+
+
+# Typed key for hass.data access at DOMAIN level
+DATA_UNIFIPROTECT: HassKey[UniFiProtectRuntimeData] = HassKey(DOMAIN)
 
 
 @callback

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -33,7 +33,6 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     AUTH_RETRIES,
@@ -51,10 +50,6 @@ from .utils import async_get_devices_by_type
 _LOGGER = logging.getLogger(__name__)
 type ProtectDeviceType = ProtectAdoptableDeviceModel | NVR
 type UFPConfigEntry = ConfigEntry[ProtectData]
-
-
-# Typed key for per-entry auth retry tracking during setup
-DATA_AUTH_RETRIES: HassKey[dict[str, int]] = HassKey(f"{DOMAIN}_auth_retries")
 
 
 @callback
@@ -91,6 +86,7 @@ class ProtectData:
         self._pending_camera_ids: set[str] = set()
         self._unsubs: list[CALLBACK_TYPE] = []
         self._auth_failures = 0
+        self.auth_retries = 0
         self.last_update_success = False
         self.api = protect
         self.adopt_signal = _async_dispatch_id(entry, DISPATCH_ADOPT)

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable
-from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import partial
 import logging
@@ -54,15 +53,8 @@ type ProtectDeviceType = ProtectAdoptableDeviceModel | NVR
 type UFPConfigEntry = ConfigEntry[ProtectData]
 
 
-@dataclass
-class UniFiProtectRuntimeData:
-    """Runtime data stored in hass.data[DOMAIN]."""
-
-    auth_retries: dict[str, int] = field(default_factory=dict)
-
-
-# Typed key for hass.data access at DOMAIN level
-DATA_UNIFIPROTECT: HassKey[UniFiProtectRuntimeData] = HassKey(DOMAIN)
+# Typed key for per-entry auth retry tracking during setup
+DATA_AUTH_RETRIES: HassKey[dict[str, int]] = HassKey(f"{DOMAIN}_auth_retries")
 
 
 @callback

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -3,61 +3,11 @@
   "name": "UniFi Protect",
   "codeowners": ["@RaHehl"],
   "config_flow": true,
-  "dependencies": ["http", "repairs"],
-  "dhcp": [
-    {
-      "macaddress": "B4FBE4*"
-    },
-    {
-      "macaddress": "802AA8*"
-    },
-    {
-      "macaddress": "F09FC2*"
-    },
-    {
-      "macaddress": "68D79A*"
-    },
-    {
-      "macaddress": "18E829*"
-    },
-    {
-      "macaddress": "245A4C*"
-    },
-    {
-      "macaddress": "784558*"
-    },
-    {
-      "macaddress": "E063DA*"
-    },
-    {
-      "macaddress": "265A4C*"
-    },
-    {
-      "macaddress": "74ACB9*"
-    }
-  ],
+  "dependencies": ["http", "repairs", "unifi_discovery"],
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "loggers": ["uiprotect", "unifi_discovery"],
+  "loggers": ["uiprotect"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==10.2.6", "unifi-discovery==1.4.0"],
-  "ssdp": [
-    {
-      "manufacturer": "Ubiquiti Networks",
-      "modelDescription": "UniFi Dream Machine"
-    },
-    {
-      "manufacturer": "Ubiquiti Networks",
-      "modelDescription": "UniFi Dream Machine Pro"
-    },
-    {
-      "manufacturer": "Ubiquiti Networks",
-      "modelDescription": "UniFi Dream Machine SE"
-    },
-    {
-      "manufacturer": "Ubiquiti Networks",
-      "modelDescription": "UniFi Dream Machine Pro Max"
-    }
-  ]
+  "requirements": ["uiprotect==10.2.6"]
 }

--- a/homeassistant/components/unifiprotect/quality_scale.yaml
+++ b/homeassistant/components/unifiprotect/quality_scale.yaml
@@ -39,7 +39,9 @@ rules:
   devices: done
   diagnostics: done
   discovery-update-info: done
-  discovery: done
+  discovery:
+    status: exempt
+    comment: Discovery is handled via unifi_discovery dependency using SOURCE_INTEGRATION_DISCOVERY.
   docs-data-update: done
   docs-examples: done
   docs-known-limitations: done

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -766,6 +766,7 @@ FLOWS = {
         "ukraine_alarm",
         "unifi",
         "unifi_access",
+        "unifi_discovery",
         "unifiprotect",
         "upb",
         "upcloud",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -1331,43 +1331,43 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "hostname": "twinkly-*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "B4FBE4*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "802AA8*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "F09FC2*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "68D79A*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "18E829*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "245A4C*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "784558*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "E063DA*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "265A4C*",
     },
     {
-        "domain": "unifiprotect",
+        "domain": "unifi_discovery",
         "macaddress": "74ACB9*",
     },
     {

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -359,7 +359,7 @@ SSDP = {
             "modelDescription": "UniFi Dream Machine Pro Max",
         },
     ],
-    "unifiprotect": [
+    "unifi_discovery": [
         {
             "manufacturer": "Ubiquiti Networks",
             "modelDescription": "UniFi Dream Machine",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3186,7 +3186,7 @@ uiprotect==10.2.6
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7
 
-# homeassistant.components.unifiprotect
+# homeassistant.components.unifi_discovery
 unifi-discovery==1.4.0
 
 # homeassistant.components.unifi_direct

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2698,7 +2698,7 @@ uiprotect==10.2.6
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7
 
-# homeassistant.components.unifiprotect
+# homeassistant.components.unifi_discovery
 unifi-discovery==1.4.0
 
 # homeassistant.components.homeassistant_hardware

--- a/script/hassfest/config_flow.py
+++ b/script/hassfest/config_flow.py
@@ -9,7 +9,7 @@ from .brand import validate as validate_brands
 from .model import Brand, Config, Integration, IntegrationType
 from .serializer import format_python_namespace
 
-UNIQUE_ID_IGNORE = {"huawei_lte", "mqtt", "adguard"}
+UNIQUE_ID_IGNORE = {"huawei_lte", "mqtt", "adguard", "unifi_discovery"}
 
 
 def _validate_integration(config: Config, integration: Integration) -> None:

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -2151,6 +2151,7 @@ NO_QUALITY_SCALE = [
     "search",
     "system_health",
     "system_log",
+    "unifi_discovery",
     "tag",
     "temperature",
     "timer",

--- a/tests/components/unifi_discovery/__init__.py
+++ b/tests/components/unifi_discovery/__init__.py
@@ -21,6 +21,15 @@ UNIFI_DISCOVERY_PROTECT = UnifiDevice(
     direct_connect_domain=DIRECT_CONNECT_DOMAIN,
 )
 
+UNIFI_DISCOVERY_NO_MAC = UnifiDevice(
+    source_ip=DEVICE_IP_ADDRESS,
+    hw_addr=None,
+    platform=DEVICE_HOSTNAME,
+    hostname=DEVICE_HOSTNAME,
+    services={UnifiService.Protect: True},
+    direct_connect_domain=DIRECT_CONNECT_DOMAIN,
+)
+
 
 def _patch_discovery(
     device: UnifiDevice | None = None, no_device: bool = False

--- a/tests/components/unifi_discovery/__init__.py
+++ b/tests/components/unifi_discovery/__init__.py
@@ -1,0 +1,41 @@
+"""Tests for the UniFi Discovery integration."""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from unifi_discovery import AIOUnifiScanner, UnifiDevice, UnifiService
+
+DEVICE_HOSTNAME = "unvr"
+DEVICE_IP_ADDRESS = "127.0.0.1"
+DEVICE_MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
+DIRECT_CONNECT_DOMAIN = "x.ui.direct"
+
+
+UNIFI_DISCOVERY_PROTECT = UnifiDevice(
+    source_ip=DEVICE_IP_ADDRESS,
+    hw_addr=DEVICE_MAC_ADDRESS,
+    platform=DEVICE_HOSTNAME,
+    hostname=DEVICE_HOSTNAME,
+    services={UnifiService.Protect: True},
+    direct_connect_domain=DIRECT_CONNECT_DOMAIN,
+)
+
+
+def _patch_discovery(
+    device: UnifiDevice | None = None, no_device: bool = False
+) -> Generator[None]:
+    mock_aio_discovery = MagicMock(auto_spec=AIOUnifiScanner)
+    scanner_return = [] if no_device else [device or UNIFI_DISCOVERY_PROTECT]
+    mock_aio_discovery.async_scan = AsyncMock(return_value=scanner_return)
+    mock_aio_discovery.found_devices = scanner_return
+
+    @contextmanager
+    def _patcher():
+        with patch(
+            "homeassistant.components.unifi_discovery.discovery.AIOUnifiScanner",
+            return_value=mock_aio_discovery,
+        ):
+            yield
+
+    return _patcher()

--- a/tests/components/unifi_discovery/__init__.py
+++ b/tests/components/unifi_discovery/__init__.py
@@ -24,7 +24,7 @@ UNIFI_DISCOVERY_PROTECT = UnifiDevice(
 
 def _patch_discovery(
     device: UnifiDevice | None = None, no_device: bool = False
-) -> Generator[None]:
+) -> Generator[MagicMock]:
     mock_aio_discovery = MagicMock(spec=AIOUnifiScanner)
     scanner_return = [] if no_device else [device or UNIFI_DISCOVERY_PROTECT]
     mock_aio_discovery.async_scan = AsyncMock(return_value=scanner_return)

--- a/tests/components/unifi_discovery/__init__.py
+++ b/tests/components/unifi_discovery/__init__.py
@@ -25,7 +25,7 @@ UNIFI_DISCOVERY_PROTECT = UnifiDevice(
 def _patch_discovery(
     device: UnifiDevice | None = None, no_device: bool = False
 ) -> Generator[None]:
-    mock_aio_discovery = MagicMock(auto_spec=AIOUnifiScanner)
+    mock_aio_discovery = MagicMock(spec=AIOUnifiScanner)
     scanner_return = [] if no_device else [device or UNIFI_DISCOVERY_PROTECT]
     mock_aio_discovery.async_scan = AsyncMock(return_value=scanner_return)
     mock_aio_discovery.found_devices = scanner_return
@@ -36,6 +36,6 @@ def _patch_discovery(
             "homeassistant.components.unifi_discovery.discovery.AIOUnifiScanner",
             return_value=mock_aio_discovery,
         ):
-            yield
+            yield mock_aio_discovery
 
     return _patcher()

--- a/tests/components/unifi_discovery/test_config_flow.py
+++ b/tests/components/unifi_discovery/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant import config_entries
@@ -40,7 +42,7 @@ async def test_dhcp_ssdp_abort_with_discovery_started(
     hass: HomeAssistant, source: str, data: DhcpServiceInfo | SsdpServiceInfo
 ) -> None:
     """Test DHCP and SSDP discovery triggers scanner and aborts."""
-    with _patch_discovery():
+    with _patch_discovery() as mock_scanner:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
@@ -50,11 +52,41 @@ async def test_dhcp_ssdp_abort_with_discovery_started(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_started"
+    assert mock_scanner.async_scan.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("source", "data"),
+    [
+        (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
+        (config_entries.SOURCE_SSDP, SSDP_DISCOVERY),
+    ],
+)
+async def test_dhcp_ssdp_abort_already_in_progress(
+    hass: HomeAssistant, source: str, data: DhcpServiceInfo | SsdpServiceInfo
+) -> None:
+    """Test DHCP and SSDP abort when another flow is already in progress."""
+    with (
+        _patch_discovery(),
+        patch(
+            "homeassistant.components.unifi_discovery.config_flow.UnifiDiscoveryFlowHandler._async_in_progress",
+            return_value=[{"flow_id": "mock_flow"}],
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": source},
+            data=data,
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"
 
 
 async def test_user_flow_aborts(hass: HomeAssistant) -> None:
     """Test user-initiated flow aborts."""
-    with _patch_discovery():
+    with _patch_discovery() as mock_scanner:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
@@ -63,3 +95,4 @@ async def test_user_flow_aborts(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_started"
+    assert mock_scanner.async_scan.call_count == 1

--- a/tests/components/unifi_discovery/test_config_flow.py
+++ b/tests/components/unifi_discovery/test_config_flow.py
@@ -53,10 +53,11 @@ async def test_dhcp_ssdp_abort_with_discovery_started(
 
 async def test_user_flow_aborts(hass: HomeAssistant) -> None:
     """Test user-initiated flow aborts."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USER},
-    )
+    with _patch_discovery():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_started"

--- a/tests/components/unifi_discovery/test_config_flow.py
+++ b/tests/components/unifi_discovery/test_config_flow.py
@@ -46,6 +46,7 @@ async def test_dhcp_ssdp_abort_with_discovery_started(
             context={"source": source},
             data=data,
         )
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_started"
@@ -58,6 +59,7 @@ async def test_user_flow_aborts(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
         )
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_started"

--- a/tests/components/unifi_discovery/test_config_flow.py
+++ b/tests/components/unifi_discovery/test_config_flow.py
@@ -1,0 +1,62 @@
+"""Test the UniFi Discovery config flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.unifi_discovery.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+
+from . import DEVICE_HOSTNAME, DEVICE_IP_ADDRESS, DEVICE_MAC_ADDRESS, _patch_discovery
+
+DHCP_DISCOVERY = DhcpServiceInfo(
+    hostname=DEVICE_HOSTNAME,
+    ip=DEVICE_IP_ADDRESS,
+    macaddress=DEVICE_MAC_ADDRESS.lower().replace(":", ""),
+)
+
+SSDP_DISCOVERY = SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    upnp={
+        "manufacturer": "Ubiquiti Networks",
+        "modelDescription": "UniFi Dream Machine",
+    },
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "data"),
+    [
+        (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
+        (config_entries.SOURCE_SSDP, SSDP_DISCOVERY),
+    ],
+)
+async def test_dhcp_ssdp_abort_with_discovery_started(
+    hass: HomeAssistant, source: str, data: DhcpServiceInfo | SsdpServiceInfo
+) -> None:
+    """Test DHCP and SSDP discovery triggers scanner and aborts."""
+    with _patch_discovery():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": source},
+            data=data,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "discovery_started"
+
+
+async def test_user_flow_aborts(hass: HomeAssistant) -> None:
+    """Test user-initiated flow aborts."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "discovery_started"

--- a/tests/components/unifi_discovery/test_init.py
+++ b/tests/components/unifi_discovery/test_init.py
@@ -6,7 +6,7 @@ from homeassistant.components.unifi_discovery.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from . import _patch_discovery
+from . import UNIFI_DISCOVERY_NO_MAC, _patch_discovery
 
 
 async def test_setup_starts_discovery(hass: HomeAssistant) -> None:
@@ -36,6 +36,16 @@ async def test_setup_only_starts_discovery_once(hass: HomeAssistant) -> None:
 async def test_setup_no_devices(hass: HomeAssistant) -> None:
     """Test setup with no devices found."""
     with _patch_discovery(no_device=True):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
+    assert len(flows) == 0
+
+
+async def test_setup_device_without_mac(hass: HomeAssistant) -> None:
+    """Test that devices without hw_addr are skipped."""
+    with _patch_discovery(device=UNIFI_DISCOVERY_NO_MAC):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/unifi_discovery/test_init.py
+++ b/tests/components/unifi_discovery/test_init.py
@@ -1,0 +1,55 @@
+"""Test the UniFi Discovery init."""
+
+from __future__ import annotations
+
+from homeassistant.components.unifi_discovery.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import _patch_discovery
+
+
+async def test_setup_starts_discovery(hass: HomeAssistant) -> None:
+    """Test that async_setup starts discovery and dispatches flows."""
+    with _patch_discovery():
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # The scanner should have dispatched a flow for the Protect consumer
+    flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
+    assert len(flows) == 1
+
+
+async def test_setup_only_starts_discovery_once(hass: HomeAssistant) -> None:
+    """Test that discovery is only started once even if setup is called multiple times."""
+    with _patch_discovery():
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    flows_after_first = hass.config_entries.flow.async_progress_by_handler(
+        "unifiprotect"
+    )
+    assert len(flows_after_first) == 1
+
+
+async def test_setup_no_devices(hass: HomeAssistant) -> None:
+    """Test setup with no devices found."""
+    with _patch_discovery(no_device=True):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
+    assert len(flows) == 0
+
+
+async def test_dependency_loads_discovery(
+    hass: HomeAssistant,
+) -> None:
+    """Test that loading unifiprotect triggers unifi_discovery as dependency."""
+    with _patch_discovery():
+        assert await async_setup_component(hass, "unifiprotect", {})
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # unifi_discovery should have been loaded as a dependency and started scanning
+    flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
+    assert len(flows) == 1

--- a/tests/components/unifi_discovery/test_init.py
+++ b/tests/components/unifi_discovery/test_init.py
@@ -22,14 +22,15 @@ async def test_setup_starts_discovery(hass: HomeAssistant) -> None:
 
 async def test_setup_only_starts_discovery_once(hass: HomeAssistant) -> None:
     """Test that discovery is only started once even if setup is called multiple times."""
-    with _patch_discovery():
+    with _patch_discovery() as mock_scanner:
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done(wait_background_tasks=True)
+        assert mock_scanner.async_scan.call_count == 1
 
-    flows_after_first = hass.config_entries.flow.async_progress_by_handler(
-        "unifiprotect"
-    )
-    assert len(flows_after_first) == 1
+        # Call setup again — discovery should not run a second time
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert mock_scanner.async_scan.call_count == 1
 
 
 async def test_setup_no_devices(hass: HomeAssistant) -> None:

--- a/tests/components/unifi_discovery/test_init.py
+++ b/tests/components/unifi_discovery/test_init.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from homeassistant import config_entries
 from homeassistant.components.unifi_discovery.const import DOMAIN
-from homeassistant.components.unifi_discovery.discovery import async_start_discovery
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -21,19 +20,6 @@ async def test_setup_starts_discovery(hass: HomeAssistant) -> None:
     flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
     assert len(flows) == 1
     assert flows[0]["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY
-
-
-async def test_discovery_only_starts_once(hass: HomeAssistant) -> None:
-    """Test that discovery is only started once even if called multiple times."""
-    with _patch_discovery() as mock_scanner:
-        assert await async_setup_component(hass, DOMAIN, {})
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_scanner.async_scan.call_count == 1
-
-        # Call async_start_discovery again — the guard should prevent a second scan
-        async_start_discovery(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert mock_scanner.async_scan.call_count == 1
 
 
 async def test_setup_no_devices(hass: HomeAssistant) -> None:

--- a/tests/components/unifi_discovery/test_init.py
+++ b/tests/components/unifi_discovery/test_init.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from homeassistant import config_entries
 from homeassistant.components.unifi_discovery.const import DOMAIN
+from homeassistant.components.unifi_discovery.discovery import async_start_discovery
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -15,20 +17,21 @@ async def test_setup_starts_discovery(hass: HomeAssistant) -> None:
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    # The scanner should have dispatched a flow for the Protect consumer
+    # The scanner should have dispatched a discovery flow for the Protect consumer
     flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
     assert len(flows) == 1
+    assert flows[0]["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY
 
 
-async def test_setup_only_starts_discovery_once(hass: HomeAssistant) -> None:
-    """Test that discovery is only started once even if setup is called multiple times."""
+async def test_discovery_only_starts_once(hass: HomeAssistant) -> None:
+    """Test that discovery is only started once even if called multiple times."""
     with _patch_discovery() as mock_scanner:
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_scanner.async_scan.call_count == 1
 
-        # Call setup again — discovery should not run a second time
-        assert await async_setup_component(hass, DOMAIN, {})
+        # Call async_start_discovery again — the guard should prevent a second scan
+        async_start_discovery(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_scanner.async_scan.call_count == 1
 
@@ -64,3 +67,4 @@ async def test_dependency_loads_discovery(
     # unifi_discovery should have been loaded as a dependency and started scanning
     flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
     assert len(flows) == 1
+    assert flows[0]["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY

--- a/tests/components/unifiprotect/__init__.py
+++ b/tests/components/unifiprotect/__init__.py
@@ -43,7 +43,7 @@ def _patch_discovery(device=None, no_device=False):
     @contextmanager
     def _patcher():
         with patch(
-            "homeassistant.components.unifiprotect.discovery.AIOUnifiScanner",
+            "homeassistant.components.unifi_discovery.discovery.AIOUnifiScanner",
             return_value=mock_aio_discovery,
         ):
             yield

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -60,6 +60,13 @@ DEFAULT_PASSWORD = "test-password"
 DEFAULT_API_KEY = "test-api-key"
 
 
+@pytest.fixture(autouse=True)
+def mock_discovery():
+    """Prevent real network scanning in all unifiprotect tests."""
+    with _patch_discovery(no_device=True):
+        yield
+
+
 @pytest.fixture(name="nvr")
 def mock_nvr():
     """Mock UniFi Protect Camera device."""
@@ -158,7 +165,6 @@ def mock_entry(
     """Mock ProtectApiClient for testing."""
 
     with (
-        _patch_discovery(no_device=True),
         patch(
             "homeassistant.components.unifiprotect.utils.ProtectApiClient"
         ) as mock_api,

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -30,8 +30,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
-from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from . import (
     DEVICE_HOSTNAME,
@@ -40,7 +38,6 @@ from . import (
     DIRECT_CONNECT_DOMAIN,
     UNIFI_DISCOVERY,
     UNIFI_DISCOVERY_PARTIAL,
-    _patch_discovery,
 )
 from .conftest import (
     DEFAULT_API_KEY,
@@ -53,24 +50,6 @@ from .conftest import (
 )
 
 from tests.common import MockConfigEntry
-
-DHCP_DISCOVERY = DhcpServiceInfo(
-    hostname=DEVICE_HOSTNAME,
-    ip=DEVICE_IP_ADDRESS,
-    macaddress=DEVICE_MAC_ADDRESS.lower().replace(":", ""),
-)
-SSDP_DISCOVERY = (
-    SsdpServiceInfo(
-        ssdp_usn="mock_usn",
-        ssdp_st="mock_st",
-        ssdp_location=f"http://{DEVICE_IP_ADDRESS}:41417/rootDesc.xml",
-        upnp={
-            "friendlyName": "UniFi Dream Machine",
-            "modelDescription": "UniFi Dream Machine Pro",
-            "serialNumber": DEVICE_MAC_ADDRESS,
-        },
-    ),
-)
 
 # Base user input without credentials (for tests that override them)
 BASE_USER_INPUT = {
@@ -563,8 +542,6 @@ async def test_form_options(
     ufp_config_entry.add_to_hass(hass)
 
     with (
-        _patch_discovery(),
-        patch("homeassistant.components.unifiprotect.async_start_discovery"),
         patch(
             "homeassistant.components.unifiprotect.utils.ProtectApiClient"
         ) as mock_api,
@@ -600,42 +577,17 @@ async def test_form_options(
         await hass.config_entries.async_unload(ufp_config_entry.entry_id)
 
 
-@pytest.mark.parametrize(
-    ("source", "data"),
-    [
-        (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
-        (config_entries.SOURCE_SSDP, SSDP_DISCOVERY),
-    ],
-)
-async def test_discovered_by_ssdp_or_dhcp(
-    hass: HomeAssistant, source: str, data: DhcpServiceInfo | SsdpServiceInfo
-) -> None:
-    """Test we handoff to unifi-discovery when discovered via ssdp or dhcp."""
-
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": source},
-            data=data,
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "discovery_started"
-
-
 async def test_discovered_by_unifi_discovery_direct_connect(
     hass: HomeAssistant, bootstrap: Bootstrap, nvr: NVR
 ) -> None:
     """Test a discovery from unifi-discovery."""
 
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
@@ -714,13 +666,12 @@ async def test_discovered_by_unifi_discovery_direct_connect_updated(
     )
     mock_config.add_to_hass(hass)
 
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -747,7 +698,6 @@ async def test_discovered_by_unifi_discovery_direct_connect_updated_but_not_usin
     mock_config.add_to_hass(hass)
 
     with (
-        _patch_discovery(),
         patch(
             "homeassistant.components.unifiprotect.config_flow.async_console_is_alive",
             return_value=False,
@@ -785,7 +735,6 @@ async def test_discovered_by_unifi_discovery_does_not_update_ip_when_console_is_
     mock_config.add_to_hass(hass)
 
     with (
-        _patch_discovery(),
         patch(
             "homeassistant.components.unifiprotect.config_flow.async_console_is_alive",
             return_value=True,
@@ -821,13 +770,12 @@ async def test_discovered_host_not_updated_if_existing_is_a_hostname(
     )
     mock_config.add_to_hass(hass)
 
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -839,13 +787,12 @@ async def test_discovered_by_unifi_discovery(
 ) -> None:
     """Test a discovery from unifi-discovery."""
 
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
@@ -909,13 +856,12 @@ async def test_discovered_by_unifi_discovery_partial(
 ) -> None:
     """Test a discovery from unifi-discovery partial."""
 
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT_PARTIAL,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT_PARTIAL,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
@@ -993,13 +939,12 @@ async def test_discovered_by_unifi_discovery_direct_connect_on_different_interfa
     )
     mock_config.add_to_hass(hass)
 
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -1024,13 +969,12 @@ async def test_discovered_by_unifi_discovery_direct_connect_on_different_interfa
     )
     mock_config.add_to_hass(hass)
 
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -1060,7 +1004,6 @@ async def test_discovered_by_unifi_discovery_direct_connect_on_different_interfa
     other_ip_dict["direct_connect_domain"] = "nomatchsameip.ui.direct"
 
     with (
-        _patch_discovery(),
         patch.object(
             hass.loop,
             "getaddrinfo",
@@ -1103,7 +1046,6 @@ async def test_discovered_by_unifi_discovery_direct_connect_on_different_interfa
     other_ip_dict["direct_connect_domain"] = "nomatchsameip.ui.direct"
 
     with (
-        _patch_discovery(),
         patch.object(hass.loop, "getaddrinfo", side_effect=OSError),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -1193,7 +1135,7 @@ async def test_discovered_by_unifi_discovery_direct_connect_on_different_interfa
     other_ip_dict["source_ip"] = "127.0.0.2"
     other_ip_dict["direct_connect_domain"] = "y.ui.direct"
 
-    with _patch_discovery(), patch.object(hass.loop, "getaddrinfo", return_value=[]):
+    with patch.object(hass.loop, "getaddrinfo", return_value=[]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
@@ -1214,13 +1156,12 @@ async def test_discovery_can_be_ignored(hass: HomeAssistant) -> None:
         source=config_entries.SOURCE_IGNORE,
     )
     mock_config.add_to_hass(hass)
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -1256,13 +1197,12 @@ async def test_discovery_with_both_ignored_and_normal_entry(
     # Discovery should:
     # 1. Skip all ignored entries with different MAC (line 182 - continue)
     # 2. Continue to discovery flow since no matching entries
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     # Flow continues to discovery step since no match found
     assert result["type"] is FlowResultType.FORM
@@ -1312,13 +1252,12 @@ async def test_discovery_confirm_fallback_to_ip(
     mock_api_meta_info: Mock,
 ) -> None:
     """Test discovery confirm falls back to IP when direct connect fails."""
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
@@ -1363,13 +1302,12 @@ async def test_discovery_confirm_with_api_key_error(
     mock_api_meta_info: Mock,
 ) -> None:
     """Test discovery confirm preserves API key in form data on error."""
-    with _patch_discovery():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-            data=UNIFI_DISCOVERY_DICT,
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data=UNIFI_DISCOVERY_DICT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -328,7 +328,7 @@ async def test_setup_failed_auth(hass: HomeAssistant, ufp: MockUFPFixture) -> No
 async def test_setup_starts_discovery(
     hass: HomeAssistant, ufp_config_entry: ConfigEntry, ufp_client: ProtectApiClient
 ) -> None:
-    """Test setting up will start discovery."""
+    """Test setting up will start discovery via unifi_discovery dependency."""
     with (
         _patch_discovery(),
         patch(
@@ -340,9 +340,9 @@ async def test_setup_starts_discovery(
         ufp = MockUFPFixture(ufp_config_entry, ufp_client)
 
         await hass.config_entries.async_setup(ufp.entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         assert ufp.entry.state is ConfigEntryState.LOADED
-        await hass.async_block_till_done()
+        # Discovery is now handled by unifi_discovery dependency
         assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
 
 
@@ -586,7 +586,6 @@ async def test_migrate_entry_version_2(hass: HomeAssistant) -> None:
         patch(
             "homeassistant.components.unifiprotect.async_setup_entry", return_value=True
         ),
-        patch("homeassistant.components.unifiprotect.async_start_discovery"),
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Add a central `unifi_discovery` integration that handles DHCP and SSDP discovery for all Ubiquiti UniFi integrations, and migrate `unifiprotect` to consume discovery from it.

### Problem

All UniFi consoles (Dream Machine, Dream Machine Pro, etc.) run multiple services — Protect, Network, Access, and potentially Talk, Connect, and NAS. Today, `unifiprotect` implements its own DHCP/SSDP discovery using the `unifi-discovery` library with a 60-second network scan. When `unifi_access` and `unifi` (Network) add discovery support, each would duplicate the same OUI matchers, SSDP matchers, and scanner code — resulting in up to 6 parallel network scans for the same hardware.

The `unifi-discovery` library does have a result cache, so repeated scans from different integrations would not all hit the network simultaneously. However, this is a workaround at the library level — the proper solution is to avoid duplicate scanning in the first place.

### Solution

A new `unifi_discovery` system integration acts as a central discovery provider:

1. **DHCP/SSDP triggers** (Ubiquiti OUI prefixes + UDM model descriptions) start the integration
2. **`AIOUnifiScanner`** scans the local network once, identifies all UniFi devices and their services
3. **`SOURCE_INTEGRATION_DISCOVERY`** flows are dispatched to consumer integrations based on detected services

Consumer integrations (`unifiprotect`, and in follow-up PRs `unifi_access` and `unifi`) add `unifi_discovery` as a dependency and handle `async_step_integration_discovery` — no scanner code needed.

### Architecture

```
DHCP/SSDP trigger
       │
       ▼
 unifi_discovery          (system integration, scans network)
       │
       ├── SOURCE_INTEGRATION_DISCOVERY ──▶ unifiprotect   (this PR)
       ├── SOURCE_INTEGRATION_DISCOVERY ──▶ unifi_access   (follow-up PR)
       └── SOURCE_INTEGRATION_DISCOVERY ──▶ unifi          (follow-up PR)
```

This mirrors how the core `dhcp`, `ssdp`, and `zeroconf` integrations work — a single system integration handles detection and dispatches to consumers.

### Scope of this PR

- **New**: `homeassistant/components/unifi_discovery/` — system/internal integration with DHCP (10 Ubiquiti OUIs) and SSDP (4 UDM models) matchers, network scanner, consumer dispatch
- **Modified**: `homeassistant/components/unifiprotect/` — removes DHCP/SSDP config flow steps, deletes `discovery.py`, adds `unifi_discovery` dependency, moves `UniFiProtectRuntimeData` to `data.py`
- **Tests**: Full test coverage for `unifi_discovery` (7 tests), updated `unifiprotect` tests (353 tests passing)

### Planned follow-up PRs

| PR | Consumer | Code owner | Status |
|----|----------|------------|--------|
| This PR | `unifiprotect` | @RaHehl | Ready |
| PR 2 | `unifi_access` | @RaHehl | Planned — I am code owner |
| PR 3 | `unifi` (Network) | @Kane610 | Planned — code owner approval obtained |

Future UniFi services (Talk, Connect, NAS) would only require adding an entry to `CONSUMER_MAPPING` and implementing `async_step_integration_discovery` in their config flow — no additional scanning code.

### Design decisions

- **`integration_type: "system"` + `config_flow: true`**: This is a new combination. It is required because DHCP/SSDP matchers need a config flow entry point, but the integration should not appear in the "Add Integration" UI. The `system` type filters it from `integrations.json` while keeping the config flow functional. The config flow always aborts immediately after starting the scanner.
- **`quality_scale: "internal"`**: Consistent with all other `system` integrations (`dhcp`, `ssdp`, `zeroconf`, etc.)
- **Static `CONSUMER_MAPPING`**: The mapping of `UnifiService` → integration domain is hardcoded, mirroring how DHCP/SSDP use static manifest matchers. A dynamic registry is not viable because consumers may not be loaded when the first scan runs.
- **`dependencies` (not `after_dependencies`)**: `unifiprotect` uses `dependencies: ["unifi_discovery"]` to ensure the scanner is always active, even for users who set up Protect manually.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44733
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
