### PR TITLE
Check device registration before completing Hive reauth flow

### DIFF
--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -122,6 +122,10 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                     try:
                         device_registered = await self.hive_auth.is_device_registered()
                     except HiveApiError:
+                        _LOGGER.debug(
+                            "Failed to check whether the Hive device is registered during reauthentication",
+                            exc_info=True,
+                        )
                         device_registered = False
                     if device_registered:
                         return await self.async_setup_hive_entry()

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -119,7 +119,10 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
             if not errors:
                 _LOGGER.debug("2FA successful")
                 if self.source == SOURCE_REAUTH:
-                    device_registered = await self.hive_auth.is_device_registered()
+                    try:
+                        device_registered = await self.hive_auth.is_device_registered()
+                    except HiveApiError:
+                        device_registered = False
                     if device_registered:
                         return await self.async_setup_hive_entry()
 

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -119,7 +119,10 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
             if not errors:
                 _LOGGER.debug("2FA successful")
                 if self.source == SOURCE_REAUTH:
-                    return await self.async_setup_hive_entry()
+                    device_registered = await self.hive_auth.is_device_registered()
+                    if device_registered:
+                        return await self.async_setup_hive_entry()
+
                 self.device_registration = True
                 return await self.async_step_configuration()
 

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -121,10 +121,9 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                 if self.source == SOURCE_REAUTH:
                     try:
                         device_registered = await self.hive_auth.is_device_registered()
-                    except HiveApiError:
+                    except HiveApiError as err:
                         _LOGGER.debug(
-                            "Failed to check whether the Hive device is registered during reauthentication",
-                            exc_info=True,
+                            "Failed to check whether the Hive device is registered during reauthentication: %s", err
                         )
                         device_registered = False
                     if device_registered:

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -123,7 +123,8 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                         device_registered = await self.hive_auth.is_device_registered()
                     except HiveApiError as err:
                         _LOGGER.debug(
-                            "Failed to check whether the Hive device is registered during reauthentication: %s", err
+                            "Failed to check whether the Hive device is registered during reauthentication: %s",
+                            err,
                         )
                         device_registered = False
                     if device_registered:

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -127,6 +127,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                             err,
                         )
                         device_registered = False
+
                     if device_registered:
                         return await self.async_setup_hive_entry()
 

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -126,13 +126,15 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                             "Failed to check whether the Hive device is registered during reauthentication: %s",
                             err,
                         )
-                        device_registered = False
-
-                    if device_registered:
-                        return await self.async_setup_hive_entry()
-
-                self.device_registration = True
-                return await self.async_step_configuration()
+                        errors["base"] = "no_internet_available"
+                    else:
+                        if device_registered:
+                            return await self.async_setup_hive_entry()
+                        self.device_registration = True
+                        return await self.async_step_configuration()
+                else:
+                    self.device_registration = True
+                    return await self.async_step_configuration()
 
         schema = vol.Schema({vol.Required(CONF_CODE): str})
         return self.async_show_form(step_id="2fa", data_schema=schema, errors=errors)
@@ -184,6 +186,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Re Authenticate a user."""
+        self.data = dict(entry_data)
         data = {
             CONF_USERNAME: entry_data[CONF_USERNAME],
             CONF_PASSWORD: entry_data[CONF_PASSWORD],

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -377,7 +377,7 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
     assert mock_config.data.get("password") == PASSWORD
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
-    assert len(mock_setup_entry.mock_calls) == 1
+    mock_setup_entry.assert_called_once()
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -312,14 +312,19 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
 
 async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
-    """Test the reauth flow."""
+    """Test the reauth 2FA flow when the device is still registered.
+
+    Reauth is triggered by invalid tokens (e.g. token expiry), not a wrong
+    password. The stored credentials remain valid but Cognito requests 2FA
+    because the device session is no longer recognised.
+    """
 
     mock_config = MockConfigEntry(
         domain=DOMAIN,
         unique_id=USERNAME,
         data={
             CONF_USERNAME: USERNAME,
-            CONF_PASSWORD: INCORRECT_PASSWORD,
+            CONF_PASSWORD: PASSWORD,
             "tokens": {
                 "AccessToken": "mock-access-token",
                 "RefreshToken": "mock-refresh-token",
@@ -330,26 +335,15 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.hive.config_flow.Auth.login",
-        side_effect=hive_exceptions.HiveInvalidPassword(),
-    ):
-        result = await mock_config.start_reauth_flow(hass)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "invalid_password"}
-
-    with patch(
-        "homeassistant.components.hive.config_flow.Auth.login",
         return_value={
             "ChallengeName": "SMS_MFA",
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: USERNAME,
-                CONF_PASSWORD: UPDATED_PASSWORD,
-            },
-        )
+        result = await mock_config.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
 
     with (
         patch(
@@ -363,6 +357,106 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
             },
         ),
         patch(
+            "homeassistant.components.hive.config_flow.Auth.is_device_registered",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.hive.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_CODE: MFA_CODE,
+            },
+        )
+    await hass.async_block_till_done()
+
+    assert mock_config.data.get("username") == USERNAME
+    assert mock_config.data.get("password") == PASSWORD
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> None:
+    """Test the reauth 2FA flow when the device has been deleted from the Hive app.
+
+    When a user deletes the Home Assistant device inside the Hive mobile app the
+    stored tokens become invalid, triggering reauth. After 2FA succeeds,
+    is_device_registered() returns False so the flow continues to the device
+    registration (configuration) step before completing reauth.
+    """
+
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USERNAME,
+        data={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            "tokens": {
+                "AccessToken": "mock-access-token",
+                "RefreshToken": "mock-refresh-token",
+            },
+        },
+    )
+    mock_config.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.hive.config_flow.Auth.login",
+        return_value={
+            "ChallengeName": "SMS_MFA",
+        },
+    ):
+        result = await mock_config.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.sms_2fa",
+            return_value={
+                "ChallengeName": "SUCCESS",
+                "AuthenticationResult": {
+                    "RefreshToken": "mock-refresh-token",
+                    "AccessToken": "mock-access-token",
+                },
+            },
+        ),
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.is_device_registered",
+            return_value=False,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_CODE: MFA_CODE,
+            },
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "configuration"
+    assert result2["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.device_registration",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.get_device_data",
+            return_value=[
+                "mock-device-group-key",
+                "mock-device-key",
+                "mock-device-password",
+            ],
+        ),
+        patch(
             "homeassistant.components.hive.async_setup_entry",
             return_value=True,
         ) as mock_setup_entry,
@@ -370,13 +464,13 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
             {
-                CONF_CODE: MFA_CODE,
+                CONF_DEVICE_NAME: DEVICE_NAME,
             },
         )
-        await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert mock_config.data.get("username") == USERNAME
-    assert mock_config.data.get("password") == UPDATED_PASSWORD
+    assert mock_config.data.get("password") == PASSWORD
     assert result3["type"] is FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -477,6 +477,104 @@ async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> Non
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
+async def test_reauth_2fa_flow_device_registration_check_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Test the reauth 2FA flow when is_device_registered() raises HiveApiError.
+
+    A transient network failure while checking device registration should not
+    crash the config flow. The flow falls back to the device registration
+    (configuration) step so the user can recover without re-entering their
+    2FA code.
+    """
+
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USERNAME,
+        data={
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            "tokens": {
+                "AccessToken": "mock-access-token",
+                "RefreshToken": "mock-refresh-token",
+            },
+        },
+    )
+    mock_config.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.hive.config_flow.Auth.login",
+        return_value={
+            "ChallengeName": "SMS_MFA",
+        },
+    ):
+        result = await mock_config.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.sms_2fa",
+            return_value={
+                "ChallengeName": "SUCCESS",
+                "AuthenticationResult": {
+                    "RefreshToken": "mock-refresh-token",
+                    "AccessToken": "mock-access-token",
+                },
+            },
+        ),
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.is_device_registered",
+            side_effect=hive_exceptions.HiveApiError(),
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_CODE: MFA_CODE,
+            },
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "configuration"
+    assert result2["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.device_registration",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.get_device_data",
+            return_value=[
+                "mock-device-group-key",
+                "mock-device-key",
+                "mock-device-password",
+            ],
+        ),
+        patch(
+            "homeassistant.components.hive.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_DEVICE_NAME: DEVICE_NAME,
+            },
+        )
+    await hass.async_block_till_done()
+
+    assert mock_config.data.get("username") == USERNAME
+    assert mock_config.data.get("password") == PASSWORD
+    assert result3["type"] is FlowResultType.ABORT
+    assert result3["reason"] == "reauth_successful"
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
 async def test_option_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
 

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -324,6 +324,11 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
                 "AccessToken": "mock-access-token",
                 "RefreshToken": "mock-refresh-token",
             },
+            "device_data": [
+                "mock-device-group-key",
+                "mock-device-key",
+                "mock-device-password",
+            ],
         },
     )
     mock_config.add_to_hass(hass)
@@ -370,6 +375,11 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD
+    assert mock_config.data.get("device_data") == [
+        "mock-device-group-key",
+        "mock-device-key",
+        "mock-device-password",
+    ]
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     mock_setup_entry.assert_called_once()
@@ -521,21 +531,23 @@ async def test_reauth_2fa_flow_device_registration_check_fails(
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "configuration"
-    assert result["errors"] == {}
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {"base": "no_internet_available"}
 
     with (
         patch(
-            "homeassistant.components.hive.config_flow.Auth.device_registration",
-            return_value=True,
+            "homeassistant.components.hive.config_flow.Auth.sms_2fa",
+            return_value={
+                "ChallengeName": "SUCCESS",
+                "AuthenticationResult": {
+                    "RefreshToken": "mock-refresh-token",
+                    "AccessToken": "mock-access-token",
+                },
+            },
         ),
         patch(
-            "homeassistant.components.hive.config_flow.Auth.get_device_data",
-            return_value=[
-                "mock-device-group-key",
-                "mock-device-key",
-                "mock-device-password",
-            ],
+            "homeassistant.components.hive.config_flow.Auth.is_device_registered",
+            return_value=True,
         ),
         patch(
             "homeassistant.components.hive.async_setup_entry",
@@ -545,7 +557,7 @@ async def test_reauth_2fa_flow_device_registration_check_fails(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_DEVICE_NAME: DEVICE_NAME,
+                CONF_CODE: MFA_CODE,
             },
         )
         await hass.async_block_till_done()
@@ -554,7 +566,7 @@ async def test_reauth_2fa_flow_device_registration_check_fails(
     assert mock_config.data.get("password") == PASSWORD
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
-    assert len(mock_setup_entry.mock_calls) == 1
+    mock_setup_entry.assert_called_once()
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -456,7 +456,7 @@ async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> Non
                 CONF_DEVICE_NAME: DEVICE_NAME,
             },
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -366,7 +366,7 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
                 CONF_CODE: MFA_CODE,
             },
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -50,15 +50,15 @@ async def test_user_flow(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == USERNAME
-    assert result2["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -97,7 +97,7 @@ async def test_user_flow_with_no_2fa(hass: HomeAssistant) -> None:
             },
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_USERNAME: USERNAME,
@@ -105,9 +105,9 @@ async def test_user_flow_with_no_2fa(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "configuration"
-    assert result2["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {}
 
     with (
         patch(
@@ -127,7 +127,7 @@ async def test_user_flow_with_no_2fa(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_DEVICE_NAME: DEVICE_NAME,
@@ -135,9 +135,9 @@ async def test_user_flow_with_no_2fa(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == USERNAME
-    assert result3["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -177,7 +177,7 @@ async def test_user_flow_2fa(hass: HomeAssistant) -> None:
             "ChallengeName": "SMS_MFA",
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_USERNAME: USERNAME,
@@ -185,9 +185,9 @@ async def test_user_flow_2fa(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == CONF_CODE
-    assert result2["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
 
     with patch(
         "homeassistant.components.hive.config_flow.Auth.sms_2fa",
@@ -199,16 +199,16 @@ async def test_user_flow_2fa(hass: HomeAssistant) -> None:
             },
         },
     ):
-        result3 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_CODE: MFA_CODE,
             },
         )
 
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == "configuration"
-    assert result3["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {}
 
     with (
         patch(
@@ -228,7 +228,7 @@ async def test_user_flow_2fa(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result4 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_DEVICE_NAME: DEVICE_NAME,
@@ -236,9 +236,9 @@ async def test_user_flow_2fa(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] is FlowResultType.CREATE_ENTRY
-    assert result4["title"] == USERNAME
-    assert result4["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -295,7 +295,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
             },
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_USERNAME: USERNAME,
@@ -306,18 +306,13 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == UPDATED_PASSWORD
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
 async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
-    """Test the reauth 2FA flow when the device is still registered.
-
-    Reauth is triggered by invalid tokens (e.g. token expiry), not a wrong
-    password. The stored credentials remain valid but Cognito requests 2FA
-    because the device session is no longer recognised.
-    """
+    """Test the reauth 2FA flow when the device is still registered."""
 
     mock_config = MockConfigEntry(
         domain=DOMAIN,
@@ -365,7 +360,7 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_CODE: MFA_CODE,
@@ -375,20 +370,14 @@ async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
     mock_setup_entry.assert_called_once()
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
 async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> None:
-    """Test the reauth 2FA flow when the device has been deleted from the Hive app.
-
-    When a user deletes the Home Assistant device inside the Hive mobile app the
-    stored tokens become invalid, triggering reauth. After 2FA succeeds,
-    is_device_registered() returns False so the flow continues to the device
-    registration (configuration) step before completing reauth.
-    """
+    """Test the reauth 2FA flow when the device has been deleted from the Hive app."""
 
     mock_config = MockConfigEntry(
         domain=DOMAIN,
@@ -432,16 +421,16 @@ async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> Non
             return_value=False,
         ),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_CODE: MFA_CODE,
             },
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "configuration"
-    assert result2["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {}
 
     with (
         patch(
@@ -461,8 +450,8 @@ async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> Non
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {
                 CONF_DEVICE_NAME: DEVICE_NAME,
             },
@@ -471,8 +460,8 @@ async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> Non
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD
-    assert result3["type"] is FlowResultType.ABORT
-    assert result3["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -480,13 +469,7 @@ async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> Non
 async def test_reauth_2fa_flow_device_registration_check_fails(
     hass: HomeAssistant,
 ) -> None:
-    """Test the reauth 2FA flow when is_device_registered() raises HiveApiError.
-
-    A transient network failure while checking device registration should not
-    crash the config flow. The flow falls back to the device registration
-    (configuration) step so the user can recover without re-entering their
-    2FA code.
-    """
+    """Test the reauth 2FA flow when is_device_registered() raises HiveApiError."""
 
     mock_config = MockConfigEntry(
         domain=DOMAIN,
@@ -530,16 +513,16 @@ async def test_reauth_2fa_flow_device_registration_check_fails(
             side_effect=hive_exceptions.HiveApiError(),
         ),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_CODE: MFA_CODE,
             },
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "configuration"
-    assert result2["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {}
 
     with (
         patch(
@@ -559,8 +542,8 @@ async def test_reauth_2fa_flow_device_registration_check_fails(
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {
                 CONF_DEVICE_NAME: DEVICE_NAME,
             },
@@ -569,8 +552,8 @@ async def test_reauth_2fa_flow_device_registration_check_fails(
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD
-    assert result3["type"] is FlowResultType.ABORT
-    assert result3["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -627,7 +610,7 @@ async def test_user_flow_2fa_send_new_code(hass: HomeAssistant) -> None:
             "ChallengeName": "SMS_MFA",
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_USERNAME: USERNAME,
@@ -635,9 +618,9 @@ async def test_user_flow_2fa_send_new_code(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == CONF_CODE
-    assert result2["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
 
     with patch(
         "homeassistant.components.hive.config_flow.Auth.login",
@@ -645,14 +628,14 @@ async def test_user_flow_2fa_send_new_code(hass: HomeAssistant) -> None:
             "ChallengeName": "SMS_MFA",
         },
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"], {CONF_CODE: MFA_RESEND_CODE}
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CODE: MFA_RESEND_CODE}
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == CONF_CODE
-    assert result3["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
 
     with patch(
         "homeassistant.components.hive.config_flow.Auth.sms_2fa",
@@ -664,16 +647,16 @@ async def test_user_flow_2fa_send_new_code(hass: HomeAssistant) -> None:
             },
         },
     ):
-        result4 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 CONF_CODE: MFA_CODE,
             },
         )
 
-    assert result4["type"] is FlowResultType.FORM
-    assert result4["step_id"] == "configuration"
-    assert result4["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {}
 
     with (
         patch(
@@ -693,14 +676,14 @@ async def test_user_flow_2fa_send_new_code(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result5 = await hass.config_entries.flow.async_configure(
-            result4["flow_id"], {CONF_DEVICE_NAME: DEVICE_NAME}
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DEVICE_NAME: DEVICE_NAME}
         )
         await hass.async_block_till_done()
 
-    assert result5["type"] is FlowResultType.CREATE_ENTRY
-    assert result5["title"] == USERNAME
-    assert result5["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"] == {
         CONF_USERNAME: USERNAME,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
@@ -756,14 +739,14 @@ async def test_user_flow_invalid_username(hass: HomeAssistant) -> None:
         "homeassistant.components.hive.config_flow.Auth.login",
         side_effect=hive_exceptions.HiveInvalidUsername(),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "invalid_username"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_username"}
 
 
 async def test_user_flow_invalid_password(hass: HomeAssistant) -> None:
@@ -779,14 +762,14 @@ async def test_user_flow_invalid_password(hass: HomeAssistant) -> None:
         "homeassistant.components.hive.config_flow.Auth.login",
         side_effect=hive_exceptions.HiveInvalidPassword(),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "invalid_password"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_password"}
 
 
 async def test_user_flow_no_internet_connection(hass: HomeAssistant) -> None:
@@ -803,14 +786,14 @@ async def test_user_flow_no_internet_connection(hass: HomeAssistant) -> None:
         "homeassistant.components.hive.config_flow.Auth.login",
         side_effect=hive_exceptions.HiveApiError(),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "no_internet_available"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "no_internet_available"}
 
 
 async def test_user_flow_2fa_no_internet_connection(hass: HomeAssistant) -> None:
@@ -829,27 +812,27 @@ async def test_user_flow_2fa_no_internet_connection(hass: HomeAssistant) -> None
             "ChallengeName": "SMS_MFA",
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == CONF_CODE
-    assert result2["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
 
     with patch(
         "homeassistant.components.hive.config_flow.Auth.sms_2fa",
         side_effect=hive_exceptions.HiveApiError(),
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {CONF_CODE: MFA_CODE},
         )
 
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == CONF_CODE
-    assert result3["errors"] == {"base": "no_internet_available"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {"base": "no_internet_available"}
 
 
 async def test_user_flow_2fa_invalid_code(hass: HomeAssistant) -> None:
@@ -867,26 +850,26 @@ async def test_user_flow_2fa_invalid_code(hass: HomeAssistant) -> None:
             "ChallengeName": "SMS_MFA",
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == CONF_CODE
-    assert result2["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {}
 
     with patch(
         "homeassistant.components.hive.config_flow.Auth.sms_2fa",
         side_effect=hive_exceptions.HiveInvalid2FACode(),
     ):
-        result3 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_CODE: MFA_INVALID_CODE},
         )
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == CONF_CODE
-    assert result3["errors"] == {"base": "invalid_code"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
+    assert result["errors"] == {"base": "invalid_code"}
 
 
 async def test_user_flow_unknown_error(hass: HomeAssistant) -> None:
@@ -902,14 +885,14 @@ async def test_user_flow_unknown_error(hass: HomeAssistant) -> None:
         "homeassistant.components.hive.config_flow.Auth.login",
         return_value={"ChallengeName": "FAILED", "InvalidAuthenticationResult": {}},
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
 
 
 async def test_user_flow_2fa_unknown_error(hass: HomeAssistant) -> None:
@@ -927,26 +910,26 @@ async def test_user_flow_2fa_unknown_error(hass: HomeAssistant) -> None:
             "ChallengeName": "SMS_MFA",
         },
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == CONF_CODE
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_CODE
 
     with patch(
         "homeassistant.components.hive.config_flow.Auth.sms_2fa",
         return_value={"ChallengeName": "FAILED", "InvalidAuthenticationResult": {}},
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {CONF_CODE: MFA_CODE},
         )
 
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == "configuration"
-    assert result3["errors"] == {}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {}
 
     with (
         patch(
@@ -962,12 +945,12 @@ async def test_user_flow_2fa_unknown_error(hass: HomeAssistant) -> None:
             ],
         ),
     ):
-        result4 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_DEVICE_NAME: DEVICE_NAME},
         )
         await hass.async_block_till_done()
 
-    assert result4["type"] is FlowResultType.FORM
-    assert result4["step_id"] == "configuration"
-    assert result4["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configuration"
+    assert result["errors"] == {"base": "unknown"}

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -548,7 +548,7 @@ async def test_reauth_2fa_flow_device_registration_check_fails(
                 CONF_DEVICE_NAME: DEVICE_NAME,
             },
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -470,6 +470,11 @@ async def test_reauth_2fa_flow_device_not_registered(hass: HomeAssistant) -> Non
 
     assert mock_config.data.get("username") == USERNAME
     assert mock_config.data.get("password") == PASSWORD
+    assert mock_config.data.get("device_data") == [
+        "mock-device-group-key",
+        "mock-device-key",
+        "mock-device-password",
+    ]
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix an issue where a user may delete a device using the Hive app and trigger a re authentication flow on the home assistant integration. This change will now check if that is the case and send the user down the device registration flow again in a reauth situation where the registered Device is no longer registered.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150890 
- This PR is related to issue: #147560 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
