### PR TITLE
Translate coordinator exceptions for RDW

### DIFF
--- a/homeassistant/components/rdw/coordinator.py
+++ b/homeassistant/components/rdw/coordinator.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from vehicle import RDW, Vehicle
+from vehicle import RDW, RDWConnectionError, RDWError, Vehicle
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_LICENSE_PLATE, DOMAIN, LOGGER, SCAN_INTERVAL
 
@@ -35,4 +35,15 @@ class RDWDataUpdateCoordinator(DataUpdateCoordinator[Vehicle]):
 
     async def _async_update_data(self) -> Vehicle:
         """Fetch data from RDW."""
-        return await self._rdw.vehicle()
+        try:
+            return await self._rdw.vehicle()
+        except RDWConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from err
+        except RDWError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+            ) from err

--- a/homeassistant/components/rdw/strings.json
+++ b/homeassistant/components/rdw/strings.json
@@ -35,5 +35,13 @@
         "name": "Ascription date"
       }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the RDW service."
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the RDW service."
+    }
   }
 }

--- a/tests/components/rdw/test_init.py
+++ b/tests/components/rdw/test_init.py
@@ -1,6 +1,9 @@
 """Tests for the RDW integration."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
+
+import pytest
+from vehicle import RDWConnectionError, RDWError
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -11,7 +14,7 @@ from tests.common import MockConfigEntry
 async def test_load_unload_config_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_rdw: AsyncMock,
+    mock_rdw: MagicMock,
 ) -> None:
     """Test the RDW configuration entry loading/unloading."""
     mock_config_entry.add_to_hass(hass)
@@ -26,19 +29,19 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@patch(
-    "homeassistant.components.rdw.coordinator.RDW.vehicle",
-    side_effect=RuntimeError,
-)
+@pytest.mark.parametrize("side_effect", [RDWConnectionError, RDWError])
 async def test_config_entry_not_ready(
-    mock_request: MagicMock,
     hass: HomeAssistant,
+    mock_rdw: MagicMock,
     mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
 ) -> None:
     """Test the RDW configuration entry not ready."""
+    mock_rdw.vehicle.side_effect = side_effect
+
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_request.call_count == 1
+    assert mock_rdw.vehicle.call_count == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change

The RDW coordinator's `_async_update_data` let library exceptions bubble up raw without translation. This PR wraps the call in a try/except that maps `RDWConnectionError` to `UpdateFailed` with translation key `communication_error` and the generic `RDWError` to `unknown_error`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
