### PR TITLE
Translate coordinator exceptions for Sensor.Community

### DIFF
--- a/homeassistant/components/luftdaten/coordinator.py
+++ b/homeassistant/components/luftdaten/coordinator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from luftdaten import Luftdaten
-from luftdaten.exceptions import LuftdatenError
+from luftdaten.exceptions import LuftdatenConnectionError, LuftdatenError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -47,11 +47,22 @@ class LuftdatenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, float | int
         """Update sensor/binary sensor data."""
         try:
             await self._sensor_community.get_data()
+        except LuftdatenConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from err
         except LuftdatenError as err:
-            raise UpdateFailed("Unable to retrieve data from Sensor.Community") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+            ) from err
 
         if not self._sensor_community.values:
-            raise UpdateFailed("Did not receive sensor data from Sensor.Community")
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="no_data_received",
+            )
 
         data: dict[str, float | int] = self._sensor_community.values
         data.update(self._sensor_community.meta)

--- a/homeassistant/components/luftdaten/strings.json
+++ b/homeassistant/components/luftdaten/strings.json
@@ -21,5 +21,16 @@
     "sensor": {
       "pressure_at_sealevel": { "name": "Pressure at sea level" }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Sensor.Community service."
+    },
+    "no_data_received": {
+      "message": "Did not receive sensor data from the Sensor.Community service."
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the Sensor.Community service."
+    }
   }
 }

--- a/tests/components/luftdaten/test_init.py
+++ b/tests/components/luftdaten/test_init.py
@@ -1,8 +1,9 @@
 """Tests for the Luftdaten integration."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-from luftdaten.exceptions import LuftdatenError
+from luftdaten.exceptions import LuftdatenConnectionError, LuftdatenError
+import pytest
 
 from homeassistant.components.luftdaten.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -14,7 +15,7 @@ from tests.common import MockConfigEntry
 async def test_load_unload_config_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_luftdaten: AsyncMock,
+    mock_luftdaten: MagicMock,
 ) -> None:
     """Test the Luftdaten configuration entry loading/unloading."""
     mock_config_entry.add_to_hass(hass)
@@ -30,21 +31,21 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@patch(
-    "homeassistant.components.luftdaten.Luftdaten.get_data",
-    side_effect=LuftdatenError,
-)
+@pytest.mark.parametrize("side_effect", [LuftdatenConnectionError, LuftdatenError])
 async def test_config_entry_not_ready(
-    mock_get_data: MagicMock,
     hass: HomeAssistant,
+    mock_luftdaten: MagicMock,
     mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
 ) -> None:
     """Test the Luftdaten configuration entry not ready."""
+    mock_luftdaten.get_data.side_effect = side_effect
+
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_get_data.call_count == 1
+    assert mock_luftdaten.get_data.call_count == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 


### PR DESCRIPTION
## Proposed change

The coordinator raised `UpdateFailed` with raw English strings. Now maps `LuftdatenConnectionError` → `communication_error`, generic `LuftdatenError` → `unknown_error`, and the no-data case → `no_data_received`, all with `translation_domain` and `translation_key`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
