### PR TITLE
Allow setting hvac_mode in generic_thermostat.set_temperature

### DIFF
--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -453,7 +453,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         self._attr_preset_mode = self._presets_inv.get(temperature, PRESET_NONE)
         self._target_temp = temperature
         if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
-            await self.async_set_hvac_mode(hvac_mode)
+            self._hvac_mode = hvac_mode
         await self._async_control_heating(force=True)
         self.async_write_ha_state()
 

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -13,6 +13,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
     PLATFORM_SCHEMA as CLIMATE_PLATFORM_SCHEMA,
     PRESET_NONE,
@@ -451,6 +452,8 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
             return
         self._attr_preset_mode = self._presets_inv.get(temperature, PRESET_NONE)
         self._target_temp = temperature
+        if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
+            await self.async_set_hvac_mode(hvac_mode)
         await self._async_control_heating(force=True)
         self.async_write_ha_state()
 

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -453,7 +453,6 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         self._attr_preset_mode = self._presets_inv.get(temperature, PRESET_NONE)
         self._target_temp = temperature
         if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
-            self._valid_mode_or_raise("hvac", hvac_mode, self.hvac_modes)
             await self.async_set_hvac_mode(hvac_mode)
         await self._async_control_heating(force=True)
         self.async_write_ha_state()

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -453,7 +453,8 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         self._attr_preset_mode = self._presets_inv.get(temperature, PRESET_NONE)
         self._target_temp = temperature
         if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
-            self._hvac_mode = hvac_mode
+            self._valid_mode_or_raise("hvac", hvac_mode, self.hvac_modes)
+            await self.async_set_hvac_mode(hvac_mode)
         await self._async_control_heating(force=True)
         self.async_write_ha_state()
 

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -454,6 +454,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         self._target_temp = temperature
         if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
             await self.async_set_hvac_mode(hvac_mode)
+            return
         await self._async_control_heating(force=True)
         self.async_write_ha_state()
 

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -839,7 +839,7 @@ async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
 
     await common.async_set_temperature(hass, temperature=30, hvac_mode=HVACMode.HEAT)
     state = hass.states.get(ENTITY)
-    assert state.attributes.get("temperature") == 30.0
+    assert state.attributes.get(ATTR_TEMPERATURE) == 30.0
     assert state.state == HVACMode.HEAT
 
 

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -817,9 +817,8 @@ async def test_no_state_change_when_operation_mode_off_2(hass: HomeAssistant) ->
     assert len(calls) == 0
 
 
-@pytest.fixture
-async def setup_comp_4(hass: HomeAssistant) -> None:
-    """Initialize components."""
+async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
+    """Test setting the target temperature and HVAC mode together."""
     hass.config.units = METRIC_SYSTEM
     assert await async_setup_component(
         hass,
@@ -838,32 +837,10 @@ async def setup_comp_4(hass: HomeAssistant) -> None:
         },
     )
     await hass.async_block_till_done()
-
-
-@pytest.mark.usefixtures("setup_comp_4")
-async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
-    """Test setting the target temperature and HVAC mode together."""
-
     await common.async_set_temperature(hass, temperature=30, hvac_mode=HVACMode.HEAT)
     state = hass.states.get(ENTITY)
     assert state.attributes.get(ATTR_TEMPERATURE) == 30.0
     assert state.state == HVACMode.HEAT
-
-
-@pytest.mark.usefixtures("setup_comp_4")
-async def test_set_target_temp_with_invalid_hvac_mode_raises(
-    hass: HomeAssistant,
-) -> None:
-    """Test that invalid hvac_mode is rejected from set_temperature."""
-
-    with pytest.raises(ServiceValidationError):
-        await common.async_set_temperature(
-            hass, temperature=30, hvac_mode=HVACMode.COOL
-        )
-
-    state = hass.states.get(ENTITY)
-    assert state.attributes.get(ATTR_TEMPERATURE) == 20.0
-    assert state.state == HVACMode.OFF
 
 
 async def test_set_target_temp_with_hvac_mode_off(hass: HomeAssistant) -> None:

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -832,6 +832,7 @@ async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
                 "heater": ENT_SWITCH,
                 "target_sensor": ENT_SENSOR,
                 "initial_hvac_mode": HVACMode.OFF,
+                "target_temp": 20,
             }
         },
     )
@@ -841,6 +842,98 @@ async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
     state = hass.states.get(ENTITY)
     assert state.attributes.get(ATTR_TEMPERATURE) == 30.0
     assert state.state == HVACMode.HEAT
+
+
+async def test_set_target_temp_with_hvac_mode_off(hass: HomeAssistant) -> None:
+    """Test setting a temperature while switching the climate mode to OFF."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.HEAT,
+                "target_temp": 20,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await common.async_set_temperature(hass, temperature=30, hvac_mode=HVACMode.OFF)
+
+    state = hass.states.get(ENTITY)
+    assert state.attributes.get(ATTR_TEMPERATURE) == 30.0
+    assert state.state == HVACMode.OFF
+
+
+async def test_set_target_temp_with_invalid_hvac_mode_raises(
+    hass: HomeAssistant,
+) -> None:
+    """Test that invalid hvac_mode is rejected from set_temperature."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.OFF,
+                "target_temp": 20,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError):
+        await common.async_set_temperature(
+            hass, temperature=30, hvac_mode=HVACMode.COOL
+        )
+
+    state = hass.states.get(ENTITY)
+    assert state.attributes.get(ATTR_TEMPERATURE) == 20.0
+    assert state.state == HVACMode.OFF
+
+
+async def test_set_target_temp_with_hvac_ac(
+    hass: HomeAssistant,
+) -> None:
+    """Test that invalid hvac_mode is rejected from set_temperature."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.OFF,
+                "target_temp": 20,
+                "ac_mode": True,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await common.async_set_temperature(hass, temperature=30, hvac_mode=HVACMode.COOL)
+
+    state = hass.states.get(ENTITY)
+    assert state.attributes.get(ATTR_TEMPERATURE) == 30.0
+    assert state.state == HVACMode.COOL
 
 
 async def _setup_thermostat_with_min_cycle_duration(

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -912,7 +912,7 @@ async def test_set_target_temp_with_hvac_mode_off(hass: HomeAssistant) -> None:
     assert state.state == HVACMode.OFF
 
 
-async def test_set_target_temp_with_hvac_ac(
+async def test_set_target_temp_with_hvac_mode_cool_when_ac_mode_enabled(
     hass: HomeAssistant,
 ) -> None:
     """Test that COOL is accepted from set_temperature when ac_mode is enabled."""

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -843,24 +843,6 @@ async def setup_comp_4(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_comp_4")
 async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
     """Test setting the target temperature and HVAC mode together."""
-    hass.config.units = METRIC_SYSTEM
-    assert await async_setup_component(
-        hass,
-        CLIMATE_DOMAIN,
-        {
-            "climate": {
-                "platform": "generic_thermostat",
-                "name": "test",
-                "cold_tolerance": 2,
-                "hot_tolerance": 4,
-                "heater": ENT_SWITCH,
-                "target_sensor": ENT_SENSOR,
-                "initial_hvac_mode": HVACMode.OFF,
-                "target_temp": 20,
-            }
-        },
-    )
-    await hass.async_block_till_done()
 
     await common.async_set_temperature(hass, temperature=30, hvac_mode=HVACMode.HEAT)
     state = hass.states.get(ENTITY)

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -817,6 +817,32 @@ async def test_no_state_change_when_operation_mode_off_2(hass: HomeAssistant) ->
     assert len(calls) == 0
 
 
+async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
+    """Test setting the target temperature and HVAC mode together."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.OFF,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await common.async_set_temperature(hass, temperature=30, hvac_mode=HVACMode.HEAT)
+    state = hass.states.get(ENTITY)
+    assert state.attributes.get("temperature") == 30.0
+    assert state.state == HVACMode.HEAT
+
+
 async def _setup_thermostat_with_min_cycle_duration(
     hass: HomeAssistant, ac_mode: bool, initial_hvac_mode: HVACMode
 ):

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -817,6 +817,30 @@ async def test_no_state_change_when_operation_mode_off_2(hass: HomeAssistant) ->
     assert len(calls) == 0
 
 
+@pytest.fixture
+async def setup_comp_4(hass: HomeAssistant) -> None:
+    """Initialize components."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "initial_hvac_mode": HVACMode.OFF,
+                "target_temp": 20,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("setup_comp_4")
 async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
     """Test setting the target temperature and HVAC mode together."""
     hass.config.units = METRIC_SYSTEM
@@ -844,6 +868,22 @@ async def test_set_target_temp_with_hvac_mode_heat(hass: HomeAssistant) -> None:
     assert state.state == HVACMode.HEAT
 
 
+@pytest.mark.usefixtures("setup_comp_4")
+async def test_set_target_temp_with_invalid_hvac_mode_raises(
+    hass: HomeAssistant,
+) -> None:
+    """Test that invalid hvac_mode is rejected from set_temperature."""
+
+    with pytest.raises(ServiceValidationError):
+        await common.async_set_temperature(
+            hass, temperature=30, hvac_mode=HVACMode.COOL
+        )
+
+    state = hass.states.get(ENTITY)
+    assert state.attributes.get(ATTR_TEMPERATURE) == 20.0
+    assert state.state == HVACMode.OFF
+
+
 async def test_set_target_temp_with_hvac_mode_off(hass: HomeAssistant) -> None:
     """Test setting a temperature while switching the climate mode to OFF."""
     hass.config.units = METRIC_SYSTEM
@@ -869,39 +909,6 @@ async def test_set_target_temp_with_hvac_mode_off(hass: HomeAssistant) -> None:
 
     state = hass.states.get(ENTITY)
     assert state.attributes.get(ATTR_TEMPERATURE) == 30.0
-    assert state.state == HVACMode.OFF
-
-
-async def test_set_target_temp_with_invalid_hvac_mode_raises(
-    hass: HomeAssistant,
-) -> None:
-    """Test that invalid hvac_mode is rejected from set_temperature."""
-    hass.config.units = METRIC_SYSTEM
-    assert await async_setup_component(
-        hass,
-        CLIMATE_DOMAIN,
-        {
-            "climate": {
-                "platform": "generic_thermostat",
-                "name": "test",
-                "cold_tolerance": 2,
-                "hot_tolerance": 4,
-                "heater": ENT_SWITCH,
-                "target_sensor": ENT_SENSOR,
-                "initial_hvac_mode": HVACMode.OFF,
-                "target_temp": 20,
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    with pytest.raises(ServiceValidationError):
-        await common.async_set_temperature(
-            hass, temperature=30, hvac_mode=HVACMode.COOL
-        )
-
-    state = hass.states.get(ENTITY)
-    assert state.attributes.get(ATTR_TEMPERATURE) == 20.0
     assert state.state == HVACMode.OFF
 
 

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -908,7 +908,7 @@ async def test_set_target_temp_with_invalid_hvac_mode_raises(
 async def test_set_target_temp_with_hvac_ac(
     hass: HomeAssistant,
 ) -> None:
-    """Test that invalid hvac_mode is rejected from set_temperature."""
+    """Test that COOL is accepted from set_temperature when ac_mode is enabled."""
     hass.config.units = METRIC_SYSTEM
     assert await async_setup_component(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the generic_thermostat integration ignores the hvac_mode attribute when calling the climate.set_temperature service. This forces users to use two separate service calls (one for mode, one for temperature) in scripts and automations, which can lead to unnecessary complexity.

This PR updates async_set_temperature to:
1. Check for the presence of hvac_mode in the service call.
2. Update the HVAC mode first if provided.
3. Update the temperature as requested

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159079
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
