### PR TITLE
Add support for Japanese LG TV to LG Infrared Integration

### DIFF
--- a/homeassistant/components/lg_infrared/__init__.py
+++ b/homeassistant/components/lg_infrared/__init__.py
@@ -14,7 +14,7 @@ PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SELECT]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up LG IR from a config entry."""
-    data = LGIRRemoteData()
+    data = LGIRRemoteData(hass, entry.entry_id)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data
     
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/lg_infrared/__init__.py
+++ b/homeassistant/components/lg_infrared/__init__.py
@@ -6,15 +6,26 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER]
+from .const import DOMAIN
+from .models import LGIRRemoteData
+
+PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SELECT]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up LG IR from a config entry."""
+    data = LGIRRemoteData()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data
+    
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a LG IR config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+        
+    return unload_ok

--- a/homeassistant/components/lg_infrared/button.py
+++ b/homeassistant/components/lg_infrared/button.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Union
 
-from infrared_protocols.codes.lg.tv import LGTVCode
+from infrared_protocols.codes.lg.tv import LGTVCode, LGTVCodeJP
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, LGDeviceType
+from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, LGDeviceType, CONF_REGION, REGION_GLOBAL, REGION_JAPAN
 from .entity import LgIrEntity
 
 PARALLEL_UPDATES = 1
@@ -21,7 +22,7 @@ PARALLEL_UPDATES = 1
 class LgIrButtonEntityDescription(ButtonEntityDescription):
     """Describes LG IR button entity."""
 
-    command_code: LGTVCode
+    command_code: Union [LGTVCode, LGTVCodeJP]
 
 
 TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
@@ -159,6 +160,277 @@ TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
     ),
 )
 
+TV_JAPAN_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
+    LgIrButtonEntityDescription(
+        key="power", translation_key="power", command_code=LGTVCodeJP.POWER
+    ),
+    LgIrButtonEntityDescription(
+        key="power_on", translation_key="power_on", command_code=LGTVCodeJP.POWER_ON
+    ),
+    LgIrButtonEntityDescription(
+        key="power_off", translation_key="power_off", command_code=LGTVCodeJP.POWER_OFF
+    ),
+    LgIrButtonEntityDescription(
+        key="tv", translation_key="tv", command_code=LGTVCodeJP.TV
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv", translation_key="dtv", command_code=LGTVCodeJP.DTV
+    ),
+    LgIrButtonEntityDescription(
+        key="bs", translation_key="bs", command_code=LGTVCodeJP.BS
+    ),
+    LgIrButtonEntityDescription(
+        key="cs", translation_key="cs", command_code=LGTVCodeJP.CS
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_1", translation_key="hdmi_1", command_code=LGTVCodeJP.HDMI_1
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_2", translation_key="hdmi_2", command_code=LGTVCodeJP.HDMI_2
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_3", translation_key="hdmi_3", command_code=LGTVCodeJP.HDMI_3
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_4", translation_key="hdmi_4", command_code=LGTVCodeJP.HDMI_4
+    ),
+    LgIrButtonEntityDescription(
+        key="aspect", translation_key="aspect", command_code=LGTVCodeJP.ASPECT
+    ),
+    LgIrButtonEntityDescription(
+        key="exit", translation_key="exit", command_code=LGTVCodeJP.EXIT
+    ),
+    LgIrButtonEntityDescription(
+        key="info", translation_key="info", command_code=LGTVCodeJP.INFO
+    ),
+    LgIrButtonEntityDescription(
+        key="guide", translation_key="guide", command_code=LGTVCodeJP.GUIDE
+    ),
+    LgIrButtonEntityDescription(
+        key="settings", translation_key="settings", command_code=LGTVCodeJP.SETTINGS
+    ),
+    LgIrButtonEntityDescription(
+        key="list", translation_key="list", command_code=LGTVCodeJP.LIST
+    ),
+    LgIrButtonEntityDescription(
+        key="text", translation_key="text", command_code=LGTVCodeJP.TEXT
+    ),
+    LgIrButtonEntityDescription(
+        key="yellow", translation_key="yellow", command_code=LGTVCodeJP.YELLOW
+    ),
+    LgIrButtonEntityDescription(
+        key="green", translation_key="green", command_code=LGTVCodeJP.GREEN
+    ),
+    LgIrButtonEntityDescription(
+        key="red", translation_key="red", command_code=LGTVCodeJP.RED
+    ),
+    LgIrButtonEntityDescription(
+        key="blue", translation_key="blue", command_code=LGTVCodeJP.BLUE
+    ),
+    LgIrButtonEntityDescription(
+        key="up", translation_key="up", command_code=LGTVCodeJP.NAV_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="down", translation_key="down", command_code=LGTVCodeJP.NAV_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="left", translation_key="left", command_code=LGTVCodeJP.NAV_LEFT
+    ),
+    LgIrButtonEntityDescription(
+        key="right", translation_key="right", command_code=LGTVCodeJP.NAV_RIGHT
+    ),
+    LgIrButtonEntityDescription(
+        key="ok", translation_key="ok", command_code=LGTVCodeJP.OK
+    ),
+    LgIrButtonEntityDescription(
+        key="back", translation_key="back", command_code=LGTVCodeJP.BACK
+    ),
+    LgIrButtonEntityDescription(
+        key="home", translation_key="home", command_code=LGTVCodeJP.HOME
+    ),
+    LgIrButtonEntityDescription(
+        key="menu", translation_key="menu", command_code=LGTVCodeJP.MENU
+    ),
+    LgIrButtonEntityDescription(
+        key="input", translation_key="input", command_code=LGTVCodeJP.INPUT
+    ),
+    LgIrButtonEntityDescription(
+        key="num_0", translation_key="num_0", command_code=LGTVCodeJP.NUM_0
+    ),
+    LgIrButtonEntityDescription(
+        key="num_1", translation_key="num_1", command_code=LGTVCodeJP.NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="num_2", translation_key="num_2", command_code=LGTVCodeJP.NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="num_3", translation_key="num_3", command_code=LGTVCodeJP.NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="num_4", translation_key="num_4", command_code=LGTVCodeJP.NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="num_5", translation_key="num_5", command_code=LGTVCodeJP.NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="num_6", translation_key="num_6", command_code=LGTVCodeJP.NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="num_7", translation_key="num_7", command_code=LGTVCodeJP.NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="num_8", translation_key="num_8", command_code=LGTVCodeJP.NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="num_9", translation_key="num_9", command_code=LGTVCodeJP.NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="num_10", translation_key="num_10", command_code=LGTVCodeJP.NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="num_11", translation_key="num_11", command_code=LGTVCodeJP.NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="num_12", translation_key="num_12", command_code=LGTVCodeJP.NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_1", translation_key="dtv_num_1", command_code=LGTVCodeJP.DTV_NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_2", translation_key="dtv_num_2", command_code=LGTVCodeJP.DTV_NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_3", translation_key="dtv_num_3", command_code=LGTVCodeJP.DTV_NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_4", translation_key="dtv_num_4", command_code=LGTVCodeJP.DTV_NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_5", translation_key="dtv_num_5", command_code=LGTVCodeJP.DTV_NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_6", translation_key="dtv_num_6", command_code=LGTVCodeJP.DTV_NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_7", translation_key="dtv_num_7", command_code=LGTVCodeJP.DTV_NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_8", translation_key="dtv_num_8", command_code=LGTVCodeJP.DTV_NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_9", translation_key="dtv_num_9", command_code=LGTVCodeJP.DTV_NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_10", translation_key="dtv_num_10", command_code=LGTVCodeJP.DTV_NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_11", translation_key="dtv_num_11", command_code=LGTVCodeJP.DTV_NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_12", translation_key="dtv_num_12", command_code=LGTVCodeJP.DTV_NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_1", translation_key="bs_num_1", command_code=LGTVCodeJP.BS_NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_2", translation_key="bs_num_2", command_code=LGTVCodeJP.BS_NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_3", translation_key="bs_num_3", command_code=LGTVCodeJP.BS_NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_4", translation_key="bs_num_4", command_code=LGTVCodeJP.BS_NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_5", translation_key="bs_num_5", command_code=LGTVCodeJP.BS_NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_6", translation_key="bs_num_6", command_code=LGTVCodeJP.BS_NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_7", translation_key="bs_num_7", command_code=LGTVCodeJP.BS_NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_8", translation_key="bs_num_8", command_code=LGTVCodeJP.BS_NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_9", translation_key="bs_num_9", command_code=LGTVCodeJP.BS_NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_10", translation_key="bs_num_10", command_code=LGTVCodeJP.BS_NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_11", translation_key="bs_num_11", command_code=LGTVCodeJP.BS_NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_12", translation_key="bs_num_12", command_code=LGTVCodeJP.BS_NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_1", translation_key="cs_num_1", command_code=LGTVCodeJP.CS_NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_2", translation_key="cs_num_2", command_code=LGTVCodeJP.CS_NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_3", translation_key="cs_num_3", command_code=LGTVCodeJP.CS_NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_4", translation_key="cs_num_4", command_code=LGTVCodeJP.CS_NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_5", translation_key="cs_num_5", command_code=LGTVCodeJP.CS_NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_6", translation_key="cs_num_6", command_code=LGTVCodeJP.CS_NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_7", translation_key="cs_num_7", command_code=LGTVCodeJP.CS_NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_8", translation_key="cs_num_8", command_code=LGTVCodeJP.CS_NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_9", translation_key="cs_num_9", command_code=LGTVCodeJP.CS_NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_10", translation_key="cs_num_10", command_code=LGTVCodeJP.CS_NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_11", translation_key="cs_num_11", command_code=LGTVCodeJP.CS_NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_12", translation_key="cs_num_12", command_code=LGTVCodeJP.CS_NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_up", translation_key="channel_up", command_code=LGTVCodeJP.CHANNEL_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_down", translation_key="channel_down", command_code=LGTVCodeJP.CHANNEL_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_up", translation_key="volume_up", command_code=LGTVCodeJP.VOLUME_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_down", translation_key="volume_down", command_code=LGTVCodeJP.VOLUME_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="mute", translation_key="mute", command_code=LGTVCodeJP.MUTE
+    ),
+    LgIrButtonEntityDescription(
+        key="sap", translation_key="sap", command_code=LGTVCodeJP.SAP
+    ),
+    LgIrButtonEntityDescription(
+        key="subtitle", translation_key="subtitle", command_code=LGTVCodeJP.SUBTITLE
+    ),
+    LgIrButtonEntityDescription(
+        key="record", translation_key="record", command_code=LGTVCodeJP.RECORD
+    ),
+    LgIrButtonEntityDescription(
+        key="rec_list", translation_key="rec_list", command_code=LGTVCodeJP.REC_LIST
+    ),
+    
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -168,10 +440,17 @@ async def async_setup_entry(
     """Set up LG IR buttons from config entry."""
     infrared_entity_id = entry.data[CONF_INFRARED_ENTITY_ID]
     device_type = entry.data[CONF_DEVICE_TYPE]
+    region = entry.data.get(CONF_REGION, REGION_GLOBAL)
+    
     if device_type == LGDeviceType.TV:
+        descriptions = (
+            TV_JAPAN_BUTTON_DESCRIPTIONS 
+            if region == REGION_JAPAN 
+            else TV_BUTTON_DESCRIPTIONS
+        )
         async_add_entities(
             LgIrButton(entry, infrared_entity_id, description)
-            for description in TV_BUTTON_DESCRIPTIONS
+            for description in descriptions
         )
 
 

--- a/homeassistant/components/lg_infrared/button.py
+++ b/homeassistant/components/lg_infrared/button.py
@@ -26,6 +26,9 @@ class LgIrButtonEntityDescription(ButtonEntityDescription):
 
 TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
     LgIrButtonEntityDescription(
+        key="power", translation_key="power", command_code=LGTVCode.POWER
+    ),
+    LgIrButtonEntityDescription(
         key="power_on", translation_key="power_on", command_code=LGTVCode.POWER_ON
     ),
     LgIrButtonEntityDescription(
@@ -44,6 +47,9 @@ TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
         key="hdmi_4", translation_key="hdmi_4", command_code=LGTVCode.HDMI_4
     ),
     LgIrButtonEntityDescription(
+        key="aspect", translation_key="aspect", command_code=LGTVCode.ASPECT
+    ),
+    LgIrButtonEntityDescription(
         key="exit", translation_key="exit", command_code=LGTVCode.EXIT
     ),
     LgIrButtonEntityDescription(
@@ -51,6 +57,27 @@ TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
     ),
     LgIrButtonEntityDescription(
         key="guide", translation_key="guide", command_code=LGTVCode.GUIDE
+    ),
+    LgIrButtonEntityDescription(
+        key="settings", translation_key="settings", command_code=LGTVCode.SETTINGS
+    ),
+    LgIrButtonEntityDescription(
+        key="list", translation_key="list", command_code=LGTVCode.LIST
+    ),
+    LgIrButtonEntityDescription(
+        key="text", translation_key="text", command_code=LGTVCode.TEXT
+    ),
+    LgIrButtonEntityDescription(
+        key="yellow", translation_key="yellow", command_code=LGTVCode.YELLOW
+    ),
+    LgIrButtonEntityDescription(
+        key="green", translation_key="green", command_code=LGTVCode.GREEN
+    ),
+    LgIrButtonEntityDescription(
+        key="red", translation_key="red", command_code=LGTVCode.RED
+    ),
+    LgIrButtonEntityDescription(
+        key="blue", translation_key="blue", command_code=LGTVCode.BLUE
     ),
     LgIrButtonEntityDescription(
         key="up", translation_key="up", command_code=LGTVCode.NAV_UP
@@ -108,6 +135,27 @@ TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
     ),
     LgIrButtonEntityDescription(
         key="num_9", translation_key="num_9", command_code=LGTVCode.NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_up", translation_key="channel_up", command_code=LGTVCode.CHANNEL_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_down", translation_key="channel_down", command_code=LGTVCode.CHANNEL_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_up", translation_key="volume_up", command_code=LGTVCode.VOLUME_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_down", translation_key="volume_down", command_code=LGTVCode.VOLUME_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="mute", translation_key="mute", command_code=LGTVCode.MUTE
+    ),
+    LgIrButtonEntityDescription(
+        key="sap", translation_key="sap", command_code=LGTVCode.SAP
+    ),
+    LgIrButtonEntityDescription(
+        key="subtitle", translation_key="subtitle", command_code=LGTVCode.SUBTITLE
     ),
 )
 

--- a/homeassistant/components/lg_infrared/button.py
+++ b/homeassistant/components/lg_infrared/button.py
@@ -12,8 +12,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, LGDeviceType, CONF_REGION, REGION_GLOBAL, REGION_JAPAN
+from .codes import resolve_numeric_code
+from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, LGDeviceType, CONF_REGION, REGION_GLOBAL, REGION_JAPAN, DOMAIN
 from .entity import LgIrEntity
+from .models import LGIRRemoteData
 
 PARALLEL_UPDATES = 1
 
@@ -22,7 +24,7 @@ PARALLEL_UPDATES = 1
 class LgIrButtonEntityDescription(ButtonEntityDescription):
     """Describes LG IR button entity."""
 
-    command_code: Union [LGTVCode, LGTVCodeJP]
+    command_code: Enum
 
 
 TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
@@ -213,7 +215,7 @@ TV_JAPAN_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
         key="list", translation_key="list", command_code=LGTVCodeJP.LIST
     ),
     LgIrButtonEntityDescription(
-        key="text", translation_key="text", command_code=LGTVCodeJP.TEXT
+        key="data", translation_key="data", command_code=LGTVCodeJP.TEXT
     ),
     LgIrButtonEntityDescription(
         key="yellow", translation_key="yellow", command_code=LGTVCodeJP.YELLOW
@@ -253,9 +255,6 @@ TV_JAPAN_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
     ),
     LgIrButtonEntityDescription(
         key="input", translation_key="input", command_code=LGTVCodeJP.INPUT
-    ),
-    LgIrButtonEntityDescription(
-        key="num_0", translation_key="num_0", command_code=LGTVCodeJP.NUM_0
     ),
     LgIrButtonEntityDescription(
         key="num_1", translation_key="num_1", command_code=LGTVCodeJP.NUM_1
@@ -441,6 +440,8 @@ async def async_setup_entry(
     infrared_entity_id = entry.data[CONF_INFRARED_ENTITY_ID]
     device_type = entry.data[CONF_DEVICE_TYPE]
     region = entry.data.get(CONF_REGION, REGION_GLOBAL)
+
+    data: LGIRRemoteData = hass.data[DOMAIN][entry.entry_id]
     
     if device_type == LGDeviceType.TV:
         descriptions = (
@@ -449,7 +450,7 @@ async def async_setup_entry(
             else TV_BUTTON_DESCRIPTIONS
         )
         async_add_entities(
-            LgIrButton(entry, infrared_entity_id, description)
+            LgIrButton(entry, infrared_entity_id, description, data)
             for description in descriptions
         )
 
@@ -464,11 +465,21 @@ class LgIrButton(LgIrEntity, ButtonEntity):
         entry: ConfigEntry,
         infrared_entity_id: str,
         description: LgIrButtonEntityDescription,
+        data: LGIRRemoteData,
     ) -> None:
         """Initialize LG IR button."""
         super().__init__(entry, infrared_entity_id, unique_id_suffix=description.key)
         self.entity_description = description
+        self._data = data
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self._send_command(self.entity_description.command_code)
+        key = self.entity_description.key
+        command = self.entity_description.command_code
+
+        if key in {"dtv", "bs", "cs"}:
+            self._data.update_tuner(key)
+        elif key.startswith("num_"):
+            command = resolve_numeric_code(command, self._data.current_tuner)
+
+        await self._send_command(command)

--- a/homeassistant/components/lg_infrared/button.py
+++ b/homeassistant/components/lg_infrared/button.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from dataclasses import dataclass
-from typing import Union
+
+import logging
+_LOGGER = logging.getLogger(__name__)
 
 from infrared_protocols.codes.lg.tv import LGTVCode, LGTVCodeJP
 
@@ -13,423 +16,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .codes import resolve_numeric_code
-from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, LGDeviceType, CONF_REGION, REGION_GLOBAL, REGION_JAPAN, DOMAIN
+from .codesets import LG_CODESETS, LGCodeset, LgIrButtonEntityDescription
+from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, LGDeviceType, CONF_CODESET, DOMAIN
 from .entity import LgIrEntity
 from .models import LGIRRemoteData
 
 PARALLEL_UPDATES = 1
-
-
-@dataclass(frozen=True, kw_only=True)
-class LgIrButtonEntityDescription(ButtonEntityDescription):
-    """Describes LG IR button entity."""
-
-    command_code: Enum
-
-
-TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
-    LgIrButtonEntityDescription(
-        key="power", translation_key="power", command_code=LGTVCode.POWER
-    ),
-    LgIrButtonEntityDescription(
-        key="power_on", translation_key="power_on", command_code=LGTVCode.POWER_ON
-    ),
-    LgIrButtonEntityDescription(
-        key="power_off", translation_key="power_off", command_code=LGTVCode.POWER_OFF
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_1", translation_key="hdmi_1", command_code=LGTVCode.HDMI_1
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_2", translation_key="hdmi_2", command_code=LGTVCode.HDMI_2
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_3", translation_key="hdmi_3", command_code=LGTVCode.HDMI_3
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_4", translation_key="hdmi_4", command_code=LGTVCode.HDMI_4
-    ),
-    LgIrButtonEntityDescription(
-        key="aspect", translation_key="aspect", command_code=LGTVCode.ASPECT
-    ),
-    LgIrButtonEntityDescription(
-        key="exit", translation_key="exit", command_code=LGTVCode.EXIT
-    ),
-    LgIrButtonEntityDescription(
-        key="info", translation_key="info", command_code=LGTVCode.INFO
-    ),
-    LgIrButtonEntityDescription(
-        key="guide", translation_key="guide", command_code=LGTVCode.GUIDE
-    ),
-    LgIrButtonEntityDescription(
-        key="settings", translation_key="settings", command_code=LGTVCode.SETTINGS
-    ),
-    LgIrButtonEntityDescription(
-        key="list", translation_key="list", command_code=LGTVCode.LIST
-    ),
-    LgIrButtonEntityDescription(
-        key="text", translation_key="text", command_code=LGTVCode.TEXT
-    ),
-    LgIrButtonEntityDescription(
-        key="yellow", translation_key="yellow", command_code=LGTVCode.YELLOW
-    ),
-    LgIrButtonEntityDescription(
-        key="green", translation_key="green", command_code=LGTVCode.GREEN
-    ),
-    LgIrButtonEntityDescription(
-        key="red", translation_key="red", command_code=LGTVCode.RED
-    ),
-    LgIrButtonEntityDescription(
-        key="blue", translation_key="blue", command_code=LGTVCode.BLUE
-    ),
-    LgIrButtonEntityDescription(
-        key="up", translation_key="up", command_code=LGTVCode.NAV_UP
-    ),
-    LgIrButtonEntityDescription(
-        key="down", translation_key="down", command_code=LGTVCode.NAV_DOWN
-    ),
-    LgIrButtonEntityDescription(
-        key="left", translation_key="left", command_code=LGTVCode.NAV_LEFT
-    ),
-    LgIrButtonEntityDescription(
-        key="right", translation_key="right", command_code=LGTVCode.NAV_RIGHT
-    ),
-    LgIrButtonEntityDescription(
-        key="ok", translation_key="ok", command_code=LGTVCode.OK
-    ),
-    LgIrButtonEntityDescription(
-        key="back", translation_key="back", command_code=LGTVCode.BACK
-    ),
-    LgIrButtonEntityDescription(
-        key="home", translation_key="home", command_code=LGTVCode.HOME
-    ),
-    LgIrButtonEntityDescription(
-        key="menu", translation_key="menu", command_code=LGTVCode.MENU
-    ),
-    LgIrButtonEntityDescription(
-        key="input", translation_key="input", command_code=LGTVCode.INPUT
-    ),
-    LgIrButtonEntityDescription(
-        key="num_0", translation_key="num_0", command_code=LGTVCode.NUM_0
-    ),
-    LgIrButtonEntityDescription(
-        key="num_1", translation_key="num_1", command_code=LGTVCode.NUM_1
-    ),
-    LgIrButtonEntityDescription(
-        key="num_2", translation_key="num_2", command_code=LGTVCode.NUM_2
-    ),
-    LgIrButtonEntityDescription(
-        key="num_3", translation_key="num_3", command_code=LGTVCode.NUM_3
-    ),
-    LgIrButtonEntityDescription(
-        key="num_4", translation_key="num_4", command_code=LGTVCode.NUM_4
-    ),
-    LgIrButtonEntityDescription(
-        key="num_5", translation_key="num_5", command_code=LGTVCode.NUM_5
-    ),
-    LgIrButtonEntityDescription(
-        key="num_6", translation_key="num_6", command_code=LGTVCode.NUM_6
-    ),
-    LgIrButtonEntityDescription(
-        key="num_7", translation_key="num_7", command_code=LGTVCode.NUM_7
-    ),
-    LgIrButtonEntityDescription(
-        key="num_8", translation_key="num_8", command_code=LGTVCode.NUM_8
-    ),
-    LgIrButtonEntityDescription(
-        key="num_9", translation_key="num_9", command_code=LGTVCode.NUM_9
-    ),
-    LgIrButtonEntityDescription(
-        key="channel_up", translation_key="channel_up", command_code=LGTVCode.CHANNEL_UP
-    ),
-    LgIrButtonEntityDescription(
-        key="channel_down", translation_key="channel_down", command_code=LGTVCode.CHANNEL_DOWN
-    ),
-    LgIrButtonEntityDescription(
-        key="volume_up", translation_key="volume_up", command_code=LGTVCode.VOLUME_UP
-    ),
-    LgIrButtonEntityDescription(
-        key="volume_down", translation_key="volume_down", command_code=LGTVCode.VOLUME_DOWN
-    ),
-    LgIrButtonEntityDescription(
-        key="mute", translation_key="mute", command_code=LGTVCode.MUTE
-    ),
-    LgIrButtonEntityDescription(
-        key="sap", translation_key="sap", command_code=LGTVCode.SAP
-    ),
-    LgIrButtonEntityDescription(
-        key="subtitle", translation_key="subtitle", command_code=LGTVCode.SUBTITLE
-    ),
-)
-
-TV_JAPAN_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
-    LgIrButtonEntityDescription(
-        key="power", translation_key="power", command_code=LGTVCodeJP.POWER
-    ),
-    LgIrButtonEntityDescription(
-        key="power_on", translation_key="power_on", command_code=LGTVCodeJP.POWER_ON
-    ),
-    LgIrButtonEntityDescription(
-        key="power_off", translation_key="power_off", command_code=LGTVCodeJP.POWER_OFF
-    ),
-    LgIrButtonEntityDescription(
-        key="tv", translation_key="tv", command_code=LGTVCodeJP.TV
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv", translation_key="dtv", command_code=LGTVCodeJP.DTV
-    ),
-    LgIrButtonEntityDescription(
-        key="bs", translation_key="bs", command_code=LGTVCodeJP.BS
-    ),
-    LgIrButtonEntityDescription(
-        key="cs", translation_key="cs", command_code=LGTVCodeJP.CS
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_1", translation_key="hdmi_1", command_code=LGTVCodeJP.HDMI_1
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_2", translation_key="hdmi_2", command_code=LGTVCodeJP.HDMI_2
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_3", translation_key="hdmi_3", command_code=LGTVCodeJP.HDMI_3
-    ),
-    LgIrButtonEntityDescription(
-        key="hdmi_4", translation_key="hdmi_4", command_code=LGTVCodeJP.HDMI_4
-    ),
-    LgIrButtonEntityDescription(
-        key="aspect", translation_key="aspect", command_code=LGTVCodeJP.ASPECT
-    ),
-    LgIrButtonEntityDescription(
-        key="exit", translation_key="exit", command_code=LGTVCodeJP.EXIT
-    ),
-    LgIrButtonEntityDescription(
-        key="info", translation_key="info", command_code=LGTVCodeJP.INFO
-    ),
-    LgIrButtonEntityDescription(
-        key="guide", translation_key="guide", command_code=LGTVCodeJP.GUIDE
-    ),
-    LgIrButtonEntityDescription(
-        key="settings", translation_key="settings", command_code=LGTVCodeJP.SETTINGS
-    ),
-    LgIrButtonEntityDescription(
-        key="list", translation_key="list", command_code=LGTVCodeJP.LIST
-    ),
-    LgIrButtonEntityDescription(
-        key="data", translation_key="data", command_code=LGTVCodeJP.TEXT
-    ),
-    LgIrButtonEntityDescription(
-        key="yellow", translation_key="yellow", command_code=LGTVCodeJP.YELLOW
-    ),
-    LgIrButtonEntityDescription(
-        key="green", translation_key="green", command_code=LGTVCodeJP.GREEN
-    ),
-    LgIrButtonEntityDescription(
-        key="red", translation_key="red", command_code=LGTVCodeJP.RED
-    ),
-    LgIrButtonEntityDescription(
-        key="blue", translation_key="blue", command_code=LGTVCodeJP.BLUE
-    ),
-    LgIrButtonEntityDescription(
-        key="up", translation_key="up", command_code=LGTVCodeJP.NAV_UP
-    ),
-    LgIrButtonEntityDescription(
-        key="down", translation_key="down", command_code=LGTVCodeJP.NAV_DOWN
-    ),
-    LgIrButtonEntityDescription(
-        key="left", translation_key="left", command_code=LGTVCodeJP.NAV_LEFT
-    ),
-    LgIrButtonEntityDescription(
-        key="right", translation_key="right", command_code=LGTVCodeJP.NAV_RIGHT
-    ),
-    LgIrButtonEntityDescription(
-        key="ok", translation_key="ok", command_code=LGTVCodeJP.OK
-    ),
-    LgIrButtonEntityDescription(
-        key="back", translation_key="back", command_code=LGTVCodeJP.BACK
-    ),
-    LgIrButtonEntityDescription(
-        key="home", translation_key="home", command_code=LGTVCodeJP.HOME
-    ),
-    LgIrButtonEntityDescription(
-        key="menu", translation_key="menu", command_code=LGTVCodeJP.MENU
-    ),
-    LgIrButtonEntityDescription(
-        key="input", translation_key="input", command_code=LGTVCodeJP.INPUT
-    ),
-    LgIrButtonEntityDescription(
-        key="num_1", translation_key="num_1", command_code=LGTVCodeJP.NUM_1
-    ),
-    LgIrButtonEntityDescription(
-        key="num_2", translation_key="num_2", command_code=LGTVCodeJP.NUM_2
-    ),
-    LgIrButtonEntityDescription(
-        key="num_3", translation_key="num_3", command_code=LGTVCodeJP.NUM_3
-    ),
-    LgIrButtonEntityDescription(
-        key="num_4", translation_key="num_4", command_code=LGTVCodeJP.NUM_4
-    ),
-    LgIrButtonEntityDescription(
-        key="num_5", translation_key="num_5", command_code=LGTVCodeJP.NUM_5
-    ),
-    LgIrButtonEntityDescription(
-        key="num_6", translation_key="num_6", command_code=LGTVCodeJP.NUM_6
-    ),
-    LgIrButtonEntityDescription(
-        key="num_7", translation_key="num_7", command_code=LGTVCodeJP.NUM_7
-    ),
-    LgIrButtonEntityDescription(
-        key="num_8", translation_key="num_8", command_code=LGTVCodeJP.NUM_8
-    ),
-    LgIrButtonEntityDescription(
-        key="num_9", translation_key="num_9", command_code=LGTVCodeJP.NUM_9
-    ),
-    LgIrButtonEntityDescription(
-        key="num_10", translation_key="num_10", command_code=LGTVCodeJP.NUM_10
-    ),
-    LgIrButtonEntityDescription(
-        key="num_11", translation_key="num_11", command_code=LGTVCodeJP.NUM_11
-    ),
-    LgIrButtonEntityDescription(
-        key="num_12", translation_key="num_12", command_code=LGTVCodeJP.NUM_12
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_1", translation_key="dtv_num_1", command_code=LGTVCodeJP.DTV_NUM_1
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_2", translation_key="dtv_num_2", command_code=LGTVCodeJP.DTV_NUM_2
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_3", translation_key="dtv_num_3", command_code=LGTVCodeJP.DTV_NUM_3
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_4", translation_key="dtv_num_4", command_code=LGTVCodeJP.DTV_NUM_4
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_5", translation_key="dtv_num_5", command_code=LGTVCodeJP.DTV_NUM_5
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_6", translation_key="dtv_num_6", command_code=LGTVCodeJP.DTV_NUM_6
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_7", translation_key="dtv_num_7", command_code=LGTVCodeJP.DTV_NUM_7
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_8", translation_key="dtv_num_8", command_code=LGTVCodeJP.DTV_NUM_8
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_9", translation_key="dtv_num_9", command_code=LGTVCodeJP.DTV_NUM_9
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_10", translation_key="dtv_num_10", command_code=LGTVCodeJP.DTV_NUM_10
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_11", translation_key="dtv_num_11", command_code=LGTVCodeJP.DTV_NUM_11
-    ),
-    LgIrButtonEntityDescription(
-        key="dtv_num_12", translation_key="dtv_num_12", command_code=LGTVCodeJP.DTV_NUM_12
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_1", translation_key="bs_num_1", command_code=LGTVCodeJP.BS_NUM_1
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_2", translation_key="bs_num_2", command_code=LGTVCodeJP.BS_NUM_2
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_3", translation_key="bs_num_3", command_code=LGTVCodeJP.BS_NUM_3
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_4", translation_key="bs_num_4", command_code=LGTVCodeJP.BS_NUM_4
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_5", translation_key="bs_num_5", command_code=LGTVCodeJP.BS_NUM_5
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_6", translation_key="bs_num_6", command_code=LGTVCodeJP.BS_NUM_6
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_7", translation_key="bs_num_7", command_code=LGTVCodeJP.BS_NUM_7
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_8", translation_key="bs_num_8", command_code=LGTVCodeJP.BS_NUM_8
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_9", translation_key="bs_num_9", command_code=LGTVCodeJP.BS_NUM_9
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_10", translation_key="bs_num_10", command_code=LGTVCodeJP.BS_NUM_10
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_11", translation_key="bs_num_11", command_code=LGTVCodeJP.BS_NUM_11
-    ),
-    LgIrButtonEntityDescription(
-        key="bs_num_12", translation_key="bs_num_12", command_code=LGTVCodeJP.BS_NUM_12
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_1", translation_key="cs_num_1", command_code=LGTVCodeJP.CS_NUM_1
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_2", translation_key="cs_num_2", command_code=LGTVCodeJP.CS_NUM_2
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_3", translation_key="cs_num_3", command_code=LGTVCodeJP.CS_NUM_3
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_4", translation_key="cs_num_4", command_code=LGTVCodeJP.CS_NUM_4
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_5", translation_key="cs_num_5", command_code=LGTVCodeJP.CS_NUM_5
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_6", translation_key="cs_num_6", command_code=LGTVCodeJP.CS_NUM_6
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_7", translation_key="cs_num_7", command_code=LGTVCodeJP.CS_NUM_7
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_8", translation_key="cs_num_8", command_code=LGTVCodeJP.CS_NUM_8
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_9", translation_key="cs_num_9", command_code=LGTVCodeJP.CS_NUM_9
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_10", translation_key="cs_num_10", command_code=LGTVCodeJP.CS_NUM_10
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_11", translation_key="cs_num_11", command_code=LGTVCodeJP.CS_NUM_11
-    ),
-    LgIrButtonEntityDescription(
-        key="cs_num_12", translation_key="cs_num_12", command_code=LGTVCodeJP.CS_NUM_12
-    ),
-    LgIrButtonEntityDescription(
-        key="channel_up", translation_key="channel_up", command_code=LGTVCodeJP.CHANNEL_UP
-    ),
-    LgIrButtonEntityDescription(
-        key="channel_down", translation_key="channel_down", command_code=LGTVCodeJP.CHANNEL_DOWN
-    ),
-    LgIrButtonEntityDescription(
-        key="volume_up", translation_key="volume_up", command_code=LGTVCodeJP.VOLUME_UP
-    ),
-    LgIrButtonEntityDescription(
-        key="volume_down", translation_key="volume_down", command_code=LGTVCodeJP.VOLUME_DOWN
-    ),
-    LgIrButtonEntityDescription(
-        key="mute", translation_key="mute", command_code=LGTVCodeJP.MUTE
-    ),
-    LgIrButtonEntityDescription(
-        key="sap", translation_key="sap", command_code=LGTVCodeJP.SAP
-    ),
-    LgIrButtonEntityDescription(
-        key="subtitle", translation_key="subtitle", command_code=LGTVCodeJP.SUBTITLE
-    ),
-    LgIrButtonEntityDescription(
-        key="record", translation_key="record", command_code=LGTVCodeJP.RECORD
-    ),
-    LgIrButtonEntityDescription(
-        key="rec_list", translation_key="rec_list", command_code=LGTVCodeJP.REC_LIST
-    ),
-    
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -438,21 +30,19 @@ async def async_setup_entry(
 ) -> None:
     """Set up LG IR buttons from config entry."""
     infrared_entity_id = entry.data[CONF_INFRARED_ENTITY_ID]
-    device_type = entry.data[CONF_DEVICE_TYPE]
-    region = entry.data.get(CONF_REGION, REGION_GLOBAL)
+    codeset_key = entry.data.get(CONF_CODESET)
+    codeset_def = LG_CODESETS.get(codeset_key)
 
+    if not codeset_def:
+        _LOGGER.error("Unknown codeset: %s", codeset_key)
+        return
+        
     data: LGIRRemoteData = hass.data[DOMAIN][entry.entry_id]
-    
-    if device_type == LGDeviceType.TV:
-        descriptions = (
-            TV_JAPAN_BUTTON_DESCRIPTIONS 
-            if region == REGION_JAPAN 
-            else TV_BUTTON_DESCRIPTIONS
-        )
-        async_add_entities(
-            LgIrButton(entry, infrared_entity_id, description, data)
-            for description in descriptions
-        )
+       
+    async_add_entities(
+        LgIrButton(entry, infrared_entity_id, description, data, codeset_def)
+            for description in codeset_def.buttons
+    )
 
 
 class LgIrButton(LgIrEntity, ButtonEntity):
@@ -466,20 +56,23 @@ class LgIrButton(LgIrEntity, ButtonEntity):
         infrared_entity_id: str,
         description: LgIrButtonEntityDescription,
         data: LGIRRemoteData,
+        codeset_def: LGCodeset,
     ) -> None:
         """Initialize LG IR button."""
         super().__init__(entry, infrared_entity_id, unique_id_suffix=description.key)
         self.entity_description = description
         self._data = data
+        self._codeset_def = codeset_def
 
     async def async_press(self) -> None:
         """Press the button."""
         key = self.entity_description.key
         command = self.entity_description.command_code
 
-        if key in {"dtv", "bs", "cs"}:
+        if self._codeset_def.tuner_options and key.upper() in self._codeset_def.tuner_options:
             self._data.update_tuner(key)
         elif key.startswith("num_"):
-            command = resolve_numeric_code(command, self._data.current_tuner)
+            tuner = self._data.current_tuner or "DTV"
+            command = resolve_numeric_code(command, tuner)
 
         await self._send_command(command)

--- a/homeassistant/components/lg_infrared/codes.py
+++ b/homeassistant/components/lg_infrared/codes.py
@@ -1,0 +1,12 @@
+"""codes.py: Shared IR command resolution utilities for the LG infrared integration."""
+from enum import Enum
+
+
+def resolve_numeric_code(base_code: Enum, tuner: str) -> Enum:
+    """Resolve NUM_X to tuner-specific variant within same codeset."""
+    if not base_code.name.startswith("NUM_"):
+        return base_code
+
+    enum_cls = type(base_code)
+    code_name = f"{tuner.upper()}_{base_code.name}"
+    return enum_cls.__members__.get(code_name, base_code)

--- a/homeassistant/components/lg_infrared/codesets.py
+++ b/homeassistant/components/lg_infrared/codesets.py
@@ -1,0 +1,442 @@
+"""Codeset and entity descriptions for LG IR integration."""
+from dataclasses import dataclass
+from enum import Enum
+
+from infrared_protocols.codes.lg.tv import LGTVCode, LGTVCodeJP
+from homeassistant.components.button import ButtonEntityDescription
+
+@dataclass(frozen=True, kw_only=True)
+class LgIrButtonEntityDescription(ButtonEntityDescription):
+    """Describes LG IR button entity."""
+
+    command_code: Enum
+
+
+TV_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
+    LgIrButtonEntityDescription(
+        key="power", translation_key="power", command_code=LGTVCode.POWER
+    ),
+    LgIrButtonEntityDescription(
+        key="power_on", translation_key="power_on", command_code=LGTVCode.POWER_ON
+    ),
+    LgIrButtonEntityDescription(
+        key="power_off", translation_key="power_off", command_code=LGTVCode.POWER_OFF
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_1", translation_key="hdmi_1", command_code=LGTVCode.HDMI_1
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_2", translation_key="hdmi_2", command_code=LGTVCode.HDMI_2
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_3", translation_key="hdmi_3", command_code=LGTVCode.HDMI_3
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_4", translation_key="hdmi_4", command_code=LGTVCode.HDMI_4
+    ),
+    LgIrButtonEntityDescription(
+        key="aspect", translation_key="aspect", command_code=LGTVCode.ASPECT
+    ),
+    LgIrButtonEntityDescription(
+        key="exit", translation_key="exit", command_code=LGTVCode.EXIT
+    ),
+    LgIrButtonEntityDescription(
+        key="info", translation_key="info", command_code=LGTVCode.INFO
+    ),
+    LgIrButtonEntityDescription(
+        key="guide", translation_key="guide", command_code=LGTVCode.GUIDE
+    ),
+    LgIrButtonEntityDescription(
+        key="settings", translation_key="settings", command_code=LGTVCode.SETTINGS
+    ),
+    LgIrButtonEntityDescription(
+        key="list", translation_key="list", command_code=LGTVCode.LIST
+    ),
+    LgIrButtonEntityDescription(
+        key="text", translation_key="text", command_code=LGTVCode.TEXT
+    ),
+    LgIrButtonEntityDescription(
+        key="yellow", translation_key="yellow", command_code=LGTVCode.YELLOW
+    ),
+    LgIrButtonEntityDescription(
+        key="green", translation_key="green", command_code=LGTVCode.GREEN
+    ),
+    LgIrButtonEntityDescription(
+        key="red", translation_key="red", command_code=LGTVCode.RED
+    ),
+    LgIrButtonEntityDescription(
+        key="blue", translation_key="blue", command_code=LGTVCode.BLUE
+    ),
+    LgIrButtonEntityDescription(
+        key="up", translation_key="up", command_code=LGTVCode.NAV_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="down", translation_key="down", command_code=LGTVCode.NAV_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="left", translation_key="left", command_code=LGTVCode.NAV_LEFT
+    ),
+    LgIrButtonEntityDescription(
+        key="right", translation_key="right", command_code=LGTVCode.NAV_RIGHT
+    ),
+    LgIrButtonEntityDescription(
+        key="ok", translation_key="ok", command_code=LGTVCode.OK
+    ),
+    LgIrButtonEntityDescription(
+        key="back", translation_key="back", command_code=LGTVCode.BACK
+    ),
+    LgIrButtonEntityDescription(
+        key="home", translation_key="home", command_code=LGTVCode.HOME
+    ),
+    LgIrButtonEntityDescription(
+        key="menu", translation_key="menu", command_code=LGTVCode.MENU
+    ),
+    LgIrButtonEntityDescription(
+        key="input", translation_key="input", command_code=LGTVCode.INPUT
+    ),
+    LgIrButtonEntityDescription(
+        key="num_0", translation_key="num_0", command_code=LGTVCode.NUM_0
+    ),
+    LgIrButtonEntityDescription(
+        key="num_1", translation_key="num_1", command_code=LGTVCode.NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="num_2", translation_key="num_2", command_code=LGTVCode.NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="num_3", translation_key="num_3", command_code=LGTVCode.NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="num_4", translation_key="num_4", command_code=LGTVCode.NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="num_5", translation_key="num_5", command_code=LGTVCode.NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="num_6", translation_key="num_6", command_code=LGTVCode.NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="num_7", translation_key="num_7", command_code=LGTVCode.NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="num_8", translation_key="num_8", command_code=LGTVCode.NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="num_9", translation_key="num_9", command_code=LGTVCode.NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_up", translation_key="channel_up", command_code=LGTVCode.CHANNEL_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_down", translation_key="channel_down", command_code=LGTVCode.CHANNEL_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_up", translation_key="volume_up", command_code=LGTVCode.VOLUME_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_down", translation_key="volume_down", command_code=LGTVCode.VOLUME_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="mute", translation_key="mute", command_code=LGTVCode.MUTE
+    ),
+    LgIrButtonEntityDescription(
+        key="sap", translation_key="sap", command_code=LGTVCode.SAP
+    ),
+    LgIrButtonEntityDescription(
+        key="subtitle", translation_key="subtitle", command_code=LGTVCode.SUBTITLE
+    ),
+)
+
+TV_JAPAN_BUTTON_DESCRIPTIONS: tuple[LgIrButtonEntityDescription, ...] = (
+    LgIrButtonEntityDescription(
+        key="power", translation_key="power", command_code=LGTVCodeJP.POWER
+    ),
+    LgIrButtonEntityDescription(
+        key="power_on", translation_key="power_on", command_code=LGTVCodeJP.POWER_ON
+    ),
+    LgIrButtonEntityDescription(
+        key="power_off", translation_key="power_off", command_code=LGTVCodeJP.POWER_OFF
+    ),
+    LgIrButtonEntityDescription(
+        key="tv", translation_key="tv", command_code=LGTVCodeJP.TV
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv", translation_key="dtv", command_code=LGTVCodeJP.DTV
+    ),
+    LgIrButtonEntityDescription(
+        key="bs", translation_key="bs", command_code=LGTVCodeJP.BS
+    ),
+    LgIrButtonEntityDescription(
+        key="cs", translation_key="cs", command_code=LGTVCodeJP.CS
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_1", translation_key="hdmi_1", command_code=LGTVCodeJP.HDMI_1
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_2", translation_key="hdmi_2", command_code=LGTVCodeJP.HDMI_2
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_3", translation_key="hdmi_3", command_code=LGTVCodeJP.HDMI_3
+    ),
+    LgIrButtonEntityDescription(
+        key="hdmi_4", translation_key="hdmi_4", command_code=LGTVCodeJP.HDMI_4
+    ),
+    LgIrButtonEntityDescription(
+        key="aspect", translation_key="aspect", command_code=LGTVCodeJP.ASPECT
+    ),
+    LgIrButtonEntityDescription(
+        key="exit", translation_key="exit", command_code=LGTVCodeJP.EXIT
+    ),
+    LgIrButtonEntityDescription(
+        key="info", translation_key="info", command_code=LGTVCodeJP.INFO
+    ),
+    LgIrButtonEntityDescription(
+        key="guide", translation_key="guide", command_code=LGTVCodeJP.GUIDE
+    ),
+    LgIrButtonEntityDescription(
+        key="settings", translation_key="settings", command_code=LGTVCodeJP.SETTINGS
+    ),
+    LgIrButtonEntityDescription(
+        key="list", translation_key="list", command_code=LGTVCodeJP.LIST
+    ),
+    LgIrButtonEntityDescription(
+        key="data", translation_key="data", command_code=LGTVCodeJP.DATA
+    ),
+    LgIrButtonEntityDescription(
+        key="yellow", translation_key="yellow", command_code=LGTVCodeJP.YELLOW
+    ),
+    LgIrButtonEntityDescription(
+        key="green", translation_key="green", command_code=LGTVCodeJP.GREEN
+    ),
+    LgIrButtonEntityDescription(
+        key="red", translation_key="red", command_code=LGTVCodeJP.RED
+    ),
+    LgIrButtonEntityDescription(
+        key="blue", translation_key="blue", command_code=LGTVCodeJP.BLUE
+    ),
+    LgIrButtonEntityDescription(
+        key="up", translation_key="up", command_code=LGTVCodeJP.NAV_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="down", translation_key="down", command_code=LGTVCodeJP.NAV_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="left", translation_key="left", command_code=LGTVCodeJP.NAV_LEFT
+    ),
+    LgIrButtonEntityDescription(
+        key="right", translation_key="right", command_code=LGTVCodeJP.NAV_RIGHT
+    ),
+    LgIrButtonEntityDescription(
+        key="ok", translation_key="ok", command_code=LGTVCodeJP.OK
+    ),
+    LgIrButtonEntityDescription(
+        key="back", translation_key="back", command_code=LGTVCodeJP.BACK
+    ),
+    LgIrButtonEntityDescription(
+        key="home", translation_key="home", command_code=LGTVCodeJP.HOME
+    ),
+    LgIrButtonEntityDescription(
+        key="menu", translation_key="menu", command_code=LGTVCodeJP.MENU
+    ),
+    LgIrButtonEntityDescription(
+        key="input", translation_key="input", command_code=LGTVCodeJP.INPUT
+    ),
+    LgIrButtonEntityDescription(
+        key="num_1", translation_key="num_1", command_code=LGTVCodeJP.NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="num_2", translation_key="num_2", command_code=LGTVCodeJP.NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="num_3", translation_key="num_3", command_code=LGTVCodeJP.NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="num_4", translation_key="num_4", command_code=LGTVCodeJP.NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="num_5", translation_key="num_5", command_code=LGTVCodeJP.NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="num_6", translation_key="num_6", command_code=LGTVCodeJP.NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="num_7", translation_key="num_7", command_code=LGTVCodeJP.NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="num_8", translation_key="num_8", command_code=LGTVCodeJP.NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="num_9", translation_key="num_9", command_code=LGTVCodeJP.NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="num_10", translation_key="num_10", command_code=LGTVCodeJP.NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="num_11", translation_key="num_11", command_code=LGTVCodeJP.NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="num_12", translation_key="num_12", command_code=LGTVCodeJP.NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_1", translation_key="dtv_num_1", command_code=LGTVCodeJP.DTV_NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_2", translation_key="dtv_num_2", command_code=LGTVCodeJP.DTV_NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_3", translation_key="dtv_num_3", command_code=LGTVCodeJP.DTV_NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_4", translation_key="dtv_num_4", command_code=LGTVCodeJP.DTV_NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_5", translation_key="dtv_num_5", command_code=LGTVCodeJP.DTV_NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_6", translation_key="dtv_num_6", command_code=LGTVCodeJP.DTV_NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_7", translation_key="dtv_num_7", command_code=LGTVCodeJP.DTV_NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_8", translation_key="dtv_num_8", command_code=LGTVCodeJP.DTV_NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_9", translation_key="dtv_num_9", command_code=LGTVCodeJP.DTV_NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_10", translation_key="dtv_num_10", command_code=LGTVCodeJP.DTV_NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_11", translation_key="dtv_num_11", command_code=LGTVCodeJP.DTV_NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="dtv_num_12", translation_key="dtv_num_12", command_code=LGTVCodeJP.DTV_NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_1", translation_key="bs_num_1", command_code=LGTVCodeJP.BS_NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_2", translation_key="bs_num_2", command_code=LGTVCodeJP.BS_NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_3", translation_key="bs_num_3", command_code=LGTVCodeJP.BS_NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_4", translation_key="bs_num_4", command_code=LGTVCodeJP.BS_NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_5", translation_key="bs_num_5", command_code=LGTVCodeJP.BS_NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_6", translation_key="bs_num_6", command_code=LGTVCodeJP.BS_NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_7", translation_key="bs_num_7", command_code=LGTVCodeJP.BS_NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_8", translation_key="bs_num_8", command_code=LGTVCodeJP.BS_NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_9", translation_key="bs_num_9", command_code=LGTVCodeJP.BS_NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_10", translation_key="bs_num_10", command_code=LGTVCodeJP.BS_NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_11", translation_key="bs_num_11", command_code=LGTVCodeJP.BS_NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="bs_num_12", translation_key="bs_num_12", command_code=LGTVCodeJP.BS_NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_1", translation_key="cs_num_1", command_code=LGTVCodeJP.CS_NUM_1
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_2", translation_key="cs_num_2", command_code=LGTVCodeJP.CS_NUM_2
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_3", translation_key="cs_num_3", command_code=LGTVCodeJP.CS_NUM_3
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_4", translation_key="cs_num_4", command_code=LGTVCodeJP.CS_NUM_4
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_5", translation_key="cs_num_5", command_code=LGTVCodeJP.CS_NUM_5
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_6", translation_key="cs_num_6", command_code=LGTVCodeJP.CS_NUM_6
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_7", translation_key="cs_num_7", command_code=LGTVCodeJP.CS_NUM_7
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_8", translation_key="cs_num_8", command_code=LGTVCodeJP.CS_NUM_8
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_9", translation_key="cs_num_9", command_code=LGTVCodeJP.CS_NUM_9
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_10", translation_key="cs_num_10", command_code=LGTVCodeJP.CS_NUM_10
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_11", translation_key="cs_num_11", command_code=LGTVCodeJP.CS_NUM_11
+    ),
+    LgIrButtonEntityDescription(
+        key="cs_num_12", translation_key="cs_num_12", command_code=LGTVCodeJP.CS_NUM_12
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_up", translation_key="channel_up", command_code=LGTVCodeJP.CHANNEL_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="channel_down", translation_key="channel_down", command_code=LGTVCodeJP.CHANNEL_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_up", translation_key="volume_up", command_code=LGTVCodeJP.VOLUME_UP
+    ),
+    LgIrButtonEntityDescription(
+        key="volume_down", translation_key="volume_down", command_code=LGTVCodeJP.VOLUME_DOWN
+    ),
+    LgIrButtonEntityDescription(
+        key="mute", translation_key="mute", command_code=LGTVCodeJP.MUTE
+    ),
+    LgIrButtonEntityDescription(
+        key="sap", translation_key="sap", command_code=LGTVCodeJP.SAP
+    ),
+    LgIrButtonEntityDescription(
+        key="subtitle", translation_key="subtitle", command_code=LGTVCodeJP.SUBTITLE
+    ),
+    LgIrButtonEntityDescription(
+        key="record", translation_key="record", command_code=LGTVCodeJP.RECORD
+    ),
+    LgIrButtonEntityDescription(
+        key="rec_list", translation_key="rec_list", command_code=LGTVCodeJP.REC_LIST
+    ),
+    
+)
+
+@dataclass(frozen=True)
+class LGCodeset:
+    key: str
+    name: str
+    codes: type[Enum]
+    buttons: tuple[LgIrButtonEntityDescription, ...]
+    has_tuner: bool = False
+    tuner_options: list[str] | None = None
+
+LG_CODESETS: dict[str, LGCodeset] = {
+    "global": LGCodeset(
+        key="global",
+        name="Global",
+        codes=LGTVCode,
+        buttons=TV_BUTTON_DESCRIPTIONS,
+    ),
+    "japan": LGCodeset(
+        key="japan",
+        name="Japan",
+        codes=LGTVCodeJP,
+        buttons=TV_JAPAN_BUTTON_DESCRIPTIONS,
+        has_tuner=True,
+        tuner_options=["DTV", "BS", "CS"],
+    ),
+}

--- a/homeassistant/components/lg_infrared/config_flow.py
+++ b/homeassistant/components/lg_infrared/config_flow.py
@@ -18,7 +18,8 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, DOMAIN, LGDeviceType, CONF_REGION, REGION_GLOBAL, REGION_JAPAN
+from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, DOMAIN, LGDeviceType, CONF_CODESET
+from .codesets import LG_CODESETS
 
 DEVICE_TYPE_NAMES: dict[LGDeviceType, str] = {
     LGDeviceType.TV: "TV",
@@ -56,6 +57,10 @@ class LgIrConfigFlow(ConfigFlow, domain=DOMAIN):
 
             return self.async_create_entry(title=title, data=user_input)
 
+        codeset_options = [
+            {"value": codeset.key, "label": codeset.name}
+            for codeset in LG_CODESETS.values()
+        ]
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -73,11 +78,13 @@ class LgIrConfigFlow(ConfigFlow, domain=DOMAIN):
                             include_entities=emitter_entity_ids,
                         )
                     ),
-                    vol.Required(CONF_REGION, default=REGION_GLOBAL): selector.SelectSelector(
+                    vol.Required(
+                        CONF_CODESET,
+                        default=next(iter(LG_CODESETS)),
+                    ): SelectSelector(
                         SelectSelectorConfig(
-                            options=[REGION_GLOBAL, REGION_JAPAN],
-                            translation_key="region",
-                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            options=codeset_options,
+                            mode=SelectSelectorMode.DROPDOWN,
                         )
                     ),
                 }

--- a/homeassistant/components/lg_infrared/config_flow.py
+++ b/homeassistant/components/lg_infrared/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, DOMAIN, LGDeviceType
+from .const import CONF_DEVICE_TYPE, CONF_INFRARED_ENTITY_ID, DOMAIN, LGDeviceType, CONF_REGION, REGION_GLOBAL, REGION_JAPAN
 
 DEVICE_TYPE_NAMES: dict[LGDeviceType, str] = {
     LGDeviceType.TV: "TV",
@@ -71,6 +71,13 @@ class LgIrConfigFlow(ConfigFlow, domain=DOMAIN):
                         EntitySelectorConfig(
                             domain=INFRARED_DOMAIN,
                             include_entities=emitter_entity_ids,
+                        )
+                    ),
+                    vol.Required(CONF_REGION, default=REGION_GLOBAL): selector.SelectSelector(
+                        SelectSelectorConfig(
+                            options=[REGION_GLOBAL, REGION_JAPAN],
+                            translation_key="region",
+                            mode=selector.SelectSelectorMode.DROPDOWN,
                         )
                     ),
                 }

--- a/homeassistant/components/lg_infrared/const.py
+++ b/homeassistant/components/lg_infrared/const.py
@@ -5,10 +5,13 @@ from enum import StrEnum
 DOMAIN = "lg_infrared"
 CONF_INFRARED_ENTITY_ID = "infrared_entity_id"
 CONF_DEVICE_TYPE = "device_type"
+CONF_CODESET = "codeset"
 
-CONF_REGION = "region"
-REGION_GLOBAL = "global"
-REGION_JAPAN = "japan"
+SIGNAL_LG_TUNER_CHANGED = "lg_ir_tuner_changed"
+
+def tuner_signal(entry_id: str) -> str:
+    """Return signal name for tuner updates for a specific config entry."""
+    return f"{SIGNAL_LG_TUNER_CHANGED}_{entry_id}"
 
 class LGDeviceType(StrEnum):
     """LG device types."""

--- a/homeassistant/components/lg_infrared/const.py
+++ b/homeassistant/components/lg_infrared/const.py
@@ -6,6 +6,9 @@ DOMAIN = "lg_infrared"
 CONF_INFRARED_ENTITY_ID = "infrared_entity_id"
 CONF_DEVICE_TYPE = "device_type"
 
+CONF_REGION = "region"
+REGION_GLOBAL = "global"
+REGION_JAPAN = "japan"
 
 class LGDeviceType(StrEnum):
     """LG device types."""

--- a/homeassistant/components/lg_infrared/entity.py
+++ b/homeassistant/components/lg_infrared/entity.py
@@ -1,8 +1,7 @@
 """Common entity for LG IR integration."""
 
 import logging
-
-from infrared_protocols.codes.lg.tv import LGTVCode, make_command as make_lg_tv_command
+from enum import Enum
 
 from homeassistant.components.infrared import async_send_command
 from homeassistant.config_entries import ConfigEntry
@@ -66,11 +65,13 @@ class LgIrEntity(Entity):
             ir_state is not None and ir_state.state != STATE_UNAVAILABLE
         )
 
-    async def _send_command(self, code: LGTVCode) -> None:
+    async def _send_command(self, code: Enum) -> None:
         """Send an IR command using the LG protocol."""
         await async_send_command(
             self.hass,
             self._infrared_entity_id,
-            make_lg_tv_command(code),
+            code.to_command(),
             context=self._context,
         )
+
+

--- a/homeassistant/components/lg_infrared/models.py
+++ b/homeassistant/components/lg_infrared/models.py
@@ -1,29 +1,29 @@
 """Models for the LG Infrared integration."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-if TYPE_CHECKING:
-    from homeassistant.components.select import SelectEntity
+from .const import tuner_signal
 
-@dataclass
 class LGIRRemoteData:
-    """
-    Shared state container for the LG IR Remote.
-    
-    This object is stored in hass.data and allows buttons and select 
-    entities to stay in sync regarding the current tuner state.
-    """
-    # The source of truth for the tuner (DTV, BS, CS)
-    current_tuner: str = "DTV"
-    
-    # Optional: store a reference to the select entity so buttons 
-    # can trigger a UI refresh if the state changes via a button press.
-    select_entity: SelectEntity | None = None
+    """Handle shared state for LG IR Remote."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Initialize the data object."""
+        self.hass = hass
+        self.entry_id = entry_id
+        self.current_tuner: str = "DTV"
 
     def update_tuner(self, tuner: str) -> None:
-        """Update the tuner state and refresh the UI entity if it exists."""
-        self.current_tuner = tuner.upper()
-        if self.select_entity:
-            self.select_entity.async_write_ha_state()
+        """Update tuner state and notify listeners."""
+        normalized_tuner = tuner.upper()
+        
+        if self.current_tuner == normalized_tuner:
+            return
+            
+        self.current_tuner = normalized_tuner
+        
+        # Fire the signal using our helper
+        async_dispatcher_send(self.hass, tuner_signal(self.entry_id))
+        

--- a/homeassistant/components/lg_infrared/models.py
+++ b/homeassistant/components/lg_infrared/models.py
@@ -1,0 +1,29 @@
+"""Models for the LG Infrared integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from homeassistant.components.select import SelectEntity
+
+@dataclass
+class LGIRRemoteData:
+    """
+    Shared state container for the LG IR Remote.
+    
+    This object is stored in hass.data and allows buttons and select 
+    entities to stay in sync regarding the current tuner state.
+    """
+    # The source of truth for the tuner (DTV, BS, CS)
+    current_tuner: str = "DTV"
+    
+    # Optional: store a reference to the select entity so buttons 
+    # can trigger a UI refresh if the state changes via a button press.
+    select_entity: SelectEntity | None = None
+
+    def update_tuner(self, tuner: str) -> None:
+        """Update the tuner state and refresh the UI entity if it exists."""
+        self.current_tuner = tuner.upper()
+        if self.select_entity:
+            self.select_entity.async_write_ha_state()

--- a/homeassistant/components/lg_infrared/select.py
+++ b/homeassistant/components/lg_infrared/select.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, CONF_INFRARED_ENTITY_ID, CONF_REGION, REGION_JAPAN
+from .entity import LgIrEntity
+from .models import LGIRRemoteData
+from infrared_protocols.codes.lg.tv import LGTVCodeJP
+
+TUNER_COMMANDS: dict[str, LGTVCodeJP] = {
+    "DTV": LGTVCodeJP.DTV,
+    "BS": LGTVCodeJP.BS,
+    "CS": LGTVCodeJP.CS,
+}
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the LG IR select entities."""
+    if entry.data.get(CONF_REGION) != REGION_JAPAN:
+        return
+
+    data: LGIRRemoteData = hass.data[DOMAIN][entry.entry_id]
+    
+    infrared_entity_id = entry.data[CONF_INFRARED_ENTITY_ID]
+    async_add_entities([LGTVTunerSelect(data, entry, infrared_entity_id)])
+
+class LGTVTunerSelect(LgIrEntity, SelectEntity):
+    """Representation of the tuner selection for Japanese LG TVs."""
+
+    _attr_options = ["DTV", "BS", "CS"]
+    _attr_has_entity_name = True
+    _attr_translation_key = "tuner_select"
+
+    def __init__(self, data: LGIRRemoteData, entry: ConfigEntry, infrared_entity_id: str) -> None:
+        """Initialize the select entity."""
+        super().__init__(entry, infrared_entity_id, unique_id_suffix="tuner_select")
+        self._data = data
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+        }
+        
+        # Link this UI entity back to the data object
+        self._data.select_entity = self
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option from the shared state."""
+        return self._data.current_tuner
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option and send the IR command."""
+        option_upper = option.upper()
+        self._data.update_tuner(option_upper)
+        await self._send_command(TUNER_COMMANDS[option_upper])
+        

--- a/homeassistant/components/lg_infrared/select.py
+++ b/homeassistant/components/lg_infrared/select.py
@@ -1,51 +1,57 @@
+"""LG IR tuner select entity (Japan only)."""
 from __future__ import annotations
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN, CONF_INFRARED_ENTITY_ID, CONF_REGION, REGION_JAPAN
+from .const import DOMAIN, CONF_INFRARED_ENTITY_ID, CONF_CODESET, tuner_signal
 from .entity import LgIrEntity
 from .models import LGIRRemoteData
-from infrared_protocols.codes.lg.tv import LGTVCodeJP
+from .codesets import LG_CODESETS, LGCodeset
 
-TUNER_COMMANDS: dict[str, LGTVCodeJP] = {
-    "DTV": LGTVCodeJP.DTV,
-    "BS": LGTVCodeJP.BS,
-    "CS": LGTVCodeJP.CS,
-}
+import logging
+_LOGGER = logging.getLogger(__name__)
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the LG IR select entities."""
-    if entry.data.get(CONF_REGION) != REGION_JAPAN:
+
+    # Does codeset support tuner?
+    codeset_key = entry.data.get(CONF_CODESET)
+    codeset_def = LG_CODESETS.get(codeset_key)
+    if not codeset_def or not codeset_def.has_tuner:
         return
 
     data: LGIRRemoteData = hass.data[DOMAIN][entry.entry_id]
     
     infrared_entity_id = entry.data[CONF_INFRARED_ENTITY_ID]
-    async_add_entities([LGTVTunerSelect(data, entry, infrared_entity_id)])
+    async_add_entities([LGTVTunerSelect(data, entry, infrared_entity_id,codeset_def)])
 
 class LGTVTunerSelect(LgIrEntity, SelectEntity):
     """Representation of the tuner selection for Japanese LG TVs."""
 
-    _attr_options = ["DTV", "BS", "CS"]
     _attr_has_entity_name = True
     _attr_translation_key = "tuner_select"
 
-    def __init__(self, data: LGIRRemoteData, entry: ConfigEntry, infrared_entity_id: str) -> None:
+    def __init__(self, data: LGIRRemoteData, entry: ConfigEntry, infrared_entity_id: str, codeset_def: LGCodeset) -> None:
         """Initialize the select entity."""
         super().__init__(entry, infrared_entity_id, unique_id_suffix="tuner_select")
+        self._codeset_def = codeset_def
         self._data = data
+        if codeset_def.tuner_options:
+            self._attr_options = codeset_def.tuner_options
+        else:
+            self._attr_options = []
+        self._entry_id = entry.entry_id
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.entry_id)},
         }
-        
-        # Link this UI entity back to the data object
-        self._data.select_entity = self
 
     @property
     def current_option(self) -> str | None:
@@ -53,8 +59,23 @@ class LGTVTunerSelect(LgIrEntity, SelectEntity):
         return self._data.current_tuner
 
     async def async_select_option(self, option: str) -> None:
-        """Change the selected option and send the IR command."""
-        option_upper = option.upper()
-        self._data.update_tuner(option_upper)
-        await self._send_command(TUNER_COMMANDS[option_upper])
+        command = getattr(self._codeset_def.codes, option.upper(), None)      
+        if command:
+            await self._send_command(command)
+            self._data.update_tuner(option.upper()) # Sync state for numeric keys
+        else:
+            _LOGGER.warning("Tuner option %s has no corresponding IR code in %s", option, self._codeset_def.name)
+    
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass."""
+        await super().async_added_to_hass()
+
+        # Connect to the tuner signal with automatic cleanup
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                tuner_signal(self._entry_id),
+                self.async_write_ha_state,
+            )
+        )
         

--- a/homeassistant/components/lg_infrared/strings.json
+++ b/homeassistant/components/lg_infrared/strings.json
@@ -35,6 +35,42 @@
       "bs": {
         "name": "BS"
       },
+      "bs_num_1": {
+        "name": "BS 1"
+      },
+      "bs_num_2": {
+        "name": "BS 2"
+      },
+      "bs_num_3": {
+        "name": "BS 3"
+      },
+      "bs_num_4": {
+        "name": "BS 4"
+      },
+      "bs_num_5": {
+        "name": "BS 5"
+      },
+      "bs_num_6": {
+        "name": "BS 6"
+      },
+      "bs_num_7": {
+        "name": "BS 7"
+      },
+      "bs_num_8": {
+        "name": "BS 8"
+      },
+      "bs_num_9": {
+        "name": "BS 9"
+      },
+      "bs_num_10": {
+        "name": "BS 10"
+      },
+      "bs_num_11": {
+        "name": "BS 11"
+      },
+      "bs_num_12": {
+        "name": "BS 12"
+      },
       "channel_down": {
         "name": "Channel down"
       },
@@ -44,11 +80,83 @@
       "cs": {
         "name": "CS"
       },
+      "cs_num_1": {
+        "name": "CS 1"
+      },
+      "cs_num_2": {
+        "name": "CS 2"
+      },
+      "cs_num_3": {
+        "name": "CS 3"
+      },
+      "cs_num_4": {
+        "name": "CS 4"
+      },
+      "cs_num_5": {
+        "name": "CS 5"
+      },
+      "cs_num_6": {
+        "name": "CS 6"
+      },
+      "cs_num_7": {
+        "name": "CS 7"
+      },
+      "cs_num_8": {
+        "name": "CS 8"
+      },
+      "cs_num_9": {
+        "name": "CS 9"
+      },
+      "cs_num_10": {
+        "name": "CS 10"
+      },
+      "cs_num_11": {
+        "name": "CS 11"
+      },
+      "cs_num_12": {
+        "name": "CS 12"
+      },
       "down": {
         "name": "Down"
       },
       "dtv": {
         "name": "DTV"
+      },
+      "dtv_num_1": {
+        "name": "DTV 1"
+      },
+      "dtv_num_2": {
+        "name": "DTV 2"
+      },
+      "dtv_num_3": {
+        "name": "DTV 3"
+      },
+      "dtv_num_4": {
+        "name": "DTV 4"
+      },
+      "dtv_num_5": {
+        "name": "DTV 5"
+      },
+      "dtv_num_6": {
+        "name": "DTV 6"
+      },
+      "dtv_num_7": {
+        "name": "DTV 7"
+      },
+      "dtv_num_8": {
+        "name": "DTV 8"
+      },
+      "dtv_num_9": {
+        "name": "DTV 9"
+      },
+      "dtv_num_10": {
+        "name": "DTV 10"
+      },
+      "dtv_num_11": {
+        "name": "DTV 11"
+      },
+      "dtv_num_12": {
+        "name": "DTV 12"
       },
       "exit": {
         "name": "Exit"
@@ -169,6 +277,9 @@
       },
       "text": {
         "name": "Teletext"
+      },
+      "data": {
+        "name": "d Button"
       },
       "tv": {
         "name": "TV"

--- a/homeassistant/components/lg_infrared/strings.json
+++ b/homeassistant/components/lg_infrared/strings.json
@@ -35,6 +35,12 @@
       "bs": {
         "name": "BS"
       },
+      "channel_down": {
+        "name": "Channel down"
+      },
+      "channel_up": {
+        "name": "Channel up"
+      },
       "cs": {
         "name": "CS"
       },
@@ -86,6 +92,9 @@
       "menu": {
         "name": "Menu"
       },
+      "mute": {
+        "name": "Mute"
+      },
       "num_0": {
         "name": "Number 0"
       },
@@ -128,6 +137,9 @@
       "ok": {
         "name": "OK"
       },
+      "power": {
+        "name": "Power toggle"
+      },
       "power_off": {
         "name": "Power off"
       },
@@ -163,6 +175,12 @@
       },
       "up": {
         "name": "Up"
+      },
+      "volume_down": {
+        "name": "Volume down"
+      },
+      "volume_up": {
+        "name": "Volume up"
       },
       "yellow": {
         "name": "Yellow"

--- a/homeassistant/components/lg_infrared/strings.json
+++ b/homeassistant/components/lg_infrared/strings.json
@@ -22,6 +22,11 @@
     }
   },
   "entity": {
+    "select": {
+      "tuner_select": {
+        "name": "Current Tuner"
+      }
+    },    
     "button": {
       "aspect": {
         "name": "Aspect"

--- a/homeassistant/components/lg_infrared/strings.json
+++ b/homeassistant/components/lg_infrared/strings.json
@@ -8,11 +8,13 @@
       "user": {
         "data": {
           "device_type": "Device type",
-          "infrared_entity_id": "Infrared transmitter"
+          "infrared_entity_id": "Infrared transmitter",
+          "region": "Region"
         },
         "data_description": {
           "device_type": "The type of LG device to control.",
-          "infrared_entity_id": "The infrared transmitter entity to use for sending commands."
+          "infrared_entity_id": "The infrared transmitter entity to use for sending commands.",
+          "region": "The regional model of the LG device."
         },
         "description": "Select the device type and the infrared transmitter entity to use for controlling your LG device.",
         "title": "Set up LG IR Remote"
@@ -21,14 +23,35 @@
   },
   "entity": {
     "button": {
+      "aspect": {
+        "name": "Aspect"
+      },
       "back": {
         "name": "Back"
+      },
+      "blue": {
+        "name": "Blue"
+      },
+      "bs": {
+        "name": "BS"
+      },
+      "cs": {
+        "name": "CS"
       },
       "down": {
         "name": "Down"
       },
+      "dtv": {
+        "name": "DTV"
+      },
       "exit": {
         "name": "Exit"
+      },
+      "fourk": {
+        "name": "4K"
+      },
+      "green": {
+        "name": "Green"
       },
       "guide": {
         "name": "Guide"
@@ -56,6 +79,9 @@
       },
       "left": {
         "name": "Left"
+      },
+      "list": {
+        "name": "List"
       },
       "menu": {
         "name": "Menu"
@@ -90,6 +116,15 @@
       "num_9": {
         "name": "Number 9"
       },
+      "num_10": {
+        "name": "Number 10"
+      },
+      "num_11": {
+        "name": "Number 11"
+      },
+      "num_12": {
+        "name": "Number 12"
+      },
       "ok": {
         "name": "OK"
       },
@@ -99,11 +134,38 @@
       "power_on": {
         "name": "Power on"
       },
+      "rec_list": {
+        "name": "Recording list"
+      },
+      "record": {
+        "name": "Record"
+      },
+      "red": {
+        "name": "Red"
+      },
       "right": {
         "name": "Right"
       },
+      "sap": {
+        "name": "SAP"
+      },
+      "settings": {
+        "name": "Quick settings"
+      },
+      "subtitle": {
+        "name": "Subtitle"
+      },
+      "text": {
+        "name": "Teletext"
+      },
+      "tv": {
+        "name": "TV"
+      },
       "up": {
         "name": "Up"
+      },
+      "yellow": {
+        "name": "Yellow"
       }
     }
   },
@@ -111,6 +173,12 @@
     "device_type": {
       "options": {
         "tv": "TV"
+      }
+    },
+    "region": {
+      "options": {
+        "global": "Global",
+        "japan": "Japan"
       }
     }
   }

--- a/homeassistant/components/lg_infrared/strings.json
+++ b/homeassistant/components/lg_infrared/strings.json
@@ -9,12 +9,12 @@
         "data": {
           "device_type": "Device type",
           "infrared_entity_id": "Infrared transmitter",
-          "region": "Region"
+          "codeset": "Codeset"
         },
         "data_description": {
           "device_type": "The type of LG device to control.",
           "infrared_entity_id": "The infrared transmitter entity to use for sending commands.",
-          "region": "The regional model of the LG device."
+          "codeset": "The codeset of the LG device."
         },
         "description": "Select the device type and the infrared transmitter entity to use for controlling your LG device.",
         "title": "Set up LG IR Remote"
@@ -75,6 +75,9 @@
       },
       "bs_num_12": {
         "name": "BS 12"
+      },
+      "bs4k": {
+        "name": "4K"
       },
       "channel_down": {
         "name": "Channel down"
@@ -165,9 +168,6 @@
       },
       "exit": {
         "name": "Exit"
-      },
-      "fourk": {
-        "name": "4K"
       },
       "green": {
         "name": "Green"
@@ -309,7 +309,7 @@
         "tv": "TV"
       }
     },
-    "region": {
+    "codeset": {
       "options": {
         "global": "Global",
         "japan": "Japan"


### PR DESCRIPTION
@abmantis I have made changes to support the Japanese LG TV. I have ordered the SEEED IR blaster, but it will take a while for it to arrive so I have not done any testing yet. I just wanted to give you a heads-up of what I plan to submit.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Often multiple codesets exist for a device type like LG TV. The change will (1) allow the choice of the region GLOABL or JAPAN when setting up the integration to select the proper codeset. (2) introduce current_tuner state to indicate which tuner on the Japanese LG TV is active (3) dynamically map the numerical button to the right IR command for the current tuner.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
