### PR TITLE
Add discovery support to unifi_access via unifi_discovery

### DIFF
--- a/homeassistant/components/unifi_access/config_flow.py
+++ b/homeassistant/components/unifi_access/config_flow.py
@@ -9,9 +9,10 @@ from typing import Any
 from unifi_access_api import ApiAuthError, ApiConnectionError, UnifiAccessApiClient
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import SOURCE_IGNORE, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_VERIFY_SSL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.util.ssl import create_no_verify_ssl_context
 
 from .const import DOMAIN
@@ -24,6 +25,11 @@ class UnifiAccessConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     MINOR_VERSION = 1
+
+    def __init__(self) -> None:
+        """Init the config flow."""
+        super().__init__()
+        self._discovered_device: dict[str, Any] = {}
 
     async def _validate_input(self, user_input: dict[str, Any]) -> dict[str, str]:
         """Validate user input and return errors dict."""
@@ -114,6 +120,66 @@ class UnifiAccessConfigFlow(ConfigFlow, domain=DOMAIN):
                 ),
                 suggested_values,
             ),
+            errors=errors,
+        )
+
+    async def async_step_integration_discovery(
+        self, discovery_info: DiscoveryInfoType
+    ) -> ConfigFlowResult:
+        """Handle discovery via unifi_discovery."""
+        self._discovered_device = discovery_info
+        source_ip = discovery_info["source_ip"]
+        mac = discovery_info["hw_addr"].replace(":", "").upper()
+        await self.async_set_unique_id(mac)
+        for entry in self._async_current_entries():
+            if entry.source == SOURCE_IGNORE:
+                continue
+            if entry.data.get(CONF_HOST) == source_ip:
+                if not entry.unique_id:
+                    self.hass.config_entries.async_update_entry(entry, unique_id=mac)
+                return self.async_abort(reason="already_configured")
+        self._abort_if_unique_id_configured(updates={CONF_HOST: source_ip})
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm discovery and collect API token."""
+        errors: dict[str, str] = {}
+        discovery_info = self._discovered_device
+        source_ip = discovery_info["source_ip"]
+
+        if user_input is not None:
+            merged_input = {
+                CONF_HOST: source_ip,
+                CONF_API_TOKEN: user_input[CONF_API_TOKEN],
+                CONF_VERIFY_SSL: user_input.get(CONF_VERIFY_SSL, False),
+            }
+            errors = await self._validate_input(merged_input)
+            if not errors:
+                return self.async_create_entry(
+                    title="UniFi Access",
+                    data=merged_input,
+                )
+
+        name = discovery_info.get("hostname") or discovery_info.get("platform")
+        if not name:
+            short_mac = discovery_info["hw_addr"].replace(":", "").upper()[-6:]
+            name = f"Access {short_mac}"
+        placeholders = {
+            "name": name,
+            "ip_address": source_ip,
+        }
+        self.context["title_placeholders"] = placeholders
+        return self.async_show_form(
+            step_id="discovery_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_API_TOKEN): str,
+                    vol.Required(CONF_VERIFY_SSL, default=False): bool,
+                }
+            ),
+            description_placeholders=placeholders,
             errors=errors,
         )
 

--- a/homeassistant/components/unifi_access/manifest.json
+++ b/homeassistant/components/unifi_access/manifest.json
@@ -3,6 +3,7 @@
   "name": "UniFi Access",
   "codeowners": ["@imhotep", "@RaHehl"],
   "config_flow": true,
+  "dependencies": ["unifi_discovery"],
   "documentation": "https://www.home-assistant.io/integrations/unifi_access",
   "integration_type": "hub",
   "iot_class": "local_push",

--- a/homeassistant/components/unifi_access/quality_scale.yaml
+++ b/homeassistant/components/unifi_access/quality_scale.yaml
@@ -42,8 +42,10 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info: todo
-  discovery: todo
+  discovery-update-info: done
+  discovery:
+    status: exempt
+    comment: Discovery is handled via unifi_discovery dependency using SOURCE_INTEGRATION_DISCOVERY.
   docs-data-update: done
   docs-examples: done
   docs-known-limitations: done

--- a/homeassistant/components/unifi_access/strings.json
+++ b/homeassistant/components/unifi_access/strings.json
@@ -12,6 +12,17 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "discovery_confirm": {
+        "data": {
+          "api_token": "[%key:common::config_flow::data::api_token%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "api_token": "[%key:component::unifi_access::config::step::user::data_description::api_token%]",
+          "verify_ssl": "[%key:component::unifi_access::config::step::user::data_description::verify_ssl%]"
+        },
+        "description": "A UniFi Access controller was discovered at {ip_address} ({name})."
+      },
       "reauth_confirm": {
         "data": {
           "api_token": "[%key:common::config_flow::data::api_token%]"

--- a/homeassistant/components/unifi_discovery/const.py
+++ b/homeassistant/components/unifi_discovery/const.py
@@ -9,4 +9,5 @@ DOMAIN = "unifi_discovery"
 # when initial discovery runs — the same pattern DHCP/SSDP use with manifest matchers.
 CONSUMER_MAPPING: dict[UnifiService, str] = {
     UnifiService.Protect: "unifiprotect",
+    UnifiService.Access: "unifi_access",
 }

--- a/tests/components/unifi_access/conftest.py
+++ b/tests/components/unifi_access/conftest.py
@@ -13,6 +13,7 @@ from unifi_access_api import (
     DoorPositionStatus,
     EmergencyStatus,
 )
+from unifi_discovery import AIOUnifiScanner
 
 from homeassistant.components.unifi_access.const import DOMAIN
 from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_VERIFY_SSL
@@ -27,6 +28,19 @@ MOCK_API_TOKEN = "test-api-token-12345"
 
 
 MOCK_ENTRY_ID = "mock-unifi-access-entry-id"
+
+
+@pytest.fixture(autouse=True)
+def mock_discovery() -> Generator[None]:
+    """Prevent real network scanning in all unifi_access tests."""
+    mock_aio_discovery = MagicMock(spec=AIOUnifiScanner)
+    mock_aio_discovery.async_scan = AsyncMock(return_value=[])
+    mock_aio_discovery.found_devices = []
+    with patch(
+        "homeassistant.components.unifi_discovery.discovery.AIOUnifiScanner",
+        return_value=mock_aio_discovery,
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/unifi_access/test_config_flow.py
+++ b/tests/components/unifi_access/test_config_flow.py
@@ -832,3 +832,27 @@ async def test_discovery_ignored_entry(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_discovery_fallback_name_from_mac(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test discovery confirm uses MAC-based name when hostname and platform are absent."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data={
+            "source_ip": "10.0.0.5",
+            "hw_addr": "aa:bb:cc:dd:ee:ff",
+            "hostname": None,
+            "platform": None,
+            "services": {"Access": True},
+            "direct_connect_domain": "x.ui.direct",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+    assert result["description_placeholders"]["name"] == "Access DDEEFF"

--- a/tests/components/unifi_access/test_config_flow.py
+++ b/tests/components/unifi_access/test_config_flow.py
@@ -9,7 +9,11 @@ import pytest
 from unifi_access_api import ApiAuthError, ApiConnectionError
 
 from homeassistant.components.unifi_access.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import (
+    SOURCE_IGNORE,
+    SOURCE_INTEGRATION_DISCOVERY,
+    SOURCE_USER,
+)
 from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -572,3 +576,259 @@ async def test_reconfigure_flow_protect_api_key(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+DISCOVERY_INFO = {
+    "source_ip": "10.0.0.5",
+    "hw_addr": "aa:bb:cc:dd:ee:ff",
+    "hostname": "unvr",
+    "platform": "unvr",
+    "services": {"Protect": True, "Access": True},
+    "direct_connect_domain": "x.ui.direct",
+}
+
+
+async def test_discovery_new_device(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test integration discovery shows confirm form for new device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+
+async def test_discovery_confirm_success(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test successful discovery confirm creates entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "UniFi Access"
+    assert result["data"] == {
+        CONF_HOST: "10.0.0.5",
+        CONF_API_TOKEN: MOCK_API_TOKEN,
+        CONF_VERIFY_SSL: False,
+    }
+
+
+async def test_discovery_confirm_errors(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test discovery confirm handles errors and recovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    mock_client.authenticate.side_effect = ApiConnectionError("Connection failed")
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_API_TOKEN: "bad-token",
+            CONF_VERIFY_SSL: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    mock_client.authenticate.side_effect = ApiAuthError()
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_API_TOKEN: "bad-token",
+            CONF_VERIFY_SSL: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_client.authenticate.side_effect = RuntimeError("boom")
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_API_TOKEN: "bad-token",
+            CONF_VERIFY_SSL: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+    mock_client.authenticate.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_discovery_already_configured_by_host(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test discovery aborts when host is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "10.0.0.5",
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_discovery_updates_host_for_known_mac(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test discovery updates host when MAC matches but IP changed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="AABBCCDDEEFF",
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == "10.0.0.5"
+
+
+async def test_discovery_sets_unique_id_on_manual_entry(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test discovery adds unique_id (MAC) to manually configured entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "10.0.0.5",
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert entry.unique_id is None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.unique_id == "AABBCCDDEEFF"
+
+
+async def test_discovery_already_configured_by_host_with_unique_id(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test discovery is a no-op when entry already has unique_id and matching IP."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="AABBCCDDEEFF",
+        data={
+            CONF_HOST: "10.0.0.5",
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.unique_id == "AABBCCDDEEFF"
+    assert entry.data[CONF_HOST] == "10.0.0.5"
+
+
+async def test_discovery_ignored_entry(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test discovery aborts when ignored entry with same unique_id exists."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_IGNORE,
+        unique_id="AABBCCDDEEFF",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Add integration discovery support to `unifi_access` via the `unifi_discovery` dependency.

When `unifi_discovery` scans the network and finds a UniFi device with the `Access` service, it now fires an `integration_discovery` flow for `unifi_access`. The user is shown a confirmation form with the discovered IP and device name, and only needs to enter the API token to complete setup.

Additionally:
- Existing entries without a `unique_id` (manually configured) get their MAC address added automatically when the device is discovered
- Existing entries with a known MAC but a changed IP get their host updated automatically (`discovery-update-info`)
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
