### PR TITLE
Update Z-Wave cover moving state based on current position and cover capabilities

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -47,8 +47,6 @@ from .entity import ZWaveBaseEntity
 from .models import ZwaveJSConfigEntry
 
 PARALLEL_UPDATES = 0
-FULLY_CLOSED_COVER_POSITION = 0
-FULLY_OPEN_COVER_POSITION = 100
 
 
 async def async_setup_entry(
@@ -497,13 +495,20 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
+        # Check before issuing the command in case targetValue report arrives early.
+        already_open = (
+            (cv := self._current_position_value) is not None
+            and cv.value is not None
+            and (tpv := self._target_position_value) is not None
+            and tpv.value == cv.value == 99
+        )
         result = await self._async_set_value(self._up_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction
         if (
             result is not None
             and result.status in SET_VALUE_SUCCESS
             and self.supported_features & CoverEntityFeature.SET_POSITION
-            and self.current_cover_position not in (None, FULLY_OPEN_COVER_POSITION)
+            and not already_open
         ):
             self._attr_is_opening = True
             self._attr_is_closing = False
@@ -511,13 +516,20 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
+        # Check before issuing the command in case targetValue report arrives early.
+        already_closed = (
+            (cv := self._current_position_value) is not None
+            and cv.value is not None
+            and (tpv := self._target_position_value) is not None
+            and tpv.value == cv.value == 0
+        )
         result = await self._async_set_value(self._down_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction
         if (
             result is not None
             and result.status in SET_VALUE_SUCCESS
             and self.supported_features & CoverEntityFeature.SET_POSITION
-            and self.current_cover_position not in (None, FULLY_CLOSED_COVER_POSITION)
+            and not already_closed
         ):
             self._attr_is_opening = False
             self._attr_is_closing = True

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -47,6 +47,8 @@ from .entity import ZWaveBaseEntity
 from .models import ZwaveJSConfigEntry
 
 PARALLEL_UPDATES = 0
+FULLY_CLOSED_COVER_POSITION = 0
+FULLY_OPEN_COVER_POSITION = 100
 
 
 async def async_setup_entry(
@@ -497,7 +499,12 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
         """Open the cover."""
         result = await self._async_set_value(self._up_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction
-        if result is not None and result.status in SET_VALUE_SUCCESS:
+        if (
+            result is not None
+            and result.status in SET_VALUE_SUCCESS
+            and self.supported_features & CoverEntityFeature.SET_POSITION
+            and self.current_cover_position not in (None, FULLY_OPEN_COVER_POSITION)
+        ):
             self._attr_is_opening = True
             self._attr_is_closing = False
             self.async_write_ha_state()
@@ -506,7 +513,12 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
         """Close the cover."""
         result = await self._async_set_value(self._down_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction
-        if result is not None and result.status in SET_VALUE_SUCCESS:
+        if (
+            result is not None
+            and result.status in SET_VALUE_SUCCESS
+            and self.supported_features & CoverEntityFeature.SET_POSITION
+            and self.current_cover_position not in (None, FULLY_CLOSED_COVER_POSITION)
+        ):
             self._attr_is_opening = False
             self._attr_is_closing = True
             self.async_write_ha_state()

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -500,7 +500,7 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
             (cv := self._current_position_value) is not None
             and cv.value is not None
             and (tpv := self._target_position_value) is not None
-            and tpv.value == cv.value == 99
+            and tpv.value == cv.value == self._fully_open_position
         )
         result = await self._async_set_value(self._up_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction
@@ -521,7 +521,7 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
             (cv := self._current_position_value) is not None
             and cv.value is not None
             and (tpv := self._target_position_value) is not None
-            and tpv.value == cv.value == 0
+            and tpv.value == cv.value == self._fully_closed_position
         )
         result = await self._async_set_value(self._down_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -1959,6 +1959,26 @@ async def test_window_covering_cover_moving_state_position_support(
                     "commandClassName": "Window Covering",
                     "commandClass": 106,
                     "endpoint": 0,
+                    "property": "targetValue",
+                    "propertyKey": 13,
+                    "newValue": 99,
+                    "prevValue": 52,
+                    "propertyName": "targetValue",
+                },
+            },
+        )
+    )
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
                     "property": "currentValue",
                     "propertyKey": 13,
                     "newValue": 99,
@@ -2011,10 +2031,30 @@ async def test_window_covering_cover_moving_state_position_support(
                     "commandClassName": "Window Covering",
                     "commandClass": 106,
                     "endpoint": 0,
+                    "property": "targetValue",
+                    "propertyKey": 13,
+                    "newValue": 0,
+                    "prevValue": 99,
+                    "propertyName": "targetValue",
+                },
+            },
+        )
+    )
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
                     "property": "currentValue",
                     "propertyKey": 13,
                     "newValue": 0,
-                    "prevValue": 52,
+                    "prevValue": 99,
                     "propertyName": "currentValue",
                 },
             },
@@ -2032,6 +2072,126 @@ async def test_window_covering_cover_moving_state_position_support(
     )
     state = hass.states.get(entity_id)
     assert state.state not in (CoverState.OPENING, CoverState.CLOSING)
+
+    # From fully closed, open_cover SHOULD set OPENING (not at fully open endpoint).
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.OPENING
+
+    # Simulate the device moving: targetValue arrives first (early report), then
+    # currentValue catches up to halfway. Moving state must stay OPENING throughout.
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
+                    "property": "targetValue",
+                    "propertyKey": 13,
+                    "newValue": 99,
+                    "prevValue": 0,
+                    "propertyName": "targetValue",
+                },
+            },
+        )
+    )
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "propertyKey": 13,
+                    "newValue": 52,
+                    "prevValue": 0,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.OPENING
+
+    # Reverse halfway: close_cover while mid-travel MUST set CLOSING (not at endpoint).
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.CLOSING
+
+    # Simulate the device moving back down: targetValue=0 arrives first (early report),
+    # then currentValue reaches halfway. Moving state must stay CLOSING throughout.
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
+                    "property": "targetValue",
+                    "propertyKey": 13,
+                    "newValue": 0,
+                    "prevValue": 99,
+                    "propertyName": "targetValue",
+                },
+            },
+        )
+    )
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "propertyKey": 13,
+                    "newValue": 52,
+                    "prevValue": 99,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.CLOSING
+
+    # Reverse halfway: open_cover while mid-travel MUST set OPENING (not at endpoint).
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.OPENING
 
 
 async def test_window_covering_cover_moving_state_no_position(

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -67,6 +67,27 @@ def platforms() -> list[str]:
     return [Platform.COVER]
 
 
+@pytest.fixture(name="window_covering_outbound_bottom_no_position")
+def window_covering_outbound_bottom_no_position_fixture(
+    client: MagicMock,
+    window_covering_outbound_bottom_state: dict[str, Any],
+) -> Node:
+    """Load a Window Covering node that does not support setting a position."""
+    node_state = copy.deepcopy(window_covering_outbound_bottom_state)
+    for value in node_state["values"]:
+        if value.get("commandClass") != CommandClass.WINDOW_COVERING:
+            continue
+        if value.get("propertyKey") != 13:
+            continue
+        value["propertyKey"] = 12
+        value["propertyKeyName"] = "Outbound Bottom (no position)"
+        if "metadata" in value and "ccSpecific" in value["metadata"]:
+            value["metadata"]["ccSpecific"]["parameter"] = 12
+    node = Node(client, node_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
 async def test_window_cover(
     hass: HomeAssistant,
     client: MagicMock,
@@ -1896,3 +1917,148 @@ async def test_multilevel_switch_cover_v3_no_moving_state_unsupervised(
     )
     state = hass.states.get(WINDOW_COVER_ENTITY)
     assert state.state == CoverState.CLOSED
+
+
+async def test_window_covering_cover_moving_state_position_support(
+    hass: HomeAssistant,
+    client: MagicMock,
+    window_covering_outbound_bottom: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test moving state is only set when not already at the target endpoint."""
+    node = window_covering_outbound_bottom
+    entity_id = "cover.node_2_outbound_bottom"
+
+    # Initial currentValue is 52 (mid-position). open_cover SHOULD set OPENING.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.OPENING
+
+    # Clear moving state before next scenario.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    # Simulate device reaching fully open (raw Z-Wave value 99 → HA position 100%).
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "propertyKey": 13,
+                    "newValue": 99,
+                    "prevValue": 52,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.OPEN
+
+    # Already fully open — open_cover must NOT set OPENING.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state not in (CoverState.OPENING, CoverState.CLOSING)
+
+    # Fully open but not fully closed — close_cover SHOULD set CLOSING.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.CLOSING
+
+    # Clear moving state before next scenario.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    # Simulate device reaching fully closed (raw Z-Wave value 0 → HA position 0%).
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Window Covering",
+                    "commandClass": 106,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "propertyKey": 13,
+                    "newValue": 0,
+                    "prevValue": 52,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.CLOSED
+
+    # Already fully closed — close_cover must NOT set CLOSING.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state not in (CoverState.OPENING, CoverState.CLOSING)
+
+
+async def test_window_covering_cover_moving_state_no_position(
+    hass: HomeAssistant,
+    client: MagicMock,
+    window_covering_outbound_bottom_no_position: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test that moving state is never set for Window Covering without position support."""
+    entity_id = "cover.node_2_outbound_bottom"
+
+    # No SET_POSITION feature — open_cover must NOT set OPENING.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state not in (CoverState.OPENING, CoverState.CLOSING)
+
+    # No SET_POSITION feature — close_cover must NOT set CLOSING.
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state not in (CoverState.OPENING, CoverState.CLOSING)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ZWaveWindowCovering` used the Open/Close values to open and close all Window Covering CC based covers using StartLevelChange commands. The nature of those commands is that they are considered successful when accepted, no matter if the device has any room left to move. 

Moving state tracking worked the following way:
- when the StartLevelChange command was accepted, we'd set the moving state to OPENING/CLOSING
- when the final position report was received after the device has stopped moving, we'd set the state to OPEN/CLOSED

If the device does not actually move, this final position report is not received. 

This PR decides based on the current state whether the moving state should be updated:
- if it is 0 and we're trying to close -> don't update moving state
- if it is 99 and we're trying to open -> don't update moving state
- if it is unknown (the device is not position aware) -> don't update moving state

The only problem with that approach is if we somehow have the wrong device state, but that problem fixes itself by using the device. The alternative would have been to set the cover position directly, but that breaks down for devices that are not position aware.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167820
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
