### PR TITLE
Deprecate firmware update button in FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/button.py
+++ b/homeassistant/components/fritz/button.py
@@ -194,6 +194,12 @@ class FritzButton(ButtonEntity):
                 "Please update your automations and dashboards to remove any usage of this button. "
                 "The action is now performed automatically at each data refresh",
             )
+        elif self.entity_description.key == "firmware_update":
+            _LOGGER.warning(
+                "The 'firmware update' button is deprecated and will be removed in Home Assistant Core "
+                "2026.11.0. It has been superseded by an update entity. Please update your automations "
+                "and dashboards to remove any usage of this button",
+            )
         await self.entity_description.press_action(self.avm_wrapper)
 
 

--- a/homeassistant/components/fritz/button.py
+++ b/homeassistant/components/fritz/button.py
@@ -45,6 +45,7 @@ BUTTONS: Final = [
         device_class=ButtonDeviceClass.UPDATE,
         entity_category=EntityCategory.CONFIG,
         press_action=lambda avm_wrapper: avm_wrapper.async_trigger_firmware_update(),
+        entity_registry_enabled_default=False,
     ),
     FritzButtonDescription(
         key="reboot",
@@ -96,6 +97,33 @@ def repair_issue_cleanup(hass: HomeAssistant, avm_wrapper: AvmWrapper) -> None:
         )
 
 
+def repair_issue_firmware_update(hass: HomeAssistant, avm_wrapper: AvmWrapper) -> None:
+    """Repair issue for firmware update button."""
+    entity_registry = er.async_get(hass)
+
+    if (
+        (
+            entity_button := entity_registry.async_get_entity_id(
+                "button", DOMAIN, f"{avm_wrapper.unique_id}-firmware_update"
+            )
+        )
+        and (entity_entry := entity_registry.async_get(entity_button))
+        and not entity_entry.disabled
+    ):
+        # Deprecate the 'firmware update' button: create a Repairs issue for users
+        ir.async_create_issue(
+            hass,
+            domain=DOMAIN,
+            issue_id="deprecated_firmware_update_button",
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="deprecated_firmware_update_button",
+            translation_placeholders={"removal_version": "2026.11.0"},
+            breaks_in_ha_version="2026.11.0",
+        )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FritzConfigEntry,
@@ -112,6 +140,7 @@ async def async_setup_entry(
     if avm_wrapper.mesh_role == MeshRoles.SLAVE:
         async_add_entities(entities_list)
         repair_issue_cleanup(hass, avm_wrapper)
+        repair_issue_firmware_update(hass, avm_wrapper)
         return
 
     data_fritz = hass.data[FRITZ_DATA_KEY]
@@ -131,6 +160,7 @@ async def async_setup_entry(
     )
 
     repair_issue_cleanup(hass, avm_wrapper)
+    repair_issue_firmware_update(hass, avm_wrapper)
 
 
 class FritzButton(ButtonEntity):

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -211,6 +211,10 @@
     "deprecated_cleanup_button": {
       "description": "The 'Cleanup' button is deprecated and will be removed in Home Assistant Core {removal_version}. Please update your automations and dashboards to remove any usage of this button. The action is now performed automatically at each data refresh.",
       "title": "'Cleanup' button is deprecated"
+    },
+    "deprecated_firmware_update_button": {
+      "description": "The 'Firmware update' button is deprecated and will be removed in Home Assistant Core {removal_version}. It has been superseded by an update entity. Please update your automations and dashboards to remove any usage of this button.",
+      "title": "'Firmware update' button is deprecated"
     }
   },
   "options": {

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -284,3 +284,23 @@ async def test_cleanup_button_deprecation_issue(
 
     issue_registry = ir.async_get(hass)
     assert issue_registry.async_get_issue(DOMAIN, "deprecated_cleanup_button")
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_firmware_update_button_deprecation_issue(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test deprecation issue is created when legacy firmware update button is enabled."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    issue_registry = ir.async_get(hass)
+    assert issue_registry.async_get_issue(DOMAIN, "deprecated_firmware_update_button")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The 'Firmware update' button is deprecated and will be removed in Home Assistant Core 2026.11.0. It has been superseded by an update entity. Please update your automations and dashboards to remove any usage of this button.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The update entity has been there for ~4years (#70096) - it's time to to remove the button.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
