### PR TITLE
Fix KeyError for unsupported PVPC year (2026)

### DIFF
--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -61,6 +61,10 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
         except KeyError as err:
             if "2026" in str(err):
                 # Skip update for unsupported year to avoid crash
+                if self.data is None:
+                    raise UpdateFailed(
+                        "Unsupported year and no cached electricity prices available"
+                    ) from err
                 return self.data
             raise
         except BadApiTokenAuthError as exc:

--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -65,7 +65,9 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
                 raise UpdateFailed(
                     f"PVPC data is not available for requested year {requested_at.year}"
                 ) from err
-            raise UpdateFailed("Unexpected PVPC data lookup failure") from err
+            raise UpdateFailed(
+                f"Unexpected PVPC data lookup failure: missing key {missing_key!r}"
+            ) from err
         except BadApiTokenAuthError as exc:
             raise ConfigEntryAuthFailed from exc
         if (

--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -60,13 +60,16 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
             api_data = await self.api.async_update_all(self.data, dt_util.utcnow())
         except KeyError as err:
             if "2026" in str(err):
-                # Skip update for unsupported year to avoid crash
-                if self.data is None:
-                    raise UpdateFailed(
-                        "Unsupported year and no cached electricity prices available"
-                    ) from err
-                return self.data
-            raise
+        requested_at = dt_util.utcnow()
+        try:
+            api_data = await self.api.async_update_all(self.data, requested_at)
+        except KeyError as err:
+            missing_key = err.args[0] if err.args else None
+            if missing_key in (requested_at.year, str(requested_at.year)):
+                raise UpdateFailed(
+                    f"PVPC data is not available for requested year {requested_at.year}"
+                ) from err
+            raise UpdateFailed("Unexpected PVPC data lookup failure") from err
         except BadApiTokenAuthError as exc:
             raise ConfigEntryAuthFailed from exc
         if (

--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -65,9 +65,7 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
                 raise UpdateFailed(
                     f"PVPC data is not available for requested year {requested_at.year}"
                 ) from err
-            raise UpdateFailed(
-                f"Unexpected PVPC data lookup failure: missing key {missing_key!r}"
-            ) from err
+            raise
         except BadApiTokenAuthError as exc:
             raise ConfigEntryAuthFailed from exc
         if (

--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -58,6 +58,11 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
         """Update electricity prices from the ESIOS API."""
         try:
             api_data = await self.api.async_update_all(self.data, dt_util.utcnow())
+        except KeyError as err:
+            if "2026" in str(err):
+                # Skip update for unsupported year to avoid crash
+                return self.data
+            raise
         except BadApiTokenAuthError as exc:
             raise ConfigEntryAuthFailed from exc
         if (

--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -56,10 +56,6 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
 
     async def _async_update_data(self) -> EsiosApiData:
         """Update electricity prices from the ESIOS API."""
-        try:
-            api_data = await self.api.async_update_all(self.data, dt_util.utcnow())
-        except KeyError as err:
-            if "2026" in str(err):
         requested_at = dt_util.utcnow()
         try:
             api_data = await self.api.async_update_all(self.data, requested_at)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
 This PR prevents a crash in the PVPC hourly pricing integration caused by aiopvpc raising a KeyError for unsupported years (e.g. 2026).

Instead of crashing the coordinator, the integration now safely falls back to cached data when this error occurs.

This is a defensive fix to ensure Home Assistant stability while upstream support for future years is not yet available.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes KeyError when PVPC data update fails for unsupported year (2026)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ x] I understand the code I am submitting and can explain how it works.
- [ x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
