### PR TITLE
Add binary sensor platform for MELCloud ATW devices

### DIFF
--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -19,7 +19,12 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
 
-PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.SENSOR,
+    Platform.WATER_HEATER,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MelCloudConfigEntry) -> bool:

--- a/homeassistant/components/melcloud/binary_sensor.py
+++ b/homeassistant/components/melcloud/binary_sensor.py
@@ -130,13 +130,16 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up MELCloud device binary sensors based on config_entry."""
-    coordinators = entry.runtime_data
+    coordinator = entry.runtime_data
+
+    if DEVICE_TYPE_ATW not in coordinator:
+        return
 
     entities: list[MelDeviceBinarySensor] = [
-        MelDeviceBinarySensor(coordinator, description)
+        MelDeviceBinarySensor(coord, description)
         for description in ATW_BINARY_SENSORS
-        for coordinator in coordinators.get(DEVICE_TYPE_ATW, [])
-        if description.enabled(coordinator)
+        for coord in coordinator[DEVICE_TYPE_ATW]
+        if description.enabled(coord)
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/melcloud/binary_sensor.py
+++ b/homeassistant/components/melcloud/binary_sensor.py
@@ -40,7 +40,8 @@ ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
     ),
     MelcloudBinarySensorEntityDescription(
         key="booster_heater1_status",
-        translation_key="booster_heater1_status",
+        translation_key="booster_heater_status",
+        translation_placeholders={"number": "1"},
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.device.booster_heater1_status,
@@ -48,7 +49,8 @@ ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
     ),
     MelcloudBinarySensorEntityDescription(
         key="booster_heater2_status",
-        translation_key="booster_heater2_status",
+        translation_key="booster_heater_status",
+        translation_placeholders={"number": "2"},
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -57,7 +59,8 @@ ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
     ),
     MelcloudBinarySensorEntityDescription(
         key="booster_heater2plus_status",
-        translation_key="booster_heater2plus_status",
+        translation_key="booster_heater_status",
+        translation_placeholders={"number": "2+"},
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -74,7 +77,8 @@ ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
     ),
     MelcloudBinarySensorEntityDescription(
         key="water_pump1_status",
-        translation_key="water_pump1_status",
+        translation_key="water_pump_status",
+        translation_placeholders={"number": "1"},
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.device.water_pump1_status,
@@ -82,7 +86,8 @@ ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
     ),
     MelcloudBinarySensorEntityDescription(
         key="water_pump2_status",
-        translation_key="water_pump2_status",
+        translation_key="water_pump_status",
+        translation_placeholders={"number": "2"},
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.device.water_pump2_status,
@@ -90,7 +95,8 @@ ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
     ),
     MelcloudBinarySensorEntityDescription(
         key="water_pump3_status",
-        translation_key="water_pump3_status",
+        translation_key="water_pump_status",
+        translation_placeholders={"number": "3"},
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -99,7 +105,8 @@ ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
     ),
     MelcloudBinarySensorEntityDescription(
         key="water_pump4_status",
-        translation_key="water_pump4_status",
+        translation_key="water_pump_status",
+        translation_placeholders={"number": "4"},
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,

--- a/homeassistant/components/melcloud/binary_sensor.py
+++ b/homeassistant/components/melcloud/binary_sensor.py
@@ -1,0 +1,165 @@
+"""Support for MelCloud device binary sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import dataclasses
+from typing import Any
+
+from pymelcloud import DEVICE_TYPE_ATW
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
+from .entity import MelCloudEntity
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class MelcloudBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes Melcloud binary sensor entity."""
+
+    value_fn: Callable[[Any], bool | None]
+    enabled: Callable[[Any], bool]
+
+
+ATW_BINARY_SENSORS: tuple[MelcloudBinarySensorEntityDescription, ...] = (
+    MelcloudBinarySensorEntityDescription(
+        key="boiler_status",
+        translation_key="boiler_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.device.boiler_status,
+        enabled=lambda data: data.device.boiler_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="booster_heater1_status",
+        translation_key="booster_heater1_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.device.booster_heater1_status,
+        enabled=lambda data: data.device.booster_heater1_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="booster_heater2_status",
+        translation_key="booster_heater2_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.device.booster_heater2_status,
+        enabled=lambda data: data.device.booster_heater2_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="booster_heater2plus_status",
+        translation_key="booster_heater2plus_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.device.booster_heater2plus_status,
+        enabled=lambda data: data.device.booster_heater2plus_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="immersion_heater_status",
+        translation_key="immersion_heater_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.device.immersion_heater_status,
+        enabled=lambda data: data.device.immersion_heater_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="water_pump1_status",
+        translation_key="water_pump1_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.device.water_pump1_status,
+        enabled=lambda data: data.device.water_pump1_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="water_pump2_status",
+        translation_key="water_pump2_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.device.water_pump2_status,
+        enabled=lambda data: data.device.water_pump2_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="water_pump3_status",
+        translation_key="water_pump3_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.device.water_pump3_status,
+        enabled=lambda data: data.device.water_pump3_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="water_pump4_status",
+        translation_key="water_pump4_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.device.water_pump4_status,
+        enabled=lambda data: data.device.water_pump4_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="valve_3way_status",
+        translation_key="valve_3way_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.device.valve_3way_status,
+        enabled=lambda data: data.device.valve_3way_status is not None,
+    ),
+    MelcloudBinarySensorEntityDescription(
+        key="valve_2way_status",
+        translation_key="valve_2way_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.device.valve_2way_status,
+        enabled=lambda data: data.device.valve_2way_status is not None,
+    ),
+)
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    entry: MelCloudConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MELCloud device binary sensors based on config_entry."""
+    coordinators = entry.runtime_data
+
+    entities: list[MelDeviceBinarySensor] = [
+        MelDeviceBinarySensor(coordinator, description)
+        for description in ATW_BINARY_SENSORS
+        for coordinator in coordinators.get(DEVICE_TYPE_ATW, [])
+        if description.enabled(coordinator)
+    ]
+    async_add_entities(entities)
+
+
+class MelDeviceBinarySensor(MelCloudEntity, BinarySensorEntity):
+    """Representation of a Binary Sensor."""
+
+    entity_description: MelcloudBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: MelCloudDeviceUpdateCoordinator,
+        description: MelcloudBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.device.serial}-{coordinator.device.mac}-{description.key}"
+        )
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the state of the binary sensor."""
+        return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/melcloud/icons.json
+++ b/homeassistant/components/melcloud/icons.json
@@ -1,5 +1,25 @@
 {
   "entity": {
+    "binary_sensor": {
+      "boiler_status": {
+        "default": "mdi:water-boiler-off",
+        "state": {
+          "on": "mdi:water-boiler"
+        }
+      },
+      "valve_2way_status": {
+        "default": "mdi:valve-closed",
+        "state": {
+          "on": "mdi:valve-open"
+        }
+      },
+      "valve_3way_status": {
+        "default": "mdi:valve-closed",
+        "state": {
+          "on": "mdi:valve-open"
+        }
+      }
+    },
     "sensor": {
       "energy_consumed": {
         "default": "mdi:factory"

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -46,14 +46,8 @@
       "boiler_status": {
         "name": "Boiler"
       },
-      "booster_heater1_status": {
-        "name": "Booster heater 1"
-      },
-      "booster_heater2_status": {
-        "name": "Booster heater 2"
-      },
-      "booster_heater2plus_status": {
-        "name": "Booster heater 2+"
+      "booster_heater_status": {
+        "name": "Booster heater {number}"
       },
       "immersion_heater_status": {
         "name": "Immersion heater"
@@ -64,17 +58,8 @@
       "valve_3way_status": {
         "name": "3-way valve"
       },
-      "water_pump1_status": {
-        "name": "Water pump 1"
-      },
-      "water_pump2_status": {
-        "name": "Water pump 2"
-      },
-      "water_pump3_status": {
-        "name": "Water pump 3"
-      },
-      "water_pump4_status": {
-        "name": "Water pump 4"
+      "water_pump_status": {
+        "name": "Water pump {number}"
       }
     },
     "sensor": {

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -42,6 +42,41 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "boiler_status": {
+        "name": "Boiler"
+      },
+      "booster_heater1_status": {
+        "name": "Booster heater 1"
+      },
+      "booster_heater2_status": {
+        "name": "Booster heater 2"
+      },
+      "booster_heater2plus_status": {
+        "name": "Booster heater 2+"
+      },
+      "immersion_heater_status": {
+        "name": "Immersion heater"
+      },
+      "valve_2way_status": {
+        "name": "2-way valve"
+      },
+      "valve_3way_status": {
+        "name": "3-way valve"
+      },
+      "water_pump1_status": {
+        "name": "Water pump 1"
+      },
+      "water_pump2_status": {
+        "name": "Water pump 2"
+      },
+      "water_pump3_status": {
+        "name": "Water pump 3"
+      },
+      "water_pump4_status": {
+        "name": "Water pump 4"
+      }
+    },
     "sensor": {
       "condensing_temperature": {
         "name": "Condensing temperature"

--- a/tests/components/melcloud/__init__.py
+++ b/tests/components/melcloud/__init__.py
@@ -1,1 +1,19 @@
 """Tests for the MELCloud integration."""
+
+from unittest.mock import patch
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_platform(
+    hass: HomeAssistant, config_entry: MockConfigEntry, platforms: list[Platform]
+) -> None:
+    """Set up the MELCloud platform."""
+    config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.melcloud.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/melcloud/conftest.py
+++ b/tests/components/melcloud/conftest.py
@@ -1,0 +1,85 @@
+"""Test helpers for MELCloud."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pymelcloud
+import pytest
+
+from homeassistant.components.melcloud.const import DOMAIN
+from homeassistant.const import CONF_TOKEN
+
+from tests.common import MockConfigEntry
+
+MOCK_SERIAL = "ABC123456"
+MOCK_MAC = "AA:BB:CC:DD:EE:FF"
+
+
+def _build_mock_atw_device() -> MagicMock:
+    """Build a mock AtwDevice with all properties."""
+    device = MagicMock()
+    device.device_id = "atw001"
+    device.building_id = "building001"
+    device.mac = MOCK_MAC
+    device.serial = MOCK_SERIAL
+    device.name = "Ecodan"
+    device.units = [{"model": "ATW-Unit", "serial": "unit-serial-1"}]
+
+    # Binary sensors
+    device.boiler_status = True
+    device.booster_heater1_status = False
+    device.booster_heater2_status = None
+    device.booster_heater2plus_status = None
+    device.immersion_heater_status = False
+    device.water_pump1_status = True
+    device.water_pump2_status = False
+    device.water_pump3_status = None
+    device.water_pump4_status = None
+    device.valve_3way_status = True
+    device.valve_2way_status = None
+
+    # Zones (required by coordinator)
+    device.zones = []
+
+    # update is async
+    device.update = AsyncMock()
+
+    return device
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock a MELCloud config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="test-email@example.com",
+        data={
+            CONF_TOKEN: "test-token",
+            "username": "test-email@example.com",
+        },
+        entry_id="melcloud_test_entry",
+        unique_id="test-email@example.com",
+    )
+
+
+@pytest.fixture
+def mock_atw_device() -> MagicMock:
+    """Return the mock ATW device for direct access in tests."""
+    return _build_mock_atw_device()
+
+
+@pytest.fixture
+def mock_get_devices(mock_atw_device: MagicMock) -> Generator[MagicMock]:
+    """Mock pymelcloud.get_devices with a single ATW device."""
+
+    async def _get_devices(**kwargs):
+        return {
+            pymelcloud.DEVICE_TYPE_ATA: [],
+            pymelcloud.DEVICE_TYPE_ATW: [mock_atw_device],
+        }
+
+    with patch(
+        "homeassistant.components.melcloud.get_devices",
+        side_effect=_get_devices,
+    ) as mock:
+        yield mock

--- a/tests/components/melcloud/conftest.py
+++ b/tests/components/melcloud/conftest.py
@@ -25,7 +25,6 @@ def _build_mock_atw_device() -> MagicMock:
     device.name = "Ecodan"
     device.units = [{"model": "ATW-Unit", "serial": "unit-serial-1"}]
 
-    # Binary sensors
     device.boiler_status = True
     device.booster_heater1_status = False
     device.booster_heater2_status = None
@@ -38,10 +37,8 @@ def _build_mock_atw_device() -> MagicMock:
     device.valve_3way_status = True
     device.valve_2way_status = None
 
-    # Zones (required by coordinator)
     device.zones = []
 
-    # update is async
     device.update = AsyncMock()
 
     return device

--- a/tests/components/melcloud/snapshots/test_binary_sensor.ambr
+++ b/tests/components/melcloud/snapshots/test_binary_sensor.ambr
@@ -132,7 +132,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'booster_heater1_status',
+    'translation_key': 'booster_heater_status',
     'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-booster_heater1_status',
     'unit_of_measurement': None,
   })
@@ -234,7 +234,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'water_pump1_status',
+    'translation_key': 'water_pump_status',
     'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-water_pump1_status',
     'unit_of_measurement': None,
   })
@@ -285,7 +285,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'water_pump2_status',
+    'translation_key': 'water_pump_status',
     'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-water_pump2_status',
     'unit_of_measurement': None,
   })

--- a/tests/components/melcloud/snapshots/test_binary_sensor.ambr
+++ b/tests/components/melcloud/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,306 @@
+# serializer version: 1
+# name: test_all_entities[binary_sensor.ecodan_3_way_valve-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ecodan_3_way_valve',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': '3-way valve',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': '3-way valve',
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'valve_3way_status',
+    'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-valve_3way_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_3_way_valve-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Ecodan 3-way valve',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ecodan_3_way_valve',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_boiler-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ecodan_boiler',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Boiler',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Boiler',
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'boiler_status',
+    'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-boiler_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_boiler-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Ecodan Boiler',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ecodan_boiler',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_booster_heater_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ecodan_booster_heater_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Booster heater 1',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Booster heater 1',
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'booster_heater1_status',
+    'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-booster_heater1_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_booster_heater_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Ecodan Booster heater 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ecodan_booster_heater_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_immersion_heater-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ecodan_immersion_heater',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Immersion heater',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Immersion heater',
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'immersion_heater_status',
+    'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-immersion_heater_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_immersion_heater-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Ecodan Immersion heater',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ecodan_immersion_heater',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_water_pump_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ecodan_water_pump_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Water pump 1',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Water pump 1',
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'water_pump1_status',
+    'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-water_pump1_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_water_pump_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Ecodan Water pump 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ecodan_water_pump_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_water_pump_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ecodan_water_pump_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Water pump 2',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Water pump 2',
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'water_pump2_status',
+    'unique_id': 'ABC123456-AA:BB:CC:DD:EE:FF-water_pump2_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.ecodan_water_pump_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Ecodan Water pump 2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ecodan_water_pump_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/melcloud/test_binary_sensor.py
+++ b/tests/components/melcloud/test_binary_sensor.py
@@ -1,7 +1,5 @@
 """Test the MELCloud binary sensor platform."""
 
-from unittest.mock import MagicMock
-
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -50,49 +48,3 @@ async def test_atw_binary_sensor_states(
     state = hass.states.get(entity_id)
     assert state is not None, f"Entity {entity_id} not found"
     assert state.state == expected_state
-
-
-@pytest.mark.usefixtures("mock_get_devices")
-async def test_binary_sensors_not_created_when_none(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_atw_device: MagicMock,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test binary sensors are not created when property is None."""
-    # booster_heater2, booster_heater2plus, water_pump3, water_pump4, valve_2way
-    # are already None in conftest and should not be created
-    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
-
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-    entity_original_names = {entry.original_name for entry in entity_entries}
-
-    assert "Booster heater 2" not in entity_original_names
-    assert "Booster heater 2+" not in entity_original_names
-    assert "Water pump 3" not in entity_original_names
-    assert "Water pump 4" not in entity_original_names
-    assert "2-way valve" not in entity_original_names
-
-
-@pytest.mark.usefixtures("mock_get_devices")
-async def test_binary_sensor_all_none_no_entities(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_atw_device: MagicMock,
-) -> None:
-    """Test no binary sensors are created when all statuses are None."""
-    mock_atw_device.boiler_status = None
-    mock_atw_device.booster_heater1_status = None
-    mock_atw_device.immersion_heater_status = None
-    mock_atw_device.water_pump1_status = None
-    mock_atw_device.water_pump2_status = None
-    mock_atw_device.valve_3way_status = None
-
-    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
-
-    entity_entries = er.async_entries_for_config_entry(
-        er.async_get(hass), mock_config_entry.entry_id
-    )
-    assert len(entity_entries) == 0

--- a/tests/components/melcloud/test_binary_sensor.py
+++ b/tests/components/melcloud/test_binary_sensor.py
@@ -1,0 +1,98 @@
+"""Test the MELCloud binary sensor platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_platform
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_get_devices")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all binary sensor entities with snapshot."""
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+@pytest.mark.parametrize(
+    ("entity_id", "expected_state"),
+    [
+        ("binary_sensor.ecodan_boiler", STATE_ON),
+        ("binary_sensor.ecodan_booster_heater_1", STATE_OFF),
+        ("binary_sensor.ecodan_immersion_heater", STATE_OFF),
+        ("binary_sensor.ecodan_water_pump_1", STATE_ON),
+        ("binary_sensor.ecodan_water_pump_2", STATE_OFF),
+        ("binary_sensor.ecodan_3_way_valve", STATE_ON),
+    ],
+)
+async def test_atw_binary_sensor_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    expected_state: str,
+) -> None:
+    """Test ATW binary sensor entity states."""
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"Entity {entity_id} not found"
+    assert state.state == expected_state
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_binary_sensors_not_created_when_none(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test binary sensors are not created when property is None."""
+    # booster_heater2, booster_heater2plus, water_pump3, water_pump4, valve_2way
+    # are already None in conftest and should not be created
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    entity_original_names = {entry.original_name for entry in entity_entries}
+
+    assert "Booster heater 2" not in entity_original_names
+    assert "Booster heater 2+" not in entity_original_names
+    assert "Water pump 3" not in entity_original_names
+    assert "Water pump 4" not in entity_original_names
+    assert "2-way valve" not in entity_original_names
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_binary_sensor_all_none_no_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """Test no binary sensors are created when all statuses are None."""
+    mock_atw_device.boiler_status = None
+    mock_atw_device.booster_heater1_status = None
+    mock_atw_device.immersion_heater_status = None
+    mock_atw_device.water_pump1_status = None
+    mock_atw_device.water_pump2_status = None
+    mock_atw_device.valve_3way_status = None
+
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+
+    entity_entries = er.async_entries_for_config_entry(
+        er.async_get(hass), mock_config_entry.entry_id
+    )
+    assert len(entity_entries) == 0

--- a/tests/components/melcloud/test_binary_sensor.py
+++ b/tests/components/melcloud/test_binary_sensor.py
@@ -3,7 +3,7 @@
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -22,29 +22,3 @@ async def test_all_entities(
     """Test all binary sensor entities with snapshot."""
     await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
-
-
-@pytest.mark.usefixtures("mock_get_devices")
-@pytest.mark.parametrize(
-    ("entity_id", "expected_state"),
-    [
-        ("binary_sensor.ecodan_boiler", STATE_ON),
-        ("binary_sensor.ecodan_booster_heater_1", STATE_OFF),
-        ("binary_sensor.ecodan_immersion_heater", STATE_OFF),
-        ("binary_sensor.ecodan_water_pump_1", STATE_ON),
-        ("binary_sensor.ecodan_water_pump_2", STATE_OFF),
-        ("binary_sensor.ecodan_3_way_valve", STATE_ON),
-    ],
-)
-async def test_atw_binary_sensor_states(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    entity_id: str,
-    expected_state: str,
-) -> None:
-    """Test ATW binary sensor entity states."""
-    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
-
-    state = hass.states.get(entity_id)
-    assert state is not None, f"Entity {entity_id} not found"
-    assert state.state == expected_state


### PR DESCRIPTION
Add binary sensor entities for MELCloud Air-to-Water (ATW/Ecodan) heat pump devices including boiler status, heater status, pump status, and valve status monitoring.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Add a new binary sensor platform for MELCloud Air-to-Water (ATW/Ecodan) heat pump devices, using newly available properties from the pymelcloud library.

### New binary sensors (new platform)
Component status indicators for ATW devices:
- **Boiler** - Boiler running status
- **Booster heater 1** - Booster heater 1 running status
- **Booster heater 2** - Booster heater 2 running status (disabled by default)
- **Booster heater 2+** - Booster heater 2+ running status (disabled by default)
- **Immersion heater** - Immersion heater running status
- **Water pump 1-4** - Water pump running status (3 & 4 disabled by default)
- **3-way valve** - 3-way valve status
- **2-way valve** - 2-way valve status (disabled by default)

All binary sensors are categorized as `EntityCategory.DIAGNOSTIC`. Sensors for less common components are disabled by default. Sensors are only created when the device actually reports the property (not `None`).

This is split from #168105 (new ATW sensor entities) as requested in review.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44769
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
