### PR TITLE
Bump pynordpool to 0.4.0

### DIFF
--- a/homeassistant/components/nordpool/coordinator.py
+++ b/homeassistant/components/nordpool/coordinator.py
@@ -108,11 +108,11 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         """Fetch data from Nord Pool."""
         data = await self.api_call()
         if data and data.entries:
-            current_day = dt_util.utcnow().strftime("%Y-%m-%d")
-            for entry in data.entries:
-                if entry.requested_date == current_day:
-                    LOGGER.debug("Data for current day found")
-                    return data
+            current_day = dt_util.now().date()
+            if current_day in data.entries:
+                LOGGER.debug("Data for current day found")
+                return data
+
         if data and not data.entries and not initial:
             # Empty response, use cache
             LOGGER.debug("No data entries received")
@@ -158,16 +158,11 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
     def merge_price_entries(self) -> list[DeliveryPeriodEntry]:
         """Return the merged price entries."""
         merged_entries: list[DeliveryPeriodEntry] = []
-        for del_period in self.data.entries:
+        for del_period in self.data.entries.values():
             merged_entries.extend(del_period.entries)
         return merged_entries
 
     def get_data_current_day(self) -> DeliveryPeriodData:
         """Return the current day data."""
-        current_day = dt_util.utcnow().strftime("%Y-%m-%d")
-        delivery_period: DeliveryPeriodData = self.data.entries[0]
-        for del_period in self.data.entries:
-            if del_period.requested_date == current_day:
-                delivery_period = del_period
-                break
-        return delivery_period
+        current_day = dt_util.now().date()
+        return self.data.entries[current_day]

--- a/homeassistant/components/nordpool/manifest.json
+++ b/homeassistant/components/nordpool/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynordpool"],
   "quality_scale": "platinum",
-  "requirements": ["pynordpool==0.3.2"],
+  "requirements": ["pynordpool==0.4.0"],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2326,7 +2326,7 @@ pynintendoparental==2.3.4
 pynobo==1.8.1
 
 # homeassistant.components.nordpool
-pynordpool==0.3.2
+pynordpool==0.4.0
 
 # homeassistant.components.nuki
 pynuki==1.6.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1991,7 +1991,7 @@ pynintendoparental==2.3.4
 pynobo==1.8.1
 
 # homeassistant.components.nordpool
-pynordpool==0.3.2
+pynordpool==0.4.0
 
 # homeassistant.components.nuki
 pynuki==1.6.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Bump pynordpool to 0.4.0
https://github.com/gjohansson-ST/pynordpool/releases/tag/v0.4.0
https://github.com/gjohansson-ST/pynordpool/compare/v0.3.2...v0.4.0

Related changes as `data.entries` is now a `dict` instead of a `list`

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 