### PR TITLE
Bump pyseventeentrack to 1.1.3

### DIFF
--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["pyseventeentrack"],
-  "requirements": ["pyseventeentrack==1.1.2"]
+  "requirements": ["pyseventeentrack==1.1.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2476,7 +2476,7 @@ pyserial==3.5
 pysesame2==1.0.1
 
 # homeassistant.components.seventeentrack
-pyseventeentrack==1.1.2
+pyseventeentrack==1.1.3
 
 # homeassistant.components.sia
 pysiaalarm==3.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2114,7 +2114,7 @@ pysenz==1.0.2
 pyserial==3.5
 
 # homeassistant.components.seventeentrack
-pyseventeentrack==1.1.2
+pyseventeentrack==1.1.3
 
 # homeassistant.components.sia
 pysiaalarm==3.2.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump `pyseventeentrack` from 1.1.2 to 1.1.3.

This library update fixes cross-subdomain cookie authentication. The login endpoint (`user.17track.net`) sets cookies without a `Domain` attribute, so aiohttp only sends them back to `user.17track.net` per RFC 6265. The buyer API (`buyer.17track.net`) never receives the session cookies, causing all API calls to return error code `-6` ("not logged in") after successful login.

### Changes in pyseventeentrack 1.1.3

- After login, cookies are now copied from the login domain to the buyer domain
- Added `NotLoggedInError` for clearer error handling when API responses indicate an unauthenticated session
- Added error code checking in `packages()` and `summary()` responses

<details>
<summary>Diff between pyseventeentrack 1.1.2 and 1.1.3</summary>

**pyseventeentrack/client.py** (+28 -1)
- Added `_copy_cookies_to_buyer_domain()` method that copies login cookies from `user.17track.net` to `buyer.17track.net` after successful authentication
- After a successful login request, automatically copies cookies to the buyer domain

**pyseventeentrack/errors.py** (+4 -0)
- Added `NotLoggedInError` exception class

**pyseventeentrack/profile.py** (+13 -1)
- Added error code checking in `packages()` and `summary()` methods, raising `NotLoggedInError` when API returns a non-zero code

</details>

Changelog: https://github.com/shaiu/pyseventeentrack/releases/tag/v1.1.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168057
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr