### PR TITLE
Add missing Bond Groups to Bond Integration

### DIFF
--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import ClientError, ClientResponseError, ClientTimeout
 from bond_async import Bond, BPUPSubscriptions, RequestorUUID, start_bpup
@@ -133,12 +133,12 @@ async def async_remove_config_entry_device(
     """Remove bond config entry from a device."""
     data = config_entry.runtime_data
     hub = data.hub
-    for identifier in device_entry.identifiers:
+    for identifier in cast(set[tuple[str, ...]], device_entry.identifiers):
         if identifier[0] != DOMAIN:
             continue
 
         if len(identifier) == 3:
-            bond_id: str = identifier[1]  # type: ignore[unreachable]
+            bond_id = identifier[1]
             # Bond still uses the 3 arg tuple before
             # the identifiers were typed
             device_id: str = identifier[2]

--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import SLOW_UPDATE_WARNING
 from homeassistant.helpers.typing import ConfigType
 
-from .const import BRIDGE_MAKE, DOMAIN
+from .const import BRIDGE_MAKE, DOMAIN, GROUP_DEVICE_IDENTIFIER
 from .models import BondData
 from .services import async_setup_services
 from .utils import BondHub
@@ -134,16 +134,27 @@ async def async_remove_config_entry_device(
     data = config_entry.runtime_data
     hub = data.hub
     for identifier in device_entry.identifiers:
-        if identifier[0] != DOMAIN or len(identifier) != 3:
+        if identifier[0] != DOMAIN:
             continue
-        bond_id: str = identifier[1]  # type: ignore[unreachable]
-        # Bond still uses the 3 arg tuple before
-        # the identifiers were typed
-        device_id: str = identifier[2]
-        # If device_id is no longer present on
-        # the hub, we allow removal.
-        if hub.bond_id != bond_id or not any(
-            device_id == device.device_id for device in hub.devices
-        ):
-            return True
+
+        if len(identifier) == 3:
+            bond_id: str = identifier[1]  # type: ignore[unreachable]
+            # Bond still uses the 3 arg tuple before
+            # the identifiers were typed
+            device_id: str = identifier[2]
+            # If device_id is no longer present on
+            # the hub, we allow removal.
+            if hub.bond_id != bond_id or not any(
+                device_id == device.device_id for device in hub.devices
+            ):
+                return True
+            continue
+
+        if len(identifier) == 4 and identifier[2] == GROUP_DEVICE_IDENTIFIER:
+            bond_id = identifier[1]
+            group_id = identifier[3]
+            if hub.bond_id != bond_id or not any(
+                group_id == group.group_id for group in hub.groups
+            ):
+                return True
     return False

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import BondConfigEntry
 from .entity import BondEntity
 from .models import BondData
-from .utils import BondDevice
+from .utils import BondDevice, BondGroup
 
 # The api requires a step size even though it does not
 # seem to matter what is is as the underlying device is likely
@@ -278,7 +278,9 @@ async def async_setup_entry(
     data = entry.runtime_data
     entities: list[BondButtonEntity] = []
 
-    for device in data.hub.devices:
+    devices = data.hub.devices + data.hub.groups
+
+    for device in devices:
         device_entities = [
             BondButtonEntity(data, device, description)
             for description in BUTTONS
@@ -308,7 +310,7 @@ class BondButtonEntity(BondEntity, ButtonEntity):
     def __init__(
         self,
         data: BondData,
-        device: BondDevice,
+        device: BondDevice | BondGroup,
         description: BondButtonEntityDescription,
     ) -> None:
         """Init Bond button."""
@@ -323,7 +325,7 @@ class BondButtonEntity(BondEntity, ButtonEntity):
             action = Action(key, argument)
         else:
             action = Action(key)
-        await self._bond.action(self._device_id, action)
+        await self._async_action(action)
 
     def _apply_state(self) -> None:
         """Apply the state."""

--- a/homeassistant/components/bond/const.py
+++ b/homeassistant/components/bond/const.py
@@ -3,5 +3,6 @@
 BRIDGE_MAKE = "Olibra"
 
 DOMAIN = "bond"
+GROUP_DEVICE_IDENTIFIER = "group"
 
 CONF_BOND_ID: str = "bond_id"

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import BondConfigEntry
 from .entity import BondEntity
 from .models import BondData
-from .utils import BondDevice
+from .utils import BondDevice, BondGroup
 
 
 def _bond_to_hass_position(bond_position: int) -> int:
@@ -38,9 +38,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up Bond cover devices."""
     data = entry.runtime_data
+    devices = data.hub.devices + data.hub.groups
     async_add_entities(
         BondCover(data, device)
-        for device in data.hub.devices
+        for device in devices
         if device.type == DeviceType.MOTORIZED_SHADES
     )
 
@@ -50,7 +51,7 @@ class BondCover(BondEntity, CoverEntity):
 
     _attr_device_class = CoverDeviceClass.SHADE
 
-    def __init__(self, data: BondData, device: BondDevice) -> None:
+    def __init__(self, data: BondData, device: BondDevice | BondGroup) -> None:
         """Create HA entity representing Bond cover."""
         super().__init__(data, device)
         supported_features = CoverEntityFeature(0)
@@ -80,31 +81,30 @@ class BondCover(BondEntity, CoverEntity):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""
-        await self._bond.action(
-            self._device_id,
-            Action.set_position(_hass_to_bond_position(kwargs[ATTR_POSITION])),
+        await self._async_action(
+            Action.set_position(_hass_to_bond_position(kwargs[ATTR_POSITION]))
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._bond.action(self._device_id, Action.open())
+        await self._async_action(Action.open())
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        await self._bond.action(self._device_id, Action.close())
+        await self._async_action(Action.close())
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Hold cover."""
-        await self._bond.action(self._device_id, Action.hold())
+        await self._async_action(Action.hold())
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
-        await self._bond.action(self._device_id, Action.tilt_open())
+        await self._async_action(Action.tilt_open())
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
-        await self._bond.action(self._device_id, Action.tilt_close())
+        await self._async_action(Action.tilt_close())
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self._bond.action(self._device_id, Action.hold())
+        await self._async_action(Action.hold())

--- a/homeassistant/components/bond/diagnostics.py
+++ b/homeassistant/components/bond/diagnostics.py
@@ -35,4 +35,13 @@ async def async_get_config_entry_diagnostics(
             }
             for device in hub.devices
         ],
+        "groups": [
+            {
+                "group_id": group.group_id,
+                "props": group.props,
+                "attrs": group._attrs,  # noqa: SLF001
+                "supported_actions": group._supported_actions,  # noqa: SLF001
+            }
+            for group in hub.groups
+        ],
     }

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -109,13 +109,11 @@ class BondEntity(Entity):
             device_info[ATTR_VIA_DEVICE] = (DOMAIN, self._hub.bond_id)
         if self._device.location is not None:
             device_info[ATTR_SUGGESTED_AREA] = self._device.location
-        if not self._hub.is_bridge:
+        if isinstance(self._device, BondGroup):
+            device_info[ATTR_MODEL] = "Bond Group"
+        elif not self._hub.is_bridge:
             if self._hub.model is not None:
                 device_info[ATTR_MODEL] = self._hub.model
-            if self._hub.fw_ver is not None:
-                device_info[ATTR_SW_VERSION] = self._hub.fw_ver
-            if self._hub.mcu_ver is not None:
-                device_info[ATTR_HW_VERSION] = self._hub.mcu_ver
         else:
             model_data = []
             if self._device.branding_profile:
@@ -124,6 +122,11 @@ class BondEntity(Entity):
                 model_data.append(self._device.template)
             if model_data:
                 device_info[ATTR_MODEL] = " ".join(model_data)
+        if not self._hub.is_bridge:
+            if self._hub.fw_ver is not None:
+                device_info[ATTR_SW_VERSION] = self._hub.fw_ver
+            if self._hub.mcu_ver is not None:
+                device_info[ATTR_HW_VERSION] = self._hub.mcu_ver
 
         return device_info
 

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import logging
 
 from aiohttp import ClientError
+from bond_async import Action
 
 from homeassistant.const import (
     ATTR_HW_VERSION,
@@ -18,13 +19,14 @@ from homeassistant.const import (
     ATTR_VIA_DEVICE,
 )
 from homeassistant.core import CALLBACK_TYPE, HassJob, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN
+from .const import DOMAIN, GROUP_DEVICE_IDENTIFIER
 from .models import BondData
-from .utils import BondDevice
+from .utils import BondDevice, BondGroup
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,14 +35,14 @@ _BPUP_ALIVE_SCAN_INTERVAL = 60
 
 
 class BondEntity(Entity):
-    """Generic Bond entity encapsulating common features of any Bond controlled device."""
+    """Generic Bond entity encapsulating common features of any Bond target."""
 
     _attr_should_poll = False
 
     def __init__(
         self,
         data: BondData,
-        device: BondDevice,
+        device: BondDevice | BondGroup,
         sub_device: str | None = None,
         sub_device_id: str | None = None,
     ) -> None:
@@ -49,7 +51,7 @@ class BondEntity(Entity):
         self._hub = hub
         self._bond = hub.bond
         self._device = device
-        self._device_id = device.device_id
+        self._device_id = device.target_id
         self._sub_device = sub_device
         self._attr_available = True
         self._bpup_subs = data.bpup_subs
@@ -61,7 +63,11 @@ class BondEntity(Entity):
             sub_device_id = f"_{sub_device}"
         else:
             sub_device_id = ""
-        self._attr_unique_id = f"{hub.bond_id}_{device.device_id}{sub_device_id}"
+        if isinstance(device, BondGroup):
+            target_id = f"group_{device.group_id}"
+        else:
+            target_id = device.device_id
+        self._attr_unique_id = f"{hub.bond_id}_{target_id}{sub_device_id}"
         if sub_device:
             sub_device_name = sub_device.replace("_", " ").title()
             self._attr_name = f"{device.name} {sub_device_name}"
@@ -76,13 +82,27 @@ class BondEntity(Entity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Get a an HA device representing this Bond controlled device."""
-        device_info = DeviceInfo(
-            manufacturer=self._hub.make,
-            # type ignore: tuple items should not be Optional
-            identifiers={(DOMAIN, self._hub.bond_id, self._device_id)},  # type: ignore[arg-type]
-            configuration_url=f"http://{self._hub.host}",
-        )
+        """Get an HA device representing this Bond controlled device."""
+        if isinstance(self._device, BondGroup):
+            device_info = DeviceInfo(
+                manufacturer=self._hub.make,
+                identifiers={
+                    (
+                        DOMAIN,
+                        self._hub.bond_id,
+                        GROUP_DEVICE_IDENTIFIER,
+                        self._device.group_id,
+                    )
+                },
+                configuration_url=f"http://{self._hub.host}",
+            )
+        else:
+            device_info = DeviceInfo(
+                manufacturer=self._hub.make,
+                # type ignore: tuple items should not be Optional
+                identifiers={(DOMAIN, self._hub.bond_id, self._device_id)},  # type: ignore[arg-type]
+                configuration_url=f"http://{self._hub.host}",
+            )
         if self.name is not None:
             device_info[ATTR_NAME] = self._device.name
         if self._hub.bond_id is not None:
@@ -136,10 +156,30 @@ class BondEntity(Entity):
             await self._async_update_from_api()
             self.async_write_ha_state()
 
+    def _async_ensure_device_only(self, action_name: str) -> None:
+        """Raise if an action is only supported for devices."""
+        if isinstance(self._device, BondGroup):
+            raise HomeAssistantError(
+                f"{self.entity_id} does not support {action_name} for Bond groups"
+            )
+
+    async def _async_action(self, action: Action) -> None:
+        """Execute an action against the Bond API."""
+        if isinstance(self._device, BondGroup):
+            await self._bond.group_action(self._device_id, action)
+            return
+        await self._bond.action(self._device_id, action)
+
+    async def _async_fetch_state(self) -> dict:
+        """Fetch the latest state for this entity target."""
+        if isinstance(self._device, BondGroup):
+            return await self._bond.group_state(self._device_id)
+        return await self._bond.device_state(self._device_id)
+
     async def _async_update_from_api(self) -> None:
         """Fetch via the API."""
         try:
-            state: dict = await self._bond.device_state(self._device_id)
+            state: dict = await self._async_fetch_state()
         except (ClientError, TimeoutError, OSError) as error:
             if self.available:
                 _LOGGER.warning(
@@ -161,7 +201,7 @@ class BondEntity(Entity):
             _LOGGER.info("Entity %s has come back", self.entity_id)
         self._attr_available = True
         _LOGGER.debug(
-            "Device state for %s (%s) is:\n%s", self.name, self.entity_id, state
+            "Bond state for %s (%s) is:\n%s", self.name, self.entity_id, state
         )
         self._device.state = state
         self._apply_state()
@@ -169,8 +209,11 @@ class BondEntity(Entity):
     @callback
     def _async_bpup_callback(self, json_msg: dict) -> None:
         """Process a state change from BPUP."""
-        topic = json_msg["t"]
-        if topic != f"devices/{self._device_id}/state":
+        if isinstance(self._device, BondGroup):
+            state_topic = f"groups/{self._device.group_id}/state"
+        else:
+            state_topic = f"devices/{self._device.device_id}/state"
+        if json_msg["t"] != state_topic:
             return
 
         self._async_state_callback(json_msg["b"])

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 from asyncio import Lock
 from datetime import datetime
 import logging
+from typing import Any, cast
 
 from aiohttp import ClientError
 from bond_async import Action
@@ -86,21 +87,26 @@ class BondEntity(Entity):
         if isinstance(self._device, BondGroup):
             device_info = DeviceInfo(
                 manufacturer=self._hub.make,
-                identifiers={
-                    (
-                        DOMAIN,
-                        self._hub.bond_id,
-                        GROUP_DEVICE_IDENTIFIER,
-                        self._device.group_id,
-                    )
-                },
+                identifiers=cast(
+                    set[tuple[str, str]],
+                    {
+                        (
+                            DOMAIN,
+                            self._hub.bond_id,
+                            GROUP_DEVICE_IDENTIFIER,
+                            self._device.group_id,
+                        )
+                    },
+                ),
                 configuration_url=f"http://{self._hub.host}",
             )
         else:
             device_info = DeviceInfo(
                 manufacturer=self._hub.make,
-                # type ignore: tuple items should not be Optional
-                identifiers={(DOMAIN, self._hub.bond_id, self._device_id)},  # type: ignore[arg-type]
+                identifiers=cast(
+                    set[tuple[str, str]],
+                    {(DOMAIN, self._hub.bond_id, self._device_id)},
+                ),
                 configuration_url=f"http://{self._hub.host}",
             )
         if self.name is not None:
@@ -173,11 +179,11 @@ class BondEntity(Entity):
             return
         await self._bond.action(self._device_id, action)
 
-    async def _async_fetch_state(self) -> dict:
+    async def _async_fetch_state(self) -> dict[Any, Any]:
         """Fetch the latest state for this entity target."""
         if isinstance(self._device, BondGroup):
-            return await self._bond.group_state(self._device_id)
-        return await self._bond.device_state(self._device_id)
+            return cast(dict[Any, Any], await self._bond.group_state(self._device_id))
+        return cast(dict[Any, Any], await self._bond.device_state(self._device_id))
 
     async def _async_update_from_api(self) -> None:
         """Fetch via the API."""

--- a/homeassistant/components/bond/fan.py
+++ b/homeassistant/components/bond/fan.py
@@ -44,9 +44,7 @@ async def async_setup_entry(
 
     devices = data.hub.devices + data.hub.groups
     async_add_entities(
-        BondFan(data, device)
-        for device in devices
-        if DeviceType.is_fan(device.type)
+        BondFan(data, device) for device in devices if DeviceType.is_fan(device.type)
     )
 
 

--- a/homeassistant/components/bond/fan.py
+++ b/homeassistant/components/bond/fan.py
@@ -27,7 +27,7 @@ from homeassistant.util.scaling import int_states_in_range
 from . import BondConfigEntry
 from .entity import BondEntity
 from .models import BondData
-from .utils import BondDevice
+from .utils import BondDevice, BondGroup
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +42,10 @@ async def async_setup_entry(
     """Set up Bond fan devices."""
     data = entry.runtime_data
 
+    devices = data.hub.devices + data.hub.groups
     async_add_entities(
         BondFan(data, device)
-        for device in data.hub.devices
+        for device in devices
         if DeviceType.is_fan(device.type)
     )
 
@@ -52,7 +53,7 @@ async def async_setup_entry(
 class BondFan(BondEntity, FanEntity):
     """Representation of a Bond fan."""
 
-    def __init__(self, data: BondData, device: BondDevice) -> None:
+    def __init__(self, data: BondData, device: BondDevice | BondGroup) -> None:
         """Create HA entity representing Bond fan."""
         self._power: bool | None = None
         self._speed: int | None = None
@@ -78,13 +79,23 @@ class BondFan(BondEntity, FanEntity):
         self._attr_preset_mode = PRESET_MODE_BREEZE if breeze[0] else None
 
     @property
-    def _speed_range(self) -> tuple[int, int]:
-        """Return the range of speeds."""
-        return (1, self._device.props.get("max_speed", 3))
+    def is_on(self) -> bool | None:
+        """Return if the fan is on."""
+        if isinstance(self._device, BondGroup) and self._power is None:
+            return None
+        return self._power == 1
 
     @property
-    def percentage(self) -> int:
+    def _speed_range(self) -> tuple[int, int]:
+        """Return the range of speeds."""
+        max_speed = self._device.props.get("max_speed")
+        return (1, max_speed if isinstance(max_speed, int) and max_speed > 0 else 3)
+
+    @property
+    def percentage(self) -> int | None:
         """Return the current speed percentage for the fan."""
+        if isinstance(self._device, BondGroup) and self._power is None:
+            return None
         if not self._speed or not self._power:
             return 0
         return min(
@@ -124,14 +135,13 @@ class BondFan(BondEntity, FanEntity):
             bond_speed,
         )
 
-        await self._bond.action(self._device_id, Action.set_speed(bond_speed))
+        await self._async_action(Action.set_speed(bond_speed))
 
     async def async_set_power_belief(self, power_state: bool) -> None:
         """Set the believed state to on or off."""
+        self._async_ensure_device_only(Action.SET_STATE_BELIEF)
         try:
-            await self._bond.action(
-                self._device_id, Action.set_power_state_belief(power_state)
-            )
+            await self._async_action(Action.set_power_state_belief(power_state))
         except ClientResponseError as ex:
             raise HomeAssistantError(
                 "The bond API returned an error calling set_power_state_belief for"
@@ -154,9 +164,7 @@ class BondFan(BondEntity, FanEntity):
             bond_speed,
         )
         try:
-            await self._bond.action(
-                self._device_id, Action.set_speed_belief(bond_speed)
-            )
+            await self._async_action(Action.set_speed_belief(bond_speed))
         except ClientResponseError as ex:
             raise HomeAssistantError(
                 "The bond API returned an error calling set_speed_belief for"
@@ -177,21 +185,21 @@ class BondFan(BondEntity, FanEntity):
         elif percentage is not None:
             await self.async_set_percentage(percentage)
         else:
-            await self._bond.action(self._device_id, Action.turn_on())
+            await self._async_action(Action.turn_on())
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
-        await self._bond.action(self._device_id, Action(Action.BREEZE_ON))
+        await self._async_action(Action(Action.BREEZE_ON))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         if self.preset_mode == PRESET_MODE_BREEZE:
-            await self._bond.action(self._device_id, Action(Action.BREEZE_OFF))
-        await self._bond.action(self._device_id, Action.turn_off())
+            await self._async_action(Action(Action.BREEZE_OFF))
+        await self._async_action(Action.turn_off())
 
     async def async_set_direction(self, direction: str) -> None:
         """Set fan rotation direction."""
         bond_direction = (
             Direction.REVERSE if direction == DIRECTION_REVERSE else Direction.FORWARD
         )
-        await self._bond.action(self._device_id, Action.set_direction(bond_direction))
+        await self._async_action(Action.set_direction(bond_direction))

--- a/homeassistant/components/bond/light.py
+++ b/homeassistant/components/bond/light.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import BondConfigEntry
 from .entity import BondEntity
 from .models import BondData
-from .utils import BondDevice
+from .utils import BondDevice, BondGroup
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,9 +31,11 @@ async def async_setup_entry(
     data = entry.runtime_data
     hub = data.hub
 
+    devices = hub.devices + hub.groups
+
     fan_lights: list[Entity] = [
         BondLight(data, device)
-        for device in hub.devices
+        for device in devices
         if DeviceType.is_fan(device.type)
         and device.supports_light()
         and not (device.supports_up_light() and device.supports_down_light())
@@ -41,31 +43,31 @@ async def async_setup_entry(
 
     fan_up_lights: list[Entity] = [
         BondUpLight(data, device, "up_light")
-        for device in hub.devices
+        for device in devices
         if DeviceType.is_fan(device.type) and device.supports_up_light()
     ]
 
     fan_down_lights: list[Entity] = [
         BondDownLight(data, device, "down_light")
-        for device in hub.devices
+        for device in devices
         if DeviceType.is_fan(device.type) and device.supports_down_light()
     ]
 
     fireplaces: list[Entity] = [
         BondFireplace(data, device)
-        for device in hub.devices
+        for device in devices
         if DeviceType.is_fireplace(device.type)
     ]
 
     fp_lights: list[Entity] = [
         BondLight(data, device, "light")
-        for device in hub.devices
+        for device in devices
         if DeviceType.is_fireplace(device.type) and device.supports_light()
     ]
 
     lights: list[Entity] = [
         BondLight(data, device)
-        for device in hub.devices
+        for device in devices
         if DeviceType.is_light(device.type)
     ]
 
@@ -82,15 +84,15 @@ class BondBaseLight(BondEntity, LightEntity):
 
     async def async_set_brightness_belief(self, brightness: int) -> None:
         """Set the belief state of the light."""
+        self._async_ensure_device_only(Action.SET_STATE_BELIEF)
         if not self._device.supports_set_brightness():
             raise HomeAssistantError("This device does not support setting brightness")
         if brightness == 0:
             await self.async_set_power_belief(False)
             return
         try:
-            await self._bond.action(
-                self._device_id,
-                Action.set_brightness_belief(round((brightness * 100) / 255)),
+            await self._async_action(
+                Action.set_brightness_belief(round((brightness * 100) / 255))
             )
         except ClientResponseError as ex:
             raise HomeAssistantError(
@@ -100,10 +102,9 @@ class BondBaseLight(BondEntity, LightEntity):
 
     async def async_set_power_belief(self, power_state: bool) -> None:
         """Set the belief state of the light."""
+        self._async_ensure_device_only(Action.SET_STATE_BELIEF)
         try:
-            await self._bond.action(
-                self._device_id, Action.set_light_state_belief(power_state)
-            )
+            await self._async_action(Action.set_light_state_belief(power_state))
         except ClientResponseError as ex:
             raise HomeAssistantError(
                 "The bond API returned an error calling set_light_state_belief for"
@@ -111,13 +112,13 @@ class BondBaseLight(BondEntity, LightEntity):
             ) from ex
 
 
-class BondLight(BondBaseLight, BondEntity, LightEntity):
+class BondLight(BondBaseLight):
     """Representation of a Bond light."""
 
     def __init__(
         self,
         data: BondData,
-        device: BondDevice,
+        device: BondDevice | BondGroup,
         sub_device: str | None = None,
     ) -> None:
         """Create HA entity representing Bond light."""
@@ -128,23 +129,26 @@ class BondLight(BondBaseLight, BondEntity, LightEntity):
 
     def _apply_state(self) -> None:
         state = self._device.state
-        self._attr_is_on = state.get("light") == 1
+        light = state.get("light")
+        if isinstance(self._device, BondGroup):
+            self._attr_is_on = None if light is None else light == 1
+        else:
+            self._attr_is_on = light == 1
         brightness = state.get("brightness")
         self._attr_brightness = round(brightness * 255 / 100) if brightness else None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
         if brightness := kwargs.get(ATTR_BRIGHTNESS):
-            await self._bond.action(
-                self._device_id,
-                Action.set_brightness(round((brightness * 100) / 255)),
+            await self._async_action(
+                Action.set_brightness(round((brightness * 100) / 255))
             )
         else:
-            await self._bond.action(self._device_id, Action.turn_light_on())
+            await self._async_action(Action.turn_light_on())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
-        await self._bond.action(self._device_id, Action.turn_light_off())
+        await self._async_action(Action.turn_light_off())
 
     @callback
     def _async_has_action_or_raise(self, action: str) -> None:
@@ -159,9 +163,7 @@ class BondLight(BondBaseLight, BondEntity, LightEntity):
             " replaced with a button; Call the button.press service instead"
         )
         self._async_has_action_or_raise(Action.START_INCREASING_BRIGHTNESS)
-        await self._bond.action(
-            self._device_id, Action(Action.START_INCREASING_BRIGHTNESS)
-        )
+        await self._async_action(Action(Action.START_INCREASING_BRIGHTNESS))
 
     async def async_start_decreasing_brightness(self) -> None:
         """Start decreasing the light brightness."""
@@ -170,9 +172,7 @@ class BondLight(BondBaseLight, BondEntity, LightEntity):
             " replaced with a button; Call the button.press service instead"
         )
         self._async_has_action_or_raise(Action.START_DECREASING_BRIGHTNESS)
-        await self._bond.action(
-            self._device_id, Action(Action.START_DECREASING_BRIGHTNESS)
-        )
+        await self._async_action(Action(Action.START_DECREASING_BRIGHTNESS))
 
     async def async_stop(self) -> None:
         """Stop all actions and clear the queue."""
@@ -181,39 +181,53 @@ class BondLight(BondBaseLight, BondEntity, LightEntity):
             " Call the button.press service instead"
         )
         self._async_has_action_or_raise(Action.STOP)
-        await self._bond.action(self._device_id, Action(Action.STOP))
+        await self._async_action(Action(Action.STOP))
 
 
-class BondDownLight(BondBaseLight, BondEntity, LightEntity):
+class BondDownLight(BondBaseLight):
     """Representation of a Bond light."""
 
     def _apply_state(self) -> None:
         state = self._device.state
-        self._attr_is_on = bool(state.get("down_light") and state.get("light"))
+        down_light = state.get("down_light")
+        light = state.get("light")
+        if isinstance(self._device, BondGroup):
+            self._attr_is_on = (
+                None if down_light is None or light is None else bool(down_light and light)
+            )
+        else:
+            self._attr_is_on = bool(down_light and light)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
-        await self._bond.action(self._device_id, Action(Action.TURN_DOWN_LIGHT_ON))
+        await self._async_action(Action(Action.TURN_DOWN_LIGHT_ON))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
-        await self._bond.action(self._device_id, Action(Action.TURN_DOWN_LIGHT_OFF))
+        await self._async_action(Action(Action.TURN_DOWN_LIGHT_OFF))
 
 
-class BondUpLight(BondBaseLight, BondEntity, LightEntity):
+class BondUpLight(BondBaseLight):
     """Representation of a Bond light."""
 
     def _apply_state(self) -> None:
         state = self._device.state
-        self._attr_is_on = bool(state.get("up_light") and state.get("light"))
+        up_light = state.get("up_light")
+        light = state.get("light")
+        if isinstance(self._device, BondGroup):
+            self._attr_is_on = (
+                None if up_light is None or light is None else bool(up_light and light)
+            )
+        else:
+            self._attr_is_on = bool(up_light and light)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
-        await self._bond.action(self._device_id, Action(Action.TURN_UP_LIGHT_ON))
+        await self._async_action(Action(Action.TURN_UP_LIGHT_ON))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
-        await self._bond.action(self._device_id, Action(Action.TURN_UP_LIGHT_OFF))
+        await self._async_action(Action(Action.TURN_UP_LIGHT_OFF))
 
 
 class BondFireplace(BondEntity, LightEntity):
@@ -234,29 +248,31 @@ class BondFireplace(BondEntity, LightEntity):
         """Turn the fireplace on."""
         _LOGGER.debug("Fireplace async_turn_on called with: %s", kwargs)
 
-        if brightness := kwargs.get(ATTR_BRIGHTNESS):
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        if brightness is not None:
             flame = round((brightness * 100) / 255)
-            await self._bond.action(self._device_id, Action.set_flame(flame))
-        else:
-            await self._bond.action(self._device_id, Action.turn_on())
+            await self._async_action(Action.set_flame(flame))
+            return
+
+        await self._async_action(Action.turn_on())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fireplace off."""
         _LOGGER.debug("Fireplace async_turn_off called with: %s", kwargs)
 
-        await self._bond.action(self._device_id, Action.turn_off())
+        await self._async_action(Action.turn_off())
 
     async def async_set_brightness_belief(self, brightness: int) -> None:
         """Set the belief state of the light."""
+        self._async_ensure_device_only(Action.SET_STATE_BELIEF)
         if not self._device.supports_set_brightness():
             raise HomeAssistantError("This device does not support setting brightness")
         if brightness == 0:
             await self.async_set_power_belief(False)
             return
         try:
-            await self._bond.action(
-                self._device_id,
-                Action.set_brightness_belief(round((brightness * 100) / 255)),
+            await self._async_action(
+                Action.set_brightness_belief(round((brightness * 100) / 255))
             )
         except ClientResponseError as ex:
             raise HomeAssistantError(
@@ -266,10 +282,9 @@ class BondFireplace(BondEntity, LightEntity):
 
     async def async_set_power_belief(self, power_state: bool) -> None:
         """Set the belief state of the light."""
+        self._async_ensure_device_only(Action.SET_STATE_BELIEF)
         try:
-            await self._bond.action(
-                self._device_id, Action.set_power_state_belief(power_state)
-            )
+            await self._async_action(Action.set_power_state_belief(power_state))
         except ClientResponseError as ex:
             raise HomeAssistantError(
                 "The bond API returned an error calling set_power_state_belief for"

--- a/homeassistant/components/bond/light.py
+++ b/homeassistant/components/bond/light.py
@@ -193,7 +193,9 @@ class BondDownLight(BondBaseLight):
         light = state.get("light")
         if isinstance(self._device, BondGroup):
             self._attr_is_on = (
-                None if down_light is None or light is None else bool(down_light and light)
+                None
+                if down_light is None or light is None
+                else bool(down_light and light)
             )
         else:
             self._attr_is_on = bool(down_light and light)

--- a/homeassistant/components/bond/switch.py
+++ b/homeassistant/components/bond/switch.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BondConfigEntry
 from .entity import BondEntity
+from .utils import BondGroup
 
 
 async def async_setup_entry(
@@ -24,9 +25,10 @@ async def async_setup_entry(
     """Set up Bond generic devices."""
     data = entry.runtime_data
 
+    devices = data.hub.devices + data.hub.groups
     async_add_entities(
         BondSwitch(data, device)
-        for device in data.hub.devices
+        for device in devices
         if DeviceType.is_generic(device.type)
     )
 
@@ -35,22 +37,25 @@ class BondSwitch(BondEntity, SwitchEntity):
     """Representation of a Bond generic device."""
 
     def _apply_state(self) -> None:
-        self._attr_is_on = self._device.state.get("power") == 1
+        power = self._device.state.get("power")
+        if isinstance(self._device, BondGroup):
+            self._attr_is_on = None if power is None else power == 1
+        else:
+            self._attr_is_on = power == 1
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        await self._bond.action(self._device_id, Action.turn_on())
+        await self._async_action(Action.turn_on())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        await self._bond.action(self._device_id, Action.turn_off())
+        await self._async_action(Action.turn_off())
 
     async def async_set_power_belief(self, power_state: bool) -> None:
         """Set switch power belief."""
+        self._async_ensure_device_only(Action.SET_STATE_BELIEF)
         try:
-            await self._bond.action(
-                self._device_id, Action.set_power_state_belief(power_state)
-            )
+            await self._async_action(Action.set_power_state_belief(power_state))
         except ClientResponseError as ex:
             raise HomeAssistantError(
                 "The bond API returned an error calling set_power_state_belief for"

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -181,6 +181,11 @@ class BondGroup(BondBaseTarget):
 
     _id_name = "group_id"
 
+    @property
+    def trust_state(self) -> bool:
+        """Check if Trust State is turned on."""
+        return self.props.get("trust_state", False)  # type: ignore[no-any-return]
+
     def __init__(
         self,
         group_id: str,

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -17,8 +17,127 @@ MAX_REQUESTS = 6
 _LOGGER = logging.getLogger(__name__)
 
 
-class BondDevice:
+class BondBaseTarget:
+    """Common functionality shared by Bond devices and groups."""
+
+    _id_name = "id"
+
+    def __init__(
+        self,
+        target_id: str,
+        attrs: dict[str, Any],
+        props: dict[str, Any],
+        state: dict[str, Any],
+    ) -> None:
+        """Create a helper target from ID and attributes returned by API."""
+        self.target_id = target_id
+        self.props = props
+        self.state = state
+        self._attrs = attrs or {}
+        self._supported_actions: set[str] = set(self._attrs.get("actions", []))
+
+    def __repr__(self) -> str:
+        """Return readable representation of a bond target."""
+        return {
+            self._id_name: self.target_id,
+            "props": self.props,
+            "attrs": self._attrs,
+            "state": self.state,
+        }.__repr__()
+
+    @property
+    def name(self) -> str:
+        """Get the name of this target."""
+        return cast(str, self._attrs["name"])
+
+    @property
+    def type(self) -> str | None:
+        """Get the primary type of this target if it has one."""
+        return None
+
+    @property
+    def location(self) -> str | None:
+        """Get the location of this target."""
+        return None
+
+    @property
+    def template(self) -> str | None:
+        """Return this model template."""
+        return None
+
+    @property
+    def branding_profile(self) -> str | None:
+        """Return this branding profile."""
+        return None
+
+    @property
+    def trust_state(self) -> bool:
+        """Check if Trust State is turned on."""
+        return True
+
+    def has_action(self, action: str) -> bool:
+        """Check to see if the target supports an action."""
+        return action in self._supported_actions
+
+    def _has_any_action(self, actions: set[str]) -> bool:
+        """Check to see if the target supports any of the actions."""
+        return bool(self._supported_actions.intersection(actions))
+
+    def supports_speed(self) -> bool:
+        """Return True if this target supports any of the speed related commands."""
+        return self._has_any_action({Action.SET_SPEED})
+
+    def supports_direction(self) -> bool:
+        """Return True if this target supports any of the direction related commands."""
+        return self._has_any_action({Action.SET_DIRECTION})
+
+    def supports_set_position(self) -> bool:
+        """Return True if this target supports setting the position."""
+        return self._has_any_action({Action.SET_POSITION})
+
+    def supports_open(self) -> bool:
+        """Return True if this target supports opening."""
+        return self._has_any_action({Action.OPEN})
+
+    def supports_close(self) -> bool:
+        """Return True if this target supports closing."""
+        return self._has_any_action({Action.CLOSE})
+
+    def supports_tilt_open(self) -> bool:
+        """Return True if this target supports tilt opening."""
+        return self._has_any_action({Action.TILT_OPEN})
+
+    def supports_tilt_close(self) -> bool:
+        """Return True if this target supports tilt closing."""
+        return self._has_any_action({Action.TILT_CLOSE})
+
+    def supports_hold(self) -> bool:
+        """Return True if this target supports hold aka stop."""
+        return self._has_any_action({Action.HOLD})
+
+    def supports_light(self) -> bool:
+        """Return True if this target supports any of the light related commands."""
+        return self._has_any_action({Action.TURN_LIGHT_ON, Action.TURN_LIGHT_OFF})
+
+    def supports_up_light(self) -> bool:
+        """Return true if the target has an up light."""
+        return self._has_any_action({Action.TURN_UP_LIGHT_ON, Action.TURN_UP_LIGHT_OFF})
+
+    def supports_down_light(self) -> bool:
+        """Return true if the target has a down light."""
+        return self._has_any_action(
+            {Action.TURN_DOWN_LIGHT_ON, Action.TURN_DOWN_LIGHT_OFF}
+        )
+
+    def supports_set_brightness(self) -> bool:
+        """Return True if this target supports setting a light brightness."""
+        return self._has_any_action({Action.SET_BRIGHTNESS})
+
+
+class BondDevice(BondBaseTarget):
     """Helper device class to hold ID and attributes together."""
+
+    _id_name = "device_id"
 
     def __init__(
         self,
@@ -29,24 +148,7 @@ class BondDevice:
     ) -> None:
         """Create a helper device from ID and attributes returned by API."""
         self.device_id = device_id
-        self.props = props
-        self.state = state
-        self._attrs = attrs or {}
-        self._supported_actions: set[str] = set(self._attrs.get("actions", []))
-
-    def __repr__(self) -> str:
-        """Return readable representation of a bond device."""
-        return {
-            "device_id": self.device_id,
-            "props": self.props,
-            "attrs": self._attrs,
-            "state": self.state,
-        }.__repr__()
-
-    @property
-    def name(self) -> str:
-        """Get the name of this device."""
-        return cast(str, self._attrs["name"])
+        super().__init__(device_id, attrs, props, state)
 
     @property
     def type(self) -> str:
@@ -73,63 +175,42 @@ class BondDevice:
         """Check if Trust State is turned on."""
         return self.props.get("trust_state", False)  # type: ignore[no-any-return]
 
-    def has_action(self, action: str) -> bool:
-        """Check to see if the device supports an actions."""
-        return action in self._supported_actions
 
-    def _has_any_action(self, actions: set[str]) -> bool:
-        """Check to see if the device supports any of the actions."""
-        return bool(self._supported_actions.intersection(actions))
+class BondGroup(BondBaseTarget):
+    """Helper group class to hold ID and attributes together."""
 
-    def supports_speed(self) -> bool:
-        """Return True if this device supports any of the speed related commands."""
-        return self._has_any_action({Action.SET_SPEED})
+    _id_name = "group_id"
 
-    def supports_direction(self) -> bool:
-        """Return True if this device supports any of the direction related commands."""
-        return self._has_any_action({Action.SET_DIRECTION})
+    def __init__(
+        self,
+        group_id: str,
+        attrs: dict[str, Any],
+        props: dict[str, Any],
+        state: dict[str, Any],
+    ) -> None:
+        """Create a helper group from ID and attributes returned by API."""
+        self.group_id = group_id
+        super().__init__(group_id, attrs, props, state)
 
-    def supports_set_position(self) -> bool:
-        """Return True if this device supports setting the position."""
-        return self._has_any_action({Action.SET_POSITION})
+    @property
+    def types(self) -> list[str]:
+        """Get all types of this group."""
+        return cast(list[str], self._attrs.get("types", []))
 
-    def supports_open(self) -> bool:
-        """Return True if this device supports opening."""
-        return self._has_any_action({Action.OPEN})
+    @property
+    def type(self) -> str | None:
+        """Get the group type when the group is homogeneous."""
+        return self.types[0] if len(self.types) == 1 else None
 
-    def supports_close(self) -> bool:
-        """Return True if this device supports closing."""
-        return self._has_any_action({Action.CLOSE})
+    @property
+    def locations(self) -> list[str]:
+        """Get all locations of this group."""
+        return cast(list[str], self._attrs.get("locations", []))
 
-    def supports_tilt_open(self) -> bool:
-        """Return True if this device supports tilt opening."""
-        return self._has_any_action({Action.TILT_OPEN})
-
-    def supports_tilt_close(self) -> bool:
-        """Return True if this device supports tilt closing."""
-        return self._has_any_action({Action.TILT_CLOSE})
-
-    def supports_hold(self) -> bool:
-        """Return True if this device supports hold aka stop."""
-        return self._has_any_action({Action.HOLD})
-
-    def supports_light(self) -> bool:
-        """Return True if this device supports any of the light related commands."""
-        return self._has_any_action({Action.TURN_LIGHT_ON, Action.TURN_LIGHT_OFF})
-
-    def supports_up_light(self) -> bool:
-        """Return true if the device has an up light."""
-        return self._has_any_action({Action.TURN_UP_LIGHT_ON, Action.TURN_UP_LIGHT_OFF})
-
-    def supports_down_light(self) -> bool:
-        """Return true if the device has a down light."""
-        return self._has_any_action(
-            {Action.TURN_DOWN_LIGHT_ON, Action.TURN_DOWN_LIGHT_OFF}
-        )
-
-    def supports_set_brightness(self) -> bool:
-        """Return True if this device supports setting a light brightness."""
-        return self._has_any_action({Action.SET_BRIGHTNESS})
+    @property
+    def location(self) -> str | None:
+        """Get the location of this group when unambiguous."""
+        return self.locations[0] if len(self.locations) == 1 else None
 
 
 class BondHub:
@@ -142,6 +223,7 @@ class BondHub:
         self._bridge: dict[str, Any] = {}
         self._version: dict[str, Any] = {}
         self._devices: list[BondDevice] = []
+        self._groups: list[BondGroup] = []
 
     async def setup(self, max_devices: int | None = None) -> None:
         """Read hub version information."""
@@ -150,6 +232,7 @@ class BondHub:
         # Fetch all available devices using Bond API.
         device_ids = await self.bond.devices()
         self._devices = []
+        self._groups = []
         setup_device_ids = []
         tasks = []
         for idx, device_id in enumerate(device_ids):
@@ -163,6 +246,18 @@ class BondHub:
                     self.bond.device_state(device_id),
                 ]
             )
+
+        setup_group_ids: list[str] = []
+        if max_devices is None and await self.bond.supports_groups():
+            setup_group_ids = await self.bond.groups()
+            for group_id in setup_group_ids:
+                tasks.extend(
+                    [
+                        self.bond.group(group_id),
+                        self.bond.group_properties(group_id),
+                        self.bond.group_state(group_id),
+                    ]
+                )
 
         responses = await gather_with_limited_concurrency(MAX_REQUESTS, *tasks)
         response_idx = 0
@@ -178,6 +273,19 @@ class BondHub:
             response_idx += 3
 
         _LOGGER.debug("Discovered Bond devices: %s", self._devices)
+
+        for group_id in setup_group_ids:
+            self._groups.append(
+                BondGroup(
+                    group_id,
+                    responses[response_idx],
+                    responses[response_idx + 1],
+                    responses[response_idx + 2],
+                )
+            )
+            response_idx += 3
+
+        _LOGGER.debug("Discovered Bond groups: %s", self._groups)
         try:
             # Smart by bond devices do not have a bridge api call
             self._bridge = await self.bond.bridge()
@@ -234,6 +342,11 @@ class BondHub:
     def devices(self) -> list[BondDevice]:
         """Return a list of all devices controlled by this hub."""
         return self._devices
+
+    @property
+    def groups(self) -> list[BondGroup]:
+        """Return a list of all groups controlled by this hub."""
+        return self._groups
 
     @property
     def is_bridge(self) -> bool:

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -55,6 +55,7 @@ async def setup_bond_entity(
         patch_bond_token(enabled=patch_token),
         patch_bond_version(enabled=patch_version),
         patch_bond_device_ids(enabled=patch_device_ids),
+        patch_bond_supports_groups(),
         patch_setup_entry("cover", enabled=patch_platforms),
         patch_setup_entry("fan", enabled=patch_platforms),
         patch_setup_entry("light", enabled=patch_platforms),
@@ -88,10 +89,59 @@ async def setup_platform(
         patch_bond_bridge(return_value=bridge),
         patch_bond_token(return_value=token),
         patch_bond_device_ids(return_value=[bond_device_id]),
+        patch_bond_supports_groups(),
         patch_start_bpup(),
         patch_bond_device(return_value=discovered_device),
         patch_bond_device_properties(return_value=props),
         patch_bond_device_state(return_value=state),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    return mock_entry
+
+
+async def setup_group_platform(
+    hass: core.HomeAssistant,
+    platform: str,
+    discovered_group: dict[str, Any],
+    *,
+    bond_group_id: str = "bond-group-id",
+    bond_version: dict[str, Any] | None = None,
+    props: dict[str, Any] | None = None,
+    state: dict[str, Any] | None = None,
+    bridge: dict[str, Any] | None = None,
+    token: dict[str, Any] | None = None,
+):
+    """Set up the specified Bond platform using a Bond group."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
+    )
+    mock_entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.bond.PLATFORMS", [platform]),
+        patch_bond_version(return_value=bond_version),
+        patch_bond_bridge(return_value=bridge),
+        patch_bond_token(return_value=token),
+        patch_bond_device_ids(return_value=[]),
+        patch(
+            "homeassistant.components.bond.Bond.supports_groups", return_value=True
+        ),
+        patch(
+            "homeassistant.components.bond.Bond.groups", return_value=[bond_group_id]
+        ),
+        patch_start_bpup(),
+        patch(
+            "homeassistant.components.bond.Bond.group",
+            return_value=discovered_group,
+        ),
+        patch(
+            "homeassistant.components.bond.Bond.group_properties",
+            return_value=props if props is not None else {},
+        ),
+        patch_bond_group_state(return_value=state),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
@@ -174,6 +224,14 @@ def patch_bond_device_ids(enabled: bool = True, return_value=None, side_effect=N
     )
 
 
+def patch_bond_supports_groups(return_value: bool = False):
+    """Patch Bond API groups support endpoint."""
+    return patch(
+        "homeassistant.components.bond.Bond.supports_groups",
+        return_value=return_value,
+    )
+
+
 def patch_bond_device(return_value=None):
     """Patch Bond API device endpoint."""
     return patch(
@@ -193,6 +251,11 @@ def patch_start_bpup():
 def patch_bond_action():
     """Patch Bond API action endpoint."""
     return patch("homeassistant.components.bond.Bond.action")
+
+
+def patch_bond_group_action():
+    """Patch Bond API group action endpoint."""
+    return patch("homeassistant.components.bond.Bond.group_action")
 
 
 def patch_bond_action_returns_clientresponseerror():
@@ -223,6 +286,18 @@ def patch_bond_device_state(return_value=None, side_effect=None):
 
     return patch(
         "homeassistant.components.bond.Bond.device_state",
+        return_value=return_value,
+        side_effect=side_effect,
+    )
+
+
+def patch_bond_group_state(return_value=None, side_effect=None):
+    """Patch Bond API group state endpoint."""
+    if return_value is None:
+        return_value = {}
+
+    return patch(
+        "homeassistant.components.bond.Bond.group_state",
         return_value=return_value,
         side_effect=side_effect,
     )

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -126,9 +126,7 @@ async def setup_group_platform(
         patch_bond_bridge(return_value=bridge),
         patch_bond_token(return_value=token),
         patch_bond_device_ids(return_value=[]),
-        patch(
-            "homeassistant.components.bond.Bond.supports_groups", return_value=True
-        ),
+        patch("homeassistant.components.bond.Bond.supports_groups", return_value=True),
         patch(
             "homeassistant.components.bond.Bond.groups", return_value=[bond_group_id]
         ),

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -8,7 +8,14 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import patch_bond_action, patch_bond_device_state, setup_platform
+from .common import (
+    patch_bond_action,
+    patch_bond_device_state,
+    patch_bond_group_action,
+    patch_bond_group_state,
+    setup_group_platform,
+    setup_platform,
+)
 
 
 def ceiling_fan(name: str):
@@ -75,6 +82,16 @@ def motorized_shade_with_preset(name: str):
     }
 
 
+def motorized_shade_group(name: str):
+    """Create a shade group with actions exposed by the button platform."""
+    return {
+        "name": name,
+        "types": [DeviceType.MOTORIZED_SHADES],
+        "locations": ["Den"],
+        "actions": [Action.OPEN, Action.OPEN_NEXT, Action.CLOSE, Action.CLOSE_NEXT],
+    }
+
+
 async def test_entity_registry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -96,6 +113,23 @@ async def test_entity_registry(
     assert entity.unique_id == "test-hub-id_test-device-id_startdecreasingbrightness"
     entity = entity_registry.entities["button.name_1_start_dimmer"]
     assert entity.unique_id == "test-hub-id_test-device-id_startdimmer"
+
+
+async def test_group_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests that group-only button actions are registered in the entity registry."""
+    await setup_group_platform(
+        hass,
+        BUTTON_DOMAIN,
+        motorized_shade_group("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_group_id="test-group-id",
+    )
+
+    entity = entity_registry.entities["button.name_1_open_next"]
+    assert entity.unique_id == "test-hub-id_group_test-group-id_opennext"
 
 
 async def test_mutually_exclusive_actions(hass: HomeAssistant) -> None:
@@ -198,6 +232,29 @@ async def test_press_button(hass: HomeAssistant) -> None:
     mock_action.assert_called_once_with(
         "test-device-id", Action(Action.START_DECREASING_BRIGHTNESS)
     )
+
+
+async def test_group_button(hass: HomeAssistant) -> None:
+    """Tests shade group actions are exposed through the button platform."""
+    await setup_group_platform(
+        hass,
+        BUTTON_DOMAIN,
+        motorized_shade_group("name-1"),
+        bond_group_id="test-group-id",
+    )
+
+    assert hass.states.get("button.name_1_open_next")
+
+    with patch_bond_group_action() as mock_action, patch_bond_group_state():
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.name_1_open_next"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_action.assert_called_once_with("test-group-id", Action(Action.OPEN_NEXT))
 
 
 async def test_motorized_shade_actions(hass: HomeAssistant) -> None:

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -29,6 +29,9 @@ from .common import (
     help_test_entity_available,
     patch_bond_action,
     patch_bond_device_state,
+    patch_bond_group_action,
+    patch_bond_group_state,
+    setup_group_platform,
     setup_platform,
 )
 
@@ -49,6 +52,26 @@ def shades_with_position(name: str):
     return {
         "name": name,
         "type": DeviceType.MOTORIZED_SHADES,
+        "actions": [Action.OPEN, Action.CLOSE, Action.HOLD, Action.SET_POSITION],
+    }
+
+
+def shade_group(name: str):
+    """Create a motorized shades group."""
+    return {
+        "name": name,
+        "types": [DeviceType.MOTORIZED_SHADES],
+        "locations": ["Den"],
+        "actions": [Action.OPEN, Action.CLOSE, Action.HOLD],
+    }
+
+
+def shade_group_with_position(name: str):
+    """Create a motorized shades group that supports set position."""
+    return {
+        "name": name,
+        "types": [DeviceType.MOTORIZED_SHADES],
+        "locations": ["Den"],
         "actions": [Action.OPEN, Action.CLOSE, Action.HOLD, Action.SET_POSITION],
     }
 
@@ -88,6 +111,23 @@ async def test_entity_registry(
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
+async def test_group_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests that Bond groups are registered in the entity registry."""
+    await setup_group_platform(
+        hass,
+        COVER_DOMAIN,
+        shade_group("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_group_id="test-group-id",
+    )
+
+    entity = entity_registry.entities["cover.name_1"]
+    assert entity.unique_id == "test-hub-id_group_test-group-id"
+
+
 async def test_open_cover(hass: HomeAssistant) -> None:
     """Tests that open cover command delegates to API."""
     await setup_platform(
@@ -104,6 +144,69 @@ async def test_open_cover(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     mock_open.assert_called_once_with("test-device-id", Action.open())
+
+
+async def test_open_cover_group(hass: HomeAssistant) -> None:
+    """Tests that open cover group command delegates to the group API."""
+    await setup_group_platform(
+        hass,
+        COVER_DOMAIN,
+        shade_group("name-1"),
+        bond_group_id="test-group-id",
+    )
+
+    with patch_bond_group_action() as mock_open, patch_bond_group_state():
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: "cover.name_1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_open.assert_called_once_with("test-group-id", Action.open())
+
+
+async def test_stop_cover_group(hass: HomeAssistant) -> None:
+    """Tests that stop cover group command delegates to the group API."""
+    await setup_group_platform(
+        hass,
+        COVER_DOMAIN,
+        shade_group("name-1"),
+        bond_group_id="test-group-id",
+    )
+
+    with patch_bond_group_action() as mock_hold, patch_bond_group_state():
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: "cover.name_1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_hold.assert_called_once_with("test-group-id", Action.hold())
+
+
+async def test_set_position_cover_group(hass: HomeAssistant) -> None:
+    """Tests that set position cover group command delegates to the group API."""
+    await setup_group_platform(
+        hass,
+        COVER_DOMAIN,
+        shade_group_with_position("name-1"),
+        bond_group_id="test-group-id",
+    )
+
+    with patch_bond_group_action() as mock_action, patch_bond_group_state():
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: "cover.name_1", ATTR_POSITION: 60},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_action.assert_called_once_with("test-group-id", Action.set_position(40))
 
 
 async def test_close_cover(hass: HomeAssistant) -> None:

--- a/tests/components/bond/test_diagnostics.py
+++ b/tests/components/bond/test_diagnostics.py
@@ -1,12 +1,29 @@
 """Test bond diagnostics."""
 
+from bond_async import Action, DeviceType
+
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.core import HomeAssistant
 
-from .common import ceiling_fan_with_breeze, setup_platform
+from .common import ceiling_fan_with_breeze, setup_group_platform, setup_platform
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
+
+
+def fan_group(name: str) -> dict[str, list[str] | str]:
+    """Create a ceiling fan group."""
+    return {
+        "name": name,
+        "types": [DeviceType.CEILING_FAN],
+        "locations": ["Den"],
+        "actions": [
+            Action.TURN_ON,
+            Action.TURN_OFF,
+            Action.SET_SPEED,
+            Action.SET_DIRECTION,
+        ],
+    }
 
 
 async def test_diagnostics(
@@ -43,6 +60,59 @@ async def test_diagnostics(
             "data": {"access_token": "**REDACTED**", "host": "some host"},
             "title": "Mock Title",
         },
+        "groups": [],
+        "hub": {
+            "version": {
+                "bondid": "ZXXX12345",
+                "fw_ver": "test-version",
+                "mcu_ver": "test-hw-version",
+                "target": "test-model",
+            }
+        },
+    }
+
+
+async def test_group_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
+    """Test generating diagnostics for a Bond group."""
+    entry = await setup_group_platform(
+        hass,
+        FAN_DOMAIN,
+        fan_group("name-1"),
+        bond_group_id="test-group-id",
+        props={"max_speed": 6},
+    )
+
+    diag = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+    mock_group = diag["groups"][0]
+    mock_group["attrs"]["actions"] = set(mock_group["attrs"]["actions"])
+    mock_group["supported_actions"] = set(mock_group["supported_actions"])
+
+    assert diag == {
+        "devices": [],
+        "entry": {
+            "data": {"access_token": "**REDACTED**", "host": "some host"},
+            "title": "Mock Title",
+        },
+        "groups": [
+            {
+                "attrs": {
+                    "actions": {"TurnOn", "TurnOff", "SetSpeed", "SetDirection"},
+                    "locations": ["Den"],
+                    "name": "name-1",
+                    "types": ["CF"],
+                },
+                "group_id": "test-group-id",
+                "props": {"max_speed": 6},
+                "supported_actions": {
+                    "SetDirection",
+                    "SetSpeed",
+                    "TurnOff",
+                    "TurnOn",
+                },
+            }
+        ],
         "hub": {
             "version": {
                 "bondid": "ZXXX12345",

--- a/tests/components/bond/test_entity.py
+++ b/tests/components/bond/test_entity.py
@@ -8,11 +8,12 @@ from bond_async.bpup import BPUP_ALIVE_TIMEOUT
 
 from homeassistant.components import fan
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.util import utcnow
 
-from .common import patch_bond_device_state, setup_platform
+from .common import patch_bond_device_state, setup_group_platform, setup_platform
 
 from tests.common import async_fire_time_changed
 
@@ -23,6 +24,16 @@ def ceiling_fan(name: str):
         "name": name,
         "type": DeviceType.CEILING_FAN,
         "actions": ["SetSpeed", "SetDirection"],
+    }
+
+
+def generic_group(name: str):
+    """Create a generic group with given name."""
+    return {
+        "name": name,
+        "types": [DeviceType.GENERIC_DEVICE],
+        "locations": ["Den"],
+        "actions": ["TurnOn", "TurnOff"],
     }
 
 
@@ -107,6 +118,34 @@ async def test_bpup_goes_offline_and_recovers_same_entity(hass: HomeAssistant) -
     state = hass.states.get("fan.name_1")
     assert state.state == STATE_ON
     assert state.attributes[fan.ATTR_PERCENTAGE] == 66
+
+
+async def test_group_bpup_update(hass: HomeAssistant) -> None:
+    """Test group state updates are processed from BPUP group topics."""
+    bpup_subs = BPUPSubscriptions()
+    with patch(
+        "homeassistant.components.bond.BPUPSubscriptions",
+        return_value=bpup_subs,
+    ):
+        await setup_group_platform(
+            hass,
+            SWITCH_DOMAIN,
+            generic_group("name-1"),
+            bond_group_id="test-group-id",
+        )
+
+    # BondEntity historically only matched devices/<id>/state. This verifies
+    # the group topic is accepted and updates entity state without polling.
+    bpup_subs.notify(
+        {
+            "s": 200,
+            "t": "groups/test-group-id/state",
+            "b": {"power": 1},
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.name_1").state == STATE_ON
 
 
 async def test_bpup_goes_offline_and_recovers_different_entity(

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -118,6 +118,7 @@ async def test_entity_registry(
 async def test_group_entity_registry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Tests that Bond fan groups are registered in the entity registry."""
     await setup_group_platform(
@@ -130,6 +131,10 @@ async def test_group_entity_registry(
 
     entity = entity_registry.entities["fan.name_1"]
     assert entity.unique_id == "test-hub-id_group_test-group-id"
+
+    device = device_registry.async_get(entity.device_id)
+    assert device is not None
+    assert device.model == "Bond Group"
 
 
 async def test_non_standard_speed_list(hass: HomeAssistant) -> None:

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -44,6 +45,9 @@ from .common import (
     patch_bond_action,
     patch_bond_action_returns_clientresponseerror,
     patch_bond_device_state,
+    patch_bond_group_action,
+    patch_bond_group_state,
+    setup_group_platform,
     setup_platform,
 )
 
@@ -56,6 +60,16 @@ def ceiling_fan_with_breeze(name: str):
         "name": name,
         "type": DeviceType.CEILING_FAN,
         "actions": ["SetSpeed", "SetDirection", "BreezeOn"],
+    }
+
+
+def ceiling_fan_group(name: str):
+    """Create a ceiling fan group."""
+    return {
+        "name": name,
+        "types": [DeviceType.CEILING_FAN],
+        "locations": ["Den"],
+        "actions": [Action.TURN_ON, Action.TURN_OFF, Action.SET_SPEED],
     }
 
 
@@ -101,6 +115,23 @@ async def test_entity_registry(
     assert device.configuration_url == "http://some host"
 
 
+async def test_group_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests that Bond fan groups are registered in the entity registry."""
+    await setup_group_platform(
+        hass,
+        FAN_DOMAIN,
+        ceiling_fan_group("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_group_id="test-group-id",
+    )
+
+    entity = entity_registry.entities["fan.name_1"]
+    assert entity.unique_id == "test-hub-id_group_test-group-id"
+
+
 async def test_non_standard_speed_list(hass: HomeAssistant) -> None:
     """Tests that the device is registered with custom speed list if number of supported speeds differs form 3."""
     await setup_platform(
@@ -143,6 +174,34 @@ async def test_fan_speed_with_no_max_speed(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("fan.name_1").attributes["percentage"] == 100
+
+
+async def test_turn_on_fan_group_with_speed(hass: HomeAssistant) -> None:
+    """Tests that turn on group command delegates to group set speed API."""
+    await setup_group_platform(
+        hass,
+        FAN_DOMAIN,
+        ceiling_fan_group("name-1"),
+        bond_group_id="test-group-id",
+        props={"max_speed": 6},
+    )
+
+    with patch_bond_group_action() as mock_set_speed, patch_bond_group_state():
+        await turn_fan_on(hass, "fan.name_1", percentage=50)
+
+    mock_set_speed.assert_called_once_with("test-group-id", Action.set_speed(3))
+
+
+async def test_group_reports_unknown(hass: HomeAssistant) -> None:
+    """Tests that group state is unknown when Bond reports indeterminate power."""
+    await setup_group_platform(
+        hass,
+        FAN_DOMAIN,
+        ceiling_fan_group("name-1"),
+        state={"power": None, "speed": 1},
+    )
+
+    assert hass.states.get("fan.name_1").state == STATE_UNKNOWN
 
 
 async def test_turn_on_fan_with_speed(hass: HomeAssistant) -> None:
@@ -413,6 +472,13 @@ async def test_set_speed_belief_speed_100(hass: HomeAssistant) -> None:
 
     mock_action.assert_any_call("test-device-id", Action.set_power_state_belief(True))
     mock_action.assert_called_with("test-device-id", Action.set_speed_belief(3))
+
+
+async def test_initial_state_defaults_off(hass: HomeAssistant) -> None:
+    """Tests that a device defaults to off when Bond has no initial power state."""
+    await setup_platform(hass, FAN_DOMAIN, ceiling_fan("name-1"))
+
+    assert hass.states.get("fan.name_1").state == "off"
 
 
 async def test_update_reports_fan_on(hass: HomeAssistant) -> None:

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -7,6 +7,7 @@ from bond_async import DeviceType
 import pytest
 
 from homeassistant.components.bond import DOMAIN, BondData
+from homeassistant.components.bond.const import GROUP_DEVICE_IDENTIFIER
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ASSUMED_STATE, CONF_ACCESS_TOKEN, CONF_HOST
@@ -25,10 +26,12 @@ from .common import (
     patch_bond_device_ids,
     patch_bond_device_properties,
     patch_bond_device_state,
+    patch_bond_supports_groups,
     patch_bond_version,
     patch_setup_entry,
     patch_start_bpup,
     setup_bond_entity,
+    setup_group_platform,
     setup_platform,
 )
 
@@ -183,6 +186,7 @@ async def test_old_identifiers_are_removed(
                 "fw_ver": "test-version",
             }
         ),
+        patch_bond_supports_groups(),
         patch_start_bpup(),
         patch_bond_device_ids(return_value=["bond-device-id", "device_id"]),
         patch_bond_device(
@@ -227,6 +231,7 @@ async def test_smart_by_bond_device_suggested_area(
                 "fw_ver": "test-version",
             }
         ),
+        patch_bond_supports_groups(),
         patch_start_bpup(),
         patch_bond_device_ids(return_value=["bond-device-id", "device_id"]),
         patch_bond_device(
@@ -277,6 +282,7 @@ async def test_bridge_device_suggested_area(
                 "fw_ver": "test-version",
             }
         ),
+        patch_bond_supports_groups(),
         patch_start_bpup(),
         patch_bond_device_ids(return_value=["bond-device-id", "device_id"]),
         patch_bond_device(
@@ -337,6 +343,62 @@ async def test_device_remove_devices(
         identifiers={(DOMAIN, "wrong-hub-id", "test-device-id")},
     )
     response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
+    assert response["success"]
+
+    hub_device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "test-hub-id")},
+    )
+    response = await client.remove_device(hub_device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+
+async def test_group_remove_devices(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test we can only remove a group that no longer exists."""
+    assert await async_setup_component(hass, "config", {})
+
+    config_entry = await setup_group_platform(
+        hass,
+        FAN_DOMAIN,
+        {
+            "name": "name-1",
+            "types": [DeviceType.CEILING_FAN],
+            "locations": ["Den"],
+            "actions": ["SetSpeed", "SetDirection"],
+        },
+        bond_version={"bondid": "test-hub-id"},
+        bond_group_id="test-group-id",
+    )
+
+    entity = entity_registry.entities["fan.name_1"]
+    assert entity.unique_id == "test-hub-id_group_test-group-id"
+
+    device_entry = device_registry.async_get(entity.device_id)
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+    dead_group_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={
+            (DOMAIN, "test-hub-id", GROUP_DEVICE_IDENTIFIER, "remove-group-id")
+        },
+    )
+    response = await client.remove_device(dead_group_entry.id, config_entry.entry_id)
+    assert response["success"]
+
+    dead_group_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={
+            (DOMAIN, "wrong-hub-id", GROUP_DEVICE_IDENTIFIER, "test-group-id")
+        },
+    )
+    response = await client.remove_device(dead_group_entry.id, config_entry.entry_id)
     assert response["success"]
 
     hub_device_entry = device_registry.async_get_or_create(

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -38,6 +38,9 @@ from .common import (
     patch_bond_action,
     patch_bond_action_returns_clientresponseerror,
     patch_bond_device_state,
+    patch_bond_group_action,
+    patch_bond_group_state,
+    setup_group_platform,
     setup_platform,
 )
 
@@ -151,6 +154,16 @@ def light_brightness_increase_decrease_only(name: str):
     }
 
 
+def light_group(name: str):
+    """Create a light group."""
+    return {
+        "name": name,
+        "types": [DeviceType.LIGHT],
+        "locations": ["Den"],
+        "actions": [Action.TURN_LIGHT_ON, Action.TURN_LIGHT_OFF, Action.SET_BRIGHTNESS],
+    }
+
+
 async def test_fan_entity_registry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -253,6 +266,23 @@ async def test_light_entity_registry(
 
     entity = entity_registry.entities["light.light_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
+
+
+async def test_group_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests that Bond light groups are registered in the entity registry."""
+    await setup_group_platform(
+        hass,
+        LIGHT_DOMAIN,
+        light_group("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_group_id="test-group-id",
+    )
+
+    entity = entity_registry.entities["light.name_1"]
+    assert entity.unique_id == "test-hub-id_group_test-group-id"
 
 
 async def test_sbb_trust_state(hass: HomeAssistant) -> None:
@@ -475,6 +505,21 @@ async def test_light_set_power_belief(hass: HomeAssistant) -> None:
     )
 
 
+async def test_group_light_set_power_belief_not_supported(
+    hass: HomeAssistant,
+) -> None:
+    """Tests that belief services are not supported for groups."""
+    await setup_group_platform(hass, LIGHT_DOMAIN, light_group("name-1"))
+
+    with pytest.raises(HomeAssistantError, match="Bond groups"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_LIGHT_POWER_TRACKED_STATE,
+            {ATTR_ENTITY_ID: "light.name_1", ATTR_POWER_STATE: False},
+            blocking=True,
+        )
+
+
 async def test_light_set_power_belief_api_error(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light throws HomeAssistantError in the event of an api error."""
     await setup_platform(
@@ -684,6 +729,41 @@ async def test_light_stop_missing_service(
             {ATTR_ENTITY_ID: "light.name_1"},
             blocking=True,
         )
+
+
+async def test_turn_on_light_group(hass: HomeAssistant) -> None:
+    """Tests that turn on command for a group delegates to the group API."""
+    await setup_group_platform(
+        hass,
+        LIGHT_DOMAIN,
+        light_group("name-1"),
+        bond_group_id="test-group-id",
+    )
+
+    with patch_bond_group_action() as mock_turn_on, patch_bond_group_state():
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "light.name_1", ATTR_BRIGHTNESS: 128},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_turn_on.assert_called_once_with(
+        "test-group-id", Action(Action.SET_BRIGHTNESS, 50)
+    )
+
+
+async def test_group_reports_unknown(hass: HomeAssistant) -> None:
+    """Tests that group state is unknown when Bond reports indeterminate power."""
+    await setup_group_platform(
+        hass,
+        LIGHT_DOMAIN,
+        light_group("name-1"),
+        state={"light": None},
+    )
+
+    assert hass.states.get("light.name_1").state == "unknown"
 
 
 async def test_turn_on_light(hass: HomeAssistant) -> None:

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -326,6 +326,27 @@ async def test_no_trust_state(hass: HomeAssistant) -> None:
     assert device.attributes.get(ATTR_ASSUMED_STATE) is not True
 
 
+async def test_group_trust_state_not_specified(hass: HomeAssistant) -> None:
+    """Assumed state should be True if group Trust State is not specified."""
+    await setup_group_platform(hass, LIGHT_DOMAIN, light_group("name-1"))
+
+    device = hass.states.get("light.name_1")
+    assert device.attributes.get(ATTR_ASSUMED_STATE) is True
+
+
+async def test_group_trust_state(hass: HomeAssistant) -> None:
+    """Assumed state should be False if group Trust State is True."""
+    await setup_group_platform(
+        hass,
+        LIGHT_DOMAIN,
+        light_group("name-1"),
+        props={"trust_state": True},
+    )
+
+    device = hass.states.get("light.name_1")
+    assert device.attributes.get(ATTR_ASSUMED_STATE) is not True
+
+
 async def test_light_set_brightness_belief_full(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light delegates to API."""
     await setup_platform(

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -22,6 +22,7 @@ from .common import (
     patch_bond_action,
     patch_bond_action_returns_clientresponseerror,
     patch_bond_device_state,
+    setup_group_platform,
     setup_platform,
 )
 
@@ -31,6 +32,16 @@ from tests.common import async_fire_time_changed
 def generic_device(name: str):
     """Create a generic device with given name."""
     return {"name": name, "type": DeviceType.GENERIC_DEVICE}
+
+
+def generic_group(name: str):
+    """Create a generic group with given name."""
+    return {
+        "name": name,
+        "types": [DeviceType.GENERIC_DEVICE],
+        "locations": ["Den"],
+        "actions": [Action.TURN_ON, Action.TURN_OFF],
+    }
 
 
 async def test_entity_registry(
@@ -48,6 +59,23 @@ async def test_entity_registry(
 
     entity = entity_registry.entities["switch.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
+
+
+async def test_group_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests that Bond groups are registered in the entity registry."""
+    await setup_group_platform(
+        hass,
+        SWITCH_DOMAIN,
+        generic_group("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_group_id="test-group-id",
+    )
+
+    entity = entity_registry.entities["switch.name_1"]
+    assert entity.unique_id == "test-hub-id_group_test-group-id"
 
 
 async def test_turn_on_switch(hass: HomeAssistant) -> None:
@@ -123,6 +151,25 @@ async def test_switch_set_power_belief_api_error(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: "switch.name_1", ATTR_POWER_STATE: False},
             blocking=True,
         )
+
+
+async def test_group_reports_unknown(hass: HomeAssistant) -> None:
+    """Tests that group state is unknown when Bond reports indeterminate power."""
+    await setup_group_platform(
+        hass,
+        SWITCH_DOMAIN,
+        generic_group("name-1"),
+        state={"power": None},
+    )
+
+    assert hass.states.get("switch.name_1").state == "unknown"
+
+
+async def test_initial_state_defaults_off(hass: HomeAssistant) -> None:
+    """Tests that a device defaults to off when Bond has no initial power state."""
+    await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
+
+    assert hass.states.get("switch.name_1").state == "off"
 
 
 async def test_update_reports_switch_is_on(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

This adds Bond's "Groups" feature to Home Assistant's [Bond integration](https://www.home-assistant.io/integrations/bond/). Groups in the Bond Bridge are a non-traditional way to create a group which allows even mixing different shade motor technologies. When the underlying motor technology supports it, they will still start together. It is an alternative to creating a "master channel" that covers multiple shades. See description [here](https://olibra.zendesk.com/hc/en-us/articles/28999191764507--Bond-Bridge-Pro-Master-channel-verses-groups).

## Type of change

The underlying python library Home Assistant uses to integrate with Bond already supported Groups, but it was never implemented. I did my best to change as little as possible other than adding group functionality.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


<img width="266" height="89" alt="Screenshot 2026-04-13 at 5 32 01 PM" src="https://github.com/user-attachments/assets/fd9acee7-2702-41dc-874d-201287d2d2d6" />


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issues:
  - https://github.com/home-assistant/core/issues/143004
  - https://github.com/home-assistant/core/issues/127367
  - https://community.home-assistant.io/t/add-group-support-to-bond-integration/878335

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

I'm not sure it's necessary.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

