### PR TITLE
Fix unifi_discovery deepcopy crash on Python 3.14

### DIFF
--- a/homeassistant/components/unifi_discovery/discovery.py
+++ b/homeassistant/components/unifi_discovery/discovery.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from collections.abc import Mapping
+from dataclasses import fields
 from datetime import timedelta
 import logging
 from typing import Any
@@ -22,6 +23,24 @@ _LOGGER = logging.getLogger(__name__)
 DISCOVERY_INTERVAL = timedelta(minutes=60)
 
 DATA_DISCOVERY_STARTED: HassKey[bool] = HassKey(DOMAIN)
+
+
+def _device_to_dict(device: UnifiDevice) -> dict[str, Any]:
+    """Convert a UnifiDevice to a plain dict.
+
+    Avoid dataclasses.asdict() because it calls copy.deepcopy() on non-builtin
+    types.  On Python 3.14+ deepcopy cannot pickle mappingproxy objects, and
+    Enum members (used as dict keys in ``services``) internally reference
+    ``__members__`` which is a mappingproxy.  This causes asdict() to crash
+    with ``TypeError: cannot pickle 'mappingproxy' object``.
+    """
+    data: dict[str, Any] = {}
+    for f in fields(device):
+        value = getattr(device, f.name)
+        if isinstance(value, Mapping):
+            value = dict(value)
+        data[f.name] = value
+    return data
 
 
 @callback
@@ -74,5 +93,5 @@ def async_trigger_discovery(
                     hass,
                     domain,
                     context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
-                    data=asdict(device),
+                    data=_device_to_dict(device),
                 )

--- a/tests/components/unifi_discovery/__init__.py
+++ b/tests/components/unifi_discovery/__init__.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from types import MappingProxyType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from unifi_discovery import AIOUnifiScanner, UnifiDevice, UnifiService
@@ -27,6 +28,21 @@ UNIFI_DISCOVERY_NO_MAC = UnifiDevice(
     platform=DEVICE_HOSTNAME,
     hostname=DEVICE_HOSTNAME,
     services={UnifiService.Protect: True},
+    direct_connect_domain=DIRECT_CONNECT_DOMAIN,
+)
+
+# In production the crash happens because asdict() deep-copies Enum keys in
+# the services dict, and on Python 3.14+ deepcopy traverses into
+# Enum.__members__ (a mappingproxy) which cannot be pickled.  Whether
+# deepcopy(enum) actually fails depends on the specific CPython build, so
+# we force the error reliably by using MappingProxyType directly as the
+# services value — deepcopy always fails on it.
+UNIFI_DISCOVERY_MAPPINGPROXY_SERVICES = UnifiDevice(
+    source_ip=DEVICE_IP_ADDRESS,
+    hw_addr=DEVICE_MAC_ADDRESS,
+    platform=DEVICE_HOSTNAME,
+    hostname=DEVICE_HOSTNAME,
+    services=MappingProxyType({UnifiService.Protect: True}),
     direct_connect_domain=DIRECT_CONNECT_DOMAIN,
 )
 

--- a/tests/components/unifi_discovery/test_init.py
+++ b/tests/components/unifi_discovery/test_init.py
@@ -7,7 +7,11 @@ from homeassistant.components.unifi_discovery.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from . import UNIFI_DISCOVERY_NO_MAC, _patch_discovery
+from . import (
+    UNIFI_DISCOVERY_MAPPINGPROXY_SERVICES,
+    UNIFI_DISCOVERY_NO_MAC,
+    _patch_discovery,
+)
 
 
 async def test_setup_starts_discovery(hass: HomeAssistant) -> None:
@@ -51,6 +55,23 @@ async def test_dependency_loads_discovery(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     # unifi_discovery should have been loaded as a dependency and started scanning
+    flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY
+
+
+async def test_discovery_does_not_deepcopy_device(hass: HomeAssistant) -> None:
+    """Test discovery works without deepcopy.
+
+    In production asdict() deep-copies Enum keys in the services dict which
+    can crash on Python 3.14+ because Enum.__members__ is a mappingproxy that
+    cannot be pickled.  We force the crash reliably by using MappingProxyType
+    as the services value.
+    """
+    with _patch_discovery(device=UNIFI_DISCOVERY_MAPPINGPROXY_SERVICES):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done(wait_background_tasks=True)
+
     flows = hass.config_entries.flow.async_progress_by_handler("unifiprotect")
     assert len(flows) == 1
     assert flows[0]["context"]["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Fix `TypeError: cannot pickle 'mappingproxy' object` crash in `unifi_discovery` when converting a `UnifiDevice` to a dict for config flow dispatch.

`dataclasses.asdict()` calls `copy.deepcopy()` on non-builtin values. On Python 3.14+ the `UnifiService` enum keys in the `services` dict get deep-copied, which traverses into `Enum.__members__` — a `mappingproxy` that cannot be pickled.

Replace `asdict(device)` with `_device_to_dict()` using `dataclasses.fields()`, converting `Mapping` fields to plain `dict` to avoid `deepcopy` entirely.

Regression test uses `MappingProxyType` as the `services` value to reliably reproduce the crash (since the enum-based crash depends on the specific CPython build).

Not tested against real hardware (WSL/Docker devcontainer can't reach LAN for broadcast discovery). The `unifi-discovery` library itself is tested against real devices.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168139
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
