### PR TITLE
Bump homematicip to 2.8.0

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.7.0"]
+  "requirements": ["homematicip==2.8.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1247,7 +1247,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.7.0
+homematicip==2.8.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1111,7 +1111,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.7.0
+homematicip==2.8.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0


### PR DESCRIPTION
## Proposed change

Bump homematicip library from 2.7.0 to 2.8.0.

What's new in [2.8.0](https://github.com/hahn-th/homematicip-rest-api/releases/tag/2.8.0):
- Add support for HmIP-SFD (Fine Dust Sensor)
- Add support for HmIP-FWI (Full Flush Wiegand Interface)
- Fix ELV-SH-SPS25 missing switch entity (mapped to correct device class)
- Code quality: ruff linter with CI enforcement

The SPS25 fix requires no HA-side changes — the device now maps to `PlugableSwitch` and is picked up by the existing switch platform. SFD and FWI entity support will follow in separate PRs.

[Library changelog](https://github.com/hahn-th/homematicip-rest-api/blob/master/CHANGELOG.md)
[Diff 2.7.0..2.8.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.7.0..2.8.0)

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue: #651 (hmip-rest-api)
- Link to documentation pull request: n/a

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr