### PR TITLE
Fix missing async_request_call in single-entity service call path

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -831,8 +831,8 @@ async def entity_service_call(
     if len(entities) == 1:
         # Single entity case avoids creating task
         entity = entities[0]
-        single_response = await _handle_entity_call(
-            hass, entity, func, data, call.context
+        single_response = await entity.async_request_call(
+            _handle_entity_call(hass, entity, func, data, call.context)
         )
         if entity.should_poll:
             # Context expires if the turn on commands took a long time.

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1683,6 +1683,47 @@ async def test_call_with_sync_attr(hass: HomeAssistant, mock_entities) -> None:
     assert mock_method.mock_calls[0][2] == {}
 
 
+async def test_call_single_entity_uses_parallel_updates(
+    hass: HomeAssistant, mock_handle_entity_call, mock_entities
+) -> None:
+    """Check that single entity calls go through async_request_call."""
+    entity = mock_entities["light.kitchen"]
+    entity.parallel_updates = asyncio.Semaphore(1)
+
+    # Hold the semaphore so the service would block if it respects it
+    await entity.parallel_updates.acquire()
+
+    call_started = asyncio.Event()
+
+    async def _delayed_handle(*args: Any, **kwargs: Any) -> None:
+        call_started.set()
+
+    mock_handle_entity_call.side_effect = _delayed_handle
+
+    service_call = service.entity_service_call(
+        hass,
+        mock_entities,
+        Mock(),
+        ServiceCall(
+            hass,
+            "test_domain",
+            "test_service",
+            {"entity_id": "light.kitchen"},
+        ),
+    )
+    task = hass.async_create_task(service_call)
+
+    # Give the event loop a chance to progress; the call should be blocked
+    await asyncio.sleep(0)
+    assert not call_started.is_set()
+
+    # Release the semaphore so the call can proceed
+    entity.parallel_updates.release()
+    await task
+
+    assert len(mock_handle_entity_call.mock_calls) == 1
+
+
 async def test_call_context_user_not_exist(hass: HomeAssistant) -> None:
     """Check we don't allow deleted users to do things."""
     with pytest.raises(exceptions.UnknownUser) as err:

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -79,6 +79,7 @@ def mock_handle_entity_call():
     """Mock service platform call."""
     with patch(
         "homeassistant.helpers.service._handle_entity_call",
+        new_callable=AsyncMock,
         return_value=None,
     ) as mock_call:
         yield mock_call
@@ -1693,13 +1694,6 @@ async def test_call_single_entity_uses_parallel_updates(
     # Hold the semaphore so the service would block if it respects it
     await entity.parallel_updates.acquire()
 
-    call_started = asyncio.Event()
-
-    async def _delayed_handle(*args: Any, **kwargs: Any) -> None:
-        call_started.set()
-
-    mock_handle_entity_call.side_effect = _delayed_handle
-
     service_call = service.entity_service_call(
         hass,
         mock_entities,
@@ -1715,13 +1709,13 @@ async def test_call_single_entity_uses_parallel_updates(
 
     # Give the event loop a chance to progress; the call should be blocked
     await asyncio.sleep(0)
-    assert not call_started.is_set()
+    assert mock_handle_entity_call.await_count == 0
 
     # Release the semaphore so the call can proceed
     entity.parallel_updates.release()
     await task
 
-    assert len(mock_handle_entity_call.mock_calls) == 1
+    assert mock_handle_entity_call.await_count == 1
 
 
 async def test_call_context_user_not_exist(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix missing `async_request_call` in single-entity service call path.

This ensures `parallel_updates` semaphore is respected. The multi-entity path used it, but the single-entity optimisation forgot it, when it was first added in #96729.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
