### PR TITLE
Improve error handling for vacuum clean_area

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -438,6 +438,7 @@ class StateVacuumEntity(
         cleaning_area_id: list[str] = data.pop("cleaning_area_id")
 
         entity_data: list[tuple[StateVacuumEntity, dict[str, Any]]] = []
+        handled_areas: set[str] = set()
         for entity in entities:
             if entity.registry_entry is None:
                 raise RuntimeError(
@@ -458,7 +459,10 @@ class StateVacuumEntity(
             # We use a dict to preserve the order of segments.
             segment_ids: dict[str, None] = {}
             for area_id in cleaning_area_id:
-                for segment_id in area_mapping.get(area_id, []):
+                if (segments := area_mapping.get(area_id)) is None:
+                    continue
+                handled_areas.add(area_id)
+                for segment_id in segments:
                     segment_ids[segment_id] = None
 
             if not segment_ids:
@@ -474,6 +478,14 @@ class StateVacuumEntity(
         if entity_data:
             await service_helper.async_handle_entity_calls(
                 "async_clean_segments", entity_data, context=call.context
+            )
+
+        unhandled_areas = set(cleaning_area_id) - handled_areas
+        if unhandled_areas:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="areas_not_mapped",
+                translation_placeholders={"areas": ", ".join(sorted(unhandled_areas))},
             )
 
     def clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.const import (  # noqa: F401 # STATE_PAUSED/IDLE are API
     SERVICE_TURN_ON,
     STATE_ON,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.entity import Entity, EntityDescription
@@ -30,6 +30,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.helpers.service import remove_entity_service_fields
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_COMPONENT, DOMAIN, VacuumActivity, VacuumEntityFeature
@@ -114,7 +115,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         {
             vol.Required("cleaning_area_id"): vol.All(cv.ensure_list, [str]),
         },
-        "async_internal_clean_area",
+        StateVacuumEntity.async_internal_clean_area,
         [VacuumEntityFeature.CLEAN_AREA],
     )
     component.async_register_entity_service(
@@ -422,27 +423,31 @@ class StateVacuumEntity(
         return [Segment(**segment) for segment in last_seen_segments]
 
     @final
+    @staticmethod
     async def async_internal_clean_area(
-        self, cleaning_area_id: list[str], **kwargs: Any
+        entity: StateVacuumEntity, call: ServiceCall
     ) -> None:
         """Perform an area clean.
 
         Calls async_clean_segments.
         """
-        if self.registry_entry is None:
+        if entity.registry_entry is None:
             raise RuntimeError(
                 "Cannot perform area clean, registry entry is not set for"
-                f" {self.entity_id}"
+                f" {entity.entity_id}"
             )
 
-        options: Mapping[str, Any] = self.registry_entry.options.get(DOMAIN, {})
+        data = remove_entity_service_fields(call)
+        cleaning_area_id: list[str] = data.pop("cleaning_area_id")
+
+        options: Mapping[str, Any] = entity.registry_entry.options.get(DOMAIN, {})
         area_mapping: dict[str, list[str]] | None = options.get("area_mapping")
 
         if area_mapping is None:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="area_mapping_not_configured",
-                translation_placeholders={"entity_id": self.entity_id},
+                translation_placeholders={"entity_id": entity.entity_id},
             )
 
         # We use a dict to preserve the order of segments.
@@ -455,11 +460,11 @@ class StateVacuumEntity(
             _LOGGER.debug(
                 "No segments found for cleaning_area_id %s on vacuum %s",
                 cleaning_area_id,
-                self.entity_id,
+                entity.entity_id,
             )
             return
 
-        await self.async_clean_segments(list(segment_ids), **kwargs)
+        await entity.async_clean_segments(list(segment_ids), **data)
 
     def clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Perform an area clean."""

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -24,13 +24,16 @@ from homeassistant.const import (  # noqa: F401 # STATE_PAUSED/IDLE are API
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers import (
+    config_validation as cv,
+    issue_registry as ir,
+    service as service_helper,
+)
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.icon import icon_for_battery_level
-from homeassistant.helpers.service import remove_entity_service_fields
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_COMPONENT, DOMAIN, VacuumActivity, VacuumEntityFeature
@@ -110,7 +113,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         "async_clean_spot",
         [VacuumEntityFeature.CLEAN_SPOT],
     )
-    component.async_register_entity_service(
+    component.async_register_batched_entity_service(
         SERVICE_CLEAN_AREA,
         {
             vol.Required("cleaning_area_id"): vol.All(cv.ensure_list, [str]),
@@ -425,46 +428,53 @@ class StateVacuumEntity(
     @final
     @staticmethod
     async def async_internal_clean_area(
-        entity: StateVacuumEntity, call: ServiceCall
+        entities: list[StateVacuumEntity], call: ServiceCall
     ) -> None:
         """Perform an area clean.
 
-        Calls async_clean_segments.
+        Calls async_clean_segments for each entity.
         """
-        if entity.registry_entry is None:
-            raise RuntimeError(
-                "Cannot perform area clean, registry entry is not set for"
-                f" {entity.entity_id}"
-            )
-
-        data = remove_entity_service_fields(call)
+        data = dict(call.data)
         cleaning_area_id: list[str] = data.pop("cleaning_area_id")
 
-        options: Mapping[str, Any] = entity.registry_entry.options.get(DOMAIN, {})
-        area_mapping: dict[str, list[str]] | None = options.get("area_mapping")
+        entity_data: list[tuple[StateVacuumEntity, dict[str, Any]]] = []
+        for entity in entities:
+            if entity.registry_entry is None:
+                raise RuntimeError(
+                    "Cannot perform area clean, registry entry is not set for"
+                    f" {entity.entity_id}"
+                )
 
-        if area_mapping is None:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="area_mapping_not_configured",
-                translation_placeholders={"entity_id": entity.entity_id},
+            options: Mapping[str, Any] = entity.registry_entry.options.get(DOMAIN, {})
+            area_mapping: dict[str, list[str]] | None = options.get("area_mapping")
+
+            if area_mapping is None:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="area_mapping_not_configured",
+                    translation_placeholders={"entity_id": entity.entity_id},
+                )
+
+            # We use a dict to preserve the order of segments.
+            segment_ids: dict[str, None] = {}
+            for area_id in cleaning_area_id:
+                for segment_id in area_mapping.get(area_id, []):
+                    segment_ids[segment_id] = None
+
+            if not segment_ids:
+                _LOGGER.debug(
+                    "No segments found for cleaning_area_id %s on vacuum %s",
+                    cleaning_area_id,
+                    entity.entity_id,
+                )
+                continue
+
+            entity_data.append((entity, {"segment_ids": list(segment_ids), **data}))
+
+        if entity_data:
+            await service_helper.async_handle_entity_calls(
+                "async_clean_segments", entity_data, context=call.context
             )
-
-        # We use a dict to preserve the order of segments.
-        segment_ids: dict[str, None] = {}
-        for area_id in cleaning_area_id:
-            for segment_id in area_mapping.get(area_id, []):
-                segment_ids[segment_id] = None
-
-        if not segment_ids:
-            _LOGGER.debug(
-                "No segments found for cleaning_area_id %s on vacuum %s",
-                cleaning_area_id,
-                entity.entity_id,
-            )
-            return
-
-        await entity.async_clean_segments(list(segment_ids), **data)
 
     def clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Perform an area clean."""

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -86,6 +86,9 @@
   "exceptions": {
     "area_mapping_not_configured": {
       "message": "Area mapping is not configured for `{entity_id}`. Configure the segment-to-area mapping before using this action."
+    },
+    "areas_not_mapped": {
+      "message": "The following areas are not mapped to any segments of targeted vacuums: {areas}"
     }
   },
   "issues": {

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -372,15 +372,13 @@ async def test_clean_area_no_segments(
         },
     )
 
-    targeted_areas.append("area_3")
-
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_CLEAN_AREA,
             {
                 "entity_id": [mock_vacuum.entity_id, mock_vacuum_2.entity_id],
-                "cleaning_area_id": targeted_areas,
+                "cleaning_area_id": [*targeted_areas, "area_3"],
             },
             blocking=True,
         )
@@ -392,6 +390,9 @@ async def test_clean_area_no_segments(
     else:
         assert len(mock_vacuum.clean_segments_calls) == 1
         assert mock_vacuum.clean_segments_calls[0][0] == cleaned_segments
+
+    assert len(mock_vacuum_2.clean_segments_calls) == 1
+    assert mock_vacuum_2.clean_segments_calls[0][0] == ["seg_3"]
 
 
 @pytest.mark.usefixtures("config_flow_fixture")

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -314,10 +314,11 @@ async def test_clean_area_not_configured(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("config_flow_fixture")
 @pytest.mark.parametrize(
-    ("area_mapping", "targeted_areas"),
+    ("area_mapping", "targeted_areas", "cleaned_segments"),
     [
-        ({}, ["area_1"]),
-        ({"area_1": ["seg_1"]}, ["area_2"]),
+        ({}, ["area_2"], None),
+        ({"area_1": ["seg_1"]}, ["area_2"], None),
+        ({"area_1": ["seg_1", "seg_2"]}, ["area_1", "area_2"], ["seg_1", "seg_2"]),
     ],
 )
 async def test_clean_area_no_segments(
@@ -325,9 +326,15 @@ async def test_clean_area_no_segments(
     entity_registry: er.EntityRegistry,
     area_mapping: dict[str, list[str]],
     targeted_areas: list[str],
+    cleaned_segments: list[str] | None,
 ) -> None:
-    """Test clean_area does nothing when no segments to clean."""
+    """Test clean_area raises error when areas are not mapped to vacuum segments."""
     mock_vacuum = MockVacuumWithCleanArea(name="Testing", entity_id="vacuum.testing")
+    mock_vacuum_2 = MockVacuumWithCleanArea(
+        name="Testing 2",
+        entity_id="vacuum.testing_2",
+        unique_id="mock_vacuum_2_unique_id",
+    )
 
     config_entry = MockConfigEntry(domain="test")
     config_entry.add_to_hass(hass)
@@ -340,7 +347,9 @@ async def test_clean_area_no_segments(
             async_unload_entry=help_async_unload_entry,
         ),
     )
-    setup_test_component_platform(hass, DOMAIN, [mock_vacuum], from_config_entry=True)
+    setup_test_component_platform(
+        hass, DOMAIN, [mock_vacuum, mock_vacuum_2], from_config_entry=True
+    )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -352,15 +361,37 @@ async def test_clean_area_no_segments(
             "last_seen_segments": [asdict(segment) for segment in mock_vacuum.segments],
         },
     )
-
-    await hass.services.async_call(
+    entity_registry.async_update_entity_options(
+        mock_vacuum_2.entity_id,
         DOMAIN,
-        SERVICE_CLEAN_AREA,
-        {"entity_id": mock_vacuum.entity_id, "cleaning_area_id": targeted_areas},
-        blocking=True,
+        {
+            "area_mapping": {"area_3": ["seg_3"]},
+            "last_seen_segments": [
+                asdict(segment) for segment in mock_vacuum_2.segments
+            ],
+        },
     )
 
-    assert len(mock_vacuum.clean_segments_calls) == 0
+    targeted_areas.append("area_3")
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {
+                "entity_id": [mock_vacuum.entity_id, mock_vacuum_2.entity_id],
+                "cleaning_area_id": targeted_areas,
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "areas_not_mapped"
+    assert exc_info.value.translation_placeholders == {"areas": "area_2"}
+
+    if cleaned_segments is None:
+        assert len(mock_vacuum.clean_segments_calls) == 0
+    else:
+        assert len(mock_vacuum.clean_segments_calls) == 1
+        assert mock_vacuum.clean_segments_calls[0][0] == cleaned_segments
 
 
 @pytest.mark.usefixtures("config_flow_fixture")

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -23,7 +23,7 @@ from homeassistant.components.vacuum import (
     VacuumActivity,
     VacuumEntityFeature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
@@ -399,7 +399,7 @@ async def test_clean_area_methods_not_implemented(hass: HomeAssistant) -> None:
         await mock_vacuum.async_clean_segments(["seg_1"])
 
 
-async def test_clean_area_no_registry_entry() -> None:
+async def test_clean_area_no_registry_entry(hass: HomeAssistant) -> None:
     """Test error handling when registry entry is not set."""
     mock_vacuum = MockVacuumWithCleanArea(name="Testing", entity_id="vacuum.testing")
 
@@ -409,11 +409,19 @@ async def test_clean_area_no_registry_entry() -> None:
     ):
         mock_vacuum.last_seen_segments  # noqa: B018
 
+    call = ServiceCall(
+        hass,
+        DOMAIN,
+        SERVICE_CLEAN_AREA,
+        {"cleaning_area_id": ["area_1"]},
+        context=Context(),
+    )
+
     with pytest.raises(
         RuntimeError,
         match="Cannot perform area clean, registry entry is not set",
     ):
-        await mock_vacuum.async_internal_clean_area(["area_1"])
+        await StateVacuumEntity.async_internal_clean_area([mock_vacuum], call)
 
     with pytest.raises(
         RuntimeError,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve error handling for vacuum clean_area.

Improve error handling for `vacuum.clean_area` by utilising batched entity service call, allowing areas to be validated across all targeted vacuums at once and raising an error when areas are not mapped to any segments on the targeted vacuums.

~~Requires #168175.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
