### PR TITLE
Fix backup test ResourceWarnings

### DIFF
--- a/tests/components/backup/test_util.py
+++ b/tests/components/backup/test_util.py
@@ -319,9 +319,9 @@ async def test_decrypted_backup_streamer(
     expected_padding = b"\0" * padding_size
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = encrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            yield chunk
+        with encrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -367,10 +367,10 @@ async def test_decrypted_backup_streamer_interrupt_stuck_reader(
     stuck = asyncio.Event()
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = encrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            await stuck.wait()
-            yield chunk
+        with encrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                await stuck.wait()
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -403,9 +403,9 @@ async def test_decrypted_backup_streamer_interrupt_stuck_writer(
     )
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = encrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            yield chunk
+        with encrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -436,9 +436,9 @@ async def test_decrypted_backup_streamer_wrong_password(hass: HomeAssistant) -> 
     )
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = encrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            yield chunk
+        with encrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -499,9 +499,9 @@ async def test_encrypted_backup_streamer(
     expected_padding = b"\0" * padding_size
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = decrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            yield chunk
+        with decrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -562,10 +562,10 @@ async def test_encrypted_backup_streamer_interrupt_stuck_reader(
     stuck = asyncio.Event()
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = decrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            await stuck.wait()
-            yield chunk
+        with decrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                await stuck.wait()
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -600,9 +600,9 @@ async def test_encrypted_backup_streamer_interrupt_stuck_writer(
     )
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = decrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            yield chunk
+        with decrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -638,9 +638,9 @@ async def test_encrypted_backup_streamer_random_nonce(hass: HomeAssistant) -> No
     )
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = decrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            yield chunk
+        with decrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()
@@ -702,9 +702,9 @@ async def test_encrypted_backup_streamer_error(hass: HomeAssistant) -> None:
     )
 
     async def send_backup() -> AsyncIterator[bytes]:
-        f = decrypted_backup_path.open("rb")
-        while chunk := f.read(1024):
-            yield chunk
+        with decrypted_backup_path.open("rb") as f:
+            while chunk := f.read(1024):
+                yield chunk
 
     async def open_backup() -> AsyncIterator[bytes]:
         return send_backup()

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -173,13 +173,13 @@ def test_restoring_backup_that_is_not_a_file(
     restore_file_path = tmp_path / ".HA_RESTORE"
 
     # Set up restore file to point to a file within the temporary directory
-    restore_config = json.load(
-        get_fixture_path(f"core/backup_restore/{restore_config}", None).open(
-            "r", encoding="utf-8"
+    restore_config = json.loads(
+        get_fixture_path(f"core/backup_restore/{restore_config}", None).read_text(
+            encoding="utf-8"
         )
     )
     restore_config["path"] = backup_file_path.as_posix()
-    json.dump(restore_config, restore_file_path.open("w", encoding="utf-8"))
+    restore_file_path.write_text(json.dumps(restore_config), encoding="utf-8")
     assert restore_file_path.exists()
 
     # Create a directory at the backup file path to simulate the backup file not being a file
@@ -211,13 +211,13 @@ def test_aborting_for_older_versions(restore_config: str, tmp_path: Path) -> Non
     restore_file_path = tmp_path / ".HA_RESTORE"
 
     # Set up restore file to point to a file within the temporary directory
-    restore_config = json.load(
-        get_fixture_path(f"core/backup_restore/{restore_config}", None).open(
-            "r", encoding="utf-8"
+    restore_config = json.loads(
+        get_fixture_path(f"core/backup_restore/{restore_config}", None).read_text(
+            encoding="utf-8"
         )
     )
     restore_config["path"] = backup_file_path.as_posix()
-    json.dump(restore_config, restore_file_path.open("w", encoding="utf-8"))
+    restore_file_path.write_text(json.dumps(restore_config), encoding="utf-8")
     assert restore_file_path.exists()
 
     get_fixture_path("core/backup_restore/backup_from_future.tar", None).copy_into(


### PR DESCRIPTION
## Proposed change
```py
tests/test_backup_restore.py::test_restoring_backup_that_is_not_a_file[restore3.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:176: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/home/runner/work/ha-core/ha-core/tests/fixtures/core/backup_restore/restore3.json' mode='r' encoding='utf-8'>
    restore_config = json.load(

tests/test_backup_restore.py::test_restoring_backup_that_is_not_a_file[restore3.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:182: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-runner/pytest-0/test_restoring_backup_that_is_0/.HA_RESTORE' mode='w' encoding='utf-8'>
    json.dump(restore_config, restore_file_path.open("w", encoding="utf-8"))

tests/test_backup_restore.py::test_restoring_backup_that_is_not_a_file[restore4.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:176: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/home/runner/work/ha-core/ha-core/tests/fixtures/core/backup_restore/restore4.json' mode='r' encoding='utf-8'>
    restore_config = json.load(

tests/test_backup_restore.py::test_restoring_backup_that_is_not_a_file[restore4.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:182: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-runner/pytest-0/test_restoring_backup_that_is_1/.HA_RESTORE' mode='w' encoding='utf-8'>
    json.dump(restore_config, restore_file_path.open("w", encoding="utf-8"))

tests/test_backup_restore.py::test_aborting_for_older_versions[restore3.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:214: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/home/runner/work/ha-core/ha-core/tests/fixtures/core/backup_restore/restore3.json' mode='r' encoding='utf-8'>
    restore_config = json.load(

tests/test_backup_restore.py::test_aborting_for_older_versions[restore3.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:220: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-runner/pytest-0/test_aborting_for_older_versio0/.HA_RESTORE' mode='w' encoding='utf-8'>
    json.dump(restore_config, restore_file_path.open("w", encoding="utf-8"))

tests/test_backup_restore.py::test_aborting_for_older_versions[restore4.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:214: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/home/runner/work/ha-core/ha-core/tests/fixtures/core/backup_restore/restore4.json' mode='r' encoding='utf-8'>
    restore_config = json.load(

tests/test_backup_restore.py::test_aborting_for_older_versions[restore4.json]
  /home/runner/work/ha-core/ha-core/tests/test_backup_restore.py:220: ResourceWarning:
      unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-runner/pytest-0/test_aborting_for_older_versio1/.HA_RESTORE' mode='w' encoding='utf-8'>
    json.dump(restore_config, restore_file_path.open("w", encoding="utf-8"))

tests/components/backup/test_util.py::test_decrypted_backup_streamer[addons0-51200-test_backups/c0cb53bd.tar.decrypted]
tests/components/backup/test_util.py::test_decrypted_backup_streamer[addons1-40960-test_backups/c0cb53bd.tar.decrypted_skip_core2]
tests/components/backup/test_util.py::test_decrypted_backup_streamer_wrong_password
  /home/runner/work/ha-core/ha-core/homeassistant/util/async_iterator.py:40: ResourceWarning:
      unclosed file <_io.BufferedReader name='/home/runner/work/ha-core/ha-core/tests/components/backup/fixtures/test_backups/c0cb53bd.tar'>
    return await anext(self._stream, None)

tests/components/backup/test_util.py::test_decrypted_backup_streamer_interrupt_stuck_reader
  /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/asyncio/base_events.py:2031: ResourceWarning:
      unclosed file <_io.BufferedReader name='/home/runner/work/ha-core/ha-core/tests/components/backup/fixtures/test_backups/c0cb53bd.tar'>
    handle = self._ready.popleft()

tests/components/backup/test_util.py::test_decrypted_backup_streamer_interrupt_stuck_writer
  /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/asyncio/events.py:94: ResourceWarning:
      unclosed file <_io.BufferedReader name='/home/runner/work/ha-core/ha-core/tests/components/backup/fixtures/test_backups/c0cb53bd.tar'>
    self._context.run(self._callback, *self._args)

tests/components/backup/test_util.py::test_encrypted_backup_streamer[addons0-51200-test_backups/c0cb53bd.tar.encrypted_v3]
tests/components/backup/test_util.py::test_encrypted_backup_streamer[addons1-40960-test_backups/c0cb53bd.tar.encrypted_v3_skip_core2]
tests/components/backup/test_util.py::test_encrypted_backup_streamer_random_nonce
  /home/runner/work/ha-core/ha-core/homeassistant/util/async_iterator.py:40: ResourceWarning:
      unclosed file <_io.BufferedReader name='/home/runner/work/ha-core/ha-core/tests/components/backup/fixtures/test_backups/c0cb53bd.tar.decrypted'>
    return await anext(self._stream, None)

tests/components/backup/test_util.py::test_encrypted_backup_streamer_interrupt_stuck_reader
  /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/asyncio/base_events.py:2031: ResourceWarning:
      unclosed file <_io.BufferedReader name='/home/runner/work/ha-core/ha-core/tests/components/backup/fixtures/test_backups/c0cb53bd.tar.decrypted'>
    handle = self._ready.popleft()

tests/components/backup/test_util.py::test_encrypted_backup_streamer_interrupt_stuck_writer
  /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/asyncio/events.py:94: ResourceWarning:
      unclosed file <_io.BufferedReader name='/home/runner/work/ha-core/ha-core/tests/components/backup/fixtures/test_backups/c0cb53bd.tar.decrypted'>
    self._context.run(self._callback, *self._args)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
