### PR TITLE
Fix mqtt test ResourceWarnings

### DIFF
--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -2179,6 +2179,9 @@ async def test_server_sock_connect_and_disconnect(
     # Should have failed
     assert len(recorded_calls) == 0
 
+    client.close()
+    server.close()
+
 
 async def test_server_sock_buffer_size(
     hass: HomeAssistant,
@@ -2201,6 +2204,9 @@ async def test_server_sock_buffer_size(
         mqtt_client_mock.on_socket_register_write(mqtt_client_mock, None, client)
         await hass.async_block_till_done()
     assert "Unable to increase the socket buffer size" in caplog.text
+
+    client.close()
+    server.close()
 
 
 async def test_server_sock_buffer_size_with_websocket(
@@ -2233,6 +2239,9 @@ async def test_server_sock_buffer_size_with_websocket(
         )
         await hass.async_block_till_done()
     assert "Unable to increase the socket buffer size" in caplog.text
+
+    client.close()
+    server.close()
 
 
 async def test_client_sock_failure_after_connect(
@@ -2267,6 +2276,9 @@ async def test_client_sock_failure_after_connect(
     unsub()
     # Should have failed
     assert len(recorded_calls) == 0
+
+    client.close()
+    server.close()
 
 
 async def test_loop_write_failure(
@@ -2308,3 +2320,6 @@ async def test_loop_write_failure(
     await hass.async_block_till_done()
 
     assert "Error returned from MQTT server: The connection was lost." in caplog.text
+
+    client.close()
+    server.close()

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -2179,8 +2179,8 @@ async def test_server_sock_connect_and_disconnect(
     # Should have failed
     assert len(recorded_calls) == 0
 
+    # Cleanup. Server is closed earlier already.
     client.close()
-    server.close()
 
 
 async def test_server_sock_buffer_size(
@@ -2205,6 +2205,7 @@ async def test_server_sock_buffer_size(
         await hass.async_block_till_done()
     assert "Unable to increase the socket buffer size" in caplog.text
 
+    # Cleanup
     client.close()
     server.close()
 
@@ -2240,6 +2241,7 @@ async def test_server_sock_buffer_size_with_websocket(
         await hass.async_block_till_done()
     assert "Unable to increase the socket buffer size" in caplog.text
 
+    # Cleanup
     client.close()
     server.close()
 
@@ -2277,7 +2279,7 @@ async def test_client_sock_failure_after_connect(
     # Should have failed
     assert len(recorded_calls) == 0
 
-    client.close()
+    # Cleanup. Client is closed earlier already.
     server.close()
 
 
@@ -2321,5 +2323,5 @@ async def test_loop_write_failure(
 
     assert "Error returned from MQTT server: The connection was lost." in caplog.text
 
+    # Cleanup. Server is closed earlier already.
     client.close()
-    server.close()


### PR DESCRIPTION
## Proposed change
```py
tests/components/mqtt/test_client.py::test_server_sock_connect_and_disconnect
  /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/asyncio/events.py:94: ResourceWarning:
      unclosed <pytest_socket.disable_socket.<locals>.GuardedSocket fd=25, family=1, type=1, proto=0>
    self._context.run(self._callback, *self._args)

tests/components/mqtt/test_client.py::test_client_sock_failure_after_connect
  /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/asyncio/events.py:94: ResourceWarning:
      unclosed <pytest_socket.disable_socket.<locals>.GuardedSocket fd=30, family=1, type=1, proto=0>
    self._context.run(self._callback, *self._args)

tests/components/mqtt/test_client.py::test_loop_write_failure
  <frozen _collections_abc>:483: ResourceWarning:
      unclosed <pytest_socket.disable_socket.<locals>.GuardedSocket fd=25, family=1, type=1, proto=0>

tests/components/mqtt/test_client.py::test_loop_write_failure
  <frozen _collections_abc>:483: ResourceWarning:
      unclosed <pytest_socket.disable_socket.<locals>.GuardedSocket fd=26, family=1, type=1, proto=0>

tests/components/mqtt/test_client.py::test_loop_write_failure
  /opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/selectors.py:273: ResourceWarning:
      unclosed <pytest_socket.disable_socket.<locals>.GuardedSocket fd=25, family=1, type=1, proto=0>
    self._fd_to_key.clear()

tests/components/mqtt/test_climate.py::test_setup_params[hass_config0]
  /home/runner/work/ha-core/ha-core/tests/conftest.py:273: ResourceWarning:
      unclosed <pytest_socket.disable_socket.<locals>.GuardedSocket fd=27, family=1, type=1, proto=0>
    gc.collect()

tests/components/mqtt/test_climate.py::test_setup_params[hass_config0]
  /home/runner/work/ha-core/ha-core/tests/conftest.py:273: ResourceWarning:
      unclosed <pytest_socket.disable_socket.<locals>.GuardedSocket fd=28, family=1, type=1, proto=0>
    gc.collect()
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
