### PR TITLE
Fix go2rtc ResourceWarnings

### DIFF
--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -175,6 +175,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             await server.start()
         except Exception:  # noqa: BLE001
             _LOGGER.warning("Could not start go2rtc server", exc_info=True)
+            await session.close()
             return False
 
         async def on_stop(event: Event) -> None:


### PR DESCRIPTION
## Proposed change
```py
tests/components/go2rtc/test_init.py::test_setup_with_setup_error[True-config6-None-True-Invalid config for 'go2rtc': Url and debug_ui cannot be set at the same time.]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/aiohttp/client.py:459: ResourceWarning:
      Unclosed client session <aiohttp.client.ClientSession object at 0x7fa2e092b8c0>
    _warnings.warn(

tests/components/go2rtc/test_init.py::test_setup_with_setup_error[True-config8-None-True-Invalid config for 'go2rtc': some but not all values in the same group of inclusion 'auth' 'go2rtc-><auth>',]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/aiohttp/client.py:459: ResourceWarning:
      Unclosed client session <aiohttp.client.ClientSession object at 0x7fa2e0af78c0>
    _warnings.warn(

tests/components/go2rtc/test_init.py::test_setup_with_setup_error[False-config4-/usr/bin/go2rtc-True-Could not start go2rtc server]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/aiohttp/client.py:459: ResourceWarning:
      Unclosed client session <aiohttp.client.ClientSession object at 0x7fa2e08e29a0>
    _warnings.warn(

tests/components/go2rtc/test_init.py::test_setup_with_setup_error[False-config7-/usr/bin/go2rtc-True-Invalid config for 'go2rtc': Username and password can only be set when a URL is configured or debug_ui is true]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/aiohttp/client.py:459: ResourceWarning:
      Unclosed client session <aiohttp.client.ClientSession object at 0x7fa2e08e22c0>
    _warnings.warn(
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
