### PR TITLE
Fix homekit ResourceWarnings

### DIFF
--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -625,10 +625,13 @@ def _get_test_socket() -> socket.socket:
 @callback
 def async_port_is_available(port: int) -> bool:
     """Check to see if a port is available."""
+    test_socket = _get_test_socket()
     try:
-        _get_test_socket().bind(("", port))
+        test_socket.bind(("", port))
     except OSError:
         return False
+    finally:
+        test_socket.close()
     return True
 
 


### PR DESCRIPTION
## Proposed change
```py
tests/components/homekit/test_config_flow.py::test_options_flow_devices
tests/components/homekit/test_config_flow.py::test_options_flow_devices_preserved_when_advanced_off
tests/components/homekit/test_homekit.py::test_setup_min
tests/components/homekit/test_homekit.py::test_yaml_can_link_with_default_name
tests/components/homekit/test_init.py::test_humanify_homekit_changed_event
  /home/runner/work/ha-core/ha-core/homeassistant/components/homekit/util.py:629: ResourceWarning:
      unclosed <socket.socket fd=24, family=2, type=1, proto=0, laddr=('0.0.0.0', 21063)>
    _get_test_socket().bind(("", port))

tests/components/homekit/test_diagnostics.py: 1 warning
tests/components/homekit/test_homekit.py: 40 warnings
tests/components/homekit/test_util.py: 1 warning
  /home/runner/work/ha-core/ha-core/homeassistant/components/homekit/util.py:629: ResourceWarning:
      unclosed <socket.socket fd=24, family=2, type=1, proto=0, laddr=('0.0.0.0', 12345)>
    _get_test_socket().bind(("", port))

tests/components/homekit/test_homekit.py::test_yaml_can_link_with_port
  /home/runner/work/ha-core/ha-core/homeassistant/components/homekit/util.py:629: ResourceWarning:
      unclosed <socket.socket fd=24, family=2, type=1, proto=0, laddr=('0.0.0.0', 12346)>
    _get_test_socket().bind(("", port))

tests/components/homekit/test_homekit.py::test_yaml_can_link_with_port
  /home/runner/work/ha-core/ha-core/homeassistant/components/homekit/util.py:629: ResourceWarning:
      unclosed <socket.socket fd=24, family=2, type=1, proto=0, laddr=('0.0.0.0', 12347)>
    _get_test_socket().bind(("", port))

tests/components/homekit/test_homekit.py::test_reload
  /home/runner/work/ha-core/ha-core/homeassistant/components/homekit/util.py:629: ResourceWarning:
      unclosed <socket.socket fd=24, family=2, type=1, proto=0, laddr=('0.0.0.0', 45678)>
    _get_test_socket().bind(("", port))
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
