### PR TITLE
Fix mcp_server ResourceWarnings

### DIFF
--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -24,6 +24,8 @@ See https://modelcontextprotocol.io/docs/concepts/transports
 """
 
 import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from http import HTTPStatus
 import logging
@@ -102,17 +104,29 @@ class Streams:
     write_stream: MemoryObjectSendStream[SessionMessage]
     write_stream_reader: MemoryObjectReceiveStream[SessionMessage]
 
+    async def aclose(self) -> None:
+        """Close open memory streams."""
+        await self.read_stream.aclose()
+        await self.read_stream_writer.aclose()
+        await self.write_stream.aclose()
+        await self.write_stream_reader.aclose()
 
-def create_streams() -> Streams:
+
+@asynccontextmanager
+async def create_streams() -> AsyncGenerator[Streams]:
     """Create a new pair of streams for MCP server communication."""
     read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
     write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
-    return Streams(
+    streams = Streams(
         read_stream=read_stream,
         read_stream_writer=read_stream_writer,
         write_stream=write_stream,
         write_stream_reader=write_stream_reader,
     )
+    try:
+        yield streams
+    finally:
+        await streams.aclose()
 
 
 async def create_mcp_server(
@@ -155,9 +169,9 @@ class ModelContextProtocolSSEView(HomeAssistantView):
         session_manager = entry.runtime_data
 
         server, options = await create_mcp_server(hass, self.context(request), entry)
-        streams = create_streams()
 
         async with (
+            create_streams() as streams,
             sse_response(request) as response,
             session_manager.create(Session(streams.read_stream_writer)) as session_id,
         ):
@@ -261,21 +275,24 @@ class ModelContextProtocolStreamableView(HomeAssistantView):
         # request is sent to the MCP server and we wait for a single response
         # then shut down the server.
         server, options = await create_mcp_server(hass, self.context(request), entry)
-        streams = create_streams()
 
-        async def run_server() -> None:
-            await server.run(
-                streams.read_stream, streams.write_stream, options, stateless=True
+        async with create_streams() as streams:
+
+            async def run_server() -> None:
+                await server.run(
+                    streams.read_stream, streams.write_stream, options, stateless=True
+                )
+
+            async with asyncio.timeout(TIMEOUT), anyio.create_task_group() as tg:
+                tg.start_soon(run_server)
+
+                await streams.read_stream_writer.send(SessionMessage(message))
+                session_message = await anext(streams.write_stream_reader)
+                tg.cancel_scope.cancel()
+
+            _LOGGER.debug("Sending response: %s", session_message)
+            return web.json_response(
+                data=session_message.message.model_dump(
+                    by_alias=True, exclude_none=True
+                ),
             )
-
-        async with asyncio.timeout(TIMEOUT), anyio.create_task_group() as tg:
-            tg.start_soon(run_server)
-
-            await streams.read_stream_writer.send(SessionMessage(message))
-            session_message = await anext(streams.write_stream_reader)
-            tg.cancel_scope.cancel()
-
-        _LOGGER.debug("Sending response: %s", session_message)
-        return web.json_response(
-            data=session_message.message.model_dump(by_alias=True, exclude_none=True),
-        )


### PR DESCRIPTION
## Proposed change
```py
tests/components/mcp_server/test_http.py::test_http_messages_missing_session_id
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f22054eb340>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_http_messages_missing_session_id
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f22054eb1e0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_http_sse_multiple_config_entries
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f2205c2f4e0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_http_sse_multiple_config_entries
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f2205403260>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_http_messages_no_config_entry
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f2205314cc0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff448b60>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff449260>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff2ab4e0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff348a20>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f22050203e0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f2204f876a0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff33dbf0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff33de20>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff172c90>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tools_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff172de0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff322f30>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f22050aba90>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff06e2f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff06e360>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f222dd03c50>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff33ebb0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff805f70>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f220524c840>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff1d14f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff1d1790>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff1c55d0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff011d40>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f2204fa29f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f2204fa0ca0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[sse]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff0123d0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[sse]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff012b40>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[sse]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff13ef30>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[sse]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff15ee50>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f2205137550>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff395090>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff1c7da0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_failed[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff1c6c90>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff163390>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fef47630>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21feda2980>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21feda2bb0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f220508ba90>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f220508b470>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fef07390>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f2205a077f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff054d80>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff0554f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff2feec0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fef947d0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21feedba20>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff011bf0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fee194f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fee1a4b0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff2ffb70>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff1316b0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f2205613c50>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f22050a9090>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fea96210>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fea97630>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff46a360>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_prompt_get[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff1d3da0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_get_unknown_prompt[sse]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21feab4a00>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_get_unknown_prompt[sse]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21feb09cd0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_get_unknown_prompt[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fee71e90>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_get_unknown_prompt[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff0564b0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_get_unknown_prompt[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff012210>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_get_unknown_prompt[streamable]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fee332b0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff133da0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21febee360>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fee0f4e0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff15fe10>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21febe8fb0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f2204f84990>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff0119c0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21feb43d30>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21feb401b0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21feb40300>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe93f4e0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_list[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe9d23d0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe9c3400>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe9c3240>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe7ca670>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe7cb630>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe9cd950>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe9cd9c0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f2204fac920>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f2204fad950>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff15ca00>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21ff224060>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff1634e0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe93e0c0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21feed9f70>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe92e7c0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff32bbe0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[sse-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fec6a670>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe9cf0f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe9cefa0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe6a6d70>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe6a6ec0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe6a2ad0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe6a2c20>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe71f2b0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resource_read_unknown_resource[streamable-stateless_assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe71f400>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_unavailable_without_live_context_tool[sse-test-api]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21feab52c0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_unavailable_without_live_context_tool[sse-test-api]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fedcfa90>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_unavailable_without_live_context_tool[streamable-test-api]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe541db0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_unavailable_without_live_context_tool[streamable-test-api]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe542360>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_unavailable_without_live_context_tool[streamable-test-api]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21ff395800>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_resources_unavailable_without_live_context_tool[streamable-test-api]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe8b7320>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe5422f0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe540610>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fd371870>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[sse-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21feca79b0>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fef46d00>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fef45800>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f2204fab320>
    warnings.warn(

tests/components/mcp_server/test_http.py::test_mcp_tool_call_unicode[streamable-assist]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe72e590>
    warnings.warn(

tests/components/mcp_server/test_init.py::test_init
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fef45790>
    warnings.warn(

tests/components/mcp_server/test_init.py::test_init
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fd414ae0>
    warnings.warn(

tests/components/mcp_server/test_init.py::test_init
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:314: ResourceWarning:
      Unclosed <MemoryObjectSendStream at 7f21fe584760>
    warnings.warn(

tests/components/mcp_server/test_init.py::test_init
  /home/runner/work/ha-core/ha-core/venv/lib/python3.14/site-packages/anyio/streams/memory.py:183: ResourceWarning:
      Unclosed <MemoryObjectReceiveStream at 7f21fe585800>
    warnings.warn(
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
