### PR TITLE
Add Renovate config for allow-listed Python dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -89,7 +89,7 @@
         "zeroconf"
       ],
       "enabled": true,
-      "labels": ["dependency", "core-dependency"]
+      "labels": ["dependency", "core"]
     },
     {
       "description": "Test dependencies (allowlisted)",
@@ -122,7 +122,7 @@
         "/^types-/"
       ],
       "enabled": true,
-      "labels": ["dependency", "test-dependency"]
+      "labels": ["dependency"]
     },
     {
       "description": "Pre-commit hook repos (allowlisted, matched by owner/repo)",
@@ -133,7 +133,7 @@
         "zizmorcore/zizmor-pre-commit"
       ],
       "enabled": true,
-      "labels": ["dependency", "test-dependency"]
+      "labels": ["dependency"]
     },
     {
       "description": "Group ruff pre-commit hook with its PyPI twin into one PR",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,8 +48,8 @@
       ],
       "matchStringsStrategy": "recursive",
       "matchStrings": [
-        "\"requirements\"\\s*:\\s*\\[(?<inner>[^\\]]*)\\]",
-        "\"(?<depName>[^\"=<>!~;\\s]+?)==(?<currentValue>[^\"]+?)\""
+        "\"requirements\"\\s*:\\s*\\[(?<inner>\\s*(?:\"(?:[^\"\\\\]|\\\\.)*\"\\s*,\\s*)*\"(?:[^\"\\\\]|\\\\.)*\"\\s*)?\\]",
+        "\"(?<depName>[^\"=<>!~;\\s\\[\\]]+)(?:\\[[^\"\\]]*\\])?==(?<currentValue>[^\"]+?)\""
       ],
       "datasourceTemplate": "pypi"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+
+  "enabledManagers": [
+    "pep621",
+    "pip_requirements",
+    "pre-commit",
+    "custom.regex"
+  ],
+
+  "pre-commit": {
+    "enabled": true
+  },
+
+  "pip_requirements": {
+    "managerFilePatterns": [
+      "/(^|/)requirements[\\w_-]*\\.txt$/",
+      "/(^|/)homeassistant/package_constraints\\.txt$/"
+    ]
+  },
+
+  "minimumReleaseAge": "7 days",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+  "schedule": ["before 6am"],
+
+  "semanticCommits": "disabled",
+  "commitMessageAction": "Update",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "to {{newVersion}}",
+
+  "automerge": false,
+
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": null,
+    "labels": ["dependency", "security"],
+    "automerge": false
+  },
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Home Assistant integration manifest.json requirements",
+      "managerFilePatterns": [
+        "/^homeassistant/components/[^/]+/manifest\\.json$/"
+      ],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        "\"requirements\"\\s*:\\s*\\[(?<inner>[^\\]]*)\\]",
+        "\"(?<depName>[^\"=<>!~;\\s]+?)==(?<currentValue>[^\"]+?)\""
+      ],
+      "datasourceTemplate": "pypi"
+    }
+  ],
+
+  "packageRules": [
+    {
+      "description": "Deny all by default — allowlist below re-enables specific packages",
+      "matchPackageNames": ["*"],
+      "enabled": false
+    },
+    {
+      "description": "Core runtime dependencies (allowlisted)",
+      "matchPackageNames": [
+        "aiohttp",
+        "aiohttp-fast-zlib",
+        "aiohttp_cors",
+        "aiohttp-asyncmdnsresolver",
+        "yarl",
+        "httpx",
+        "requests",
+        "urllib3",
+        "certifi",
+        "orjson",
+        "PyYAML",
+        "Jinja2",
+        "cryptography",
+        "pyOpenSSL",
+        "PyJWT",
+        "SQLAlchemy",
+        "Pillow",
+        "attrs",
+        "voluptuous",
+        "voluptuous-serialize",
+        "voluptuous-openapi",
+        "zeroconf"
+      ],
+      "enabled": true,
+      "labels": ["dependency", "core-dependency"]
+    },
+    {
+      "description": "Test dependencies (allowlisted)",
+      "matchPackageNames": [
+        "pytest",
+        "pytest-asyncio",
+        "pytest-aiohttp",
+        "pytest-cov",
+        "pytest-freezer",
+        "pytest-github-actions-annotate-failures",
+        "pytest-socket",
+        "pytest-sugar",
+        "pytest-timeout",
+        "pytest-unordered",
+        "pytest-picked",
+        "pytest-xdist",
+        "mypy",
+        "pylint",
+        "pylint-per-file-ignores",
+        "astroid",
+        "coverage",
+        "freezegun",
+        "syrupy",
+        "respx",
+        "requests-mock",
+        "ruff",
+        "codespell",
+        "yamllint",
+        "zizmor",
+        "/^types-/"
+      ],
+      "enabled": true,
+      "labels": ["dependency", "test-dependency"]
+    },
+    {
+      "description": "Pre-commit hook repos (allowlisted, matched by owner/repo)",
+      "matchPackageNames": [
+        "astral-sh/ruff-pre-commit",
+        "codespell-project/codespell",
+        "adrienverge/yamllint",
+        "zizmorcore/zizmor-pre-commit"
+      ],
+      "enabled": true,
+      "labels": ["dependency", "test-dependency"]
+    },
+    {
+      "description": "Group ruff pre-commit hook with its PyPI twin into one PR",
+      "matchPackageNames": ["astral-sh/ruff-pre-commit", "ruff"],
+      "groupName": "ruff",
+      "groupSlug": "ruff"
+    },
+    {
+      "description": "Group codespell pre-commit hook with its PyPI twin into one PR",
+      "matchPackageNames": ["codespell-project/codespell", "codespell"],
+      "groupName": "codespell",
+      "groupSlug": "codespell"
+    },
+    {
+      "description": "Group yamllint pre-commit hook with its PyPI twin into one PR",
+      "matchPackageNames": ["adrienverge/yamllint", "yamllint"],
+      "groupName": "yamllint",
+      "groupSlug": "yamllint"
+    },
+    {
+      "description": "Group zizmor pre-commit hook with its PyPI twin into one PR",
+      "matchPackageNames": ["zizmorcore/zizmor-pre-commit", "zizmor"],
+      "groupName": "zizmor",
+      "groupSlug": "zizmor"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -82,6 +82,7 @@
         "SQLAlchemy",
         "Pillow",
         "attrs",
+        "uv",
         "voluptuous",
         "voluptuous-serialize",
         "voluptuous-openapi",


### PR DESCRIPTION
## Proposed change

Adds `.github/renovate.json` to opt Home Assistant core into automated Python dependency update PRs from the Mend Renovate GitHub App, for a narrow allow-list of packages only. Everything else stays disabled.

**In scope (for now):**
- Core runtime deps in `pyproject.toml`: `uv`, `aiohttp`, `yarl`, `httpx`,   `requests`, `urllib3`, `orjson`, `PyYAML`, `Jinja2`, `cryptography`,  `pyOpenSSL`, `PyJWT`, `SQLAlchemy`, `Pillow`, `attrs`, `voluptuous*`, `zeroconf`, and a handful more.
- Test deps in `requirements_test.txt`: `pytest*`, `mypy`, `pylint`, `astroid`, `coverage`, `freezegun`, `syrupy`, `respx`, `requests-mock`, and `types-*`.
- Pre-commit tools in `.pre-commit-config.yaml`: `ruff`, `codespell`, `yamllint`, `zizmor`.

**Out of scope (deny by default):**
- Integration-specific libraries in `manifest.json` (the machinery to support them is present, but no integration libraries are on the allow-list right now).
- Packages with human-authored constraints in `package_constraints.txt`
  (`numpy`, `pandas`, `pydantic`, `protobuf`, `grpcio*`, `setuptools`, wheel-builder pins).
- **Auto-merge is disabled everywhere** and stays that way. Every PR goes through human review. Security PRs bypass the 7-day cooldown but still require review.

Renovate's `pep621`, `pip_requirements`, `pre-commit`, and a small `customManagers` regex (for `manifest.json`) run in lockstep: a single package bump edits every file where the pin appears in one atomic PR, so hassfest stays green on arrival without a regeneration step. 

Example: a `SQLAlchemy` bump edits `pyproject.toml`, `recorder/manifest.json`, `sql/manifest.json`, `package_constraints.txt`, `requirements.txt`, `requirements_all.txt`, and `requirements_test_all.txt` in one commit.

**Merging this PR is a no-op** until the Mend Renovate GitHub App is enabled on the repo as a separate follow-up step.

### How to test

From the repo root:

```bash
RENOVATE_CONFIG_FILE=$PWD/.github/renovate.json \
LOG_LEVEL=debug \
  npx --yes --package renovate -- renovate \
    --platform=local \
    --dry-run=full \
    --onboarding=false \
    2>&1 | tee ./renovate-dryrun.log
```

First run takes a few minutes (one PyPI lookup per discovered package).

### Expected output

~~~
INFO: Repository finished (repository=local)
  "result": "done"
  "status": "onboarded"
~~~

Four managers, roughly these counts (they'll drift as new integrations and deps land):

| Manager | Files | Deps |
|---|---|---|
| `pep621` | 1 | ~52 |
| `pip_requirements` | 6 | ~2270 |
| `pre-commit` | 1 | 7 |
| `regex` (custom, for `manifest.json`) | ~1070 | ~1180 |
| **total** | **~1080** | **~3510** |

Around 20–30 unique branches, one per allow-listed package that has a newer release on PyPI. Every branch name starts with `renovate/` and corresponds to an allow-listed package. Non-allow-listed packages (`numpy`, `pandas`, `pydantic`, `openai`, etc.) are extracted but produce zero branches.

Quick checks on the captured log:

~~~bash
# Did it finish cleanly?
grep -A4 "Repository finished" ./renovate-dryrun.log

# Manager summary
grep -E "fileCount.*depCount" ./renovate-dryrun.log

# All proposed branches
grep -oE '"branchName":\s*"renovate/[^"]+"' ./renovate-dryrun.log | sort -u
~~~

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
