### PR TITLE
mqtt: expose expire_after and other config parameters as read-only state attributes

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -35,7 +35,7 @@ from homeassistant.util import dt as dt_util
 
 from . import subscription
 from .config import MQTT_RO_SCHEMA
-from .const import CONF_OFF_DELAY, CONF_STATE_TOPIC, PAYLOAD_NONE
+from .const import CONF_OFF_DELAY, CONF_QOS, CONF_STATE_TOPIC, PAYLOAD_NONE
 from .entity import MqttAvailabilityMixin, MqttEntity, async_setup_entity_entry_helper
 from .models import MqttValueTemplate, ReceiveMessage
 from .schemas import MQTT_ENTITY_COMMON_SCHEMA
@@ -256,3 +256,24 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
         return MqttAvailabilityMixin.available.fget(self) and (  # type: ignore[attr-defined]
             self._expire_after is None or not self._expired
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose selected MQTT config parameters as read-only state attributes.
+
+        Makes runtime-relevant config values accessible to automations and
+        templates without hardcoding, e.g. for watchdog automations that
+        compare last_updated against expire_after or off_delay.
+        """
+        attrs: dict[str, Any] = {}
+        if (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None:
+            attrs["expire_after"] = expire_after
+        if (off_delay := self._config.get(CONF_OFF_DELAY)) is not None:
+            attrs["off_delay"] = off_delay
+        if (force_update := self._config.get(CONF_FORCE_UPDATE)) is not None:
+            attrs["force_update"] = force_update
+        if (qos := self._config.get(CONF_QOS)) is not None:
+            attrs["qos"] = qos
+        if (state_topic := self._config.get(CONF_STATE_TOPIC)) is not None:
+            attrs["state_topic"] = state_topic
+        return attrs or None

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -46,6 +47,7 @@ from .const import (
     CONF_EXPIRE_AFTER,
     CONF_LAST_RESET_VALUE_TEMPLATE,
     CONF_OPTIONS,
+    CONF_QOS,
     CONF_STATE_TOPIC,
     CONF_SUGGESTED_DISPLAY_PRECISION,
     PAYLOAD_NONE,
@@ -398,3 +400,22 @@ class MqttSensor(MqttEntity, RestoreSensor):
         return MqttAvailabilityMixin.available.fget(self) and (  # type: ignore[attr-defined]
             self._expire_after is None or not self._expired
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose selected MQTT config parameters as read-only state attributes.
+
+        Makes runtime-relevant config values accessible to automations and
+        templates without hardcoding, e.g. for watchdog automations that
+        compare last_updated against expire_after.
+        """
+        attrs: dict[str, Any] = {}
+        if (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None:
+            attrs["expire_after"] = expire_after
+        if (force_update := self._config.get(CONF_FORCE_UPDATE)) is not None:
+            attrs["force_update"] = force_update
+        if (qos := self._config.get(CONF_QOS)) is not None:
+            attrs["qos"] = qos
+        if (state_topic := self._config.get(CONF_STATE_TOPIC)) is not None:
+            attrs["state_topic"] = state_topic
+        return attrs or None

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -745,6 +745,147 @@ async def test_off_delay(
     assert len(events) == 3
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "expire_after": 120,
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_expire_after(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that expire_after is exposed as a state attribute."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "ON")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state is not None
+    assert state.attributes.get("expire_after") == 120
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_expire_after_absent_when_not_set(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that expire_after is absent from attributes when not configured."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "ON")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state is not None
+    assert "expire_after" not in state.attributes
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "off_delay": 30,
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_off_delay(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that off_delay is exposed as a state attribute."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "ON")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state is not None
+    assert state.attributes.get("off_delay") == 30
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_off_delay_absent_when_not_set(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that off_delay is absent from attributes when not configured."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "ON")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state is not None
+    assert "off_delay" not in state.attributes
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                binary_sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "home/door/contact",
+                    "expire_after": 3600,
+                    "off_delay": 60,
+                    "force_update": True,
+                    "qos": 1,
+                }
+            }
+        }
+    ],
+)
+async def test_config_attributes_all_together(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that all new config attributes coexist on binary_sensor."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "home/door/contact", "ON")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state is not None
+    attrs = state.attributes
+    assert attrs.get("expire_after") == 3600
+    assert attrs.get("off_delay") == 60
+    assert attrs.get("force_update") is True
+    assert attrs.get("qos") == 1
+    assert attrs.get("state_topic") == "home/door/contact"
+
+
 async def test_setting_attribute_via_mqtt_json_message(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -769,6 +769,199 @@ async def test_force_update_enabled(
     assert len(events) == 2
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "expire_after": 300,
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_expire_after(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that expire_after is exposed as a state attribute."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "100")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert state.attributes.get("expire_after") == 300
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_expire_after_absent_when_not_set(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that expire_after is absent from attributes when not configured."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "100")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert "expire_after" not in state.attributes
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "force_update": True,
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_force_update(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that force_update is exposed as a state attribute."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "100")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert state.attributes.get("force_update") is True
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "qos": 1,
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_qos(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that qos is exposed as a state attribute."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "test-topic", "100")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert state.attributes.get("qos") == 1
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "home/h60/energy",
+                }
+            }
+        }
+    ],
+)
+async def test_config_attribute_state_topic(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that state_topic is exposed as a state attribute."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "home/h60/energy", "100")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert state.attributes.get("state_topic") == "home/h60/energy"
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "home/h60/energy",
+                    "expire_after": 600,
+                    "force_update": True,
+                    "qos": 2,
+                }
+            }
+        }
+    ],
+)
+async def test_config_attributes_all_together(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that all new config attributes coexist when all parameters are set."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(hass, "home/h60/energy", "100")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    attrs = state.attributes
+    assert attrs.get("expire_after") == 600
+    assert attrs.get("force_update") is True
+    assert attrs.get("qos") == 2
+    assert attrs.get("state_topic") == "home/h60/energy"
+
+
+async def test_config_attribute_expire_after_via_discovery(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test that expire_after configured via MQTT discovery is exposed as attribute."""
+    await mqtt_mock_entry()
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/sensor/h60_test/config",
+        json.dumps(
+            {
+                "name": "test",
+                "state_topic": "home/h60/energy",
+                "expire_after": 300,
+                "unique_id": "h60_energy_test",
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+    async_fire_mqtt_message(hass, "home/h60/energy", "100")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert state.attributes.get("expire_after") == 300
+    assert state.attributes.get("state_topic") == "home/h60/energy"
+
+
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
 async def test_availability_when_connection_lost(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator


### PR DESCRIPTION
## Proposed change

Add `extra_state_attributes` to `MqttSensor` and `MqttBinarySensor` that expose runtime-relevant MQTT configuration parameters as read-only state attributes.

### Problem

Several MQTT sensor configuration parameters that directly affect runtime behavior are invisible after the entity is set up. They are not accessible via `state_attr()`, the States UI, or the entity registry.

This forces users to duplicate values — for example, hardcoding `expire_after: 300` both in the sensor config and in every watchdog automation that references the sensor. It also makes generic automations and dashboards impossible to write without coupling them to specific numeric constants.

### Solution

Expose the following as read-only state attributes:

**`sensor.mqtt`:**
| Attribute | Type | Purpose |
|---|---|---|
| `expire_after` | `int` (seconds) | Enables watchdog automations without hardcoding timeout values |
| `force_update` | `bool` | Communicates whether `state_changed` fires on repeated identical values |
| `qos` | `int` | Useful for diagnosing dropped messages |
| `state_topic` | `str` | Enables generic automations that inspect their own MQTT source |

**`binary_sensor.mqtt`** (same as above, plus):
| Attribute | Type | Purpose |
|---|---|---|
| `off_delay` | `int` (seconds) | Analogous to `expire_after`, same watchdog use case |

Attributes are only present when the corresponding config key is set, keeping the attribute namespace clean for unconfigured parameters.

### Example use case

A heat meter (H60) publishes via MQTT with `expire_after: 300`. A watchdog automation needs to alert when the sensor goes stale. Today the timeout must be hardcoded in the automation. With this change:

```yaml
condition:
  - condition: template
    value_template: >
      {{ (now() - states.sensor.h60_energy.last_updated).total_seconds()
         > state_attr('sensor.h60_energy', 'expire_after') | int(300) }}
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
(`mqtt.set_expire_after`) for runtime mutation of `expire_after`, dependent on this PR being merged first.
- No schema changes, no migration needed, no new dependencies.
- Attributes return `None` (omitted from HA state dict) when no relevant config keys are set, so existing entities are unaffected.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass
- [x] Tests have been added to verify the new code works (`test_config_attribute_*` functions in `test_sensor.py` and `test_binary_sensor.py`)
- [ ] The documentation is updated (will update `sensor.mqtt` and `binary_sensor.mqtt` docs pages if this approach is confirmed by maintainers)
