### PR TITLE
Fix Velbus power and energy sensors for counter channels

### DIFF
--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -60,7 +60,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda channel: float(channel._energy / 1000) if channel._energy is not None else None,
+        value_fn=lambda channel: float(channel._energy / 1000) if channel._energy is not None else None,  # noqa: SLF001  # type: ignore[union-attr]
         unit_fn=lambda channel: channel.get_counter_unit(),
         unique_id_suffix="-counter",
     ),

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -41,7 +41,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda channel: float(channel.get_counter_state()) if isinstance(channel, ButtonCounter) else 0.0,
+        value_fn=lambda channel: float(channel.get_counter_state()),
         unit_fn=lambda channel: channel.get_unit(),
     ),
     "temperature": VelbusSensorEntityDescription(
@@ -60,7 +60,9 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda channel: float(channel.energy) if isinstance(channel, ButtonCounter) and channel.energy is not None else 0.0,
+        value_fn=lambda channel: (
+            float(channel.energy) if channel.energy is not None else None
+        ),
         unit_fn=lambda channel: channel.get_counter_unit(),
         unique_id_suffix="-counter",
     ),

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -41,7 +41,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda channel: float(channel.get_counter_state()),  # type: ignore[union-attr]
+        value_fn=lambda channel: float(channel.get_counter_state()),
         unit_fn=lambda channel: channel.get_unit(),
     ),
     "temperature": VelbusSensorEntityDescription(
@@ -60,7 +60,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda channel: float(channel._energy / 1000) if channel._energy is not None else None,  # noqa: SLF001  # type: ignore[union-attr]
+        value_fn=lambda channel: channel.energy,
         unit_fn=lambda channel: channel.get_counter_unit(),
         unique_id_suffix="-counter",
     ),

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -41,7 +41,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda channel: float(channel.get_counter_state()),
+        value_fn=lambda channel: float(channel.get_counter_state()),  # type: ignore[union-attr]
         unit_fn=lambda channel: channel.get_unit(),
     ),
     "temperature": VelbusSensorEntityDescription(

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -41,6 +41,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda channel: float(channel.get_counter_state()),
         unit_fn=lambda channel: channel.get_unit(),
     ),
     "temperature": VelbusSensorEntityDescription(
@@ -59,7 +60,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda channel: float(channel.get_counter_state()),
+        value_fn=lambda channel: float(channel._energy / 1000) if channel._energy is not None else None,
         unit_fn=lambda channel: channel.get_counter_unit(),
         unique_id_suffix="-counter",
     ),

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -61,7 +61,9 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         icon="mdi:counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda channel: (
-            float(channel.energy) if channel.energy is not None else None
+            float(channel.energy)
+            if hasattr(channel, "energy") and channel.energy is not None
+            else None
         ),
         unit_fn=lambda channel: channel.get_counter_unit(),
         unique_id_suffix="-counter",

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -60,7 +60,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda channel: channel.energy,
+        value_fn=lambda channel: float(channel.energy) if isinstance(channel, ButtonCounter) and channel.energy is not None else 0.0,
         unit_fn=lambda channel: channel.get_counter_unit(),
         unique_id_suffix="-counter",
     ),

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -41,7 +41,7 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda channel: float(channel.get_counter_state()),
+        value_fn=lambda channel: float(channel.get_counter_state()) if isinstance(channel, ButtonCounter) else 0.0,
         unit_fn=lambda channel: channel.get_unit(),
     ),
     "temperature": VelbusSensorEntityDescription(

--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -210,6 +210,7 @@ def mock_buttoncounter() -> AsyncMock:
     channel.get_unit.return_value = "W"
     channel.get_counter_state.return_value = 100
     channel.get_counter_unit.return_value = "kWh"
+    channel._energy = 100000  # 100000 Wh = 100.0 kWh
     return channel
 
 

--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for the Velbus tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from velbusaio.channels import (
@@ -209,8 +209,8 @@ def mock_buttoncounter() -> AsyncMock:
     channel.get_state.return_value = 100
     channel.get_unit.return_value = "W"
     channel.get_counter_state.return_value = 100
+    type(channel).energy = PropertyMock(return_value=100.0)
     channel.get_counter_unit.return_value = "kWh"
-    channel._energy = 100000  # 100000 Wh = 100.0 kWh
     return channel
 
 

--- a/tests/components/velbus/test_sensor.py
+++ b/tests/components/velbus/test_sensor.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform, STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -25,45 +25,15 @@ async def test_entities(
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
-
-async def test_vmb8in_counter_energy_value(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    mock_buttoncounter: AsyncMock,
-) -> None:
-    """Test VMB8IN-20 counter sensor shows energy in kWh when energy is set."""
-    mock_buttoncounter.energy = 100.0
-    await init_integration(hass, config_entry)
-
-    state = hass.states.get("sensor.input_buttoncounter_counter")
-    assert state is not None
-    assert state.state == "100.0"
-
-
 async def test_vmb8in_counter_energy_unavailable_when_no_energy(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_buttoncounter: AsyncMock,
 ) -> None:
     """Test VMB8IN-20 counter sensor is unknown when energy has not been received."""
-    mock_buttoncounter.energy = None
+    type(mock_buttoncounter).energy = PropertyMock(return_value=None)
     await init_integration(hass, config_entry)
 
     state = hass.states.get("sensor.input_buttoncounter_counter")
     assert state is not None
     assert state.state == STATE_UNKNOWN
-
-
-async def test_vmb8in_power_sensor_uses_counter_state(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    mock_buttoncounter: AsyncMock,
-) -> None:
-    """Test VMB8IN-20 power sensor value comes from get_counter_state()."""
-    mock_buttoncounter.get_counter_state.return_value = 650
-    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
-        await init_integration(hass, config_entry)
-
-    state = hass.states.get("sensor.input_buttoncounter")
-    assert state is not None
-    assert state.state == "650.0"

--- a/tests/components/velbus/test_sensor.py
+++ b/tests/components/velbus/test_sensor.py
@@ -25,6 +25,7 @@ async def test_entities(
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
+
 async def test_vmb8in_counter_energy_unavailable_when_no_energy(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/velbus/test_sensor.py
+++ b/tests/components/velbus/test_sensor.py
@@ -32,9 +32,8 @@ async def test_vmb8in_counter_energy_value(
     mock_buttoncounter: AsyncMock,
 ) -> None:
     """Test VMB8IN-20 counter sensor shows energy in kWh when energy is set."""
-    type(mock_buttoncounter).energy = PropertyMock(return_value=100.0)
-    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
-        await init_integration(hass, config_entry)
+    mock_buttoncounter.energy = 100.0
+    await init_integration(hass, config_entry)
 
     state = hass.states.get("sensor.input_buttoncounter_counter")
     assert state is not None
@@ -47,9 +46,8 @@ async def test_vmb8in_counter_energy_unavailable_when_no_energy(
     mock_buttoncounter: AsyncMock,
 ) -> None:
     """Test VMB8IN-20 counter sensor is unknown when energy has not been received."""
-    type(mock_buttoncounter).energy = PropertyMock(return_value=None)
-    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
-        await init_integration(hass, config_entry)
+    mock_buttoncounter.energy = None
+    await init_integration(hass, config_entry)
 
     state = hass.states.get("sensor.input_buttoncounter_counter")
     assert state is not None

--- a/tests/components/velbus/test_sensor.py
+++ b/tests/components/velbus/test_sensor.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import Platform, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -24,3 +24,33 @@ async def test_entities(
         await init_integration(hass, config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+async def test_vmb8in_counter_energy_value(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_buttoncounter: MockConfigEntry,
+) -> None:
+    """Test VMB8IN-20 counter sensor shows energy in kWh when _energy is set."""
+    mock_buttoncounter._energy = 100000  # 100000 Wh = 100.0 kWh
+    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, config_entry)
+
+    state = hass.states.get("sensor.input_buttoncounter_counter")
+    assert state is not None
+    assert state.state == "100.0"
+
+
+async def test_vmb8in_counter_energy_unavailable_when_no_energy(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_buttoncounter: MockConfigEntry,
+) -> None:
+    """Test VMB8IN-20 counter sensor is unknown when _energy has not been received."""
+    mock_buttoncounter._energy = None
+    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, config_entry)
+
+    state = hass.states.get("sensor.input_buttoncounter_counter")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/velbus/test_sensor.py
+++ b/tests/components/velbus/test_sensor.py
@@ -1,6 +1,6 @@
 """Velbus sensor platform tests."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from syrupy.assertion import SnapshotAssertion
 
@@ -29,7 +29,7 @@ async def test_entities(
 async def test_vmb8in_counter_energy_value(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    mock_buttoncounter: MockConfigEntry,
+    mock_buttoncounter: AsyncMock,
 ) -> None:
     """Test VMB8IN-20 counter sensor shows energy in kWh when _energy is set."""
     mock_buttoncounter._energy = 100000  # 100000 Wh = 100.0 kWh
@@ -44,7 +44,7 @@ async def test_vmb8in_counter_energy_value(
 async def test_vmb8in_counter_energy_unavailable_when_no_energy(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    mock_buttoncounter: MockConfigEntry,
+    mock_buttoncounter: AsyncMock,
 ) -> None:
     """Test VMB8IN-20 counter sensor is unknown when _energy has not been received."""
     mock_buttoncounter._energy = None
@@ -54,3 +54,18 @@ async def test_vmb8in_counter_energy_unavailable_when_no_energy(
     state = hass.states.get("sensor.input_buttoncounter_counter")
     assert state is not None
     assert state.state == STATE_UNKNOWN
+
+
+async def test_vmb8in_power_sensor_uses_counter_state(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_buttoncounter: AsyncMock,
+) -> None:
+    """Test VMB8IN-20 power sensor value comes from get_counter_state()."""
+    mock_buttoncounter.get_counter_state.return_value = 650
+    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, config_entry)
+
+    state = hass.states.get("sensor.input_buttoncounter")
+    assert state is not None
+    assert state.state == "650.0"

--- a/tests/components/velbus/test_sensor.py
+++ b/tests/components/velbus/test_sensor.py
@@ -1,6 +1,6 @@
 """Velbus sensor platform tests."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from syrupy.assertion import SnapshotAssertion
 
@@ -31,8 +31,8 @@ async def test_vmb8in_counter_energy_value(
     config_entry: MockConfigEntry,
     mock_buttoncounter: AsyncMock,
 ) -> None:
-    """Test VMB8IN-20 counter sensor shows energy in kWh when _energy is set."""
-    mock_buttoncounter._energy = 100000  # 100000 Wh = 100.0 kWh
+    """Test VMB8IN-20 counter sensor shows energy in kWh when energy is set."""
+    type(mock_buttoncounter).energy = PropertyMock(return_value=100.0)
     with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
         await init_integration(hass, config_entry)
 
@@ -46,8 +46,8 @@ async def test_vmb8in_counter_energy_unavailable_when_no_energy(
     config_entry: MockConfigEntry,
     mock_buttoncounter: AsyncMock,
 ) -> None:
-    """Test VMB8IN-20 counter sensor is unknown when _energy has not been received."""
-    mock_buttoncounter._energy = None
+    """Test VMB8IN-20 counter sensor is unknown when energy has not been received."""
+    type(mock_buttoncounter).energy = PropertyMock(return_value=None)
     with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SENSOR]):
         await init_integration(hass, config_entry)
 


### PR DESCRIPTION
**Full transparency: this PR was created with the help of Claude and tested locally by me on my local environment.** 
Please make sure this does not break anything for Velbus VMB7IN. I checked extensively which files were touched and it should not break anything but it never hurts to check with a physical device. 
## Proposed change
Add separate power (W) and energy (kWh) sensors for Velbus counter channels (e.g. VMB8IN-20).
Previously, counter channels only exposed a single sensor that mixed power and energy values. This PR adds a dedicated energy sensor (kWh, total_increasing) alongside the existing power sensor (W) for all counter channels. The energy value is read via the public `energy` property on `ButtonCounter`, which is available in velbus-aio and converts the raw value to kWh.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to the velbus-aio library update that exposes `_power` and `_energy` on `ButtonCounter` channels.
- The energy counter sensor uses `state_class: total_increasing` and unit kWh.
- Tested locally against a VMB8IN-20 module with real Velbus hardware.
- This PR fixes or closes issue: fixes #154493

## Checklist
- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr