### PR TITLE
Fix Victron BLE false reauth on unrecognised advertisement mode bytes

### DIFF
--- a/homeassistant/components/victron_ble/__init__.py
+++ b/homeassistant/components/victron_ble/__init__.py
@@ -41,20 +41,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update = data.update(service_info)
 
         # Only assess key validity for instant-readout advertisements
-        # (0x10 prefix) whose device type the parser actually recognises.
-        # Unrecognised mode bytes or non-instant-readout packets are neutral:
+        # (0x10 prefix) whose device type the parser actually recognizes.
+        # Unrecognized mode bytes or non-instant-readout packets are neutral:
         # they say nothing about whether the encryption key is correct, so
         # they must not increment or reset the failure counter.
         raw_data = service_info.manufacturer_data.get(VICTRON_IDENTIFIER)
         if update.devices and raw_data is not None:
             try:
-                is_recognisable = (
+                is_recognizable = (
                     raw_data[:1] == b"\x10" and detect_device_type(raw_data) is not None
                 )
             except struct_error, IndexError:
-                is_recognisable = False
+                is_recognizable = False
 
-            if is_recognisable:
+            if is_recognizable:
                 if not data.validate_advertisement_key(raw_data):
                     consecutive_failures += 1
                     if consecutive_failures >= REAUTH_AFTER_FAILURES:

--- a/homeassistant/components/victron_ble/__init__.py
+++ b/homeassistant/components/victron_ble/__init__.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+from struct import error as struct_error
 
 from sensor_state_data import SensorUpdate
 from victron_ble_ha_parser import VictronBluetoothDeviceData
+from victron_ble_ha_parser.parser import detect_device_type
 
 from homeassistant.components.bluetooth import (
     BluetoothScanningMode,
@@ -38,25 +40,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         nonlocal consecutive_failures
         update = data.update(service_info)
 
-        # Only consider a reauth when the device type is recognised (devices
-        # populated) but the advertisement key fails the quick-check built into
-        # validate_advertisement_key.  Using the key check instead of counting
-        # entity values avoids false positives: some devices legitimately return
-        # few (or zero) sensor values when in certain error or alarm states.
+        # Only assess key validity for instant-readout advertisements
+        # (0x10 prefix) whose device type the parser actually recognises.
+        # Unrecognised mode bytes or non-instant-readout packets are neutral:
+        # they say nothing about whether the encryption key is correct, so
+        # they must not increment or reset the failure counter.
         raw_data = service_info.manufacturer_data.get(VICTRON_IDENTIFIER)
         if update.devices and raw_data is not None:
-            if not data.validate_advertisement_key(raw_data):
-                consecutive_failures += 1
-                if consecutive_failures >= REAUTH_AFTER_FAILURES:
-                    _LOGGER.debug(
-                        "Triggering reauth for %s after %d consecutive failures",
-                        address,
-                        consecutive_failures,
-                    )
-                    entry.async_start_reauth(hass)
+            try:
+                is_recognisable = (
+                    raw_data[:1] == b"\x10" and detect_device_type(raw_data) is not None
+                )
+            except struct_error, IndexError:
+                is_recognisable = False
+
+            if is_recognisable:
+                if not data.validate_advertisement_key(raw_data):
+                    consecutive_failures += 1
+                    if consecutive_failures >= REAUTH_AFTER_FAILURES:
+                        _LOGGER.debug(
+                            "Triggering reauth for %s after %d consecutive failures",
+                            address,
+                            consecutive_failures,
+                        )
+                        entry.async_start_reauth(hass)
+                        consecutive_failures = 0
+                else:
                     consecutive_failures = 0
-            else:
-                consecutive_failures = 0
         else:
             consecutive_failures = 0
 

--- a/tests/components/victron_ble/fixtures.py
+++ b/tests/components/victron_ble/fixtures.py
@@ -201,11 +201,11 @@ VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
-# Same Victron manufacturer data prefix but with an unrecognised mode byte
+# Same Victron manufacturer data prefix but with an unrecognized mode byte
 # (0xEE at offset 4).  detect_device_type returns None for this payload,
 # so validate_advertisement_key would also return False.  The reauth logic
 # must treat this as neutral (not a key failure).
-VICTRON_VEBUS_UNRECOGNISED_MODE_SERVICE_INFO = BluetoothServiceInfo(
+VICTRON_VEBUS_UNRECOGNIZED_MODE_SERVICE_INFO = BluetoothServiceInfo(
     name="Inverter Charger",
     address="01:02:03:04:05:06",
     rssi=-60,

--- a/tests/components/victron_ble/fixtures.py
+++ b/tests/components/victron_ble/fixtures.py
@@ -201,6 +201,22 @@ VICTRON_DC_DC_CONVERTER_UNKNOWN_OFF_REASON_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+# Same Victron manufacturer data prefix but with an unrecognised mode byte
+# (0xEE at offset 4).  detect_device_type returns None for this payload,
+# so validate_advertisement_key would also return False.  The reauth logic
+# must treat this as neutral (not a key failure).
+VICTRON_VEBUS_UNRECOGNISED_MODE_SERVICE_INFO = BluetoothServiceInfo(
+    name="Inverter Charger",
+    address="01:02:03:04:05:06",
+    rssi=-60,
+    manufacturer_data={
+        0x02E1: bytes.fromhex("10038027ee1252dad26f0b8eb39162074d140df410")
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
 VICTRON_VEBUS_SENSORS = {
     "inverter_charger_device_state": "float",
     "inverter_charger_battery_voltage": "14.45",

--- a/tests/components/victron_ble/test_sensor.py
+++ b/tests/components/victron_ble/test_sensor.py
@@ -41,7 +41,7 @@ from .fixtures import (
     VICTRON_VEBUS_BAD_KEY_SERVICE_INFO,
     VICTRON_VEBUS_SERVICE_INFO,
     VICTRON_VEBUS_TOKEN,
-    VICTRON_VEBUS_UNRECOGNISED_MODE_SERVICE_INFO,
+    VICTRON_VEBUS_UNRECOGNIZED_MODE_SERVICE_INFO,
 )
 
 from tests.common import MockConfigEntry, snapshot_platform
@@ -166,13 +166,13 @@ def _inject_bad_advertisement(hass: HomeAssistant, seq: int = 0) -> None:
     )
 
 
-def _inject_unrecognised_mode_advertisement(hass: HomeAssistant, seq: int = 0) -> None:
-    """Inject a Victron advertisement with an unrecognised mode byte.
+def _inject_unrecognized_mode_advertisement(hass: HomeAssistant, seq: int = 0) -> None:
+    """Inject a Victron advertisement with an unrecognized mode byte.
 
     detect_device_type returns None for this payload so the reauth guard
     must treat it as neutral (neither increment nor reset the failure counter).
     """
-    info = VICTRON_VEBUS_UNRECOGNISED_MODE_SERVICE_INFO
+    info = VICTRON_VEBUS_UNRECOGNIZED_MODE_SERVICE_INFO
     raw = bytearray(info.manufacturer_data[VICTRON_IDENTIFIER])
     raw[-1] = seq & 0xFF
     device = generate_ble_device(address=info.address, name=info.name, details={})
@@ -349,14 +349,14 @@ async def test_charger_error_state(
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_reauth_not_triggered_on_unrecognised_mode(
+async def test_reauth_not_triggered_on_unrecognized_mode(
     hass: HomeAssistant,
     mock_config_entry_added_to_hass: MockConfigEntry,
 ) -> None:
-    """Test reauth is NOT triggered by advertisements with unrecognised mode bytes.
+    """Test reauth is NOT triggered by advertisements with unrecognized mode bytes.
 
     Some Victron devices broadcast advertisements with mode bytes that
-    detect_device_type does not recognise (returns None).
+    detect_device_type does not recognize (returns None).
     validate_advertisement_key also returns False for these, but that does
     not mean the encryption key is wrong.
 
@@ -371,9 +371,9 @@ async def test_reauth_not_triggered_on_unrecognised_mode(
     inject_bluetooth_service_info(hass, VICTRON_VEBUS_SERVICE_INFO)
     await hass.async_block_till_done()
 
-    # Now send many unrecognised-mode advertisements
+    # Now send many unrecognized-mode advertisements
     for i in range(REAUTH_AFTER_FAILURES + 5):
-        _inject_unrecognised_mode_advertisement(hass, seq=i)
+        _inject_unrecognized_mode_advertisement(hass, seq=i)
         await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
@@ -381,14 +381,14 @@ async def test_reauth_not_triggered_on_unrecognised_mode(
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_reauth_still_triggers_across_unrecognised_mode(
+async def test_reauth_still_triggers_across_unrecognized_mode(
     hass: HomeAssistant,
     mock_config_entry_added_to_hass: MockConfigEntry,
 ) -> None:
-    """Test that unrecognised-mode advertisements are neutral for the failure counter.
+    """Test that unrecognized-mode advertisements are neutral for the failure counter.
 
-    The sequence bad → bad → unrecognised → bad must still trigger reauth
-    because unrecognised advertisements should neither increment nor reset the
+    The sequence bad → bad → unrecognized → bad must still trigger reauth
+    because unrecognized advertisements should neither increment nor reset the
     consecutive failure counter.
 
     Regression test for https://github.com/home-assistant/core/issues/168019
@@ -408,8 +408,8 @@ async def test_reauth_still_triggers_across_unrecognised_mode(
     _inject_bad_advertisement(hass, seq=101)
     await hass.async_block_till_done()
 
-    # unrecognised mode — should be neutral
-    _inject_unrecognised_mode_advertisement(hass, seq=50)
+    # unrecognized mode — should be neutral
+    _inject_unrecognized_mode_advertisement(hass, seq=50)
     await hass.async_block_till_done()
 
     # one more bad → 3 consecutive failures → reauth

--- a/tests/components/victron_ble/test_sensor.py
+++ b/tests/components/victron_ble/test_sensor.py
@@ -41,6 +41,7 @@ from .fixtures import (
     VICTRON_VEBUS_BAD_KEY_SERVICE_INFO,
     VICTRON_VEBUS_SERVICE_INFO,
     VICTRON_VEBUS_TOKEN,
+    VICTRON_VEBUS_UNRECOGNISED_MODE_SERVICE_INFO,
 )
 
 from tests.common import MockConfigEntry, snapshot_platform
@@ -150,6 +151,28 @@ def _inject_bad_advertisement(hass: HomeAssistant, seq: int = 0) -> None:
     """
     info = VICTRON_VEBUS_BAD_KEY_SERVICE_INFO
     # Vary the last byte so each injection is unique
+    raw = bytearray(info.manufacturer_data[VICTRON_IDENTIFIER])
+    raw[-1] = seq & 0xFF
+    device = generate_ble_device(address=info.address, name=info.name, details={})
+    adv = generate_advertisement_data(
+        local_name=info.name,
+        manufacturer_data={VICTRON_IDENTIFIER: bytes(raw)},
+        service_data=info.service_data,
+        service_uuids=info.service_uuids,
+        rssi=-60,
+    )
+    inject_advertisement_with_time_and_source_connectable(
+        hass, device, adv, time.monotonic(), "local", True
+    )
+
+
+def _inject_unrecognised_mode_advertisement(hass: HomeAssistant, seq: int = 0) -> None:
+    """Inject a Victron advertisement with an unrecognised mode byte.
+
+    detect_device_type returns None for this payload so the reauth guard
+    must treat it as neutral (neither increment nor reset the failure counter).
+    """
+    info = VICTRON_VEBUS_UNRECOGNISED_MODE_SERVICE_INFO
     raw = bytearray(info.manufacturer_data[VICTRON_IDENTIFIER])
     raw[-1] = seq & 0xFF
     device = generate_ble_device(address=info.address, name=info.name, details={})
@@ -323,3 +346,76 @@ async def test_charger_error_state(
     state = hass.states.get("sensor.solar_charger_charger_error")
     assert state is not None
     assert state.state == expected_state
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_reauth_not_triggered_on_unrecognised_mode(
+    hass: HomeAssistant,
+    mock_config_entry_added_to_hass: MockConfigEntry,
+) -> None:
+    """Test reauth is NOT triggered by advertisements with unrecognised mode bytes.
+
+    Some Victron devices broadcast advertisements with mode bytes that
+    detect_device_type does not recognise (returns None).
+    validate_advertisement_key also returns False for these, but that does
+    not mean the encryption key is wrong.
+
+    Regression test for https://github.com/home-assistant/core/issues/168019
+    """
+    entry = mock_config_entry_added_to_hass
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # First inject a valid advertisement so update.devices is populated
+    inject_bluetooth_service_info(hass, VICTRON_VEBUS_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    # Now send many unrecognised-mode advertisements
+    for i in range(REAUTH_AFTER_FAILURES + 5):
+        _inject_unrecognised_mode_advertisement(hass, seq=i)
+        await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 0
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_reauth_still_triggers_across_unrecognised_mode(
+    hass: HomeAssistant,
+    mock_config_entry_added_to_hass: MockConfigEntry,
+) -> None:
+    """Test that unrecognised-mode advertisements are neutral for the failure counter.
+
+    The sequence bad → bad → unrecognised → bad must still trigger reauth
+    because unrecognised advertisements should neither increment nor reset the
+    consecutive failure counter.
+
+    Regression test for https://github.com/home-assistant/core/issues/168019
+    """
+    entry = mock_config_entry_added_to_hass
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # First inject a valid advertisement so update.devices is populated
+    inject_bluetooth_service_info(hass, VICTRON_VEBUS_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    # bad, bad (2 failures)
+    _inject_bad_advertisement(hass, seq=100)
+    await hass.async_block_till_done()
+    _inject_bad_advertisement(hass, seq=101)
+    await hass.async_block_till_done()
+
+    # unrecognised mode — should be neutral
+    _inject_unrecognised_mode_advertisement(hass, seq=50)
+    await hass.async_block_till_done()
+
+    # one more bad → 3 consecutive failures → reauth
+    _inject_bad_advertisement(hass, seq=102)
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"


### PR DESCRIPTION
## Proposed change

Guard the reauth key-validity check so it only runs on BLE advertisements
whose device type `detect_device_type()` actually recognises.

Advertisements with unrecognised mode bytes caused `validate_advertisement_key()`
to return `False` (because it calls `detect_device_type()` internally, which
returns `None`). The reauth guard counted this as a key failure, and after 3 such
advertisements the integration would incorrectly trigger a reauth flow telling
users their encryption key had expired — even though the key was perfectly valid.

Unrecognised advertisements are now treated as **neutral**: they neither increment
nor reset the consecutive failure counter.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #168019
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
