### PR TITLE
Fix UnboundLocalError in Tado config_flow when auth times out

### DIFF
--- a/homeassistant/components/tado/config_flow.py
+++ b/homeassistant/components/tado/config_flow.py
@@ -167,6 +167,7 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
                 step_id="timeout",
             )
         del self.login_task
+        self.tado = None
         return await self.async_step_user()
 
     async def async_step_homekit(


### PR DESCRIPTION
## Proposed change

When `async_step_timeout` retries authentication by calling `async_step_user()`, `self.tado` is still set from the previous attempt. This causes `tado_device_url` to never be assigned (it is only set inside the `if self.tado is None` block), resulting in an `UnboundLocalError` when trying to show the progress form — which surfaces as an opaque "unknown error" in the UI.

Resetting `self.tado = None` before calling `async_step_user()` ensures a completely fresh device activation flow is started on retry.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 

Error seen in logs:
```
UnboundLocalError: cannot access local variable 'tado_device_url' where it is not associated with a value
```

Reproduced on HA 2026.4.1. After the fix, clicking retry correctly starts a new device activation flow instead of crashing.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (if any)
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr/)
- [x] The code has been formatted using Ruff (`python3 -m script.run_hassfmt`)
- [ ] Tests have been added to verify that the new code works