### PR TITLE
Refine Renovate config with built-in manager and review follow-ups

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
     "pep621",
     "pip_requirements",
     "pre-commit",
-    "custom.regex"
+    "homeassistant-manifest"
   ],
 
   "pre-commit": {
@@ -17,6 +17,12 @@
     "managerFilePatterns": [
       "/(^|/)requirements[\\w_-]*\\.txt$/",
       "/(^|/)homeassistant/package_constraints\\.txt$/"
+    ]
+  },
+
+  "homeassistant-manifest": {
+    "managerFilePatterns": [
+      "/^homeassistant/components/[^/]+/manifest\\.json$/"
     ]
   },
 
@@ -38,22 +44,6 @@
     "labels": ["dependency", "security"],
     "automerge": false
   },
-
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Home Assistant integration manifest.json requirements",
-      "managerFilePatterns": [
-        "/^homeassistant/components/[^/]+/manifest\\.json$/"
-      ],
-      "matchStringsStrategy": "recursive",
-      "matchStrings": [
-        "\"requirements\"\\s*:\\s*\\[(?<inner>\\s*(?:\"(?:[^\"\\\\]|\\\\.)*\"\\s*,\\s*)*\"(?:[^\"\\\\]|\\\\.)*\"\\s*)?\\]",
-        "\"(?<depName>[^\"=<>!~;\\s\\[\\]]+)(?:\\[[^\"\\]]*\\])?==(?<currentValue>[^\"]+?)\""
-      ],
-      "datasourceTemplate": "pypi"
-    }
-  ],
 
   "packageRules": [
     {
@@ -106,7 +96,6 @@
         "pytest-unordered",
         "pytest-picked",
         "pytest-xdist",
-        "mypy",
         "pylint",
         "pylint-per-file-ignores",
         "astroid",
@@ -118,9 +107,15 @@
         "ruff",
         "codespell",
         "yamllint",
-        "zizmor",
-        "/^types-/"
+        "zizmor"
       ],
+      "enabled": true,
+      "labels": ["dependency"]
+    },
+    {
+      "description": "For types-* stubs, only allow patch updates. Major/minor bumps track the upstream runtime package version and must be manually coordinated with the corresponding pin.",
+      "matchPackageNames": ["/^types-/"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "labels": ["dependency"]
     },
@@ -158,6 +153,12 @@
       "matchPackageNames": ["zizmorcore/zizmor-pre-commit", "zizmor"],
       "groupName": "zizmor",
       "groupSlug": "zizmor"
+    },
+    {
+      "description": "Group pylint with astroid (their versions are linked and must move together)",
+      "matchPackageNames": ["pylint", "astroid"],
+      "groupName": "pylint",
+      "groupSlug": "pylint"
     }
   ]
 }


### PR DESCRIPTION
## Proposed change

A small batch of improvements to the Renovate config introduced in [#168192](https://github.com/home-assistant/core/pull/168192), based on review feedback and real-world behavior observed after Mend Renovate was enabled on the repository.

1. **Replace the hand-written `customManagers` regex with the built-in `homeassistant-manifest` manager.** The built-in manager uses a proper JSON parser, so it handles requirement strings with extras (e.g., `adb-shell[async]==0.4.4`) natively and removes the need for a custom regex that had to be rewritten during the original review.  
   Scoped via `managerFilePatterns` to only `homeassistant/components/*/manifest.json`, otherwise the default would also match scaffold templates and test fixtures.

2. **Group pylint with astroid into one PR.** Their versions are linked (astroid is pylint's internal dependency) and must move together, per @cdce8p. Uses `groupName: "pylint"` so a pylint or astroid bump lands as a single branch editing both pins.

3. **Restrict `types-*` packages to patch updates only.** The major and minor segments of a `types-*` version mirror the upstream runtime package's version; bumping them across a major or minor boundary (e.g., `types-protobuf==6.32.1.20260221` to `==7.34.1.20260403`) breaks the coupling with the pinned runtime package. The rule now allows only patch-level bumps (typically the stub-release-date segment), and non-patch updates fall through to the deny-by-default rule so they stay manual, per @cdce8p.

4. **Temporarily drop `mypy` from the allowlist.** mypy is coupled to `librt` (its internal typing dependency) in a way analogous to pylint/astroid, and `librt` is not currently on the allowlist. Rather than add a half-working mypy rule, drop mypy for now. A follow-up PR can add `librt` to the allowlist and group `mypy` + `librt` together, similar to what this PR does for pylint + astroid.

### Hope-to-fix: split vulnerability-alert PRs

After Renovate went live, three packages (`Pillow`, `PyJWT`, `uv`) each produced two concurrent PRs with file changes partitioned between them in a way that makes neither PR mergeable on its own:

- [#168214](https://github.com/home-assistant/core/pull/168214) `Update Pillow to 12.2.0 [SECURITY]`
  edits 4 files (`pyproject.toml` and three `requirements*.txt`).
- [#168223](https://github.com/home-assistant/core/pull/168223) `Update Pillow to 12.2.0`
  edits the 9 remaining files (`homeassistant/package_constraints.txt`
  and eight Pillow `manifest.json` files).
- [#168215](https://github.com/home-assistant/core/pull/168215) `Update PyJWT to 2.12.0 [SECURITY]` /
  [#168220](https://github.com/home-assistant/core/pull/168220) `Update PyJWT to 2.12.1`
  show the same split.
- [#168213](https://github.com/home-assistant/core/pull/168213) `Update uv to 0.11.6 [SECURITY]` /
  [#168221](https://github.com/home-assistant/core/pull/168221) `Update uv to 0.11.3`
  show the same split.

The symptom is consistent: the security flow only edits files matched by Renovate's built-in default file patterns, and the normal flow's "leftovers" end up in a separate PR once Renovate deduplicates file edits across open branches for the same package. `customManagers` entries appear not to be honored by the vulnerability-alert code pat.

Switching to the first-class `homeassistant-manifest` manager *may* cause the vulnerability-alert flow to pick up `manifest.json` files natively, since the manager is a built-in module rather than a custom regex. This would eliminate the Pillow split (where the 8 `manifest.json` files are the main offender). It would not on its own fix the split on `homeassistant/package_constraints.txt`, which still relies on the `pip_requirements.managerFilePatterns` override.

This cannot be verified without a fresh security alert landing on one of the allow-listed packages after this PR merges. If the split persists, the next step would be to disable `vulnerabilityAlerts` entirely and let the normal flow handle CVE updates through the standard cooldown. A separate discussion with the Renovate maintainers on the underlying behavior will also be opened.

## How to test

From the repo root:

~~~bash
RENOVATE_CONFIG_FILE=$PWD/.github/renovate.json \
LOG_LEVEL=debug \
  npx --yes --package renovate -- renovate \
    --platform=local \
    --dry-run=full \
    --onboarding=false \
    2>&1 | tee ./renovate-dryrun.log
~~~

Requires Node.js 24+ (older Renovate releases on Node 22 do not know
about the `homeassistant-manifest` manager yet).

### Expected output

~~~
INFO: Repository finished (repository=local)
  "result": "done"
  "status": "onboarded"
~~~

Four managers, roughly these counts (drift with repo state):

| Manager | Files | Deps |
|---|---|---|
| `pep621` | 1 | ~52 |
| `pip_requirements` | 6 | ~2270 |
| `pre-commit` | 1 | 7 |
| `homeassistant-manifest` | ~1070 | ~1190 |
| **total** | **~1080** | **~3520** |

Every branch name starts with `renovate/` and corresponds to an
allow-listed package. Non-patch `types-*` bumps, any `mypy` bump, and
any non-allow-listed package produce zero branches.

Spot-checks on the captured log:

~~~bash
# Clean finish
grep -A4 "Repository finished" ./renovate-dryrun.log

# All four managers reported
grep -E "fileCount.*depCount" ./renovate-dryrun.log

# No leaks: every branch is an allow-listed package
grep -oE '"branchName":\s*"renovate/[^"]+"' ./renovate-dryrun.log \
  | sort -u

# No types-* branches remain (current types-* updates are all major bumps)
grep -oE '"branchName":\s*"renovate/types-[^"]+"' ./renovate-dryrun.log

# No mypy branch
grep -oE '"branchName":\s*"renovate/mypy[^"]*"' ./renovate-dryrun.log
~~~

### Credits

- @felipecrs for contributing the built-in
  [`homeassistant-manifest`](https://docs.renovatebot.com/modules/manager/homeassistant-manifest/)
  manager upstream in
  [renovatebot/renovate#39906](https://github.com/renovatebot/renovate/pull/39906),
  and for the prior HA core adoption PR
  [#165501](https://github.com/home-assistant/core/pull/165501) which
  surfaced the manager's existence.
- @cdce8p for the review feedback on
  [#168192](https://github.com/home-assistant/core/pull/168192)
  calling out the pylint/astroid coupling, the mypy/librt coupling,
  and the risk of auto-bumping `types-*` packages.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
