### PR TITLE
Disable Renovate vulnerability alerts flow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,10 +39,7 @@
   "automerge": false,
 
   "vulnerabilityAlerts": {
-    "enabled": true,
-    "minimumReleaseAge": null,
-    "labels": ["dependency", "security"],
-    "automerge": false
+    "enabled": false
   },
 
   "packageRules": [


### PR DESCRIPTION
## Proposed change

Disables Renovate's vulnerability alerts flow on this repository by collapsing the `vulnerabilityAlerts` block to a single `enabled: false` entry. CVE-driven package updates will now flow through Renovate's normal extraction path, which uses the full Renovate config on this repository (including the `enabledManagers` additions and the `managerFilePatterns` overrides) and produces PRs with complete lockstep file coverage.

After Mend Renovate was enabled on this repository, every security PR it produced was incomplete and could not be merged on its own. Pillow, PyJWT, and uv all received security PRs that only edited the files reachable through Renovate's default-enabled managers using their default file patterns, silently omitting the files we reach through `enabledManagers` (specifically the `homeassistant-manifest` manager for integration `manifest.json` files) and the files we reach through `pip_requirements.managerFilePatterns` overrides (specifically `homeassistant/package_constraints.txt`).

For the same packages and the same repository state, the normal flow produces complete PRs in local dry-runs on the same Renovate version, so the bug is specifically in Renovate's vulnerability alerts pipeline and it cannot be worked around from inside the config. It has to be bypassed by switching CVE handling off.

The trade-off is that CVE patch releases become subject to the repository's `minimumReleaseAge: "7 days"` cooldown for normal updates, the same as any other release.

To test this PR, run the usual local dry-run from the repo root with `RENOVATE_CONFIG_FILE=$PWD/.github/renovate.json`, `LOG_LEVEL=debug`, and `npx --yes --package renovate -- renovate --platform=local --dry-run=full --onboarding=false`, piped through `tee` to a log file for inspection.

The actual behavioral difference only shows up against a live GitHub vulnerability alert, which cannot be simulated locally.

Opened up an upstream discussion to find the root cause: https://github.com/renovatebot/renovate/discussions/42634

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
