### PR TITLE
Add SerialSelector

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine, Sequence
+import dataclasses
 from datetime import datetime, timedelta
 import logging
 import os
@@ -163,6 +164,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     await usb_discovery.async_setup()
     hass.data[_USB_DATA] = usb_discovery
     websocket_api.async_register_command(hass, websocket_usb_scan)
+    websocket_api.async_register_command(hass, websocket_usb_list_serial_ports)
 
     return True
 
@@ -477,3 +479,19 @@ async def websocket_usb_scan(
     """Scan for new usb devices."""
     await async_request_scan(hass)
     connection.send_result(msg["id"])
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "usb/list_serial_ports"})
+@websocket_api.async_response
+async def websocket_usb_list_serial_ports(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """List available serial ports."""
+    ports = await async_scan_serial_ports(hass)
+    connection.send_result(
+        msg["id"],
+        [dataclasses.asdict(port) for port in ports],
+    )

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -490,7 +490,11 @@ async def websocket_usb_list_serial_ports(
     msg: dict[str, Any],
 ) -> None:
     """List available serial ports."""
-    ports = await async_scan_serial_ports(hass)
+    try:
+        ports = await async_scan_serial_ports(hass)
+    except OSError as err:
+        connection.send_error(msg["id"], websocket_api.ERR_UNKNOWN_ERROR, str(err))
+        return
     connection.send_result(
         msg["id"],
         [dataclasses.asdict(port) for port in ports],

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1771,6 +1771,28 @@ class SelectSelector(Selector[SelectSelectorConfig]):
         return [parent_schema(vol.Schema(str)(val)) for val in data]
 
 
+class SerialSelectorConfig(BaseSelectorConfig):
+    """Class to represent a serial selector config."""
+
+
+@SELECTORS.register("serial")
+class SerialSelector(Selector[SerialSelectorConfig]):
+    """Selector for a serial port."""
+
+    selector_type = "serial"
+
+    CONFIG_SCHEMA = make_selector_config_schema()
+
+    def __init__(self, config: SerialSelectorConfig | None = None) -> None:
+        """Instantiate a selector."""
+        super().__init__(config)
+
+    def __call__(self, data: Any) -> str:
+        """Validate the passed selection."""
+        serial: str = vol.Schema(str)(data)
+        return serial
+
+
 class StateSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent an state selector config."""
 

--- a/tests/components/homeassistant_connect_zbt2/test_init.py
+++ b/tests/components/homeassistant_connect_zbt2/test_init.py
@@ -14,11 +14,8 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.components.usb import (
-    async_request_scan,
-    force_usb_polling_watcher,  # noqa: F401
-    patch_scanned_serial_ports,
-)
+from tests.components.usb import async_request_scan, patch_scanned_serial_ports
+from tests.components.usb.conftest import force_usb_polling_watcher  # noqa: F401
 
 
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -26,11 +26,8 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.components.usb import (
-    async_request_scan,
-    force_usb_polling_watcher,  # noqa: F401
-    patch_scanned_serial_ports,
-)
+from tests.components.usb import async_request_scan, patch_scanned_serial_ports
+from tests.components.usb.conftest import force_usb_polling_watcher  # noqa: F401
 
 
 async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:

--- a/tests/components/usb/__init__.py
+++ b/tests/components/usb/__init__.py
@@ -1,45 +1,14 @@
 """Tests for the USB Discovery integration."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from aiousbwatcher import InotifyNotAvailableError
-import pytest
-
-from homeassistant.components.usb import (
-    DOMAIN,
-    async_request_scan as usb_async_request_scan,
-)
+from homeassistant.components.usb import async_request_scan as usb_async_request_scan
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
-
-
-@pytest.fixture(name="force_usb_polling_watcher")
-def force_usb_polling_watcher():
-    """Patch the USB integration to not use inotify and fall back to polling."""
-    with patch(
-        "homeassistant.components.usb.AIOUSBWatcher.async_start",
-        side_effect=InotifyNotAvailableError,
-    ):
-        yield
 
 
 def patch_scanned_serial_ports(**kwargs) -> None:
     """Patch the USB integration's list of scanned serial ports."""
     return patch("homeassistant.components.usb.utils.scan_serial_ports", **kwargs)
-
-
-@pytest.fixture(name="setup_usb")
-async def setup_usb_fixture(
-    hass: HomeAssistant, force_usb_polling_watcher: None
-) -> MagicMock:
-    """Set up USB integration and return the scanned serial ports mock."""
-    with (
-        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
-        patch_scanned_serial_ports(return_value=[]) as mock_serial_ports,
-    ):
-        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
-        await hass.async_block_till_done()
-        yield mock_serial_ports
 
 
 async def async_request_scan(hass: HomeAssistant) -> None:

--- a/tests/components/usb/__init__.py
+++ b/tests/components/usb/__init__.py
@@ -1,12 +1,16 @@
 """Tests for the USB Discovery integration."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from aiousbwatcher import InotifyNotAvailableError
 import pytest
 
-from homeassistant.components.usb import async_request_scan as usb_async_request_scan
+from homeassistant.components.usb import (
+    DOMAIN,
+    async_request_scan as usb_async_request_scan,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(name="force_usb_polling_watcher")
@@ -22,6 +26,20 @@ def force_usb_polling_watcher():
 def patch_scanned_serial_ports(**kwargs) -> None:
     """Patch the USB integration's list of scanned serial ports."""
     return patch("homeassistant.components.usb.utils.scan_serial_ports", **kwargs)
+
+
+@pytest.fixture(name="setup_usb")
+async def setup_usb_fixture(
+    hass: HomeAssistant, force_usb_polling_watcher: None
+) -> MagicMock:
+    """Set up USB integration and return the scanned serial ports mock."""
+    with (
+        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
+        patch_scanned_serial_ports(return_value=[]) as mock_serial_ports,
+    ):
+        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
+        await hass.async_block_till_done()
+        yield mock_serial_ports
 
 
 async def async_request_scan(hass: HomeAssistant) -> None:

--- a/tests/components/usb/conftest.py
+++ b/tests/components/usb/conftest.py
@@ -1,0 +1,36 @@
+"""Fixtures for USB Discovery integration tests."""
+
+from unittest.mock import MagicMock, patch
+
+from aiousbwatcher import InotifyNotAvailableError
+import pytest
+
+from homeassistant.components.usb import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import patch_scanned_serial_ports
+
+
+@pytest.fixture(name="force_usb_polling_watcher")
+def force_usb_polling_watcher():
+    """Patch the USB integration to not use inotify and fall back to polling."""
+    with patch(
+        "homeassistant.components.usb.AIOUSBWatcher.async_start",
+        side_effect=InotifyNotAvailableError,
+    ):
+        yield
+
+
+@pytest.fixture(name="setup_usb")
+async def setup_usb_fixture(
+    hass: HomeAssistant, force_usb_polling_watcher: None
+) -> MagicMock:
+    """Set up USB integration and return the scanned serial ports mock."""
+    with (
+        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
+        patch_scanned_serial_ports(return_value=[]) as mock_serial_ports,
+    ):
+        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
+        await hass.async_block_till_done()
+        yield mock_serial_ports

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -28,6 +28,7 @@ from . import (
 
 from tests.common import (
     MockModule,
+    MockUser,
     async_fire_time_changed,
     mock_config_flow,
     mock_integration,
@@ -1646,3 +1647,79 @@ async def test_removal_aborts_discovery_flows(
         final_flows = hass.config_entries.flow.async_progress()
         assert len(final_flows) == 1
         assert final_flows[0]["handler"] == "test2"
+
+
+@pytest.mark.usefixtures("force_usb_polling_watcher")
+async def test_list_serial_ports(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test listing serial ports via websocket."""
+    mock_ports = [
+        USBDevice(
+            device="/dev/ttyUSB0",
+            vid="10C4",
+            pid="EA60",
+            serial_number="001234",
+            manufacturer="Silicon Labs",
+            description="CP2102 USB to UART",
+        ),
+        SerialDevice(
+            device="/dev/ttyS0",
+            serial_number=None,
+            manufacturer=None,
+            description="ttyS0",
+        ),
+    ]
+
+    with (
+        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
+        patch_scanned_serial_ports(return_value=mock_ports),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
+        await hass.async_block_till_done()
+
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
+        response = await ws_client.receive_json()
+
+    assert response["success"]
+    result = response["result"]
+    assert len(result) == 2
+
+    assert result[0]["device"] == "/dev/ttyUSB0"
+    assert result[0]["vid"] == "10C4"
+    assert result[0]["pid"] == "EA60"
+    assert result[0]["serial_number"] == "001234"
+    assert result[0]["manufacturer"] == "Silicon Labs"
+    assert result[0]["description"] == "CP2102 USB to UART"
+
+    assert result[1]["device"] == "/dev/ttyS0"
+    assert result[1]["serial_number"] is None
+    assert result[1]["manufacturer"] is None
+    assert result[1]["description"] == "ttyS0"
+    assert "vid" not in result[1]
+    assert "pid" not in result[1]
+
+
+@pytest.mark.usefixtures("force_usb_polling_watcher")
+async def test_list_serial_ports_require_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that listing serial ports requires admin."""
+    hass_admin_user.groups = []
+
+    with (
+        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
+        patch_scanned_serial_ports(return_value=[]),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
+        await hass.async_block_till_done()
+
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
+        response = await ws_client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "unauthorized"

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -21,11 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from . import (
-    force_usb_polling_watcher,  # noqa: F401
-    patch_scanned_serial_ports,
-    setup_usb_fixture,  # noqa: F401
-)
+from . import patch_scanned_serial_ports
 
 from tests.common import (
     MockModule,

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.util import dt as dt_util
 from . import (
     force_usb_polling_watcher,  # noqa: F401
     patch_scanned_serial_ports,
+    setup_usb_fixture,  # noqa: F401
 )
 
 from tests.common import (
@@ -1649,12 +1650,13 @@ async def test_removal_aborts_discovery_flows(
         assert final_flows[0]["handler"] == "test2"
 
 
-@pytest.mark.usefixtures("force_usb_polling_watcher")
 async def test_list_serial_ports(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    setup_usb: MagicMock,
 ) -> None:
     """Test listing serial ports via websocket."""
-    mock_ports = [
+    setup_usb.return_value = [
         USBDevice(
             device="/dev/ttyUSB0",
             vid="10C4",
@@ -1671,16 +1673,9 @@ async def test_list_serial_ports(
         ),
     ]
 
-    with (
-        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
-        patch_scanned_serial_ports(return_value=mock_ports),
-    ):
-        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
-        await hass.async_block_till_done()
-
-        ws_client = await hass_ws_client(hass)
-        await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
-        response = await ws_client.receive_json()
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
+    response = await ws_client.receive_json()
 
     assert response["success"]
     result = response["result"]
@@ -1701,25 +1696,35 @@ async def test_list_serial_ports(
     assert "pid" not in result[1]
 
 
-@pytest.mark.usefixtures("force_usb_polling_watcher")
 async def test_list_serial_ports_require_admin(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_admin_user: MockUser,
+    setup_usb: MagicMock,
 ) -> None:
     """Test that listing serial ports requires admin."""
     hass_admin_user.groups = []
 
-    with (
-        patch("homeassistant.components.usb.async_get_usb", return_value=[]),
-        patch_scanned_serial_ports(return_value=[]),
-    ):
-        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
-        await hass.async_block_till_done()
-
-        ws_client = await hass_ws_client(hass)
-        await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
-        response = await ws_client.receive_json()
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
+    response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "unauthorized"
+
+
+async def test_list_serial_ports_os_error(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    setup_usb: MagicMock,
+) -> None:
+    """Test listing serial ports handles OSError."""
+    setup_usb.side_effect = OSError("Permission denied")
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
+    response = await ws_client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "unknown_error"
+    assert "Permission denied" in response["error"]["message"]

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1125,6 +1125,22 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
     [
+        (None, ("/dev/ttyUSB0", "/dev/ttyACM1", "COM3"), (None, 1, True)),
+        ({}, ("/dev/ttyUSB0",), (None,)),
+    ],
+)
+def test_serial_selector_schema(
+    schema: dict | None,
+    valid_selections: tuple[Any, ...],
+    invalid_selections: tuple[Any, ...],
+) -> None:
+    """Test serial selector."""
+    _test_selector("serial", schema, valid_selections, invalid_selections)
+
+
+@pytest.mark.parametrize(
+    ("schema", "valid_selections", "invalid_selections"),
+    [
         ({}, ({"entity_id": ["sensor.abc123"]},), ("abc123", None)),
         ({"entity": {}}, (), ()),
         ({"entity": {"domain": "light"}}, (), ()),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new `SerialSelector`, which validates a string value. It will allow the frontend to query the serial ports from the backend and offer an interactive UI to select the right serial port without requiring each integration to implement it.

Frontend https://github.com/home-assistant/frontend/pull/51573

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
