### PR TITLE
Ensure `extra_fields` in Z-Wave automation config are strings

### DIFF
--- a/homeassistant/components/zwave_js/config_validation.py
+++ b/homeassistant/components/zwave_js/config_validation.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import voluptuous as vol
+from zwave_js_server.const import CommandClass
 
 from homeassistant.helpers import config_validation as cv
 
@@ -16,6 +17,10 @@ BITMASK_SCHEMA = vol.All(
         msg="Must provide an integer (e.g. 255) or a bitmask in hex form (e.g. 0xff)",
     ),
     lambda value: int(value, 16),
+)
+
+COMMAND_CLASS_SCHEMA = vol.All(
+    vol.Coerce(int), vol.In([cc.value for cc in CommandClass])
 )
 
 

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -30,7 +30,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
-from .config_validation import VALUE_SCHEMA
+from .config_validation import COMMAND_CLASS_SCHEMA, VALUE_SCHEMA
 from .const import (
     ATTR_COMMAND_CLASS,
     ATTR_CONFIG_PARAMETER,
@@ -122,7 +122,7 @@ SET_LOCK_USERCODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
 SET_VALUE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): SERVICE_SET_VALUE,
-        vol.Required(ATTR_COMMAND_CLASS): vol.In([cc.value for cc in CommandClass]),
+        vol.Required(ATTR_COMMAND_CLASS): COMMAND_CLASS_SCHEMA,
         vol.Required(ATTR_PROPERTY): vol.Any(int, str),
         vol.Optional(ATTR_PROPERTY_KEY): vol.Any(vol.Coerce(int), cv.string),
         vol.Optional(ATTR_ENDPOINT): vol.Coerce(int),
@@ -334,7 +334,7 @@ async def async_get_action_capabilities(
                 {
                     vol.Required(ATTR_COMMAND_CLASS): vol.In(
                         {
-                            CommandClass(cc.id).value: cc.name
+                            str(CommandClass(cc.id).value): cc.name
                             for cc in sorted(
                                 node.command_classes, key=lambda cc: cc.name
                             )

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -15,7 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition, config_validation as cv
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
-from .config_validation import VALUE_SCHEMA
+from .config_validation import COMMAND_CLASS_SCHEMA, VALUE_SCHEMA
 from .const import (
     ATTR_COMMAND_CLASS,
     ATTR_ENDPOINT,
@@ -65,7 +65,7 @@ CONFIG_PARAMETER_CONDITION_SCHEMA = cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
 VALUE_CONDITION_SCHEMA = cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): VALUE_TYPE,
-        vol.Required(ATTR_COMMAND_CLASS): vol.In([cc.value for cc in CommandClass]),
+        vol.Required(ATTR_COMMAND_CLASS): COMMAND_CLASS_SCHEMA,
         vol.Required(ATTR_PROPERTY): vol.Any(vol.Coerce(int), cv.string),
         vol.Optional(ATTR_PROPERTY_KEY): vol.Any(vol.Coerce(int), cv.string),
         vol.Optional(ATTR_ENDPOINT): vol.Coerce(int),
@@ -221,7 +221,7 @@ async def async_get_condition_capabilities(
                 {
                     vol.Required(ATTR_COMMAND_CLASS): vol.In(
                         {
-                            CommandClass(cc.id).value: cc.name
+                            str(CommandClass(cc.id).value): cc.name
                             for cc in sorted(
                                 node.command_classes, key=lambda cc: cc.name
                             )

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -31,7 +31,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
-from .config_validation import VALUE_SCHEMA
+from .config_validation import COMMAND_CLASS_SCHEMA, VALUE_SCHEMA
 from .const import (
     ATTR_COMMAND_CLASS,
     ATTR_DATA_TYPE,
@@ -91,7 +91,7 @@ NOTIFICATION_EVENT_CC_MAPPINGS = (
 # Event based trigger schemas
 BASE_EVENT_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(ATTR_COMMAND_CLASS): vol.In([cc.value for cc in CommandClass]),
+        vol.Required(ATTR_COMMAND_CLASS): COMMAND_CLASS_SCHEMA,
     }
 )
 
@@ -162,7 +162,7 @@ NODE_STATUS_SCHEMA = BASE_STATE_SCHEMA.extend(
 # zwave_js.value_updated based trigger schemas
 BASE_VALUE_UPDATED_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(ATTR_COMMAND_CLASS): vol.In([cc.value for cc in CommandClass]),
+        vol.Required(ATTR_COMMAND_CLASS): COMMAND_CLASS_SCHEMA,
         vol.Required(ATTR_PROPERTY): vol.Any(int, str),
         vol.Optional(ATTR_PROPERTY_KEY): vol.Any(None, vol.Coerce(int), str),
         vol.Optional(ATTR_ENDPOINT, default=0): vol.Any(None, vol.Coerce(int)),
@@ -558,7 +558,7 @@ async def async_get_trigger_capabilities(
                 {
                     vol.Required(ATTR_COMMAND_CLASS): vol.In(
                         {
-                            CommandClass(cc.id).value: cc.name
+                            str(CommandClass(cc.id).value): cc.name
                             for cc in sorted(
                                 node.command_classes, key=lambda cc: cc.name
                             )

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -572,12 +572,12 @@ def get_value_state_schema(
             return vol.Coerce(bool)
 
         if value.configuration_value_type == ConfigurationValueType.ENUMERATED:
-            return vol.In({int(k): v for k, v in value.metadata.states.items()})
+            return vol.In({str(int(k)): v for k, v in value.metadata.states.items()})
 
         return None
 
     if value.metadata.states:
-        return vol.In({int(k): v for k, v in value.metadata.states.items()})
+        return vol.In({str(int(k)): v for k, v in value.metadata.states.items()})
 
     return vol.All(
         vol.Coerce(int),

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -7,6 +7,7 @@ import functools
 from typing import Any
 
 import voluptuous as vol
+from zwave_js_server.const import CommandClass
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import Value, get_value_id_str
 
@@ -18,7 +19,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
 from homeassistant.helpers.typing import ConfigType
 
-from ..config_validation import COMMAND_CLASS_SCHEMA, VALUE_SCHEMA
+from ..config_validation import VALUE_SCHEMA
 from ..const import (
     ATTR_COMMAND_CLASS,
     ATTR_COMMAND_CLASS_NAME,
@@ -50,7 +51,9 @@ ATTR_TO = "to"
 _OPTIONS_SCHEMA_DICT = {
     vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_COMMAND_CLASS): COMMAND_CLASS_SCHEMA,
+    vol.Required(ATTR_COMMAND_CLASS): vol.All(
+        vol.Coerce(int), vol.In({cc.value: cc.name for cc in CommandClass})
+    ),
     vol.Required(ATTR_PROPERTY): vol.Any(vol.Coerce(int), cv.string),
     vol.Optional(ATTR_ENDPOINT): vol.Coerce(int),
     vol.Optional(ATTR_PROPERTY_KEY): vol.Any(vol.Coerce(int), cv.string),

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -7,7 +7,6 @@ import functools
 from typing import Any
 
 import voluptuous as vol
-from zwave_js_server.const import CommandClass
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import Value, get_value_id_str
 
@@ -19,7 +18,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
 from homeassistant.helpers.typing import ConfigType
 
-from ..config_validation import VALUE_SCHEMA
+from ..config_validation import COMMAND_CLASS_SCHEMA, VALUE_SCHEMA
 from ..const import (
     ATTR_COMMAND_CLASS,
     ATTR_COMMAND_CLASS_NAME,
@@ -51,9 +50,7 @@ ATTR_TO = "to"
 _OPTIONS_SCHEMA_DICT = {
     vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_COMMAND_CLASS): vol.In(
-        {cc.value: cc.name for cc in CommandClass}
-    ),
+    vol.Required(ATTR_COMMAND_CLASS): COMMAND_CLASS_SCHEMA,
     vol.Required(ATTR_PROPERTY): vol.Any(vol.Coerce(int), cv.string),
     vol.Optional(ATTR_ENDPOINT): vol.Coerce(int),
     vol.Optional(ATTR_PROPERTY_KEY): vol.Any(vol.Coerce(int), cv.string),

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -838,15 +838,19 @@ async def test_unavailable_entity_actions(
 
 
 def test_action_schema_coerces_string_command_class() -> None:
-    """Test that SET_VALUE action schema accepts and coerces string command_class."""
-    config = device_action.SET_VALUE_SCHEMA(
-        {
-            "device_id": "device123",
-            "domain": DOMAIN,
-            "type": "set_value",
-            "command_class": str(CommandClass.DOOR_LOCK.value),
-            "property": "targetMode",
-            "value": 255,
-        }
-    )
-    assert config["command_class"] == CommandClass.DOOR_LOCK.value
+    """Test that SET_VALUE action schema accepts both int and string command_class."""
+    for command_class_value in (
+        CommandClass.DOOR_LOCK.value,
+        str(CommandClass.DOOR_LOCK.value),
+    ):
+        config = device_action.SET_VALUE_SCHEMA(
+            {
+                "device_id": "device123",
+                "domain": DOMAIN,
+                "type": "set_value",
+                "command_class": command_class_value,
+                "property": "targetMode",
+                "value": 255,
+            }
+        )
+        assert config["command_class"] == CommandClass.DOOR_LOCK.value

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -583,26 +583,26 @@ async def test_get_action_capabilities(
     assert capabilities and "extra_fields" in capabilities
 
     cc_options = [
-        (133, "Association"),
-        (89, "Association Group Information"),
-        (128, "Battery"),
-        (129, "Clock"),
-        (112, "Configuration"),
-        (90, "Device Reset Locally"),
-        (122, "Firmware Update Meta Data"),
-        (135, "Indicator"),
-        (114, "Manufacturer Specific"),
-        (96, "Multi Channel"),
-        (142, "Multi Channel Association"),
-        (49, "Multilevel Sensor"),
-        (115, "Powerlevel"),
-        (68, "Thermostat Fan Mode"),
-        (69, "Thermostat Fan State"),
-        (64, "Thermostat Mode"),
-        (66, "Thermostat Operating State"),
-        (67, "Thermostat Setpoint"),
-        (134, "Version"),
-        (94, "Z-Wave Plus Info"),
+        ("133", "Association"),
+        ("89", "Association Group Information"),
+        ("128", "Battery"),
+        ("129", "Clock"),
+        ("112", "Configuration"),
+        ("90", "Device Reset Locally"),
+        ("122", "Firmware Update Meta Data"),
+        ("135", "Indicator"),
+        ("114", "Manufacturer Specific"),
+        ("96", "Multi Channel"),
+        ("142", "Multi Channel Association"),
+        ("49", "Multilevel Sensor"),
+        ("115", "Powerlevel"),
+        ("68", "Thermostat Fan Mode"),
+        ("69", "Thermostat Fan State"),
+        ("64", "Thermostat Mode"),
+        ("66", "Thermostat Operating State"),
+        ("67", "Thermostat Setpoint"),
+        ("134", "Version"),
+        ("94", "Z-Wave Plus Info"),
     ]
 
     assert voluptuous_serialize.convert(
@@ -649,11 +649,11 @@ async def test_get_action_capabilities(
             "name": "value",
             "required": True,
             "options": [
-                (0, "Disabled"),
-                (1, "0.5° F"),
-                (2, "1.0° F"),
-                (3, "1.5° F"),
-                (4, "2.0° F"),
+                ("0", "Disabled"),
+                ("1", "0.5° F"),
+                ("2", "1.0° F"),
+                ("3", "1.5° F"),
+                ("4", "2.0° F"),
             ],
             "type": "select",
         }
@@ -835,3 +835,18 @@ async def test_unavailable_entity_actions(
         action.get("entity_id") == entity_id_unavailable for action in actions
     )
     assert not any(action.get("entity_id") == binary_sensor.id for action in actions)
+
+
+def test_action_schema_coerces_string_command_class() -> None:
+    """Test that SET_VALUE action schema accepts and coerces string command_class."""
+    config = device_action.SET_VALUE_SCHEMA(
+        {
+            "device_id": "device123",
+            "domain": DOMAIN,
+            "type": "set_value",
+            "command_class": str(CommandClass.DOOR_LOCK.value),
+            "property": "targetMode",
+            "value": 255,
+        }
+    )
+    assert config["command_class"] == CommandClass.DOOR_LOCK.value

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -490,15 +490,15 @@ async def test_get_condition_capabilities_value(
     assert capabilities and "extra_fields" in capabilities
 
     cc_options = [
-        (133, "Association"),
-        (128, "Battery"),
-        (98, "Door Lock"),
-        (122, "Firmware Update Meta Data"),
-        (114, "Manufacturer Specific"),
-        (113, "Notification"),
-        (152, "Security"),
-        (99, "User Code"),
-        (134, "Version"),
+        ("133", "Association"),
+        ("128", "Battery"),
+        ("98", "Door Lock"),
+        ("122", "Firmware Update Meta Data"),
+        ("114", "Manufacturer Specific"),
+        ("113", "Notification"),
+        ("152", "Security"),
+        ("99", "User Code"),
+        ("134", "Version"),
     ]
 
     assert voluptuous_serialize.convert(
@@ -552,11 +552,11 @@ async def test_get_condition_capabilities_config_parameter(
             "name": "value",
             "required": True,
             "options": [
-                (0, "Disabled"),
-                (1, "0.5° F"),
-                (2, "1.0° F"),
-                (3, "1.5° F"),
-                (4, "2.0° F"),
+                ("0", "Disabled"),
+                ("1", "0.5° F"),
+                ("2", "1.0° F"),
+                ("3", "1.5° F"),
+                ("4", "2.0° F"),
             ],
             "type": "select",
         }
@@ -694,3 +694,19 @@ async def test_get_value_from_config_failure(
                 "endpoint": 10,
             },
         )
+
+
+def test_condition_schema_coerces_string_command_class() -> None:
+    """Test that VALUE condition schema accepts and coerces string command_class."""
+    config = device_condition.CONDITION_SCHEMA(
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "device_id": "device123",
+            "type": "value",
+            "command_class": str(CommandClass.DOOR_LOCK.value),
+            "property": "latchStatus",
+            "value": "open",
+        }
+    )
+    assert config["command_class"] == CommandClass.DOOR_LOCK.value

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -697,16 +697,20 @@ async def test_get_value_from_config_failure(
 
 
 def test_condition_schema_coerces_string_command_class() -> None:
-    """Test that VALUE condition schema accepts and coerces string command_class."""
-    config = device_condition.CONDITION_SCHEMA(
-        {
-            "condition": "device",
-            "domain": DOMAIN,
-            "device_id": "device123",
-            "type": "value",
-            "command_class": str(CommandClass.DOOR_LOCK.value),
-            "property": "latchStatus",
-            "value": "open",
-        }
-    )
-    assert config["command_class"] == CommandClass.DOOR_LOCK.value
+    """Test that VALUE condition schema accepts both int and string command_class."""
+    for command_class_value in (
+        CommandClass.DOOR_LOCK.value,
+        str(CommandClass.DOOR_LOCK.value),
+    ):
+        config = device_condition.CONDITION_SCHEMA(
+            {
+                "condition": "device",
+                "domain": DOMAIN,
+                "device_id": "device123",
+                "type": "value",
+                "command_class": command_class_value,
+                "property": "latchStatus",
+                "value": "open",
+            }
+        )
+        assert config["command_class"] == CommandClass.DOOR_LOCK.value

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -1753,34 +1753,41 @@ async def test_failure_scenarios(
 
 
 def test_trigger_schema_coerces_string_values() -> None:
-    """Test that trigger schemas accept and coerce string values for numeric fields."""
-    # Central scene: string command_class and string value are both coerced to int
-    config = device_trigger.TRIGGER_SCHEMA(
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "device_id": "device123",
-            "type": "event.value_notification.central_scene",
-            "command_class": str(CommandClass.CENTRAL_SCENE.value),
-            "property": "scene",
-            "property_key": "001",
-            "endpoint": 0,
-            "subtype": "Endpoint 0 Scene 001",
-            "value": "2",
-        }
-    )
-    assert config["command_class"] == CommandClass.CENTRAL_SCENE.value
-    assert config["value"] == 2
+    """Test that trigger schemas accept both int and string values for numeric fields."""
+    for command_class_value in (
+        CommandClass.CENTRAL_SCENE.value,
+        str(CommandClass.CENTRAL_SCENE.value),
+    ):
+        for value in (2, "2"):
+            config = device_trigger.TRIGGER_SCHEMA(
+                {
+                    "platform": "device",
+                    "domain": DOMAIN,
+                    "device_id": "device123",
+                    "type": "event.value_notification.central_scene",
+                    "command_class": command_class_value,
+                    "property": "scene",
+                    "property_key": "001",
+                    "endpoint": 0,
+                    "subtype": "Endpoint 0 Scene 001",
+                    "value": value,
+                }
+            )
+            assert config["command_class"] == CommandClass.CENTRAL_SCENE.value
+            assert config["value"] == 2
 
-    # Value updated: string command_class is coerced to int
-    config = device_trigger.TRIGGER_SCHEMA(
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "device_id": "device123",
-            "type": "zwave_js.value_updated.value",
-            "command_class": str(CommandClass.DOOR_LOCK.value),
-            "property": "latchStatus",
-        }
-    )
-    assert config["command_class"] == CommandClass.DOOR_LOCK.value
+    for command_class_value in (
+        CommandClass.DOOR_LOCK.value,
+        str(CommandClass.DOOR_LOCK.value),
+    ):
+        config = device_trigger.TRIGGER_SCHEMA(
+            {
+                "platform": "device",
+                "domain": DOMAIN,
+                "device_id": "device123",
+                "type": "zwave_js.value_updated.value",
+                "command_class": command_class_value,
+                "property": "latchStatus",
+            }
+        )
+        assert config["command_class"] == CommandClass.DOOR_LOCK.value

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -997,7 +997,11 @@ async def test_get_trigger_capabilities_central_scene_value_notification(
             "optional": True,
             "required": False,
             "type": "select",
-            "options": [(0, "KeyPressed"), (1, "KeyReleased"), (2, "KeyHeldDown")],
+            "options": [
+                ("0", "KeyPressed"),
+                ("1", "KeyReleased"),
+                ("2", "KeyHeldDown"),
+            ],
         },
     ]
 
@@ -1419,15 +1423,15 @@ async def test_get_trigger_capabilities_value_updated_value(
             "required": True,
             "type": "select",
             "options": [
-                (133, "Association"),
-                (128, "Battery"),
-                (98, "Door Lock"),
-                (122, "Firmware Update Meta Data"),
-                (114, "Manufacturer Specific"),
-                (113, "Notification"),
-                (152, "Security"),
-                (99, "User Code"),
-                (134, "Version"),
+                ("133", "Association"),
+                ("128", "Battery"),
+                ("98", "Door Lock"),
+                ("122", "Firmware Update Meta Data"),
+                ("114", "Manufacturer Specific"),
+                ("113", "Notification"),
+                ("152", "Security"),
+                ("99", "User Code"),
+                ("134", "Version"),
             ],
         },
         {"name": "property", "required": True, "type": "string"},
@@ -1628,14 +1632,14 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
             "name": "from",
             "optional": True,
             "required": False,
-            "options": [(0, "Disable Beeper"), (255, "Enable Beeper")],
+            "options": [("0", "Disable Beeper"), ("255", "Enable Beeper")],
             "type": "select",
         },
         {
             "name": "to",
             "optional": True,
             "required": False,
-            "options": [(0, "Disable Beeper"), (255, "Enable Beeper")],
+            "options": [("0", "Disable Beeper"), ("255", "Enable Beeper")],
             "type": "select",
         },
     ]
@@ -1746,3 +1750,37 @@ async def test_failure_scenarios(
                 "endpoint": 9999,
             },
         )
+
+
+def test_trigger_schema_coerces_string_values() -> None:
+    """Test that trigger schemas accept and coerce string values for numeric fields."""
+    # Central scene: string command_class and string value are both coerced to int
+    config = device_trigger.TRIGGER_SCHEMA(
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": "device123",
+            "type": "event.value_notification.central_scene",
+            "command_class": str(CommandClass.CENTRAL_SCENE.value),
+            "property": "scene",
+            "property_key": "001",
+            "endpoint": 0,
+            "subtype": "Endpoint 0 Scene 001",
+            "value": "2",
+        }
+    )
+    assert config["command_class"] == CommandClass.CENTRAL_SCENE.value
+    assert config["value"] == 2
+
+    # Value updated: string command_class is coerced to int
+    config = device_trigger.TRIGGER_SCHEMA(
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": "device123",
+            "type": "zwave_js.value_updated.value",
+            "command_class": str(CommandClass.DOOR_LOCK.value),
+            "property": "latchStatus",
+        }
+    )
+    assert config["command_class"] == CommandClass.DOOR_LOCK.value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`SelectOption` values in the frontend are strings, but some of the `extra_fields` we were sending to the frontend for selects were actually numbers:
https://github.com/home-assistant/frontend/blob/25e7d3fb331d8a9b6fbc4d26660e8a36435409af/src/data/selector.ts#L430

Some recent changes surfaced this in the automation editor: https://github.com/home-assistant/frontend/issues/30010

https://github.com/home-assistant/frontend/pull/51564 works around this issue in the frontend, but we should still make sure to send valid data. This way we avoid similar issues in the future, and we are able to deal with strings in place of numbers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
