### PR TITLE
Add test coverage for add_job and fix docstring

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -544,8 +544,9 @@ class HomeAssistant:
     ) -> None:
         """Add a job to be executed by the event loop or by an executor.
 
-        If the job is either a coroutine or decorated with @callback, it will be
-        run by the event loop, if not it will be run by an executor.
+        If the job is a coroutine, coroutine function, or decorated with
+        @callback, it will be run by the event loop, if not it will be run
+        by an executor.
 
         target: target to call.
         args: parameters for method to call.

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -599,8 +599,9 @@ class HomeAssistant:
     ) -> asyncio.Future[_R] | None:
         """Add a job to be executed by the event loop or by an executor.
 
-        If the job is either a coroutine or decorated with @callback, it will be
-        run by the event loop, if not it will be run by an executor.
+        If the job is a coroutine, coroutine function, or decorated with
+        @callback, it will be run by the event loop, if not it will be run
+        by an executor.
 
         This method must be run in the event loop.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -955,6 +955,21 @@ async def test_add_job_partial_coroutine_function(
     assert result == [("partial", 2)]
 
 
+async def test_add_job_async_with_callback_decorator(hass: HomeAssistant) -> None:
+    """Test add_job with an async function incorrectly marked as @callback."""
+    result: list[str] = []
+
+    @ha.callback
+    async def my_async(value: str) -> None:  # pylint: disable=hass-async-callback-decorator
+        assert asyncio.get_running_loop() is hass.loop
+        result.append(value)
+
+    await hass.async_add_executor_job(hass.add_job, my_async, "called")
+    await hass.async_block_till_done()
+
+    assert result == ["called"]
+
+
 def test_event_eq() -> None:
     """Test events."""
     now = dt_util.utcnow()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -856,6 +856,105 @@ async def test_add_job_with_none(hass: HomeAssistant) -> None:
         hass.async_add_job(None, "test_arg")
 
 
+async def test_add_job_coroutine_object(hass: HomeAssistant) -> None:
+    """Test add_job with a coroutine object from an executor thread."""
+    result: list[str] = []
+
+    async def my_coro() -> None:
+        assert asyncio.get_running_loop() is hass.loop
+        result.append("called")
+
+    await hass.async_add_executor_job(hass.add_job, my_coro())
+    await hass.async_block_till_done()
+
+    assert result == ["called"]
+
+
+async def test_add_job_coroutine_function(hass: HomeAssistant) -> None:
+    """Test add_job with a coroutine function from an executor thread."""
+    result: list[str] = []
+
+    async def my_coro() -> None:
+        assert asyncio.get_running_loop() is hass.loop
+        result.append("called")
+
+    await hass.async_add_executor_job(hass.add_job, my_coro)
+    await hass.async_block_till_done()
+
+    assert result == ["called"]
+
+
+async def test_add_job_callback(hass: HomeAssistant) -> None:
+    """Test add_job with a @callback from an executor thread."""
+    result: list[str] = []
+
+    @ha.callback
+    def my_callback() -> None:
+        assert asyncio.get_running_loop() is hass.loop
+        result.append("called")
+
+    await hass.async_add_executor_job(hass.add_job, my_callback)
+    # Callback targets go through two deferrals: call_soon_threadsafe
+    # schedules _async_add_hass_job, which then call_soon's the actual target.
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert result == ["called"]
+
+
+async def test_add_job_executor(hass: HomeAssistant) -> None:
+    """Test add_job with a regular function from an executor thread."""
+    result: list[str] = []
+
+    def my_func() -> None:
+        with pytest.raises(RuntimeError):
+            asyncio.get_running_loop()
+        result.append("called")
+
+    await hass.async_add_executor_job(hass.add_job, my_func)
+    await hass.async_block_till_done()
+
+    assert result == ["called"]
+
+
+async def test_add_job_partial_callback(hass: HomeAssistant) -> None:
+    """Test add_job with a partial-wrapped @callback from an executor thread."""
+    result: list[tuple[str, int]] = []
+
+    @ha.callback
+    def my_callback(name: str, value: int) -> None:
+        assert asyncio.get_running_loop() is hass.loop
+        result.append((name, value))
+
+    await hass.async_add_executor_job(
+        hass.add_job, functools.partial(my_callback, "partial"), 1
+    )
+    # Callback targets go through two deferrals: call_soon_threadsafe
+    # schedules _async_add_hass_job, which then call_soon's the actual target.
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert result == [("partial", 1)]
+
+
+async def test_add_job_partial_coroutine_function(
+    hass: HomeAssistant,
+) -> None:
+    """Test add_job with a partial-wrapped coroutine function from an executor thread."""
+    result: list[tuple[str, int]] = []
+
+    async def my_coro(name: str, value: int) -> None:
+        assert asyncio.get_running_loop() is hass.loop
+        result.append((name, value))
+
+    await hass.async_add_executor_job(
+        hass.add_job, functools.partial(my_coro, "partial"), 2
+    )
+    await hass.async_block_till_done()
+
+    assert result == [("partial", 2)]
+
+
 def test_event_eq() -> None:
     """Test events."""
     now = dt_util.utcnow()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -874,11 +874,11 @@ async def test_add_job_coroutine_function(hass: HomeAssistant) -> None:
     """Test add_job with a coroutine function from an executor thread."""
     result: list[str] = []
 
-    async def my_coro() -> None:
+    async def my_coro(value: str) -> None:
         assert asyncio.get_running_loop() is hass.loop
-        result.append("called")
+        result.append(value)
 
-    await hass.async_add_executor_job(hass.add_job, my_coro)
+    await hass.async_add_executor_job(hass.add_job, my_coro, "called")
     await hass.async_block_till_done()
 
     assert result == ["called"]
@@ -889,11 +889,11 @@ async def test_add_job_callback(hass: HomeAssistant) -> None:
     result: list[str] = []
 
     @ha.callback
-    def my_callback() -> None:
+    def my_callback(value: str) -> None:
         assert asyncio.get_running_loop() is hass.loop
-        result.append("called")
+        result.append(value)
 
-    await hass.async_add_executor_job(hass.add_job, my_callback)
+    await hass.async_add_executor_job(hass.add_job, my_callback, "called")
     # Callback targets go through two deferrals: call_soon_threadsafe
     # schedules _async_add_hass_job, which then call_soon's the actual target.
     await hass.async_block_till_done()
@@ -906,12 +906,12 @@ async def test_add_job_executor(hass: HomeAssistant) -> None:
     """Test add_job with a regular function from an executor thread."""
     result: list[str] = []
 
-    def my_func() -> None:
+    def my_func(value: str) -> None:
         with pytest.raises(RuntimeError):
             asyncio.get_running_loop()
-        result.append("called")
+        result.append(value)
 
-    await hass.async_add_executor_job(hass.add_job, my_func)
+    await hass.async_add_executor_job(hass.add_job, my_func, "called")
     await hass.async_block_till_done()
 
     assert result == ["called"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for all target types accepted by `add_job()` called from an executor thread: coroutine objects, coroutine functions, `@callback`, plain functions, and partial-wrapped variants. Each test verifies the target runs on the correct thread (event loop or executor). Linked to #168198

Also fix the docstring to mention coroutine functions, which were missing from the description.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
