### PR TITLE
Extend Renovate allowlist with common packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -79,6 +79,50 @@
       "labels": ["dependency", "core"]
     },
     {
+      "description": "Common Python utilities (allowlisted)",
+      "matchPackageNames": [
+        "astral",
+        "atomicwrites-homeassistant",
+        "audioop-lts",
+        "awesomeversion",
+        "bcrypt",
+        "ciso8601",
+        "cronsim",
+        "defusedxml",
+        "fnv-hash-fast",
+        "getmac",
+        "ical",
+        "ifaddr",
+        "lru-dict",
+        "mutagen",
+        "propcache",
+        "pyserial",
+        "python-slugify",
+        "PyTurboJPEG",
+        "securetar",
+        "standard-aifc",
+        "standard-telnetlib",
+        "ulid-transform",
+        "url-normalize",
+        "xmltodict"
+      ],
+      "enabled": true,
+      "labels": ["dependency"]
+    },
+    {
+      "description": "Home Assistant ecosystem packages (core-maintained, no cooldown)",
+      "matchPackageNames": [
+        "hassil",
+        "home-assistant-bluetooth",
+        "home-assistant-frontend",
+        "home-assistant-intents",
+        "infrared-protocols"
+      ],
+      "enabled": true,
+      "minimumReleaseAge": null,
+      "labels": ["dependency", "core"]
+    },
+    {
       "description": "Test dependencies (allowlisted)",
       "matchPackageNames": [
         "pytest",


### PR DESCRIPTION
## Proposed change

Extends the Renovate allowlist introduced in [#168192](https://github.com/home-assistant/core/pull/168192) and refined in [#168225](https://github.com/home-assistant/core/pull/168225) and [#168233](https://github.com/home-assistant/core/pull/168233) with two new `packageRules` entries covering more of the project's direct dependencies. The two entries are kept separate from the existing "Core runtime dependencies" rule so that the allowlist stays categorized and a future reader can tell at a glance why each package is there.

The first new rule, "Common Python utilities (allowlisted)", adds twenty-four general-purpose Python libraries pinned in `pyproject.toml` that are not device or service abstractions and have stable, well-maintained upstream releases: `astral`, `atomicwrites-homeassistant`, `audioop-lts`, `awesomeversion`, `bcrypt`, `ciso8601`, `cronsim`, `defusedxml`, `fnv-hash-fast`, `getmac`, `ical`, `ifaddr`, `lru-dict`, `mutagen`, `propcache`, `pyserial`, `python-slugify`, `PyTurboJPEG`, `securetar`, `standard-aifc`, `standard-telnetlib`, `ulid-transform`, `url-normalize`, and `xmltodict`. Five of these (`defusedxml`, `getmac`, `ical`, `pyserial`, `xmltodict`) are picked up by multiple integration `manifest.json` files as well as `pyproject.toml`, so a bump will flow through the `homeassistant-manifest` manager and the `pip_requirements` manager in lockstep and land as a single PR that edits every file where the pin appears.

The second new rule, "Home Assistant ecosystem packages (core-maintained, no cooldown)", adds five packages maintained by the Home Assistant core team or directly adjacent to it: `hassil`, `home-assistant-bluetooth`, `home-assistant-frontend`, `home-assistant-intents`, and `infrared-protocols`. This rule sets `minimumReleaseAge: null` locally to override the repository-wide seven-day cooldown, because for these packages the release cadence is controlled by the same group of people who would be reviewing the resulting Renovate PR on this repository.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr