### PR TITLE
Bump `imgw-pib` to 2.1.0

### DIFF
--- a/homeassistant/components/imgw_pib/manifest.json
+++ b/homeassistant/components/imgw_pib/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["imgw_pib==2.0.2"]
+  "requirements": ["imgw_pib==2.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1313,7 +1313,7 @@ ihcsdk==2.8.5
 imeon_inverter_api==0.4.0
 
 # homeassistant.components.imgw_pib
-imgw_pib==2.0.2
+imgw_pib==2.1.0
 
 # homeassistant.components.incomfort
 incomfort-client==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1165,7 +1165,7 @@ igloohome-api==0.1.1
 imeon_inverter_api==0.4.0
 
 # homeassistant.components.imgw_pib
-imgw_pib==2.0.2
+imgw_pib==2.1.0
 
 # homeassistant.components.incomfort
 incomfort-client==0.7.0

--- a/tests/components/imgw_pib/conftest.py
+++ b/tests/components/imgw_pib/conftest.py
@@ -21,6 +21,8 @@ HYDROLOGICAL_DATA = HydrologicalData(
     water_temperature=SensorData(name="Water Temperature", value=10.8),
     flood_alarm=None,
     flood_warning=None,
+    ice_phenomenon=SensorData(name="Ice Phenomenon", value=20),
+    ice_phenomenon_measurement_date=datetime(2024, 4, 27, 10, 0, tzinfo=UTC),
     water_level_measurement_date=datetime(2024, 4, 27, 10, 0, tzinfo=UTC),
     water_temperature_measurement_date=datetime(2024, 4, 27, 10, 10, tzinfo=UTC),
     water_flow=SensorData(name="Water Flow", value=123.45),

--- a/tests/components/imgw_pib/snapshots/test_diagnostics.ambr
+++ b/tests/components/imgw_pib/snapshots/test_diagnostics.ambr
@@ -41,6 +41,12 @@
         'valid_to': '2024-04-28T11:00:00+00:00',
         'value': 'rapid_water_level_rise',
       }),
+      'ice_phenomenon': dict({
+        'name': 'Ice Phenomenon',
+        'unit': None,
+        'value': 20,
+      }),
+      'ice_phenomenon_measurement_date': '2024-04-27T10:00:00+00:00',
       'latitude': None,
       'longitude': None,
       'river': 'River Name',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Release note: https://github.com/bieniu/imgw-pib/releases/tag/2.1.0
Diff: https://github.com/bieniu/imgw-pib/compare/2.0.2...2.1.0

Fixes:

```
2026-04-15 21:29:18.727 ERROR (MainThread) [homeassistant.components.imgw_pib.coordinator] Unexpected error fetching imgw_pib data
Traceback (most recent call last):
  File "/workspaces/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 426, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/imgw_pib/coordinator.py", line 64, in _async_update_data
    return await self.imgwpib.get_hydrological_data()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/imgw_pib/__init__.py", line 249, in get_hydrological_data
    return self._parse_hydrological_data(hydrological_data, hydrological_alerts)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/imgw_pib/__init__.py", line 367, in _parse_hydrological_data
    water_flow = data[ApiNames.WATER_FLOW] if water_flow_current else None
                 ~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: <ApiNames.WATER_FLOW: 'przelyw'>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
