### PR TITLE
Migrate remaining Core integrations from pyserial to serialx

### DIFF
--- a/homeassistant/components/acer_projector/const.py
+++ b/homeassistant/components/acer_projector/const.py
@@ -6,10 +6,11 @@ from typing import Final
 
 from homeassistant.const import STATE_OFF, STATE_ON
 
+CONF_READ_TIMEOUT: Final = "timeout"
 CONF_WRITE_TIMEOUT: Final = "write_timeout"
 
 DEFAULT_NAME: Final = "Acer Projector"
-DEFAULT_TIMEOUT: Final = 1
+DEFAULT_READ_TIMEOUT: Final = 1
 DEFAULT_WRITE_TIMEOUT: Final = 1
 
 ECO_MODE: Final = "ECO Mode"

--- a/homeassistant/components/acer_projector/manifest.json
+++ b/homeassistant/components/acer_projector/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/acer_projector",
   "iot_class": "local_polling",
   "quality_scale": "legacy",
-  "requirements": ["pyserial==3.5"]
+  "requirements": ["serialx==1.2.2"]
 }

--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -6,7 +6,7 @@ import logging
 import re
 from typing import Any
 
-import serial
+from serialx import Serial, SerialException
 import voluptuous as vol
 
 from homeassistant.components.switch import (
@@ -16,21 +16,22 @@ from homeassistant.components.switch import (
 from homeassistant.const import (
     CONF_FILENAME,
     CONF_NAME,
-    CONF_TIMEOUT,
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
     CMD_DICT,
+    CONF_READ_TIMEOUT,
     CONF_WRITE_TIMEOUT,
     DEFAULT_NAME,
-    DEFAULT_TIMEOUT,
+    DEFAULT_READ_TIMEOUT,
     DEFAULT_WRITE_TIMEOUT,
     ECO_MODE,
     ICON,
@@ -45,7 +46,7 @@ PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_FILENAME): cv.isdevice,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_READ_TIMEOUT, default=DEFAULT_READ_TIMEOUT): cv.positive_int,
         vol.Optional(
             CONF_WRITE_TIMEOUT, default=DEFAULT_WRITE_TIMEOUT
         ): cv.positive_int,
@@ -62,10 +63,10 @@ def setup_platform(
     """Connect with serial port and return Acer Projector."""
     serial_port = config[CONF_FILENAME]
     name = config[CONF_NAME]
-    timeout = config[CONF_TIMEOUT]
+    read_timeout = config[CONF_READ_TIMEOUT]
     write_timeout = config[CONF_WRITE_TIMEOUT]
 
-    add_entities([AcerSwitch(serial_port, name, timeout, write_timeout)], True)
+    add_entities([AcerSwitch(serial_port, name, read_timeout, write_timeout)], True)
 
 
 class AcerSwitch(SwitchEntity):
@@ -77,14 +78,14 @@ class AcerSwitch(SwitchEntity):
         self,
         serial_port: str,
         name: str,
-        timeout: int,
+        read_timeout: int,
         write_timeout: int,
     ) -> None:
         """Init of the Acer projector."""
-        self.serial = serial.Serial(
-            port=serial_port, timeout=timeout, write_timeout=write_timeout
-        )
         self._serial_port = serial_port
+        self._read_timeout = read_timeout
+        self._write_timeout = write_timeout
+
         self._attr_name = name
         self._attributes = {
             LAMP_HOURS: STATE_UNKNOWN,
@@ -94,22 +95,26 @@ class AcerSwitch(SwitchEntity):
 
     def _write_read(self, msg: str) -> str:
         """Write to the projector and read the return."""
-        ret = ""
+
         # Sometimes the projector won't answer for no reason or the projector
         # was disconnected during runtime.
         # This way the projector can be reconnected and will still work
         try:
-            if not self.serial.is_open:
-                self.serial.open()
-            self.serial.write(msg.encode("utf-8"))
-            # Size is an experience value there is no real limit.
-            # AFAIK there is no limit and no end character so we will usually
-            # need to wait for timeout
-            ret = self.serial.read_until(size=20).decode("utf-8")
-        except serial.SerialException:
-            _LOGGER.error("Problem communicating with %s", self._serial_port)
-        self.serial.close()
-        return ret
+            with Serial.from_url(
+                self._serial_port,
+                read_timeout=self._read_timeout,
+                write_timeout=self._write_timeout,
+            ) as serial:
+                serial.write(msg.encode("utf-8"))
+
+                # Size is an experience value there is no real limit.
+                # AFAIK there is no limit and no end character so we will usually
+                # need to wait for timeout
+                return serial.read_until(size=20).decode("utf-8")
+        except (OSError, SerialException, TimeoutError) as exc:
+            raise HomeAssistantError(
+                f"Problem communicating with {self._serial_port}"
+            ) from exc
 
     def _write_read_format(self, msg: str) -> str:
         """Write msg, obtain answer and format output."""

--- a/homeassistant/components/serial/manifest.json
+++ b/homeassistant/components/serial/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": ["@fabaff"],
   "documentation": "https://www.home-assistant.io/integrations/serial",
   "iot_class": "local_polling",
-  "requirements": ["pyserial-asyncio-fast==0.16"]
+  "requirements": ["serialx==1.2.2"]
 }

--- a/homeassistant/components/serial/sensor.py
+++ b/homeassistant/components/serial/sensor.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from asyncio import Task
 import json
 import logging
+from typing import cast
 
-from serial import SerialException
-import serial_asyncio_fast as serial_asyncio
+from serialx import Parity, SerialException, StopBits, open_serial_connection
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -18,6 +19,7 @@ from homeassistant.const import CONF_NAME, CONF_VALUE_TEMPLATE, EVENT_HOMEASSIST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,9 +35,9 @@ CONF_DSRDTR = "dsrdtr"
 
 DEFAULT_NAME = "Serial Sensor"
 DEFAULT_BAUDRATE = 9600
-DEFAULT_BYTESIZE = serial_asyncio.serial.EIGHTBITS
-DEFAULT_PARITY = serial_asyncio.serial.PARITY_NONE
-DEFAULT_STOPBITS = serial_asyncio.serial.STOPBITS_ONE
+DEFAULT_BYTESIZE = 8
+DEFAULT_PARITY = Parity.NONE
+DEFAULT_STOPBITS = StopBits.ONE
 DEFAULT_XONXOFF = False
 DEFAULT_RTSCTS = False
 DEFAULT_DSRDTR = False
@@ -46,28 +48,21 @@ PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE): cv.positive_int,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-        vol.Optional(CONF_BYTESIZE, default=DEFAULT_BYTESIZE): vol.In(
-            [
-                serial_asyncio.serial.FIVEBITS,
-                serial_asyncio.serial.SIXBITS,
-                serial_asyncio.serial.SEVENBITS,
-                serial_asyncio.serial.EIGHTBITS,
-            ]
-        ),
+        vol.Optional(CONF_BYTESIZE, default=DEFAULT_BYTESIZE): vol.In([5, 6, 7, 8]),
         vol.Optional(CONF_PARITY, default=DEFAULT_PARITY): vol.In(
             [
-                serial_asyncio.serial.PARITY_NONE,
-                serial_asyncio.serial.PARITY_EVEN,
-                serial_asyncio.serial.PARITY_ODD,
-                serial_asyncio.serial.PARITY_MARK,
-                serial_asyncio.serial.PARITY_SPACE,
+                Parity.NONE,
+                Parity.EVEN,
+                Parity.ODD,
+                Parity.MARK,
+                Parity.SPACE,
             ]
         ),
         vol.Optional(CONF_STOPBITS, default=DEFAULT_STOPBITS): vol.In(
             [
-                serial_asyncio.serial.STOPBITS_ONE,
-                serial_asyncio.serial.STOPBITS_ONE_POINT_FIVE,
-                serial_asyncio.serial.STOPBITS_TWO,
+                StopBits.ONE,
+                StopBits.ONE_POINT_FIVE,
+                StopBits.TWO,
             ]
         ),
         vol.Optional(CONF_XONXOFF, default=DEFAULT_XONXOFF): cv.boolean,
@@ -84,16 +79,16 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Serial sensor platform."""
-    name = config.get(CONF_NAME)
-    port = config.get(CONF_SERIAL_PORT)
-    baudrate = config.get(CONF_BAUDRATE)
-    bytesize = config.get(CONF_BYTESIZE)
-    parity = config.get(CONF_PARITY)
-    stopbits = config.get(CONF_STOPBITS)
-    xonxoff = config.get(CONF_XONXOFF)
-    rtscts = config.get(CONF_RTSCTS)
-    dsrdtr = config.get(CONF_DSRDTR)
-    value_template = config.get(CONF_VALUE_TEMPLATE)
+    name = cast(str, config[CONF_NAME])
+    port = cast(str, config[CONF_SERIAL_PORT])
+    baudrate = cast(int, config[CONF_BAUDRATE])
+    bytesize = cast(int, config[CONF_BYTESIZE])
+    parity = cast(Parity, config[CONF_PARITY])
+    stopbits = cast(StopBits, config[CONF_STOPBITS])
+    xonxoff = cast(bool, config[CONF_XONXOFF])
+    rtscts = cast(bool, config[CONF_RTSCTS])
+    dsrdtr = cast(bool, config[CONF_DSRDTR])
+    value_template = cast(Template, config[CONF_VALUE_TEMPLATE])
 
     sensor = SerialSensor(
         name,
@@ -119,17 +114,17 @@ class SerialSensor(SensorEntity):
 
     def __init__(
         self,
-        name,
-        port,
-        baudrate,
-        bytesize,
-        parity,
-        stopbits,
-        xonxoff,
-        rtscts,
-        dsrdtr,
-        value_template,
-    ):
+        name: str,
+        port: str,
+        baudrate: int,
+        bytesize: int,
+        parity: Parity,
+        stopbits: StopBits,
+        xonxoff: bool,
+        rtscts: bool,
+        dsrdtr: bool,
+        value_template: Template,
+    ) -> None:
         """Initialize the Serial sensor."""
         self._attr_name = name
         self._port = port
@@ -140,12 +135,12 @@ class SerialSensor(SensorEntity):
         self._xonxoff = xonxoff
         self._rtscts = rtscts
         self._dsrdtr = dsrdtr
-        self._serial_loop_task = None
+        self._serial_loop_task: Task[None] | None = None
         self._template = value_template
 
     async def async_added_to_hass(self) -> None:
         """Handle when an entity is about to be added to Home Assistant."""
-        self._serial_loop_task = self.hass.loop.create_task(
+        self._serial_loop_task = self.hass.async_create_background_task(
             self.serial_read(
                 self._port,
                 self._baudrate,
@@ -155,26 +150,31 @@ class SerialSensor(SensorEntity):
                 self._xonxoff,
                 self._rtscts,
                 self._dsrdtr,
-            )
+            ),
+            "Serial reader",
         )
 
     async def serial_read(
         self,
-        device,
-        baudrate,
-        bytesize,
-        parity,
-        stopbits,
-        xonxoff,
-        rtscts,
-        dsrdtr,
+        device: str,
+        baudrate: int,
+        bytesize: int,
+        parity: Parity,
+        stopbits: StopBits,
+        xonxoff: bool,
+        rtscts: bool,
+        dsrdtr: bool,
         **kwargs,
     ):
         """Read the data from the port."""
         logged_error = False
+
         while True:
+            reader = None
+            writer = None
+
             try:
-                reader, _ = await serial_asyncio.open_serial_connection(
+                reader, writer = await open_serial_connection(
                     url=device,
                     baudrate=baudrate,
                     bytesize=bytesize,
@@ -185,8 +185,7 @@ class SerialSensor(SensorEntity):
                     dsrdtr=dsrdtr,
                     **kwargs,
                 )
-
-            except SerialException:
+            except OSError, SerialException:
                 if not logged_error:
                     _LOGGER.exception(
                         "Unable to connect to the serial device %s. Will retry", device
@@ -197,15 +196,15 @@ class SerialSensor(SensorEntity):
                 _LOGGER.debug("Serial device %s connected", device)
                 while True:
                     try:
-                        line = await reader.readline()
-                    except SerialException:
+                        line_bytes = await reader.readline()
+                    except OSError, SerialException:
                         _LOGGER.exception(
                             "Error while reading serial device %s", device
                         )
                         await self._handle_error()
                         break
                     else:
-                        line = line.decode("utf-8").strip()
+                        line = line_bytes.decode("utf-8").strip()
 
                         try:
                             data = json.loads(line)
@@ -223,6 +222,10 @@ class SerialSensor(SensorEntity):
                         _LOGGER.debug("Received: %s", line)
                         self._attr_native_value = line
                         self.async_write_ha_state()
+            finally:
+                if writer is not None:
+                    writer.close()
+                    await writer.wait_closed()
 
     async def _handle_error(self):
         """Handle error for serial connection."""

--- a/homeassistant/components/serial/sensor.py
+++ b/homeassistant/components/serial/sensor.py
@@ -185,7 +185,7 @@ class SerialSensor(SensorEntity):
                     dsrdtr=dsrdtr,
                     **kwargs,
                 )
-            except OSError, SerialException:
+            except OSError, SerialException, TimeoutError:
                 if not logged_error:
                     _LOGGER.exception(
                         "Unable to connect to the serial device %s. Will retry", device

--- a/homeassistant/components/serial/sensor.py
+++ b/homeassistant/components/serial/sensor.py
@@ -6,7 +6,6 @@ import asyncio
 from asyncio import Task
 import json
 import logging
-from typing import cast
 
 from serialx import Parity, SerialException, StopBits, open_serial_connection
 import voluptuous as vol
@@ -79,28 +78,17 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Serial sensor platform."""
-    name = cast(str, config[CONF_NAME])
-    port = cast(str, config[CONF_SERIAL_PORT])
-    baudrate = cast(int, config[CONF_BAUDRATE])
-    bytesize = cast(int, config[CONF_BYTESIZE])
-    parity = cast(Parity, config[CONF_PARITY])
-    stopbits = cast(StopBits, config[CONF_STOPBITS])
-    xonxoff = cast(bool, config[CONF_XONXOFF])
-    rtscts = cast(bool, config[CONF_RTSCTS])
-    dsrdtr = cast(bool, config[CONF_DSRDTR])
-    value_template = cast(Template, config[CONF_VALUE_TEMPLATE])
-
     sensor = SerialSensor(
-        name,
-        port,
-        baudrate,
-        bytesize,
-        parity,
-        stopbits,
-        xonxoff,
-        rtscts,
-        dsrdtr,
-        value_template,
+        name=config[CONF_NAME],
+        port=config[CONF_SERIAL_PORT],
+        baudrate=config[CONF_BAUDRATE],
+        bytesize=config[CONF_BYTESIZE],
+        parity=config[CONF_PARITY],
+        stopbits=config[CONF_STOPBITS],
+        xonxoff=config[CONF_XONXOFF],
+        rtscts=config[CONF_RTSCTS],
+        dsrdtr=config[CONF_DSRDTR],
+        value_template=config.get(CONF_VALUE_TEMPLATE),
     )
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, sensor.stop_serial_read)
@@ -123,7 +111,7 @@ class SerialSensor(SensorEntity):
         xonxoff: bool,
         rtscts: bool,
         dsrdtr: bool,
-        value_template: Template,
+        value_template: Template | None,
     ) -> None:
         """Initialize the Serial sensor."""
         self._attr_name = name

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2465,9 +2465,6 @@ pysensibo==1.2.1
 # homeassistant.components.senz
 pysenz==1.0.2
 
-# homeassistant.components.acer_projector
-pyserial==3.5
-
 # homeassistant.components.sesame
 pysesame2==1.0.1
 
@@ -2924,6 +2921,7 @@ sentence-stream==1.2.0
 # homeassistant.components.sentry
 sentry-sdk==2.48.0
 
+# homeassistant.components.acer_projector
 # homeassistant.components.homeassistant_hardware
 # homeassistant.components.serial
 # homeassistant.components.usb

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2465,9 +2465,6 @@ pysensibo==1.2.1
 # homeassistant.components.senz
 pysenz==1.0.2
 
-# homeassistant.components.serial
-pyserial-asyncio-fast==0.16
-
 # homeassistant.components.acer_projector
 pyserial==3.5
 
@@ -2928,6 +2925,7 @@ sentence-stream==1.2.0
 sentry-sdk==2.48.0
 
 # homeassistant.components.homeassistant_hardware
+# homeassistant.components.serial
 # homeassistant.components.usb
 # homeassistant.components.zha
 serialx==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2481,6 +2481,7 @@ sentence-stream==1.2.0
 # homeassistant.components.sentry
 sentry-sdk==2.48.0
 
+# homeassistant.components.acer_projector
 # homeassistant.components.homeassistant_hardware
 # homeassistant.components.serial
 # homeassistant.components.usb

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2482,6 +2482,7 @@ sentence-stream==1.2.0
 sentry-sdk==2.48.0
 
 # homeassistant.components.homeassistant_hardware
+# homeassistant.components.serial
 # homeassistant.components.usb
 # homeassistant.components.zha
 serialx==1.2.2

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -17,7 +17,6 @@ from unittest.mock import (
 import uuid
 
 import pytest
-from serial.tools.list_ports_common import ListPortInfo
 from zha.application.const import RadioType
 from zigpy.application import ControllerApplication
 from zigpy.backups import BackupManager
@@ -33,7 +32,7 @@ import zigpy.types
 
 from homeassistant import config_entries
 from homeassistant.components.hassio import AddonError, AddonState
-from homeassistant.components.usb import USBDevice
+from homeassistant.components.usb import SerialDevice, USBDevice
 from homeassistant.components.zha import config_flow, radio_manager
 from homeassistant.components.zha.const import (
     CONF_BAUDRATE,
@@ -66,9 +65,7 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
-type RadioPicker = Callable[
-    [RadioType], Coroutine[Any, Any, tuple[ConfigFlowResult, ListPortInfo]]
-]
+type RadioPicker = Callable[[RadioType], Coroutine[Any, Any, ConfigFlowResult]]
 PROBE_FUNCTION_PATH = "zigbee.application.ControllerApplication.probe"
 
 
@@ -168,15 +165,14 @@ def mock_detect_radio_type(
     return detect
 
 
-def com_port(device="/dev/ttyUSB1234") -> ListPortInfo:
+def com_port(device="/dev/ttyUSB1234") -> SerialDevice:
     """Mock of a serial port."""
-    port = ListPortInfo(device)
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = device
-    port.description = "Some serial port"
-
-    return port
+    return SerialDevice(
+        device=device,
+        serial_number="1234",
+        manufacturer="Virtual serial port",
+        description="Some serial port",
+    )
 
 
 def usb_port(device="/dev/ttyUSB1234") -> USBDevice:
@@ -1129,7 +1125,7 @@ async def test_user_flow_not_detected(hass: HomeAssistant) -> None:
     """Test user flow, radio not detected."""
 
     port = com_port()
-    port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
+    port_select = f"{port.device} - {port.description}, s/n: {port.serial_number} - {port.manufacturer}"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -1700,14 +1696,12 @@ def test_prevent_overwrite_ezsp_ieee() -> None:
 
 
 @pytest.fixture
-def advanced_pick_radio(
-    hass: HomeAssistant,
-) -> Generator[RadioPicker]:
+def advanced_pick_radio(hass: HomeAssistant) -> Generator[RadioPicker]:
     """Fixture for the first step of the config flow (where a radio is picked)."""
 
-    async def wrapper(radio_type: RadioType) -> tuple[ConfigFlowResult, ListPortInfo]:
+    async def wrapper(radio_type: RadioType) -> ConfigFlowResult:
         port = com_port()
-        port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
+        port_select = f"{port.device} - {port.description}, s/n: {port.serial_number} - {port.manufacturer}"
 
         with patch(
             "homeassistant.components.zha.radio_manager.ZhaRadioManager.detect_radio_type",

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
-import serial.tools.list_ports
 from zha.application.const import RadioType
 from zigpy.backups import BackupManager
 import zigpy.config
@@ -75,17 +74,6 @@ def mock_detect_radio_type(
         return ret
 
     return detect
-
-
-def com_port(device="/dev/ttyUSB1234"):
-    """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = device
-    port.description = "Some serial port"
-
-    return port
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Part of https://github.com/OpenHomeFoundation/roadmap/issues/77.

This PR migrates the remaining Core integrations directly dependent on pyserial to instead use serialx. These are only _direct_ dependencies, nine more integrations depend on pyserial indirectly (with two of them already switching), in addition to the handful of custom components still using it.

To be honest, the two integrations being migrated as part of this PR should probably be deprecated or removed outright:
- https://www.home-assistant.io/integrations/serial/ has 283 users. Its integration name can be repurposed for serial helpers, which currently live in `usb`. It exposes line-oriented serial streams as sensors and asks the user to write templates to parse the data. This is super niche and arguably should belong in a custom component or be renamed.
- https://www.home-assistant.io/integrations/acer_projector/ has 0 users

They have no unit tests so this PR is best-effort, as I have no way to test the changes at runtime. I've added type annotations and cleaned up lifecycles in the code. There are still issues but they are pre-existing and not something I think is worth tackling in this PR (i.e. using the sync interface instead of an async interface).

ZHA had one remaining use of pyserial within unit tests that has been cleaned up as part of this PR as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
