### PR TITLE
Bump python-duco-client to 0.3.1

### DIFF
--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["duco"],
   "quality_scale": "bronze",
-  "requirements": ["python-duco-client==0.3.0"]
+  "requirements": ["python-duco-client==0.3.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2569,7 +2569,7 @@ python-digitalocean==1.13.2
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.0
+python-duco-client==0.3.1
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2189,7 +2189,7 @@ python-bsblan==5.1.4
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.0
+python-duco-client==0.3.1
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2


### PR DESCRIPTION
## Proposed change

Bump the `python-duco-client` library from `0.3.0` to `0.3.1`.

This release fixes a `KeyError` crash in `async_get_lan_info()` when the Duco box is connected via ethernet. On a wired box, the `/info?module=General&submodule=Lan` API response does not include the `RssiWifi` field at all. The library previously accessed `lan["RssiWifi"]` unconditionally, causing a raw `KeyError`. `LanInfo.rssi_wifi` is now typed as `int | None` and returns `None` when the field is absent.

**Changelog**: https://github.com/ronaldvdmeer/python-duco-client/releases/tag/v0.3.1
**Release diff**: https://github.com/ronaldvdmeer/python-duco-client/compare/v0.3.0...v0.3.1

**Diff**: `LanInfo.rssi_wifi: int` → `int | None`; `async_get_lan_info()` uses conditional key access instead of unconditional dict lookup.

https://github.com/ronaldvdmeer/python-duco-client/compare/v0.3.0...v0.3.1

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: A [discussion](https://github.com/home-assistant/core/pull/168290#discussion_r3091495407) in another PR
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#perfect-pr-recommendation
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/