### PR TITLE
Add duration to state based entity conditions

### DIFF
--- a/homeassistant/components/motion/condition.py
+++ b/homeassistant/components/motion/condition.py
@@ -15,8 +15,12 @@ _MOTION_DOMAIN_SPECS = {
 
 
 CONDITIONS: dict[str, type[Condition]] = {
-    "is_detected": make_entity_state_condition(_MOTION_DOMAIN_SPECS, STATE_ON),
-    "is_not_detected": make_entity_state_condition(_MOTION_DOMAIN_SPECS, STATE_OFF),
+    "is_detected": make_entity_state_condition(
+        _MOTION_DOMAIN_SPECS, STATE_ON, support_duration=True
+    ),
+    "is_not_detected": make_entity_state_condition(
+        _MOTION_DOMAIN_SPECS, STATE_OFF, support_duration=True
+    ),
 }
 
 

--- a/homeassistant/components/motion/conditions.yaml
+++ b/homeassistant/components/motion/conditions.yaml
@@ -8,6 +8,11 @@
         options:
           - all
           - any
+  for:
+    required: true
+    default: 00:00:00
+    selector:
+      duration:
 
 is_detected:
   fields: *condition_common_fields

--- a/homeassistant/components/motion/strings.json
+++ b/homeassistant/components/motion/strings.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "condition_behavior_name": "Condition passes if",
+    "condition_for_name": "For at least",
     "trigger_behavior_name": "Trigger when",
     "trigger_for_name": "For at least"
   },
@@ -10,6 +11,9 @@
       "fields": {
         "behavior": {
           "name": "[%key:component::motion::common::condition_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::motion::common::condition_for_name%]"
         }
       },
       "name": "Motion is detected"
@@ -19,6 +23,9 @@
       "fields": {
         "behavior": {
           "name": "[%key:component::motion::common::condition_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::motion::common::condition_for_name%]"
         }
       },
       "name": "Motion is not detected"

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -401,7 +401,8 @@ class EntityConditionBase(Condition):
 
         def check_any_match_state(states: list[State]) -> bool:
             """Test if any entity matches the state."""
-            if self._duration is None:
+            if not self._duration:
+                # Skip duration check if duration is not specified or 0
                 return any(self.is_valid_state(state) for state in states)
             duration = dt_util.utcnow() - self._duration
             return any(
@@ -411,7 +412,8 @@ class EntityConditionBase(Condition):
 
         def check_all_match_state(states: list[State]) -> bool:
             """Test if all entities match the state."""
-            if self._duration is None:
+            if not self._duration:
+                # Skip duration check if duration is not specified or 0
                 return all(self.is_valid_state(state) for state in states)
             duration = dt_util.utcnow() - self._duration
             return all(

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -345,6 +345,16 @@ ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL = vol.Schema(
     }
 )
 
+ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL_FOR = (
+    ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL.extend(
+        {
+            vol.Required(CONF_OPTIONS): {
+                vol.Optional(CONF_FOR): cv.positive_time_period_dict,
+            },
+        }
+    )
+)
+
 
 class EntityConditionBase(Condition):
     """Base class for entity conditions."""
@@ -368,6 +378,7 @@ class EntityConditionBase(Condition):
             assert config.options
         self._target_selection = TargetSelection(config.target)
         self._behavior = config.options[ATTR_BEHAVIOR]
+        self._duration: timedelta | None = config.options.get(CONF_FOR)
 
     def entity_filter(self, entities: set[str]) -> set[str]:
         """Filter entities matching any of the domain specs."""
@@ -390,11 +401,23 @@ class EntityConditionBase(Condition):
 
         def check_any_match_state(states: list[State]) -> bool:
             """Test if any entity matches the state."""
-            return any(self.is_valid_state(state) for state in states)
+            if self._duration is None:
+                return any(self.is_valid_state(state) for state in states)
+            duration = dt_util.utcnow() - self._duration
+            return any(
+                self.is_valid_state(state) and duration > state.last_changed
+                for state in states
+            )
 
         def check_all_match_state(states: list[State]) -> bool:
             """Test if all entities match the state."""
-            return all(self.is_valid_state(state) for state in states)
+            if self._duration is None:
+                return all(self.is_valid_state(state) for state in states)
+            duration = dt_util.utcnow() - self._duration
+            return all(
+                self.is_valid_state(state) and duration > state.last_changed
+                for state in states
+            )
 
         matcher: Callable[[list[State]], bool]
         if self._behavior == BEHAVIOR_ANY:
@@ -444,6 +467,8 @@ def _normalize_domain_specs(
 def make_entity_state_condition(
     domain_specs: Mapping[str, DomainSpec] | str,
     states: str | bool | set[str | bool],
+    *,
+    support_duration: bool = False,
 ) -> type[EntityStateConditionBase]:
     """Create a condition for entity state changes to specific state(s).
 
@@ -461,6 +486,11 @@ def make_entity_state_condition(
         """Condition for entity state."""
 
         _domain_specs = specs
+        _schema = (
+            ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL_FOR
+            if support_duration
+            else ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL
+        )
         _states = states_set
 
     return CustomCondition

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from freezegun import freeze_time
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytest_unordered import unordered
 import voluptuous as vol
@@ -26,6 +27,7 @@ from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_FOR,
     CONF_OPTIONS,
     CONF_TARGET,
     STATE_OFF,
@@ -3950,11 +3952,13 @@ async def _setup_state_condition(
     states: str | bool | set[str | bool],
     condition_options: dict[str, Any] | None = None,
     domain_specs: Mapping[str, DomainSpec] | None = None,
+    support_duration: bool = False,
 ) -> condition.ConditionCheckerType:
     """Set up a state condition via a mock platform and return the checker."""
     condition_cls = make_entity_state_condition(
         domain_specs or _DEFAULT_DOMAIN_SPECS,
         states,
+        support_duration=support_duration,
     )
 
     async def async_get_conditions(
@@ -4127,3 +4131,189 @@ async def test_state_condition_behavior(
     # Neither on → False for any and all
     hass.states.async_set("test.entity_1", STATE_OFF)
     assert test(hass) is False
+
+
+async def test_state_condition_duration_not_met(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test state condition with duration: entity hasn't been in state long enough."""
+    test = await _setup_state_condition(
+        hass,
+        entity_ids="test.entity_1",
+        states=STATE_ON,
+        condition_options={CONF_FOR: {"seconds": 10}},
+        support_duration=True,
+    )
+
+    hass.states.async_set("test.entity_1", STATE_ON)
+    await hass.async_block_till_done()
+
+    # Just turned on — duration not met
+    assert test(hass) is False
+
+    # Advance 5 seconds — still not enough
+    freezer.tick(timedelta(seconds=5))
+    assert test(hass) is False
+
+
+async def test_state_condition_duration_met(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test state condition with duration: entity has been in state long enough."""
+    test = await _setup_state_condition(
+        hass,
+        entity_ids="test.entity_1",
+        states=STATE_ON,
+        condition_options={CONF_FOR: {"seconds": 10}},
+        support_duration=True,
+    )
+
+    hass.states.async_set("test.entity_1", STATE_ON)
+    await hass.async_block_till_done()
+
+    # Advance past duration
+    freezer.tick(timedelta(seconds=11))
+    assert test(hass) is True
+
+
+async def test_state_condition_duration_wrong_state(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test state condition with duration: entity in wrong state even after duration."""
+    test = await _setup_state_condition(
+        hass,
+        entity_ids="test.entity_1",
+        states=STATE_ON,
+        condition_options={CONF_FOR: {"seconds": 10}},
+        support_duration=True,
+    )
+
+    hass.states.async_set("test.entity_1", STATE_OFF)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=11))
+    assert test(hass) is False
+
+
+async def test_state_condition_duration_reset_on_state_change(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test state condition with duration: timer resets when state changes."""
+    test = await _setup_state_condition(
+        hass,
+        entity_ids="test.entity_1",
+        states=STATE_ON,
+        condition_options={CONF_FOR: {"seconds": 10}},
+        support_duration=True,
+    )
+
+    hass.states.async_set("test.entity_1", STATE_ON)
+    await hass.async_block_till_done()
+
+    # Advance 8 seconds, then toggle off and back on — resets last_changed
+    freezer.tick(timedelta(seconds=8))
+    hass.states.async_set("test.entity_1", STATE_OFF)
+    await hass.async_block_till_done()
+    hass.states.async_set("test.entity_1", STATE_ON)
+    await hass.async_block_till_done()
+
+    # 5 seconds after retrigger — not enough
+    freezer.tick(timedelta(seconds=5))
+    assert test(hass) is False
+
+    # 6 more seconds (11 from retrigger) — now met
+    freezer.tick(timedelta(seconds=6))
+    assert test(hass) is True
+
+
+@pytest.mark.parametrize(
+    ("behavior", "one_match_expected"),
+    [(BEHAVIOR_ANY, True), (BEHAVIOR_ALL, False)],
+)
+async def test_state_condition_duration_behavior(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    behavior: str,
+    one_match_expected: bool,
+) -> None:
+    """Test state condition with duration and behavior any/all."""
+    test = await _setup_state_condition(
+        hass,
+        entity_ids=["test.entity_1", "test.entity_2"],
+        states=STATE_ON,
+        condition_options={ATTR_BEHAVIOR: behavior, CONF_FOR: {"seconds": 10}},
+        support_duration=True,
+    )
+
+    hass.states.async_set("test.entity_1", STATE_ON)
+    hass.states.async_set("test.entity_2", STATE_ON)
+    await hass.async_block_till_done()
+
+    # Both on but duration not met
+    assert test(hass) is False
+
+    # Advance past duration — both on for long enough
+    freezer.tick(timedelta(seconds=11))
+    assert test(hass) is True
+
+    # Turn entity_2 off — only one on for duration → depends on behavior
+    hass.states.async_set("test.entity_2", STATE_OFF)
+    await hass.async_block_till_done()
+    assert test(hass) is one_match_expected
+
+    # Neither on → False for any and all
+    hass.states.async_set("test.entity_1", STATE_OFF)
+    await hass.async_block_till_done()
+    assert test(hass) is False
+
+
+@pytest.mark.parametrize(
+    "state_value",
+    [STATE_UNAVAILABLE, STATE_UNKNOWN],
+)
+async def test_state_condition_duration_unavailable_unknown(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, state_value: str
+) -> None:
+    """Test state condition with duration: unavailable/unknown entities are skipped.
+
+    Uses three entities: entity_1=on, entity_2=unavailable, entity_3 varies.
+    """
+    # behavior any: entity_1=on (long enough), entity_2=unavailable, entity_3=off
+    # → True (entity_1 matches and meets duration, entity_2 skipped)
+    test_any = await _setup_state_condition(
+        hass,
+        entity_ids=["test.entity_1", "test.entity_2", "test.entity_3"],
+        states=STATE_ON,
+        condition_options={ATTR_BEHAVIOR: BEHAVIOR_ANY, CONF_FOR: {"seconds": 10}},
+        support_duration=True,
+    )
+    hass.states.async_set("test.entity_1", STATE_ON)
+    hass.states.async_set("test.entity_2", state_value)
+    hass.states.async_set("test.entity_3", STATE_OFF)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=11))
+    assert test_any(hass) is True
+
+    # behavior all: entity_1=on, entity_2=unavailable, entity_3=on (all long enough)
+    # → True (all available entities match and meet duration)
+    test_all = await _setup_state_condition(
+        hass,
+        entity_ids=["test.entity_1", "test.entity_2", "test.entity_3"],
+        states=STATE_ON,
+        condition_options={ATTR_BEHAVIOR: BEHAVIOR_ALL, CONF_FOR: {"seconds": 10}},
+        support_duration=True,
+    )
+    hass.states.async_set("test.entity_1", STATE_ON)
+    hass.states.async_set("test.entity_2", state_value)
+    hass.states.async_set("test.entity_3", STATE_ON)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=11))
+    assert test_all(hass) is True
+
+    # entity_3 off → not all available match
+    hass.states.async_set("test.entity_3", STATE_OFF)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=11))
+    assert test_all(hass) is False

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -4176,6 +4176,30 @@ async def test_state_condition_duration_met(
     assert test(hass) is True
 
 
+async def test_state_condition_duration_zero_behaves_like_no_duration(
+    hass: HomeAssistant,
+) -> None:
+    """Test that for: 0 behaves the same as omitting for.
+
+    The UI defaults to 00:00:00, so a zero duration must not require the
+    entity to have been in the state for any time — it should pass
+    immediately, just like when for is not specified.
+    """
+    test = await _setup_state_condition(
+        hass,
+        entity_ids="test.entity_1",
+        states=STATE_ON,
+        condition_options={CONF_FOR: {"seconds": 0}},
+        support_duration=True,
+    )
+
+    hass.states.async_set("test.entity_1", STATE_ON)
+    await hass.async_block_till_done()
+
+    # Should pass immediately — zero duration is the same as no duration
+    assert test(hass) is True
+
+
 async def test_state_condition_duration_wrong_state(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add duration to state based entity conditions

The implementation in the PR only works for conditions which are true when entities are in a single specific state determined by looking at the main state, not state attributes.
That limitation was agreed with @nielsrowinbik 

This PR adds duration support only to motion conditions, support for other conditions will be added in a follow-up.

As a future extension, conditions could subscribe to state changes for their entities which would remove that limitiation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
