### PR TITLE
Fix helper tests for Python 3.14.3

### DIFF
--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -124,23 +124,25 @@ async def test_setup_does_discovery(
 async def test_set_scan_interval_via_config(hass: HomeAssistant) -> None:
     """Test the setting of the scan interval via configuration."""
 
-    def platform_setup(
+    async def async_platform_setup(
         hass: HomeAssistant,
         config: ConfigType,
-        add_entities: AddEntitiesCallback,
+        async_add_entities: AddEntitiesCallback,
         discovery_info: DiscoveryInfoType | None = None,
     ) -> None:
         """Test the platform setup."""
-        add_entities([MockEntity(should_poll=True)])
+        async_add_entities([MockEntity(should_poll=True)])
 
     mock_platform(
-        hass, "platform.test_domain", MockPlatform(setup_platform=platform_setup)
+        hass,
+        "platform.test_domain",
+        MockPlatform(async_setup_platform=async_platform_setup),
     )
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     with patch.object(hass.loop, "call_later") as mock_track:
-        component.setup(
+        await component.async_setup(
             {DOMAIN: {"platform": "platform", "scan_interval": timedelta(seconds=30)}}
         )
 
@@ -152,22 +154,24 @@ async def test_set_scan_interval_via_config(hass: HomeAssistant) -> None:
 async def test_set_entity_namespace_via_config(hass: HomeAssistant) -> None:
     """Test setting an entity namespace."""
 
-    def platform_setup(
+    async def async_platform_setup(
         hass: HomeAssistant,
         config: ConfigType,
-        add_entities: AddEntitiesCallback,
+        async_add_entities: AddEntitiesCallback,
         discovery_info: DiscoveryInfoType | None = None,
     ) -> None:
         """Test the platform setup."""
-        add_entities([MockEntity(name="beer"), MockEntity(name=None)])
+        async_add_entities([MockEntity(name="beer"), MockEntity(name=None)])
 
-    platform = MockPlatform(setup_platform=platform_setup)
+    platform = MockPlatform(async_setup_platform=async_platform_setup)
 
     mock_platform(hass, "platform.test_domain", platform)
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    component.setup({DOMAIN: {"platform": "platform", "entity_namespace": "yummy"}})
+    await component.async_setup(
+        {DOMAIN: {"platform": "platform", "entity_namespace": "yummy"}}
+    )
 
     await hass.async_block_till_done()
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -281,24 +281,28 @@ async def test_platform_slow_setup_cancel_warning(hass: HomeAssistant) -> None:
     with patch.object(hass.loop, "call_at") as mock_call:
         await component.async_setup({DOMAIN: {"platform": "platform"}})
         await hass.async_block_till_done()
+        assert mock_call.called
 
-        # Find the platform setup warning call by matching on the logger method
+        # Find the platform setup warning by matching the exact format string
         platform_warn_call = next(
-            call for call in mock_call.call_args_list if call[0][1] == _LOGGER.warning
+            call
+            for call in mock_call.call_args_list
+            if len(call[0]) >= 3
+            and call[0][1] == _LOGGER.warning
+            and call[0][2] == "Setup of %s platform %s is taking over %s seconds."
         )
         scheduled_time = platform_warn_call[0][0]
 
-        assert mock_call.called
         assert scheduled_time - hass.loop.time() == pytest.approx(
             entity_platform.SLOW_SETUP_WARNING, 0.5
         )
-        assert mock_call().cancel.called
+        assert mock_call.return_value.cancel.called
 
 
-async def test_platform_slow_setup_warning(
+async def test_platform_slow_setup_timeout(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Don't block startup more than SLOW_SETUP_MAX_WAIT."""
+    """Test that platform setup is aborted after SLOW_SETUP_MAX_WAIT."""
     with patch.object(entity_platform, "SLOW_SETUP_MAX_WAIT", 0):
         called = []
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -270,8 +270,8 @@ async def test_adding_entities_with_generator_and_thread_callback(
 
 
 @pytest.mark.usefixtures("disable_translations_once")
-async def test_platform_warn_slow_setup(hass: HomeAssistant) -> None:
-    """Warn we log when platform setup takes a long time."""
+async def test_platform_slow_setup_cancel_warning(hass: HomeAssistant) -> None:
+    """Test slow setup warning timer is scheduled and cancelled on success."""
     platform = MockPlatform()
 
     mock_platform(hass, "platform.test_domain", platform)
@@ -281,21 +281,21 @@ async def test_platform_warn_slow_setup(hass: HomeAssistant) -> None:
     with patch.object(hass.loop, "call_at") as mock_call:
         await component.async_setup({DOMAIN: {"platform": "platform"}})
         await hass.async_block_till_done()
+
+        # Find the platform setup warning call by matching on the logger method
+        platform_warn_call = next(
+            call for call in mock_call.call_args_list if call[0][1] == _LOGGER.warning
+        )
+        scheduled_time = platform_warn_call[0][0]
+
         assert mock_call.called
-
-        # mock_calls[3] is the warning message for component setup
-        # mock_calls[10] is the warning message for platform setup
-        timeout, logger_method = mock_call.mock_calls[10][1][:2]
-
-        assert timeout - hass.loop.time() == pytest.approx(
+        assert scheduled_time - hass.loop.time() == pytest.approx(
             entity_platform.SLOW_SETUP_WARNING, 0.5
         )
-        assert logger_method == _LOGGER.warning
-
         assert mock_call().cancel.called
 
 
-async def test_platform_error_slow_setup(
+async def test_platform_slow_setup_warning(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Don't block startup more than SLOW_SETUP_MAX_WAIT."""

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import logging
 import types
 from typing import Any
-from unittest.mock import ANY, AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -278,25 +278,31 @@ async def test_platform_slow_setup_cancel_warning(hass: HomeAssistant) -> None:
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    with patch.object(hass.loop, "call_at") as mock_call:
+    call_at_handles: list[tuple[tuple, MagicMock]] = []
+
+    def mock_call_at(*args: Any, **kwargs: Any) -> MagicMock:
+        handle = MagicMock()
+        call_at_handles.append((args, handle))
+        return handle
+
+    with patch.object(hass.loop, "call_at", side_effect=mock_call_at):
         await component.async_setup({DOMAIN: {"platform": "platform"}})
         await hass.async_block_till_done()
-        assert mock_call.called
+        assert call_at_handles
 
         # Find the platform setup warning by matching the exact format string
-        platform_warn_call = next(
-            call
-            for call in mock_call.call_args_list
-            if len(call[0]) >= 3
-            and call[0][1] == _LOGGER.warning
-            and call[0][2] == "Setup of %s platform %s is taking over %s seconds."
+        warn_args, warn_handle = next(
+            (args, handle)
+            for args, handle in call_at_handles
+            if len(args) >= 3
+            and args[1] == _LOGGER.warning
+            and args[2] == "Setup of %s platform %s is taking over %s seconds."
         )
-        scheduled_time = platform_warn_call[0][0]
 
-        assert scheduled_time - hass.loop.time() == pytest.approx(
+        assert warn_args[0] - hass.loop.time() == pytest.approx(
             entity_platform.SLOW_SETUP_WARNING, 0.5
         )
-        assert mock_call.return_value.cancel.called
+        assert warn_handle.cancel.call_count == 1
 
 
 async def test_platform_slow_setup_timeout(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update three helper tests which are broken on the new Python 3.14.3 (#162263) version due to how tasks are scheduled.

- `test_set_scan_interval_via_config` / `test_set_entity_namespace_via_config`: Switch from sync `component.setup()` + sync `setup_platform` to `await component.async_setup()` + `async_setup_platform`, eliminating the `call_soon_threadsafe` deferrals that caused entities to not be added before assertions ran.
- `test_platform_slow_setup_cancel_warning` (renamed from `test_platform_warn_slow_setup`): Replace fragile hardcoded mock_calls[10] index with a content-based lookup. Also rename `test_platform_error_slow_setup` → `test_platform_slow_setup_timeout` to match what the tests actually verify.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
