### PR TITLE
Fix flaky airtouch5 test for Python 3.14.3

### DIFF
--- a/tests/components/airtouch5/test_cover.py
+++ b/tests/components/airtouch5/test_cover.py
@@ -94,6 +94,8 @@ async def test_cover_callbacks(
     # Capture initial state of zone 2 cover to verify it's unaffected
     zone_2_initial = hass.states.get(COVER_ZONE_2_ENTITY_ID)
     assert zone_2_initial
+    zone_2_initial_state = zone_2_initial.state
+    zone_2_initial_position = zone_2_initial.attributes.get(ATTR_CURRENT_POSITION)
 
     # Define a method to call all zone_status_callbacks, as the real client would
     async def _call_zone_status_callback(open_percentage: float) -> None:
@@ -121,7 +123,9 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 70
-    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial
+    zone_2 = hass.states.get(COVER_ZONE_2_ENTITY_ID)
+    assert zone_2 and zone_2.state == zone_2_initial_state
+    assert zone_2.attributes.get(ATTR_CURRENT_POSITION) == zone_2_initial_position
 
     # Fully open
     await _call_zone_status_callback(1)
@@ -129,7 +133,9 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 100
-    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial
+    zone_2 = hass.states.get(COVER_ZONE_2_ENTITY_ID)
+    assert zone_2 and zone_2.state == zone_2_initial_state
+    assert zone_2.attributes.get(ATTR_CURRENT_POSITION) == zone_2_initial_position
 
     # Fully closed
     await _call_zone_status_callback(0.0)
@@ -137,7 +143,9 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.CLOSED
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
-    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial
+    zone_2 = hass.states.get(COVER_ZONE_2_ENTITY_ID)
+    assert zone_2 and zone_2.state == zone_2_initial_state
+    assert zone_2.attributes.get(ATTR_CURRENT_POSITION) == zone_2_initial_position
 
     # Partly reopened
     await _call_zone_status_callback(0.3)
@@ -145,4 +153,6 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 30
-    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial
+    zone_2 = hass.states.get(COVER_ZONE_2_ENTITY_ID)
+    assert zone_2 and zone_2.state == zone_2_initial_state
+    assert zone_2.attributes.get(ATTR_CURRENT_POSITION) == zone_2_initial_position

--- a/tests/components/airtouch5/test_cover.py
+++ b/tests/components/airtouch5/test_cover.py
@@ -1,6 +1,5 @@
 """Tests for the Airtouch5 cover platform."""
 
-from collections.abc import Callable
 from unittest.mock import AsyncMock, patch
 
 from airtouch5py.packets.zone_status import (
@@ -28,6 +27,7 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 COVER_ENTITY_ID = "cover.zone_1_damper"
+COVER_ZONE_2_ENTITY_ID = "cover.zone_2_damper"
 
 
 async def test_all_entities(
@@ -91,13 +91,12 @@ async def test_cover_callbacks(
 
     await setup_integration(hass, mock_config_entry)
 
-    # We find the callback method on the mock client
-    zone_status_callback: Callable[[dict[int, ZoneStatusZone]], None] = (
-        mock_airtouch5_client.zone_status_callbacks[2]
-    )
+    # Capture initial state of zone 2 cover to verify it's unaffected
+    zone_2_initial = hass.states.get(COVER_ZONE_2_ENTITY_ID)
+    assert zone_2_initial
 
-    # Define a method to simply call it
-    async def _call_zone_status_callback(open_percentage: int) -> None:
+    # Define a method to call all zone_status_callbacks, as the real client would
+    async def _call_zone_status_callback(open_percentage: float) -> None:
         zsz = ZoneStatusZone(
             zone_power_state=ZonePowerState.ON,
             zone_number=1,
@@ -109,7 +108,9 @@ async def test_cover_callbacks(
             spill_active=False,
             is_low_battery=False,
         )
-        zone_status_callback({1: zsz})
+        data = {1: zsz}
+        for callback in mock_airtouch5_client.zone_status_callbacks:
+            callback(data)
         await hass.async_block_till_done()
 
     # And call it to effectively launch the callback as the server would do
@@ -120,6 +121,7 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 70
+    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial
 
     # Fully open
     await _call_zone_status_callback(1)
@@ -127,6 +129,7 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 100
+    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial
 
     # Fully closed
     await _call_zone_status_callback(0.0)
@@ -134,6 +137,7 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.CLOSED
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
+    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial
 
     # Partly reopened
     await _call_zone_status_callback(0.3)
@@ -141,3 +145,4 @@ async def test_cover_callbacks(
     assert state
     assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 30
+    assert hass.states.get(COVER_ZONE_2_ENTITY_ID) == zone_2_initial


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix test_cover_callbacks relying on a hardcoded callback index (zone_status_callbacks[2]) which became non-deterministic due to `asyncio.gather` platform setup ordering in Python 3.14.3 (#162263).
- Call all registered zone_status_callbacks instead, matching what the real Airtouch5SimpleClient does
- Add assertions that zone 2's cover state is unaffected by zone 1 callbacks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
