### PR TITLE
matter: add multi-press event entity with press count data (backwards-compatible)

### DIFF
--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -9,16 +9,21 @@ from chip.clusters import Objects as clusters
 from matter_server.client.models import device_types
 from matter_server.common.models import EventType, MatterNodeEvent
 
+from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.event import (
     EventDeviceClass,
     EventEntity,
     EventEntityDescription,
 )
+from homeassistant.components.script import scripts_with_entity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
+from .const import DOMAIN
 from .entity import MatterEntity, MatterEntityDescription
 from .helpers import get_matter
 from .models import MatterDiscoverySchema
@@ -36,6 +41,12 @@ EVENT_TYPES_MAP = {
     6: "multi_press_complete",  # clusters.Switch.Events.MultiPressComplete
 }
 
+MULTI_PRESS_COUNT_TO_NAME: dict[int, str] = {
+    1: "single",
+    2: "double",
+    3: "triple",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -44,12 +55,92 @@ async def async_setup_entry(
 ) -> None:
     """Set up Matter switches from Config Entry."""
     matter = get_matter(hass)
-    matter.register_platform_handler(Platform.EVENT, async_add_entities)
+
+    @callback
+    def async_add_entities_filtered(
+        entities: list[MatterEventEntity],
+    ) -> None:
+        async_add_entities(
+            entity
+            for entity in entities
+            if async_check_create_deprecated(
+                hass,
+                Platform.EVENT,
+                entity.unique_id or "",
+                entity.entity_description,
+            )
+        )
+
+    matter.register_platform_handler(Platform.EVENT, async_add_entities_filtered)
+
+
+@dataclass(slots=True)
+class DeprecatedInfo:
+    """Class to define deprecation info for deprecated entities."""
+
+    new_platform: Platform
+    breaks_in_ha_version: str
 
 
 @dataclass(frozen=True, kw_only=True)
 class MatterEventEntityDescription(EventEntityDescription, MatterEntityDescription):
     """Describe Matter Event entities."""
+
+    deprecated_info: DeprecatedInfo | None = None
+
+
+def async_check_create_deprecated(
+    hass: HomeAssistant,
+    platform: Platform,
+    unique_id: str,
+    entity_description: MatterEventEntityDescription,
+) -> bool:
+    """Return true if the entity should be created based on the deprecated_info.
+
+    If deprecated_info is not defined will return true.
+    If entity not yet created will return false.
+    If entity disabled will delete it and return false.
+    Otherwise will return true and create issues for scripts or automations.
+    """
+    if not entity_description.deprecated_info:
+        return True
+
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id(
+        platform,
+        DOMAIN,
+        unique_id,
+    )
+    if not entity_id:
+        return False
+
+    entity_entry = ent_reg.async_get(entity_id)
+    assert entity_entry
+    if entity_entry.disabled:
+        ent_reg.async_remove(entity_id)
+        return False
+
+    entity_automations = automations_with_entity(hass, entity_id)
+    entity_scripts = scripts_with_entity(hass, entity_id)
+    deprecated_info = entity_description.deprecated_info
+    for item in entity_automations + entity_scripts:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"deprecated_entity_{entity_id}_{item}",
+            breaks_in_ha_version=deprecated_info.breaks_in_ha_version,
+            is_fixable=False,
+            is_persistent=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_entity",
+            translation_placeholders={
+                "entity": entity_id,
+                "info": item,
+                "platform": str(platform),
+                "new_platform": str(deprecated_info.new_platform),
+            },
+        )
+    return True
 
 
 class MatterEventEntity(MatterEntity, EventEntity):
@@ -134,6 +225,81 @@ class MatterEventEntity(MatterEntity, EventEntity):
         self.async_write_ha_state()
 
 
+class MatterMultiPressEventEntity(MatterEventEntity):
+    """Representation of a Matter Multi-Press Event entity with press count data."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the entity."""
+        super().__init__(*args, **kwargs)
+        self._previous_press_count: int = 0
+        # Override event types with flat if-chain per Matter spec
+        event_types: list[str] = []
+        feature_map = int(
+            self.get_matter_attribute_value(clusters.Switch.Attributes.FeatureMap)
+        )
+        # Either momentary xor latching is required
+        if feature_map & SwitchFeature.kLatchingSwitch:
+            event_types.append("switch_latched")
+
+        if feature_map & SwitchFeature.kMomentarySwitch:
+            event_types.append("initial_press")
+
+        # The specs are more strict about what features a device must support
+        # We just trust the device. No harm in expecting more events.
+
+        # release is optional, but requires momentary support
+        if feature_map & SwitchFeature.kMomentarySwitchRelease:
+            event_types.append("short_release")
+
+        # multi press is optional, but requires release support
+        if feature_map & SwitchFeature.kMomentarySwitchMultiPress:
+            event_types.append("multi_press_ongoing")
+            event_types.append("multi_press_complete")
+
+        # long press is optional, but requires release support
+        if feature_map & SwitchFeature.kMomentarySwitchLongPress:
+            event_types.append("long_press")
+            event_types.append("long_release")
+
+        self._attr_event_types = event_types
+
+    @callback
+    def _on_matter_node_event(
+        self,
+        event: EventType,
+        data: MatterNodeEvent,
+    ) -> None:
+        """Call on NodeEvent."""
+        if data.endpoint_id != self._endpoint.endpoint_id:
+            return
+        event_type = EVENT_TYPES_MAP[data.event_id]
+
+        if event_type == "initial_press":
+            self._previous_press_count = 0
+
+        if event_type == "multi_press_ongoing" and data.data:
+            press_count = data.data.get("currentNumberOfPressesCounted", 1)
+            data.data["press_count"] = press_count
+            data.data["press_step"] = press_count - self._previous_press_count
+            self._previous_press_count = press_count
+
+        if event_type == "multi_press_complete" and data.data:
+            press_count = data.data.get("totalNumberOfPressesCounted", 1)
+            data.data["press_count"] = press_count
+            if press_count in MULTI_PRESS_COUNT_TO_NAME:
+                data.data["event_type_extra"] = MULTI_PRESS_COUNT_TO_NAME[press_count]
+            self._previous_press_count = 0
+
+        if event_type not in self.event_types:
+            # this should not happen, but guard for bad things
+            # some remotes send events that they do not report as supported (sigh...)
+            return
+
+        # pass the rest of the data as-is (such as the advanced Position data)
+        self._trigger_event(event_type, data.data)
+        self.async_write_ha_state()
+
+
 # Discovery schema(s) to map Matter Attributes to HA entities
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
@@ -142,6 +308,10 @@ DISCOVERY_SCHEMAS = [
             key="GenericSwitch",
             device_class=EventDeviceClass.BUTTON,
             translation_key="button",
+            deprecated_info=DeprecatedInfo(
+                new_platform=Platform.EVENT,
+                breaks_in_ha_version="2026.11.0",
+            ),
         ),
         entity_class=MatterEventEntity,
         required_attributes=(
@@ -153,6 +323,25 @@ DISCOVERY_SCHEMAS = [
             clusters.Switch.Attributes.NumberOfPositions,
             clusters.FixedLabel.Attributes.LabelList,
         ),
-        allow_multi=True,  # also used for sensor (current position) entity
+        allow_multi=True,
+    ),
+    MatterDiscoverySchema(
+        platform=Platform.EVENT,
+        entity_description=MatterEventEntityDescription(
+            key="MatterMultiPressSwitch",
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="button",
+        ),
+        entity_class=MatterMultiPressEventEntity,
+        required_attributes=(
+            clusters.Switch.Attributes.CurrentPosition,
+            clusters.Switch.Attributes.FeatureMap,
+        ),
+        device_type=(device_types.GenericSwitch,),
+        optional_attributes=(
+            clusters.Switch.Attributes.NumberOfPositions,
+            clusters.FixedLabel.Attributes.LabelList,
+        ),
+        allow_multi=True,
     ),
 ]

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -272,7 +272,9 @@ class MatterMultiPressEventEntity(MatterEventEntity):
         """Call on NodeEvent."""
         if data.endpoint_id != self._endpoint.endpoint_id:
             return
-        event_type = EVENT_TYPES_MAP[data.event_id]
+        event_type = EVENT_TYPES_MAP.get(data.event_id)
+        if event_type is None:
+            return
 
         if event_type == "initial_press":
             self._previous_press_count = 0

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Matter switches from Config Entry."""
+    """Set up Matter event entities from Config Entry."""
     matter = get_matter(hass)
 
     @callback

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from chip.clusters import Objects as clusters
 from matter_server.client.models import device_types
@@ -20,6 +21,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
@@ -58,17 +60,21 @@ async def async_setup_entry(
 
     @callback
     def async_add_entities_filtered(
-        entities: list[MatterEventEntity],
+        entities: Iterable[Entity],
+        update_before_add: bool = False,
     ) -> None:
         async_add_entities(
-            entity
-            for entity in entities
-            if async_check_create_deprecated(
-                hass,
-                Platform.EVENT,
-                entity.unique_id or "",
-                entity.entity_description,
-            )
+            (
+                entity
+                for entity in entities
+                if async_check_create_deprecated(
+                    hass,
+                    Platform.EVENT,
+                    entity.unique_id or "",
+                    cast(MatterEventEntityDescription, entity.entity_description),
+                )
+            ),
+            update_before_add,
         )
 
     matter.register_platform_handler(Platform.EVENT, async_add_entities_filtered)

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -58,7 +58,6 @@ async def async_setup_entry(
     """Set up Matter event entities from Config Entry."""
     matter = get_matter(hass)
 
-    @callback
     def async_add_entities_filtered(
         entities: Iterable[Entity],
         update_before_add: bool = False,
@@ -77,7 +76,10 @@ async def async_setup_entry(
             update_before_add,
         )
 
-    matter.register_platform_handler(Platform.EVENT, async_add_entities_filtered)
+    matter.register_platform_handler(
+        Platform.EVENT,
+        async_add_entities_filtered,  # type: ignore[arg-type]
+    )
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -179,6 +179,8 @@
               "multi_press_6": "Pressed 6 times",
               "multi_press_7": "Pressed 7 times",
               "multi_press_8": "Pressed 8 times",
+              "multi_press_complete": "Multiple presses finished",
+              "multi_press_ongoing": "Multiple presses in progress",
               "short_release": "Released after being pressed",
               "switch_latched": "Switch latched"
             }

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -655,8 +655,8 @@
   },
   "issues": {
     "deprecated_entity": {
-      "title": "Deprecated Matter event entity",
-      "description": "The entity `{entity}` is deprecated and will be removed in Home Assistant {breaks_in_ha_version}. It has been replaced by a new entity on the `{new_platform}` platform. Please update `{info}` to use the new entity."
+      "description": "The entity `{entity}` is deprecated and will be removed in Home Assistant {breaks_in_ha_version}. It has been replaced by a new entity on the `{new_platform}` platform. Please update `{info}` to use the new entity.",
+      "title": "Deprecated Matter event entity"
     },
     "server_version_version_too_new": {
       "description": "The version of the Matter Server you are currently running is too new for this version of Home Assistant. Please update Home Assistant or downgrade the Matter Server to an older version to fix this issue.",

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -654,6 +654,10 @@
     }
   },
   "issues": {
+    "deprecated_entity": {
+      "title": "Deprecated Matter event entity",
+      "description": "The entity `{entity}` is deprecated and will be removed in Home Assistant {breaks_in_ha_version}. It has been replaced by a new entity on the `{new_platform}` platform. Please update `{info}` to use the new entity."
+    },
     "server_version_version_too_new": {
       "description": "The version of the Matter Server you are currently running is too new for this version of Home Assistant. Please update Home Assistant or downgrade the Matter Server to an older version to fix this issue.",
       "title": "Older version of Matter Server needed"

--- a/tests/components/matter/snapshots/test_event.ambr
+++ b/tests/components/matter/snapshots/test_event.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_3-entry]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -7,8 +7,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -20,7 +22,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.climate_sensor_w100_button_3',
+    'entity_id': 'event.climate_sensor_w100',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -28,43 +30,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (3)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (3)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-3-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-3-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_3-state]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Climate Sensor W100 Button (3)',
+      'friendly_name': 'Climate Sensor W100',
     }),
     'context': <ANY>,
-    'entity_id': 'event.climate_sensor_w100_button_3',
+    'entity_id': 'event.climate_sensor_w100',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_4-entry]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -72,8 +76,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -85,7 +91,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.climate_sensor_w100_button_4',
+    'entity_id': 'event.climate_sensor_w100_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -93,43 +99,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (4)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (4)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-4-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-4-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_4-state]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Climate Sensor W100 Button (4)',
+      'friendly_name': 'Climate Sensor W100',
     }),
     'context': <ANY>,
-    'entity_id': 'event.climate_sensor_w100_button_4',
+    'entity_id': 'event.climate_sensor_w100_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_5-entry]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -137,8 +145,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -150,7 +160,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.climate_sensor_w100_button_5',
+    'entity_id': 'event.climate_sensor_w100_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -158,43 +168,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (5)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (5)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-5-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-5-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_5-state]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Climate Sensor W100 Button (5)',
+      'friendly_name': 'Climate Sensor W100',
     }),
     'context': <ANY>,
-    'entity_id': 'event.climate_sensor_w100_button_5',
+    'entity_id': 'event.climate_sensor_w100_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_1-entry]
+# name: test_events[haojai_switch][event.hjmt_6b-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -202,8 +214,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -215,7 +229,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.hjmt_6b_button_1',
+    'entity_id': 'event.hjmt_6b',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -223,43 +237,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (1)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (1)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-1-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-1-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_1-state]
+# name: test_events[haojai_switch][event.hjmt_6b-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'HJMT-6B Button (1)',
+      'friendly_name': 'HJMT-6B',
     }),
     'context': <ANY>,
-    'entity_id': 'event.hjmt_6b_button_1',
+    'entity_id': 'event.hjmt_6b',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_2-entry]
+# name: test_events[haojai_switch][event.hjmt_6b_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -267,8 +283,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -280,7 +298,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.hjmt_6b_button_2',
+    'entity_id': 'event.hjmt_6b_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -288,43 +306,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (2)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (2)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-2-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-2-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_2-state]
+# name: test_events[haojai_switch][event.hjmt_6b_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'HJMT-6B Button (2)',
+      'friendly_name': 'HJMT-6B',
     }),
     'context': <ANY>,
-    'entity_id': 'event.hjmt_6b_button_2',
+    'entity_id': 'event.hjmt_6b_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_3-entry]
+# name: test_events[haojai_switch][event.hjmt_6b_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -332,8 +352,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -345,7 +367,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.hjmt_6b_button_3',
+    'entity_id': 'event.hjmt_6b_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -353,43 +375,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (3)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (3)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-3-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-3-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_3-state]
+# name: test_events[haojai_switch][event.hjmt_6b_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'HJMT-6B Button (3)',
+      'friendly_name': 'HJMT-6B',
     }),
     'context': <ANY>,
-    'entity_id': 'event.hjmt_6b_button_3',
+    'entity_id': 'event.hjmt_6b_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_4-entry]
+# name: test_events[haojai_switch][event.hjmt_6b_4-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -397,8 +421,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -410,7 +436,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.hjmt_6b_button_4',
+    'entity_id': 'event.hjmt_6b_4',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -418,43 +444,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (4)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (4)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-4-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-4-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_4-state]
+# name: test_events[haojai_switch][event.hjmt_6b_4-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'HJMT-6B Button (4)',
+      'friendly_name': 'HJMT-6B',
     }),
     'context': <ANY>,
-    'entity_id': 'event.hjmt_6b_button_4',
+    'entity_id': 'event.hjmt_6b_4',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_5-entry]
+# name: test_events[haojai_switch][event.hjmt_6b_5-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -462,8 +490,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -475,7 +505,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.hjmt_6b_button_5',
+    'entity_id': 'event.hjmt_6b_5',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -483,43 +513,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (5)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (5)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-5-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-5-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_5-state]
+# name: test_events[haojai_switch][event.hjmt_6b_5-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'HJMT-6B Button (5)',
+      'friendly_name': 'HJMT-6B',
     }),
     'context': <ANY>,
-    'entity_id': 'event.hjmt_6b_button_5',
+    'entity_id': 'event.hjmt_6b_5',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_6-entry]
+# name: test_events[haojai_switch][event.hjmt_6b_6-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -527,8 +559,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -540,7 +574,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.hjmt_6b_button_6',
+    'entity_id': 'event.hjmt_6b_6',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -548,43 +582,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (6)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (6)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-6-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000003-MatterNodeDevice-6-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[haojai_switch][event.hjmt_6b_button_6-state]
+# name: test_events[haojai_switch][event.hjmt_6b_6-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'HJMT-6B Button (6)',
+      'friendly_name': 'HJMT-6B',
     }),
     'context': <ANY>,
-    'entity_id': 'event.hjmt_6b_button_6',
+    'entity_id': 'event.hjmt_6b_6',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_1-entry]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -592,8 +628,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -605,7 +643,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_dual_button_button_1',
+    'entity_id': 'event.bilresa_dual_button',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -613,43 +651,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (1)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (1)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-1-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-1-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_1-state]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'BILRESA dual button Button (1)',
+      'friendly_name': 'BILRESA dual button',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_dual_button_button_1',
+    'entity_id': 'event.bilresa_dual_button',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_2-entry]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -657,8 +697,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -670,7 +712,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_dual_button_button_2',
+    'entity_id': 'event.bilresa_dual_button_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -678,43 +720,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (2)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (2)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-2-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-2-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_2-state]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'BILRESA dual button Button (2)',
+      'friendly_name': 'BILRESA dual button',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_dual_button_button_2',
+    'entity_id': 'event.bilresa_dual_button_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_1-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -722,14 +766,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -739,7 +779,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_1',
+    'entity_id': 'event.bilresa_scroll_wheel',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -747,47 +787,43 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (1)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (1)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_1-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (1)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_1',
+    'entity_id': 'event.bilresa_scroll_wheel',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_2-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -795,14 +831,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -812,7 +844,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_2',
+    'entity_id': 'event.bilresa_scroll_wheel_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -820,47 +852,43 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (2)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (2)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-2-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-2-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_2-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (2)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_2',
+    'entity_id': 'event.bilresa_scroll_wheel_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_3-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -868,9 +896,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -882,7 +911,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_3',
+    'entity_id': 'event.bilresa_scroll_wheel_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -890,44 +919,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (3)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (3)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-3-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-3-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_3-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (3)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_3',
+    'entity_id': 'event.bilresa_scroll_wheel_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_4-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_4-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -935,14 +965,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -952,7 +978,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_4',
+    'entity_id': 'event.bilresa_scroll_wheel_4',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -960,47 +986,43 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (4)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (4)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-4-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-4-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_4-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_4-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (4)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_4',
+    'entity_id': 'event.bilresa_scroll_wheel_4',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_5-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_5-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1008,14 +1030,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -1025,7 +1043,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_5',
+    'entity_id': 'event.bilresa_scroll_wheel_5',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1033,47 +1051,43 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (5)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (5)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-5-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-5-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_5-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_5-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (5)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_5',
+    'entity_id': 'event.bilresa_scroll_wheel_5',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_6-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_6-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1081,9 +1095,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1095,7 +1110,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_6',
+    'entity_id': 'event.bilresa_scroll_wheel_6',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1103,44 +1118,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (6)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (6)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-6-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-6-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_6-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_6-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (6)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_6',
+    'entity_id': 'event.bilresa_scroll_wheel_6',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_7-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_7-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1148,14 +1164,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -1165,7 +1177,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_7',
+    'entity_id': 'event.bilresa_scroll_wheel_7',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1173,47 +1185,43 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (7)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (7)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-7-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-7-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_7-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_7-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (7)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_7',
+    'entity_id': 'event.bilresa_scroll_wheel_7',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_8-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_8-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1221,14 +1229,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -1238,7 +1242,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_8',
+    'entity_id': 'event.bilresa_scroll_wheel_8',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1246,47 +1250,43 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (8)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (8)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-8-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-8-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_8-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_8-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (8)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_8',
+    'entity_id': 'event.bilresa_scroll_wheel_8',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_9-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_9-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1294,9 +1294,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1308,7 +1309,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_9',
+    'entity_id': 'event.bilresa_scroll_wheel_9',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1316,44 +1317,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (9)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (9)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-9-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-9-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_9-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_9-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'BILRESA scroll wheel Button (9)',
+      'friendly_name': 'BILRESA scroll wheel',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_9',
+    'entity_id': 'event.bilresa_scroll_wheel_9',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_button_config-entry]
+# name: test_events[inovelli_vtm30][event.white_series_onoff_switch-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1361,11 +1363,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1377,7 +1378,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.white_series_onoff_switch_button_config',
+    'entity_id': 'event.white_series_onoff_switch',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1385,46 +1386,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (Config)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (Config)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000100-MatterNodeDevice-5-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000100-MatterNodeDevice-3-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_button_config-state]
+# name: test_events[inovelli_vtm30][event.white_series_onoff_switch-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'White Series OnOff Switch Button (Config)',
+      'friendly_name': 'White Series OnOff Switch',
     }),
     'context': <ANY>,
-    'entity_id': 'event.white_series_onoff_switch_button_config',
+    'entity_id': 'event.white_series_onoff_switch',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_button_down-entry]
+# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1432,11 +1432,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1448,7 +1447,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.white_series_onoff_switch_button_down',
+    'entity_id': 'event.white_series_onoff_switch_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1456,46 +1455,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (Down)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (Down)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000100-MatterNodeDevice-4-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000100-MatterNodeDevice-4-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_button_down-state]
+# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'White Series OnOff Switch Button (Down)',
+      'friendly_name': 'White Series OnOff Switch',
     }),
     'context': <ANY>,
-    'entity_id': 'event.white_series_onoff_switch_button_down',
+    'entity_id': 'event.white_series_onoff_switch_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_button_up-entry]
+# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1503,11 +1501,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1519,7 +1516,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.white_series_onoff_switch_button_up',
+    'entity_id': 'event.white_series_onoff_switch_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1527,46 +1524,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (Up)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (Up)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000100-MatterNodeDevice-3-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000100-MatterNodeDevice-5-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_button_up-state]
+# name: test_events[inovelli_vtm30][event.white_series_onoff_switch_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'White Series OnOff Switch Button (Up)',
+      'friendly_name': 'White Series OnOff Switch',
     }),
     'context': <ANY>,
-    'entity_id': 'event.white_series_onoff_switch_button_up',
+    'entity_id': 'event.white_series_onoff_switch_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[inovelli_vtm31][event.inovelli_button_config-entry]
+# name: test_events[inovelli_vtm31][event.inovelli-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1574,11 +1570,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1590,7 +1585,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.inovelli_button_config',
+    'entity_id': 'event.inovelli',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1598,46 +1593,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (Config)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (Config)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-00000000000000C5-MatterNodeDevice-5-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-00000000000000C5-MatterNodeDevice-3-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[inovelli_vtm31][event.inovelli_button_config-state]
+# name: test_events[inovelli_vtm31][event.inovelli-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Inovelli Button (Config)',
+      'friendly_name': 'Inovelli',
     }),
     'context': <ANY>,
-    'entity_id': 'event.inovelli_button_config',
+    'entity_id': 'event.inovelli',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[inovelli_vtm31][event.inovelli_button_down-entry]
+# name: test_events[inovelli_vtm31][event.inovelli_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1645,11 +1639,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1661,7 +1654,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.inovelli_button_down',
+    'entity_id': 'event.inovelli_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1669,46 +1662,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (Down)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (Down)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-00000000000000C5-MatterNodeDevice-4-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-00000000000000C5-MatterNodeDevice-4-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[inovelli_vtm31][event.inovelli_button_down-state]
+# name: test_events[inovelli_vtm31][event.inovelli_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Inovelli Button (Down)',
+      'friendly_name': 'Inovelli',
     }),
     'context': <ANY>,
-    'entity_id': 'event.inovelli_button_down',
+    'entity_id': 'event.inovelli_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[inovelli_vtm31][event.inovelli_button_up-entry]
+# name: test_events[inovelli_vtm31][event.inovelli_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1716,11 +1708,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1732,7 +1723,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.inovelli_button_up',
+    'entity_id': 'event.inovelli_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1740,46 +1731,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (Up)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (Up)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-00000000000000C5-MatterNodeDevice-3-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-00000000000000C5-MatterNodeDevice-5-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[inovelli_vtm31][event.inovelli_button_up-state]
+# name: test_events[inovelli_vtm31][event.inovelli_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Inovelli Button (Up)',
+      'friendly_name': 'Inovelli',
     }),
     'context': <ANY>,
-    'entity_id': 'event.inovelli_button_up',
+    'entity_id': 'event.inovelli_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[mock_generic_switch][event.mock_generic_switch_button-entry]
+# name: test_events[mock_generic_switch][event.mock_generic_switch-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1800,7 +1790,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.mock_generic_switch_button',
+    'entity_id': 'event.mock_generic_switch',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1808,22 +1798,22 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000013-MatterNodeDevice-1-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000013-MatterNodeDevice-1-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[mock_generic_switch][event.mock_generic_switch_button-state]
+# name: test_events[mock_generic_switch][event.mock_generic_switch-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
@@ -1834,17 +1824,17 @@
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Mock Generic Switch Button',
+      'friendly_name': 'Mock Generic Switch',
     }),
     'context': <ANY>,
-    'entity_id': 'event.mock_generic_switch_button',
+    'entity_id': 'event.mock_generic_switch',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_button_1-entry]
+# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1852,8 +1842,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1865,7 +1857,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.mock_generic_switch_button_1',
+    'entity_id': 'event.mock_generic_switch_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1873,43 +1865,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (1)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (1)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000012-MatterNodeDevice-1-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000012-MatterNodeDevice-1-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_button_1-state]
+# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Mock Generic Switch Button (1)',
+      'friendly_name': 'Mock Generic Switch',
     }),
     'context': <ANY>,
-    'entity_id': 'event.mock_generic_switch_button_1',
+    'entity_id': 'event.mock_generic_switch_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_button_fancy_button-entry]
+# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1917,10 +1911,10 @@
     'area_id': None,
     'capabilities': dict({
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
@@ -1932,7 +1926,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.mock_generic_switch_button_fancy_button',
+    'entity_id': 'event.mock_generic_switch_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1940,45 +1934,45 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (Fancy Button)',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (Fancy Button)',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000012-MatterNodeDevice-2-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000012-MatterNodeDevice-2-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_button_fancy_button-state]
+# name: test_events[mock_generic_switch_multi][event.mock_generic_switch_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
       'event_types': list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
+        'initial_press',
+        'short_release',
+        'multi_press_ongoing',
+        'multi_press_complete',
         'long_press',
         'long_release',
       ]),
-      'friendly_name': 'Mock Generic Switch Button (Fancy Button)',
+      'friendly_name': 'Mock Generic Switch',
     }),
     'context': <ANY>,
-    'entity_id': 'event.mock_generic_switch_button_fancy_button',
+    'entity_id': 'event.mock_generic_switch_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[silabs_light_switch][event.light_switch_example_button-entry]
+# name: test_events[silabs_light_switch][event.light_switch_example-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1997,7 +1991,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.light_switch_example_button',
+    'entity_id': 'event.light_switch_example',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2005,22 +1999,22 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-000000000000008E-MatterNodeDevice-2-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-000000000000008E-MatterNodeDevice-2-MatterMultiPressSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[silabs_light_switch][event.light_switch_example_button-state]
+# name: test_events[silabs_light_switch][event.light_switch_example-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
@@ -2029,10 +2023,10 @@
         'initial_press',
         'short_release',
       ]),
-      'friendly_name': 'Light switch example Button',
+      'friendly_name': 'Light switch example',
     }),
     'context': <ANY>,
-    'entity_id': 'event.light_switch_example_button',
+    'entity_id': 'event.light_switch_example',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/test_event.py
+++ b/tests/components/matter/test_event.py
@@ -32,10 +32,10 @@ async def test_generic_switch_node(
     matter_node: MatterNode,
 ) -> None:
     """Test event entity for a GenericSwitch node."""
-    state = hass.states.get("event.mock_generic_switch_button")
+    state = hass.states.get("event.mock_generic_switch")
     assert state
     assert state.state == "unknown"
-    assert state.name == "Mock Generic Switch Button"
+    assert state.name == "Mock Generic Switch"
     # check event_types from featuremap 14 (0b1110)
     assert state.attributes[ATTR_EVENT_TYPES] == [
         "initial_press",
@@ -60,7 +60,7 @@ async def test_generic_switch_node(
             data=None,
         ),
     )
-    state = hass.states.get("event.mock_generic_switch_button")
+    state = hass.states.get("event.mock_generic_switch")
     assert state.attributes[ATTR_EVENT_TYPE] == "initial_press"
 
 
@@ -71,35 +71,33 @@ async def test_generic_switch_multi_node(
     matter_node: MatterNode,
 ) -> None:
     """Test event entity for a GenericSwitch node with multiple buttons."""
-    state_button_1 = hass.states.get("event.mock_generic_switch_button_1")
+    state_button_1 = hass.states.get("event.mock_generic_switch")
     assert state_button_1
     assert state_button_1.state == "unknown"
-    # name should be 'DeviceName Button (1)'
-    assert state_button_1.name == "Mock Generic Switch Button (1)"
-    # check event_types from featuremap 30 (0b11110) and MultiPressMax unset (default 2)
+    # check event_types from featuremap 30 (0b11110)
     assert state_button_1.attributes[ATTR_EVENT_TYPES] == [
-        "multi_press_1",
-        "multi_press_2",
+        "initial_press",
+        "short_release",
+        "multi_press_ongoing",
+        "multi_press_complete",
         "long_press",
         "long_release",
     ]
     # check button 2
-    state_button_2 = hass.states.get("event.mock_generic_switch_button_fancy_button")
+    state_button_2 = hass.states.get("event.mock_generic_switch_2")
     assert state_button_2
     assert state_button_2.state == "unknown"
-    # name should be 'DeviceName Button (Fancy Button)' due to ha_entitylabel 'Fancy Button'
-    assert state_button_2.name == "Mock Generic Switch Button (Fancy Button)"
-    # check event_types from featuremap 30 (0b11110) and MultiPressMax 4
+    # check event_types from featuremap 30 (0b11110)
     assert state_button_2.attributes[ATTR_EVENT_TYPES] == [
-        "multi_press_1",
-        "multi_press_2",
-        "multi_press_3",
-        "multi_press_4",
+        "initial_press",
+        "short_release",
+        "multi_press_ongoing",
+        "multi_press_complete",
         "long_press",
         "long_release",
     ]
 
-    # trigger firing a multi press event
+    # trigger firing a multi press complete event
     await trigger_subscription_callback(
         hass,
         matter_client,
@@ -116,5 +114,209 @@ async def test_generic_switch_multi_node(
             data={"totalNumberOfPressesCounted": 2},
         ),
     )
-    state = hass.states.get("event.mock_generic_switch_button_1")
-    assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_2"
+    state = hass.states.get("event.mock_generic_switch")
+    assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_complete"
+    assert state.attributes["press_count"] == 2
+    assert state.attributes["event_type_extra"] == "double"
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_generic_switch_multi"])
+async def test_multi_press_event_entity(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test MatterMultiPressEventEntity with press count data."""
+    # Find the multi-press entity for endpoint 1 via entity registry
+    entity_registry = er.async_get(hass)
+    multi_press_entity_id = None
+    for entry in entity_registry.entities.values():
+        if (
+            entry.platform == "matter"
+            and "-1-MatterMultiPressSwitch-" in entry.unique_id
+        ):
+            multi_press_entity_id = entry.entity_id
+            break
+    assert multi_press_entity_id is not None, (
+        "MatterMultiPressSwitch entity not found in registry"
+    )
+
+    # Verify event_types for the new entity (featuremap 30)
+    state = hass.states.get(multi_press_entity_id)
+    assert state
+    assert state.attributes[ATTR_EVENT_TYPES] == [
+        "initial_press",
+        "short_release",
+        "multi_press_ongoing",
+        "multi_press_complete",
+        "long_press",
+        "long_release",
+    ]
+
+    # Test multi_press_ongoing with press_count and press_step (first event)
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=5,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={"currentNumberOfPressesCounted": 3},
+        ),
+    )
+    state = hass.states.get(multi_press_entity_id)
+    assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_ongoing"
+    assert state.attributes["press_count"] == 3
+    assert state.attributes["press_step"] == 3  # first event: 3 - 0
+
+    # Test multi_press_ongoing sequence (press_step delta calculation)
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=5,
+            event_number=1,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={"currentNumberOfPressesCounted": 5},
+        ),
+    )
+    state = hass.states.get(multi_press_entity_id)
+    assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_ongoing"
+    assert state.attributes["press_count"] == 5
+    assert state.attributes["press_step"] == 2  # 5 - 3
+
+    # Test initial_press resets press_step tracking (previous was 5)
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=1,
+            event_number=2,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data=None,
+        ),
+    )
+    state = hass.states.get(multi_press_entity_id)
+    assert state.attributes[ATTR_EVENT_TYPE] == "initial_press"
+
+    # After reset, multi_press_ongoing calculates step from 0
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=5,
+            event_number=3,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={"currentNumberOfPressesCounted": 2},
+        ),
+    )
+    state = hass.states.get(multi_press_entity_id)
+    assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_ongoing"
+    assert state.attributes["press_count"] == 2
+    assert state.attributes["press_step"] == 2  # 2 - 0 (reset by initial_press)
+
+    # Test multi_press_complete with press_count=2 (event_type_extra="double")
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=6,
+            event_number=4,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={"totalNumberOfPressesCounted": 2},
+        ),
+    )
+    state = hass.states.get(multi_press_entity_id)
+    assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_complete"
+    assert state.attributes["press_count"] == 2
+    assert state.attributes["event_type_extra"] == "double"
+
+    # Test multi_press_complete with press_count=5 (no event_type_extra)
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=6,
+            event_number=5,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data={"totalNumberOfPressesCounted": 5},
+        ),
+    )
+    state = hass.states.get(multi_press_entity_id)
+    assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_complete"
+    assert state.attributes["press_count"] == 5
+    assert "event_type_extra" not in state.attributes
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_generic_switch_multi"])
+async def test_deprecated_multi_press_entity(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test that deprecated MatterEventEntity is not created on new installs."""
+    # On a new install (no pre-existing registry entry), the deprecated entity
+    # should NOT be created. Only the new MatterMultiPressEventEntity should exist.
+    entity_registry = er.async_get(hass)
+
+    # Verify no deprecated entity (key="GenericSwitch") exists
+    deprecated_entity_id = None
+    for entry in entity_registry.entities.values():
+        if (
+            entry.platform == "matter"
+            and "-1-GenericSwitch-" in entry.unique_id
+        ):
+            deprecated_entity_id = entry.entity_id
+            break
+    assert deprecated_entity_id is None, (
+        "Deprecated GenericSwitch entity should not be created on new install"
+    )
+
+    # Verify the new entity IS created
+    new_entity_id = None
+    for entry in entity_registry.entities.values():
+        if (
+            entry.platform == "matter"
+            and "-1-MatterMultiPressSwitch-" in entry.unique_id
+        ):
+            new_entity_id = entry.entity_id
+            break
+    assert new_entity_id is not None, (
+        "New MatterMultiPressSwitch entity should be created"
+    )

--- a/tests/components/matter/test_event.py
+++ b/tests/components/matter/test_event.py
@@ -298,10 +298,7 @@ async def test_deprecated_multi_press_entity(
     # Verify no deprecated entity (key="GenericSwitch") exists
     deprecated_entity_id = None
     for entry in entity_registry.entities.values():
-        if (
-            entry.platform == "matter"
-            and "-1-GenericSwitch-" in entry.unique_id
-        ):
+        if entry.platform == "matter" and "-1-GenericSwitch-" in entry.unique_id:
             deprecated_entity_id = entry.entity_id
             break
     assert deprecated_entity_id is None, (


### PR DESCRIPTION
## Summary

This PR adds a new `MatterMultiPressEventEntity` that exposes `multi_press_ongoing` and `multi_press_complete` events with structured press count data, while preserving the existing `MatterEventEntity` (`multi_press_1..8`) as a deprecated entity for existing users.

This supersedes the approach in #159045 and directly addresses the code owner feedback from @arturpragacz and @abmantis requesting a backwards-compatible deprecation path.

## Motivation

The IKEA BILRESA scroll wheel (and other Matter switches) send `MultiPressOngoing` events that Home Assistant currently suppresses. This prevents real-time dimming automation. The original PR #159045 proposed a clean break, but code owners requested backwards compatibility.

## Changes

### New entity: `MatterMultiPressEventEntity`
- **Flat `if` chain** for feature detection (per Matter spec — features are additive, not exclusive)
- **Event types**: `initial_press`, `short_release`, `multi_press_ongoing`, `multi_press_complete`, `long_press`, `long_release`, `switch_latched`
- **`multi_press_ongoing` event data**: includes `press_count` (= `currentNumberOfPressesCounted`) and `press_step` (delta from previous count — useful for scroll wheel acceleration)
- **`multi_press_complete` event data**: includes `press_count` (= `totalNumberOfPressesCounted`) and `event_type_extra` (`"single"`, `"double"`, `"triple"` for counts 1–3)

### Deprecated entity: `MatterEventEntity` (existing)
- Preserved with exact same behavior (`multi_press_1..8` event types)
- Only created for **existing installs** (entity already in registry) — new installs get only the new entity
- Scheduled for removal in **2026.11.0** (approximately 6 months)
- Creates issues for automations/scripts referencing the deprecated entity

### Deprecation mechanism
Follows the Ring integration pattern (`ring/entity.py`):
- `DeprecatedInfo` dataclass with `breaks_in_ha_version`
- `async_check_create_deprecated()` checks entity registry — skips creation if entity doesn't exist (new install), removes if disabled, creates issues if automations reference it

## Breaking Change

**Existing users**: The deprecated entity continues to work unchanged. Automations using `multi_press_1..8` events will continue to fire. A repair issue will be created if automations reference the deprecated entity.

**New installs**: Only the new entity is created. Use `multi_press_complete` with `press_count` in event data instead of `multi_press_1..8`.

**Removal**: The deprecated entity will be removed in 2026.11.0.

## Test Plan

- `test_multi_press_event_entity`: verifies new entity event types, `press_count`, `press_step` delta calculation, `event_type_extra` for named counts
- `test_deprecated_multi_press_entity`: verifies deprecated entity is NOT created on new installs
- Updated `test_generic_switch_node` and `test_generic_switch_multi_node` to test new entity behavior

## Related

- Supersedes #159045 (stalled since Dec 2025)
- Addresses code owner feedback from @arturpragacz: "Preserve the old entity to not break backwards compatibility and deprecate it to give time to users. For the new behaviour use a new entity instead."
- Addresses core team suggestion from @abmantis: "new event entity with the press count as the event data... deprecate the old entity and keep it around for 6 months"

## Attribution

Original implementation work by @phoffmeister in #159045. This PR implements the same core changes with the backwards-compatible deprecation path that was requested but not implemented in the original PR.

## CLA

I will sign the CLA as soon as this PR is submitted.