### PR TITLE
Add tests asserting air_quality trigger features

### DIFF
--- a/tests/components/air_quality/test_trigger.py
+++ b/tests/components/air_quality/test_trigger.py
@@ -25,6 +25,7 @@ from tests.components.common import (
     assert_trigger_behavior_first,
     assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
+    assert_trigger_options_supported,
     parametrize_numerical_state_value_changed_trigger_states,
     parametrize_numerical_state_value_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -93,6 +94,83 @@ async def test_air_quality_triggers_gated_by_labs_flag(
 ) -> None:
     """Test the air quality triggers are gated by the labs flag."""
     await assert_trigger_gated_by_labs_flag(hass, caplog, trigger_key)
+
+
+_CHANGED_THRESHOLD = {"threshold": {"type": "any"}}
+_PLAIN_CROSSED_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
+_PPB_CROSSED_THRESHOLD = {
+    "threshold": {
+        "type": "above",
+        "value": {
+            "number": 50,
+            "unit_of_measurement": CONCENTRATION_PARTS_PER_BILLION,
+        },
+    }
+}
+_UGM3_CROSSED_THRESHOLD = {
+    "threshold": {
+        "type": "above",
+        "value": {
+            "number": 50,
+            "unit_of_measurement": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        },
+    }
+}
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
+    [
+        ("air_quality.gas_detected", {}, True, True),
+        ("air_quality.gas_cleared", {}, True, True),
+        ("air_quality.co_detected", {}, True, True),
+        ("air_quality.co_cleared", {}, True, True),
+        ("air_quality.smoke_detected", {}, True, True),
+        ("air_quality.smoke_cleared", {}, True, True),
+        ("air_quality.co_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.co_crossed_threshold", _UGM3_CROSSED_THRESHOLD, True, True),
+        ("air_quality.co2_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.co2_crossed_threshold", _PLAIN_CROSSED_THRESHOLD, True, True),
+        ("air_quality.pm1_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.pm1_crossed_threshold", _PLAIN_CROSSED_THRESHOLD, True, True),
+        ("air_quality.pm25_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.pm25_crossed_threshold", _PLAIN_CROSSED_THRESHOLD, True, True),
+        ("air_quality.pm4_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.pm4_crossed_threshold", _PLAIN_CROSSED_THRESHOLD, True, True),
+        ("air_quality.pm10_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.pm10_crossed_threshold", _PLAIN_CROSSED_THRESHOLD, True, True),
+        ("air_quality.ozone_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.ozone_crossed_threshold", _UGM3_CROSSED_THRESHOLD, True, True),
+        ("air_quality.voc_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.voc_crossed_threshold", _UGM3_CROSSED_THRESHOLD, True, True),
+        ("air_quality.voc_ratio_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.voc_ratio_crossed_threshold", _PPB_CROSSED_THRESHOLD, True, True),
+        ("air_quality.no_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.no_crossed_threshold", _UGM3_CROSSED_THRESHOLD, True, True),
+        ("air_quality.no2_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.no2_crossed_threshold", _UGM3_CROSSED_THRESHOLD, True, True),
+        ("air_quality.n2o_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.n2o_crossed_threshold", _PLAIN_CROSSED_THRESHOLD, True, True),
+        ("air_quality.so2_changed", _CHANGED_THRESHOLD, False, False),
+        ("air_quality.so2_crossed_threshold", _UGM3_CROSSED_THRESHOLD, True, True),
+    ],
+)
+async def test_air_quality_trigger_options_validation(
+    hass: HomeAssistant,
+    trigger_key: str,
+    base_options: dict[str, Any] | None,
+    supports_behavior: bool,
+    supports_duration: bool,
+) -> None:
+    """Test that air_quality triggers support the expected options."""
+    await assert_trigger_options_supported(
+        hass,
+        trigger_key,
+        base_options,
+        supports_behavior=supports_behavior,
+        supports_duration=supports_duration,
+    )
 
 
 @pytest.mark.usefixtures("enable_labs_preview_features")

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any, TypedDict
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_AREA_ID,
@@ -1093,6 +1094,65 @@ async def assert_trigger_gated_by_labs_flag(
         "feature to be enabled in Home Assistant Labs settings (feature flag: "
         "'new_triggers_conditions')"
     ) in caplog.text
+
+
+async def _validate_trigger_options(
+    hass: HomeAssistant,
+    trigger: str,
+    options: dict[str, Any] | None,
+    *,
+    valid: bool,
+) -> None:
+    """Assert that a trigger accepts or rejects the given options during validation."""
+    trigger_config: dict[str, Any] = {
+        CONF_PLATFORM: trigger,
+        CONF_TARGET: {ATTR_LABEL_ID: "test_label"},
+    }
+    if options is not None:
+        trigger_config[CONF_OPTIONS] = options
+    if valid:
+        await async_validate_trigger_config(hass, [trigger_config])
+    else:
+        with pytest.raises(vol.Invalid):
+            await async_validate_trigger_config(hass, [trigger_config])
+
+
+async def assert_trigger_options_supported(
+    hass: HomeAssistant,
+    trigger: str,
+    base_options: dict[str, Any] | None,
+    *,
+    supports_behavior: bool,
+    supports_duration: bool,
+) -> None:
+    """Assert which options a trigger supports.
+
+    Tests that the trigger:
+    - Accepts the minimal config (base_options)
+    - Accepts/rejects behavior depending on supports_behavior
+    - Accepts/rejects duration depending on supports_duration
+    - Rejects unknown options
+    """
+    # Minimal config should always be valid
+    await _validate_trigger_options(hass, trigger, base_options, valid=True)
+
+    def _merge(extra: dict[str, Any]) -> dict[str, Any]:
+        return {**(base_options or {}), **extra}
+
+    # Behavior
+    await _validate_trigger_options(
+        hass, trigger, _merge({"behavior": "first"}), valid=supports_behavior
+    )
+
+    # Duration
+    await _validate_trigger_options(
+        hass, trigger, _merge({"for": {"seconds": 5}}), valid=supports_duration
+    )
+
+    # Unknown option should always be rejected
+    await _validate_trigger_options(
+        hass, trigger, _merge({"unknown_option": True}), valid=False
+    )
 
 
 async def assert_condition_behavior_any(

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -1140,9 +1140,10 @@ async def assert_trigger_options_supported(
         return {**(base_options or {}), **extra}
 
     # Behavior
-    await _validate_trigger_options(
-        hass, trigger, _merge({"behavior": "first"}), valid=supports_behavior
-    )
+    for behavior in ("any", "first", "last"):
+        await _validate_trigger_options(
+            hass, trigger, _merge({"behavior": behavior}), valid=supports_behavior
+        )
 
     # Duration
     await _validate_trigger_options(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests asserting air_quality trigger features

Rationale: Make sure we don't accidentally add or remove features in concrete trigger classes when modifying the base classes

If the pattern is OK, I'll open a follow-up with the same test for all other triggers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
