### PR TITLE
Fix shelly test RuntimeWarnings

### DIFF
--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -4689,11 +4689,7 @@ async def test_bluetooth_provision_secure_device_both_enabled(
     )
 
     # Provision and verify security calls
-    mock_device = AsyncMock()
-    mock_device.initialize = AsyncMock()
-    mock_device.wifi_setconfig = AsyncMock(return_value={})
-    mock_device.ble_setconfig = AsyncMock(return_value={"restart_required": False})
-    mock_device.shutdown = AsyncMock()
+    mock_device = create_mock_rpc_device()
 
     with (
         patch(
@@ -4802,10 +4798,7 @@ async def test_bluetooth_provision_secure_device_only_ap_disabled(
     )
 
     # Provision and verify only AP disabled
-    mock_device = AsyncMock()
-    mock_device.initialize = AsyncMock()
-    mock_device.wifi_setconfig = AsyncMock(return_value={})
-    mock_device.shutdown = AsyncMock()
+    mock_device = create_mock_rpc_device()
 
     with (
         patch(
@@ -4864,10 +4857,7 @@ async def test_bluetooth_provision_secure_device_only_ble_disabled(
     )
 
     # Provision and verify only BLE disabled
-    mock_device = AsyncMock()
-    mock_device.initialize = AsyncMock()
-    mock_device.ble_setconfig = AsyncMock(return_value={"restart_required": False})
-    mock_device.shutdown = AsyncMock()
+    mock_device = create_mock_rpc_device()
 
     with (
         patch(
@@ -4926,12 +4916,8 @@ async def test_bluetooth_provision_secure_device_with_restart_required(
     )
 
     # Provision and verify restart is triggered
-    mock_device = AsyncMock()
-    mock_device.initialize = AsyncMock()
-    mock_device.wifi_setconfig = AsyncMock(return_value={})
+    mock_device = create_mock_rpc_device()
     mock_device.ble_setconfig = AsyncMock(return_value={"restart_required": True})
-    mock_device.trigger_reboot = AsyncMock()
-    mock_device.shutdown = AsyncMock()
 
     with (
         patch(
@@ -4990,10 +4976,8 @@ async def test_bluetooth_provision_secure_device_fails_gracefully(
     )
 
     # Provision with security calls failing - wifi_setconfig will fail
-    mock_device = AsyncMock()
-    mock_device.initialize = AsyncMock()
+    mock_device = create_mock_rpc_device()
     mock_device.wifi_setconfig = AsyncMock(side_effect=RpcCallError("RPC call failed"))
-    mock_device.shutdown = AsyncMock()
 
     with (
         patch(
@@ -5121,9 +5105,8 @@ async def test_bluetooth_ble_initialize_failure_cleans_up(
     hass: HomeAssistant,
 ) -> None:
     """Test that initialize failure properly cleans up the device."""
-    mock_device = AsyncMock()
+    mock_device = create_mock_rpc_device()
     mock_device.initialize = AsyncMock(side_effect=DeviceConnectionError)
-    mock_device.shutdown = AsyncMock()
 
     inject_bluetooth_service_info_bleak(hass, BLE_DISCOVERY_INFO)
 


### PR DESCRIPTION
## Proposed change
```py
tests/components/shelly/test_config_flow.py::test_bluetooth_flow_abort_cleans_up_ble_connection
  /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/unittest/mock.py:495: RuntimeWarning:
    coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/.../homeassistant/components/shelly/config_flow.py", line 1008, in _async_provision_wifi_and_wait_for_zeroconf
      device_info = await validate_input(
    File "/.../homeassistant/components/shelly/config_flow.py", line 180, in validate_input
      rpc_device.xmod_info.get("p") or rpc_device.shelly.get(CONF_MODEL)

tests/components/shelly/test_config_flow.py::test_bluetooth_provision_ble_reconnect_fails_during_ip_fetch
  /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/traceback.py:295: RuntimeWarning:
    coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/.../homeassistant/components/shelly/config_flow.py", line 1008, in _async_provision_wifi_and_wait_for_zeroconf
      device_info = await validate_input(
    File "/.../homeassistant/components/shelly/config_flow.py", line 180, in validate_input
      rpc_device.xmod_info.get("p") or rpc_device.shelly.get(CONF_MODEL)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
