### PR TITLE
Fix disabled discovered MQTT entities cleaned up

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -574,8 +574,8 @@ async def async_start(  # noqa: C901
         else:
             if (
                 (
-                    entity_hash := mqtt_data.discovery_discovered_and_disabled.get(
-                        discovery_hash
+                    entity_hash := mqtt_data.discovery_discovered_and_disabled.pop(
+                        discovery_hash, None
                     )
                 )
                 and (entity_registry := er.async_get(hass))

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -21,7 +21,11 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_DEVICE, CONF_PLATFORM
 from homeassistant.core import HassJobType, HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, discovery_flow
+from homeassistant.helpers import (
+    config_validation as cv,
+    discovery_flow,
+    entity_registry as er,
+)
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -47,7 +51,10 @@ from .const import (
 )
 from .models import DATA_MQTT, MqttComponentConfig, MqttOriginInfo, ReceiveMessage
 from .schemas import DEVICE_DISCOVERY_SCHEMA, MQTT_ORIGIN_INFO_SCHEMA, SHARED_OPTIONS
-from .util import async_forward_entry_setup_and_setup_discovery
+from .util import (
+    async_cleanup_device_registry,
+    async_forward_entry_setup_and_setup_discovery,
+)
 
 ABBREVIATIONS_SET = set(ABBREVIATIONS)
 DEVICE_ABBREVIATIONS_SET = set(DEVICE_ABBREVIATIONS)
@@ -565,7 +572,28 @@ async def async_start(  # noqa: C901
         elif payload:
             _async_add_component(payload)
         else:
-            # Unhandled discovery message
+            if (
+                (
+                    entity_hash := mqtt_data.discovery_discovered_and_disabled.get(
+                        discovery_hash
+                    )
+                )
+                and (entity_registry := er.async_get(hass))
+                and (entity_id := entity_registry.entities.get_entity_id(entity_hash))
+                and (entity_entry := entity_registry.async_get(entity_id))
+            ):
+                # Cleanup discovered disabled entity / device
+                entity_registry.async_remove(entity_id)
+                hass.async_create_task(
+                    async_cleanup_device_registry(
+                        hass,
+                        device_id=entity_entry.device_id,
+                        config_entry_id=entity_entry.config_entry_id,
+                    ),
+                    name=f"Check for cleanup device registry for {entity_id}",
+                )
+
+            # Finish handling discovery message
             async_dispatcher_send(
                 hass, MQTT_DISCOVERY_DONE.format(*discovery_hash), None
             )

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -572,13 +572,13 @@ async def async_start(  # noqa: C901
         elif payload:
             _async_add_component(payload)
         else:
+            entity_registry = er.async_get(hass)
             if (
                 (
                     entity_hash := mqtt_data.discovery_discovered_and_disabled.pop(
                         discovery_hash, None
                     )
                 )
-                and (entity_registry := er.async_get(hass))
                 and (entity_id := entity_registry.entities.get_entity_id(entity_hash))
                 and (entity_entry := entity_registry.async_get(entity_id))
             ):

--- a/homeassistant/components/mqtt/entity.py
+++ b/homeassistant/components/mqtt/entity.py
@@ -1452,7 +1452,7 @@ class MqttEntity(
 
         # Store discovery hash for new entities that are initial disabled
         # or for entries that are disabled in the registry,
-        # so then can be removed removed with an empty discovery payload
+        # so they can be removed with an empty discovery payload
         if (
             existing_entity_id is None
             or (existing_entry and existing_entry.disabled_by is not None)

--- a/homeassistant/components/mqtt/entity.py
+++ b/homeassistant/components/mqtt/entity.py
@@ -125,7 +125,11 @@ from .subscription import (
     async_subscribe_topics_internal,
     async_unsubscribe_topics,
 )
-from .util import learn_more_url, mqtt_config_entry_enabled
+from .util import (
+    async_cleanup_device_registry,
+    learn_more_url,
+    mqtt_config_entry_enabled,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -713,34 +717,6 @@ class MqttAvailabilityMixin(Entity):
         return self._available_latest
 
 
-async def cleanup_device_registry(
-    hass: HomeAssistant, device_id: str | None, config_entry_id: str | None
-) -> None:
-    """Clean up the device registry after MQTT removal.
-
-    Remove MQTT from the device registry entry if there are no remaining
-    entities, triggers or tags.
-    """
-    # Local import to avoid circular dependencies
-    from . import device_trigger, tag  # noqa: PLC0415
-
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-    if (
-        device_id
-        and device_id not in device_registry.deleted_devices
-        and config_entry_id
-        and not er.async_entries_for_device(
-            entity_registry, device_id, include_disabled_entities=False
-        )
-        and not await device_trigger.async_get_triggers(hass, device_id)
-        and not tag.async_has_tags(hass, device_id)
-    ):
-        device_registry.async_update_device(
-            device_id, remove_config_entry_id=config_entry_id
-        )
-
-
 def get_discovery_hash(discovery_data: DiscoveryInfoType) -> tuple[str, str]:
     """Get the discovery hash from the discovery data."""
     discovery_hash: tuple[str, str] = discovery_data[ATTR_DISCOVERY_HASH]
@@ -995,7 +971,7 @@ class MqttDiscoveryDeviceUpdateMixin(ABC):
         if not self._skip_device_removal:
             # Prevent a second cleanup round after the device is removed
             self._skip_device_removal = True
-            await cleanup_device_registry(
+            await async_cleanup_device_registry(
                 self.hass, self._device_id, self._config_entry_id
             )
 
@@ -1063,7 +1039,7 @@ class MqttDiscoveryUpdateMixin(Entity):
         entity_registry = er.async_get(self.hass)
         if entity_entry := entity_registry.async_get(self.entity_id):
             entity_registry.async_remove(self.entity_id)
-            await cleanup_device_registry(
+            await async_cleanup_device_registry(
                 self.hass, entity_entry.device_id, entity_entry.config_entry_id
             )
         else:
@@ -1411,7 +1387,7 @@ class MqttEntity(
         self._setup_common_attributes_from_config(self._config)
 
         # Initialize entity_id from config
-        self._init_entity_id()
+        self._init_entity_registry(discovery_data)
 
         # Initialize mixin classes
         MqttAttributesMixin.__init__(self, config)
@@ -1422,16 +1398,19 @@ class MqttEntity(
         MqttEntityDeviceInfo.__init__(self, config.get(CONF_DEVICE), config_entry)
         ensure_via_device_exists(self.hass, self.device_info, self._config_entry)
 
-    def _init_entity_id(self) -> None:
-        """Set entity_id from default_entity_id if defined in config."""
+    def _init_entity_registry(self, discovery_data: DiscoveryInfoType | None) -> None:
+        """Set entity_id from default_entity_id if defined in config.
+
+        Check if the previous registry state was disabled
+        or is set to be disabled initially for discovered entities.
+        """
         object_id: str
         default_entity_id: str | None
-        if (default_entity_id := self._config.get(CONF_DEFAULT_ENTITY_ID)) is None:
-            return
-        _, _, object_id = default_entity_id.partition(".")
-        self.entity_id = async_generate_entity_id(
-            self._entity_id_format, object_id, None, self.hass
-        )
+        if default_entity_id := self._config.get(CONF_DEFAULT_ENTITY_ID):
+            _, _, object_id = default_entity_id.partition(".")
+            self.entity_id = async_generate_entity_id(
+                self._entity_id_format, object_id, None, self.hass
+            )
 
         if self.unique_id is None:
             return
@@ -1446,6 +1425,42 @@ class MqttEntity(
             # Plan to update the entity_id based on `default_entity_id`
             # if a deleted entity was found
             self._update_registry_entity_id = self.entity_id
+
+        if (
+            self._config[CONF_ENABLED_BY_DEFAULT]
+            and deleted_entry
+            and deleted_entry.disabled_by is not None
+        ):
+            # Enable previous deleted entity and enable it
+            recreated_entry = entity_registry.async_get_or_create(
+                entity_platform, DOMAIN, self.unique_id
+            )
+            entity_registry.async_update_entity(
+                recreated_entry.entity_id,
+                disabled_by=None,
+            )
+
+        if discovery_data is None:
+            return
+
+        # Allow a disabled entity and device registry
+        # to be cleaned up via MQTT discovery
+        if existing_entity_id := entity_registry.async_get_entity_id(
+            entity_platform, DOMAIN, self.unique_id
+        ):
+            existing_entry = entity_registry.async_get(existing_entity_id)
+
+        # Store discovery hash for new entities that are initial disabled
+        # or for entries that are disabled in the registry,
+        # so then can be removed removed with an empty discovery payload
+        if (
+            existing_entity_id is None
+            or (existing_entry and existing_entry.disabled_by is not None)
+        ) and not self._config[CONF_ENABLED_BY_DEFAULT]:
+            mqtt_data = self.hass.data[DATA_MQTT]
+            mqtt_data.discovery_discovered_and_disabled[
+                discovery_data[ATTR_DISCOVERY_HASH]
+            ] = (entity_platform, DOMAIN, self.unique_id)
 
     @final
     async def async_added_to_hass(self) -> None:
@@ -1577,7 +1592,7 @@ class MqttEntity(
         """(Re)Setup the common attributes for the entity."""
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_entity_registry_enabled_default = bool(
-            config.get(CONF_ENABLED_BY_DEFAULT)
+            config.get(CONF_ENABLED_BY_DEFAULT, True)
         )
         self._attr_icon = config.get(CONF_ICON)
         self._attr_entity_picture = config.get(CONF_ENTITY_PICTURE)

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -400,7 +400,7 @@ class MqttData:
     )
     device_triggers: dict[str, Trigger] = field(default_factory=dict)
     data_config_flow_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    # Attribute `discovery_discovered_and_disabled`` maps a discovery hash to
+    # Attribute `discovery_discovered_and_disabled` maps a discovery hash to
     # the entity registry index, which is a tuple (entity_platform, "mqtt", unique_id)
     # It allows to cleanup disabled entities when an empty payload is received.
     discovery_discovered_and_disabled: dict[tuple[str, str], tuple[str, str, str]] = (

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -400,6 +400,9 @@ class MqttData:
     )
     device_triggers: dict[str, Trigger] = field(default_factory=dict)
     data_config_flow_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # Attribute `discovery_discovered_and_disabled`` maps a discovery hash to
+    # the entity registry index, which is a tuple (entity_platform, "mqtt", unique_id)
+    # It allows to cleanup disabled entities when an empty payload is received.
     discovery_discovered_and_disabled: dict[tuple[str, str], tuple[str, str, str]] = (
         field(default_factory=dict)
     )

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -400,6 +400,9 @@ class MqttData:
     )
     device_triggers: dict[str, Trigger] = field(default_factory=dict)
     data_config_flow_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    discovery_discovered_and_disabled: dict[tuple[str, str], tuple[str, str, str]] = (
+        field(default_factory=dict)
+    )
     discovery_already_discovered: set[tuple[str, str]] = field(default_factory=set)
     discovery_pending_discovered: dict[tuple[str, str], PendingDiscovered] = field(
         default_factory=dict

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -17,7 +17,12 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import MAX_LENGTH_STATE_STATE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, template
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+    template,
+)
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.async_ import create_eager_task
 
@@ -421,3 +426,31 @@ def migrate_certificate_file_to_content(file_name_or_auto: str) -> str | None:
 def learn_more_url(platform: str) -> str:
     """Return the URL for the platform specific MQTT documentation."""
     return f"https://www.home-assistant.io/integrations/{platform}.mqtt/"
+
+
+async def async_cleanup_device_registry(
+    hass: HomeAssistant, device_id: str | None, config_entry_id: str | None
+) -> None:
+    """Clean up the device registry after MQTT removal.
+
+    Remove MQTT from the device registry entry if there are no remaining
+    entities, triggers or tags.
+    """
+    # Local import to avoid circular dependencies
+    from . import device_trigger, tag  # noqa: PLC0415
+
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+    if (
+        device_id
+        and device_id not in device_registry.deleted_devices
+        and config_entry_id
+        and not er.async_entries_for_device(
+            entity_registry, device_id, include_disabled_entities=False
+        )
+        and not await device_trigger.async_get_triggers(hass, device_id)
+        and not tag.async_has_tags(hass, device_id)
+    ):
+        device_registry.async_update_device(
+            device_id, remove_config_entry_id=config_entry_id
+        )

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -532,7 +532,7 @@ async def test_registry_enable_not_enabled_by_default_entity(
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test to enable an entity that is was not enabled by default or not."""
+    """Test enabling an entity that was not enabled by default."""
     await mqtt_mock_entry()
 
     discovery_topic = "homeassistant/sensor/bla/config"

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
     issue_registry as ir,
+    json,
 )
 from homeassistant.util import slugify
 
@@ -466,6 +467,163 @@ async def test_value_template_fails(
         "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
         in caplog.text
     )
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "enabled_by_default": True,
+                    "unique_id": "very_unique",
+                }
+            }
+        },
+    ],
+)
+async def test_registry_enabled_by_default(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test an entity that is enabled by default or not."""
+    await mqtt_mock_entry()
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    entry = entity_registry.async_get("sensor.test")
+    assert not entry.disabled
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                sensor.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "enabled_by_default": False,
+                    "unique_id": "very_unique",
+                }
+            }
+        },
+    ],
+)
+async def test_registry_not_enabled_by_default(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test an entity that is not enabled by default or not."""
+    await mqtt_mock_entry()
+    state = hass.states.get("sensor.test")
+    assert state is None
+    entry = entity_registry.async_get("sensor.test")
+    assert entry is not None
+    assert entry.disabled
+
+
+async def test_registry_enable_not_enabled_by_default_entity(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test to enable an entity that is was not enabled by default or not."""
+    await mqtt_mock_entry()
+
+    discovery_topic = "homeassistant/sensor/bla/config"
+    config_disabled = json.json_dumps(
+        {
+            "name": None,
+            "state_topic": "state-topic",
+            "enabled_by_default": False,
+            "unique_id": "very_unique",
+            "default_entity_id": "sensor.test",
+            "device": {"identifiers": "very_unique_device", "name": "test"},
+        }
+    )
+    config_enabled = json.json_dumps(
+        {
+            "name": None,
+            "state_topic": "state-topic",
+            "enabled_by_default": True,
+            "unique_id": "very_unique",
+            "default_entity_id": "sensor.test",
+            "device": {"identifiers": "very_unique_device", "name": "test"},
+        }
+    )
+    config_enabled_new_entity_name = json.json_dumps(
+        {
+            "name": None,
+            "state_topic": "state-topic",
+            "enabled_by_default": True,
+            "unique_id": "very_unique",
+            "default_entity_id": "sensor.test_new",
+            "device": {"identifiers": "very_unique_device", "name": "test"},
+        }
+    )
+
+    async_fire_mqtt_message(hass, discovery_topic, config_disabled)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test")
+    assert state is None
+    entry = entity_registry.async_get("sensor.test")
+    assert entry is not None
+    assert entry.disabled
+    assert (device_id := entry.device_id)
+    assert device_registry.async_get(device_id) is not None
+
+    # Remove the entity and device
+    # At this stage no entry existsed during the initization
+    async_fire_mqtt_message(hass, discovery_topic, "")
+    await hass.async_block_till_done(wait_background_tasks=True)
+    entry = entity_registry.async_get("sensor.test")
+    assert entry is None
+    # Assert device is cleaned up
+    assert device_registry.async_get(device_id) is None
+
+    # Rediscover the previous deleted entity and allow it to be enabled
+    async_fire_mqtt_message(hass, discovery_topic, config_enabled)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    entry = entity_registry.async_get("sensor.test")
+    assert entry is not None
+    assert not entry.disabled
+    assert device_registry.async_get(device_id) is not None
+
+    # Update entity to not be enabled by default
+    # The entity should stay available as it was enabled before
+    async_fire_mqtt_message(hass, discovery_topic, config_disabled)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    entry = entity_registry.async_get("sensor.test")
+    assert entry is not None
+    assert not entry.disabled
+    assert device_registry.async_get(device_id) is not None
+
+    # Delete the entity again
+    async_fire_mqtt_message(hass, discovery_topic, "")
+    await hass.async_block_till_done(wait_background_tasks=True)
+    entry = entity_registry.async_get("sensor.test")
+    assert entry is None
+    # Assert device is cleaned up
+    assert device_registry.async_get(device_id) is None
+
+    # Repeat the re-discovery, with a new entity name
+    async_fire_mqtt_message(hass, discovery_topic, config_enabled_new_entity_name)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test_new")
+    assert state is not None
+    entry = entity_registry.async_get("sensor.test_new")
+    assert entry is not None
+    assert not entry.disabled
+    assert device_registry.async_get(device_id) is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -578,7 +578,7 @@ async def test_registry_enable_not_enabled_by_default_entity(
     assert device_registry.async_get(device_id) is not None
 
     # Remove the entity and device
-    # At this stage no entry existsed during the initization
+    # At this stage no entry existed during the initialization
     async_fire_mqtt_message(hass, discovery_topic, "")
     await hass.async_block_till_done(wait_background_tasks=True)
     entry = entity_registry.async_get("sensor.test")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT Entities that are added via MQTT discovery can be configured to be inititially disabled. As disabled entities are not loaded, they are not responding to updates, which is okay. A side effect is that once discovered, the entitie cannot be removed to alllow re-discovery. This PR fixes cleaning the entity and device registry when an empty configuration payload is sent to a discovered but disaabled entity. Also this allow an enabled re-discovery if `enabled_by_default` is `true`, a new `default_entity`_id` will be respected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
