### PR TITLE
Migrate Twente Milieu sensor unique IDs to snake_case and domainless

### DIFF
--- a/homeassistant/components/twentemilieu/__init__.py
+++ b/homeassistant/components/twentemilieu/__init__.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from typing import Any
 
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN, SENSOR_UNIQUE_ID_MIGRATION
 from .coordinator import TwenteMilieuConfigEntry, TwenteMilieuDataUpdateCoordinator
 
 PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
@@ -14,6 +18,21 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: TwenteMilieuConfigEntry
 ) -> bool:
     """Set up Twente Milieu from a config entry."""
+    old_prefix = f"{DOMAIN}_{entry.unique_id}_"
+
+    @callback
+    def _migrate_unique_id(
+        entity_entry: er.RegistryEntry,
+    ) -> dict[str, Any] | None:
+        if not entity_entry.unique_id.startswith(old_prefix):
+            return None
+        old_key = entity_entry.unique_id.removeprefix(old_prefix)
+        if (new_key := SENSOR_UNIQUE_ID_MIGRATION.get(old_key)) is None:
+            return None
+        return {"new_unique_id": f"{entry.unique_id}_{new_key}"}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _migrate_unique_id)
+
     coordinator = TwenteMilieuDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/twentemilieu/const.py
+++ b/homeassistant/components/twentemilieu/const.py
@@ -22,3 +22,11 @@ WASTE_TYPE_TO_DESCRIPTION = {
     WasteType.PAPER: "Paper waste pickup",
     WasteType.TREE: "Christmas tree pickup",
 }
+
+SENSOR_UNIQUE_ID_MIGRATION = {
+    "tree": "tree",
+    "Non-recyclable": "non_recyclable",
+    "Organic": "organic",
+    "Paper": "paper",
+    "Plastic": "packages",
+}

--- a/homeassistant/components/twentemilieu/sensor.py
+++ b/homeassistant/components/twentemilieu/sensor.py
@@ -12,11 +12,9 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import TwenteMilieuConfigEntry
 from .entity import TwenteMilieuEntity
 
@@ -36,25 +34,25 @@ SENSORS: tuple[TwenteMilieuSensorDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
     ),
     TwenteMilieuSensorDescription(
-        key="Non-recyclable",
+        key="non_recyclable",
         translation_key="non_recyclable_waste_pickup",
         waste_type=WasteType.NON_RECYCLABLE,
         device_class=SensorDeviceClass.DATE,
     ),
     TwenteMilieuSensorDescription(
-        key="Organic",
+        key="organic",
         translation_key="organic_waste_pickup",
         waste_type=WasteType.ORGANIC,
         device_class=SensorDeviceClass.DATE,
     ),
     TwenteMilieuSensorDescription(
-        key="Paper",
+        key="paper",
         translation_key="paper_waste_pickup",
         waste_type=WasteType.PAPER,
         device_class=SensorDeviceClass.DATE,
     ),
     TwenteMilieuSensorDescription(
-        key="Plastic",
+        key="packages",
         translation_key="packages_waste_pickup",
         waste_type=WasteType.PACKAGES,
         device_class=SensorDeviceClass.DATE,
@@ -86,7 +84,7 @@ class TwenteMilieuSensor(TwenteMilieuEntity, SensorEntity):
         """Initialize the Twente Milieu entity."""
         super().__init__(entry)
         self.entity_description = description
-        self._attr_unique_id = f"{DOMAIN}_{entry.data[CONF_ID]}_{description.key}"
+        self._attr_unique_id = f"{entry.unique_id}_{description.key}"
 
     @property
     def native_value(self) -> date | None:

--- a/tests/components/twentemilieu/snapshots/test_sensor.ambr
+++ b/tests/components/twentemilieu/snapshots/test_sensor.ambr
@@ -46,7 +46,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'christmas_tree_pickup',
-    'unique_id': 'twentemilieu_12345_tree',
+    'unique_id': '12345_tree',
     'unit_of_measurement': None,
   })
 # ---
@@ -128,7 +128,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'non_recyclable_waste_pickup',
-    'unique_id': 'twentemilieu_12345_Non-recyclable',
+    'unique_id': '12345_non_recyclable',
     'unit_of_measurement': None,
   })
 # ---
@@ -210,7 +210,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'organic_waste_pickup',
-    'unique_id': 'twentemilieu_12345_Organic',
+    'unique_id': '12345_organic',
     'unit_of_measurement': None,
   })
 # ---
@@ -292,7 +292,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'packages_waste_pickup',
-    'unique_id': 'twentemilieu_12345_Plastic',
+    'unique_id': '12345_packages',
     'unit_of_measurement': None,
   })
 # ---
@@ -374,7 +374,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'paper_waste_pickup',
-    'unique_id': 'twentemilieu_12345_Paper',
+    'unique_id': '12345_paper',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/twentemilieu/test_init.py
+++ b/tests/components/twentemilieu/test_init.py
@@ -5,8 +5,16 @@ from unittest.mock import MagicMock
 import pytest
 from twentemilieu import TwenteMilieuConnectionError, TwenteMilieuError
 
+from homeassistant.components.twentemilieu.const import (
+    CONF_HOUSE_LETTER,
+    CONF_HOUSE_NUMBER,
+    CONF_POST_CODE,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -47,3 +55,52 @@ async def test_config_entry_not_ready(
 
     assert mock_twentemilieu.update.call_count == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("mock_twentemilieu")
+async def test_migrate_unique_ids(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migration of sensor entity unique IDs."""
+    mock_config_entry = MockConfigEntry(
+        title="1234AB 1",
+        domain=DOMAIN,
+        data={
+            CONF_ID: 12345,
+            CONF_POST_CODE: "1234AB",
+            CONF_HOUSE_NUMBER: "1",
+            CONF_HOUSE_LETTER: "A",
+        },
+        unique_id="12345",
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    old_to_new_unique_ids = {
+        "twentemilieu_12345_tree": "12345_tree",
+        "twentemilieu_12345_Non-recyclable": "12345_non_recyclable",
+        "twentemilieu_12345_Organic": "12345_organic",
+        "twentemilieu_12345_Paper": "12345_paper",
+        "twentemilieu_12345_Plastic": "12345_packages",
+    }
+    for old_unique_id in old_to_new_unique_ids:
+        entity_registry.async_get_or_create(
+            domain="sensor",
+            platform=DOMAIN,
+            unique_id=old_unique_id,
+            config_entry=mock_config_entry,
+        )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    for old_unique_id, new_unique_id in old_to_new_unique_ids.items():
+        assert (
+            entity_registry.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
+        )
+        assert (
+            entity_registry.async_get_entity_id("sensor", DOMAIN, new_unique_id)
+            is not None
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Normalize sensor entity unique IDs to use consistent snake_case keys and drop the legacy domain prefix. Old unique IDs (e.g., `twentemilieu_12345_Non-recyclable`) are migrated automatically on setup to the new format (e.g., `12345_non_recyclable`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr