### PR TITLE
Add Broadlink infrared emitter support to native infrared platform

### DIFF
--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -6,6 +6,7 @@ DOMAIN = "broadlink"
 
 DOMAINS_AND_TYPES = {
     Platform.CLIMATE: {"HYS"},
+    Platform.INFRARED: {"RM4MINI", "RM4PRO", "RMMINI", "RMMINIB", "RMPRO"},
     Platform.LIGHT: {"LB1", "LB2"},
     Platform.REMOTE: {"RM4MINI", "RM4PRO", "RMMINI", "RMMINIB", "RMPRO"},
     Platform.SELECT: {"HYS"},
@@ -44,3 +45,6 @@ DEVICE_TYPES = set.union(*DOMAINS_AND_TYPES.values())
 
 DEFAULT_PORT = 80
 DEFAULT_TIMEOUT = 5
+
+# Broadlink IR packet format - repeat count byte offset
+IR_PACKET_REPEAT_INDEX = 1

--- a/homeassistant/components/broadlink/infrared.py
+++ b/homeassistant/components/broadlink/infrared.py
@@ -1,0 +1,184 @@
+"""Infrared platform for Broadlink remotes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from broadlink.exceptions import BroadlinkException
+from broadlink.remote import pulses_to_data as _bl_pulses_to_data
+import infrared_protocols
+
+from homeassistant.components.infrared import InfraredCommand, InfraredEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN, IR_PACKET_REPEAT_INDEX
+from .entity import BroadlinkEntity
+
+if TYPE_CHECKING:
+    from .device import BroadlinkDevice
+
+PARALLEL_UPDATES = 1
+
+
+class BroadlinkIRCommand(InfraredCommand):
+    """Raw IR command with optional Broadlink hardware repeat count.
+
+    This class lets you send raw timing data through a Broadlink infrared
+    entity. The repeat_count maps directly to the Broadlink packet repeat
+    byte: the device will re-transmit the entire IR burst that many
+    additional times after the first transmission.
+
+    Use this when you have existing Broadlink-encoded IR data (e.g. from
+    IR code databases like SmartIR) and want to use it with the new
+    infrared platform.
+
+    Protocol-aware commands (infrared_protocols.NECCommand, LgTVCommand,
+    etc.) manage repeats *inside* get_raw_timings() and should use the
+    default repeat=0. Only BroadlinkIRCommand should set hardware repeat.
+
+    Example: Migrating IR code database base64 codes to the infrared platform:
+
+        import base64
+        from broadlink.remote import data_to_pulses
+        from homeassistant.components.broadlink.infrared import BroadlinkIRCommand
+        from homeassistant.components.broadlink.const import IR_PACKET_REPEAT_INDEX
+
+        # Decode base64 IR code (e.g. from IR code database)
+        packet_data = base64.b64decode(b64_code)
+        repeat_count = packet_data[IR_PACKET_REPEAT_INDEX]
+
+        # Parse Broadlink packet to microsecond timings
+        pulses = data_to_pulses(packet_data)
+        timings = list(zip(pulses[::2], pulses[1::2]))
+        if len(pulses) % 2:
+            timings.append((pulses[-1], 0))
+
+        # Create command
+        cmd = BroadlinkIRCommand(timings, repeat_count=repeat_count)
+        await infrared.async_send_command(hass, entity_id, cmd)
+    """
+
+    # Standard IR carrier frequency. Broadlink hardware handles the carrier
+    # internally, so this value is informational only.
+    MODULATION = 38000
+
+    def __init__(
+        self,
+        timings: list[tuple[int, int]],
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize with timing pairs and optional repeat count.
+
+        Args:
+            timings: List of (mark_us, space_us) pairs in microseconds.
+            repeat_count: Broadlink hardware repeat count (0 = send once).
+                Must be 0–255 (the hardware repeat byte is a single unsigned byte).
+
+        Raises:
+            ValueError: If repeat_count is outside 0–255 range.
+        """
+        if not 0 <= repeat_count <= 255:
+            raise ValueError(f"repeat_count must be 0–255, got {repeat_count}")
+        super().__init__(modulation=self.MODULATION, repeat_count=repeat_count)
+        self._timings = [
+            infrared_protocols.Timing(high_us=high, low_us=low) for high, low in timings
+        ]
+
+    def get_raw_timings(self) -> list[infrared_protocols.Timing]:
+        """Return timing pairs for transmission."""
+        return self._timings
+
+
+def timings_to_broadlink_packet(
+    timings: list[tuple[int, int]],
+    repeat: int = 0,
+) -> bytes:
+    """Convert raw timing pairs (high_us, low_us) to a Broadlink IR packet.
+
+    Args:
+        timings: List of (mark_us, space_us) pairs in microseconds.
+        repeat: Number of extra repeats (0 = send once).
+
+    Returns:
+        Binary packet ready for Broadlink send_data().
+
+    """
+    if not 0 <= repeat <= 255:
+        raise ValueError(f"repeat must be 0–255, got {repeat}")
+
+    # Flatten (mark, space) pairs into a pulse list, omitting any zero-length spaces
+    pulses: list[int] = []
+    for high_us, low_us in timings:
+        pulses.append(high_us)
+        if low_us:
+            pulses.append(low_us)
+
+    # Use broadlink library's encoder (tick=32.84 µs)
+    packet = bytearray(_bl_pulses_to_data(pulses))
+    packet[IR_PACKET_REPEAT_INDEX] = repeat
+    return bytes(packet)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Broadlink infrared entity."""
+    device = hass.data[DOMAIN].devices[config_entry.entry_id]
+    async_add_entities([BroadlinkInfraredEntity(device)])
+
+
+class BroadlinkInfraredEntity(BroadlinkEntity, InfraredEntity):
+    """Broadlink infrared transmitter entity."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "infrared"
+
+    def __init__(self, device: BroadlinkDevice) -> None:
+        """Initialize the entity."""
+        super().__init__(device)
+        self._attr_unique_id = f"{device.unique_id}-infrared"
+
+    async def async_send_command(self, command: InfraredCommand) -> None:
+        """Send an IR command via the Broadlink device.
+
+        Handles two types of repeat behavior:
+
+        1. Protocol-aware commands (NECCommand, etc.): These encode repeats
+           (like NEC repeat codes) inside their get_raw_timings() data. The
+           Broadlink packet is sent with repeat=0.
+
+        2. BroadlinkIRCommand: Carries Broadlink hardware repeat count,
+           which tells the device to re-transmit the entire burst N times.
+           This is used for protocols/commands that need multiple full frame
+           transmissions (e.g. legacy SmartIR data).
+
+        Using isinstance check ensures protocol-level repeats (already in
+        timing data) don't get conflated with hardware repeats.
+        """
+        timings = [
+            (timing.high_us, timing.low_us) for timing in command.get_raw_timings()
+        ]
+
+        # Only BroadlinkIRCommand uses Broadlink hardware repeat. Protocol-aware
+        # commands (NECCommand, etc.) encode repeats inside get_raw_timings()
+        # and must use hardware repeat=0 to avoid double-repeating.
+        if isinstance(command, BroadlinkIRCommand):
+            repeat = command.repeat_count
+        else:
+            repeat = 0
+
+        packet = timings_to_broadlink_packet(timings, repeat=repeat)
+
+        try:
+            await self._device.async_request(self._device.api.send_data, packet)
+        except (BroadlinkException, OSError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_command_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/broadlink/manifest.json
+++ b/homeassistant/components/broadlink/manifest.json
@@ -3,6 +3,7 @@
   "name": "Broadlink",
   "codeowners": ["@danielhiversen", "@felipediel", "@L-I-Am", "@eifinger"],
   "config_flow": true,
+  "dependencies": ["infrared"],
   "dhcp": [
     {
       "registered_devices": true

--- a/homeassistant/components/broadlink/strings.json
+++ b/homeassistant/components/broadlink/strings.json
@@ -49,6 +49,11 @@
     }
   },
   "entity": {
+    "infrared": {
+      "infrared": {
+        "name": "IR transmitter"
+      }
+    },
     "select": {
       "day_of_week": {
         "name": "Day of week",
@@ -76,6 +81,11 @@
       "total_consumption": {
         "name": "Total consumption"
       }
+    }
+  },
+  "exceptions": {
+    "send_command_failed": {
+      "message": "Failed to send IR command: {error}"
     }
   }
 }

--- a/tests/components/broadlink/test_infrared.py
+++ b/tests/components/broadlink/test_infrared.py
@@ -1,0 +1,161 @@
+"""Tests for Broadlink infrared platform."""
+
+import pytest
+
+from homeassistant.components.broadlink.const import IR_PACKET_REPEAT_INDEX
+from homeassistant.components.broadlink.infrared import (
+    BroadlinkIRCommand,
+    timings_to_broadlink_packet,
+)
+
+# Test-only constants for Broadlink IR packet format
+IR_PACKET_TYPE = 0x26  # IR data packet type byte
+IR_PACKET_PAYLOAD_OFFSET = 4  # Byte offset where payload starts
+
+# NEC IR protocol timings (microseconds)
+NEC_HEADER_MARK_US = 9000
+NEC_HEADER_SPACE_US = 4500
+NEC_BIT_MARK_US = 562
+NEC_ONE_SPACE_US = 1687
+NEC_ZERO_SPACE_US = 562
+
+
+def test_packet_header() -> None:
+    """Test IR type byte, repeat, and length fields."""
+    timings = [(NEC_HEADER_MARK_US, NEC_HEADER_SPACE_US)]
+    packet = timings_to_broadlink_packet(timings, repeat=0)
+
+    assert packet[0] == IR_PACKET_TYPE
+    assert packet[1] == 0  # no repeat
+
+    payload_len = packet[2] | (packet[3] << 8)
+    assert payload_len == len(packet) - IR_PACKET_PAYLOAD_OFFSET
+
+
+def test_packet_ends_with_silence() -> None:
+    """Test packet structure is well-formed."""
+    timings = [(NEC_BIT_MARK_US, NEC_ZERO_SPACE_US)]
+    packet = timings_to_broadlink_packet(timings)
+    assert packet[0] == IR_PACKET_TYPE
+    assert len(packet) >= IR_PACKET_PAYLOAD_OFFSET  # header + minimum payload
+
+
+def test_packet_repeat_count() -> None:
+    """Test repeat count is set."""
+    timings = [(NEC_BIT_MARK_US, NEC_ZERO_SPACE_US)]
+    packet = timings_to_broadlink_packet(timings, repeat=2)
+    assert packet[IR_PACKET_REPEAT_INDEX] == 2
+
+
+def test_packet_repeat_out_of_range() -> None:
+    """Test that out-of-range repeat raises ValueError."""
+    timings = [(NEC_BIT_MARK_US, NEC_ZERO_SPACE_US)]
+    with pytest.raises(ValueError, match="repeat must be 0"):
+        timings_to_broadlink_packet(timings, repeat=-1)
+    with pytest.raises(ValueError, match="repeat must be 0"):
+        timings_to_broadlink_packet(timings, repeat=256)
+
+
+def test_packet_nec_header_encoding() -> None:
+    """Test that a NEC header encodes correctly."""
+    timings = [(NEC_HEADER_MARK_US, NEC_HEADER_SPACE_US)]
+    packet = timings_to_broadlink_packet(timings)
+
+    # Skip packet header to get encoded payload
+    data = packet[IR_PACKET_PAYLOAD_OFFSET:]
+
+    # 9000µs → 274 (>255 → 3 bytes: 0x00, 0x01, 0x12)
+    assert data[0] == 0x00
+    assert data[1] == 0x01
+    assert data[2] == 0x12
+
+    # 4500µs → 137 (<=255 → 1 byte)
+    assert data[3] == 0x89
+
+
+def test_packet_known_nec_command() -> None:
+    """Encode a full NEC power command and verify it's well-formed."""
+    nec_timings: list[tuple[int, int]] = [(NEC_HEADER_MARK_US, NEC_HEADER_SPACE_US)]
+    for bit in (
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,  # address
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,  # ~address
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,  # command
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,  # ~command
+    ):
+        if bit:
+            nec_timings.append((NEC_BIT_MARK_US, NEC_ONE_SPACE_US))
+        else:
+            nec_timings.append((NEC_BIT_MARK_US, NEC_ZERO_SPACE_US))
+    nec_timings.append((NEC_BIT_MARK_US, 0))  # stop bit
+
+    packet = timings_to_broadlink_packet(nec_timings)
+
+    assert packet[0] == IR_PACKET_TYPE
+    assert len(packet) > 10
+
+
+def test_broadlink_ir_command_basic() -> None:
+    """Test BroadlinkIRCommand initialization and interface."""
+    timings = [(500, 500), (500, 1000), (NEC_BIT_MARK_US, NEC_ZERO_SPACE_US)]
+    cmd = BroadlinkIRCommand(timings, repeat_count=3)
+
+    assert cmd.repeat_count == 3
+    raw_timings = cmd.get_raw_timings()
+    assert len(raw_timings) == 3
+    assert raw_timings[0].high_us == 500
+    assert raw_timings[0].low_us == 500
+    assert raw_timings[2].high_us == NEC_BIT_MARK_US
+    assert raw_timings[2].low_us == NEC_ZERO_SPACE_US
+
+
+def test_broadlink_ir_command_default_repeat() -> None:
+    """Test BroadlinkIRCommand defaults to repeat=0."""
+    timings = [(500, 500)]
+    cmd = BroadlinkIRCommand(timings)
+
+    assert cmd.repeat_count == 0
+
+
+def test_broadlink_ir_command_invalid_repeat() -> None:
+    """Test that BroadlinkIRCommand raises ValueError for out-of-range repeat_count."""
+    timings = [(500, 500)]
+
+    # Test negative repeat count
+    with pytest.raises(ValueError, match="repeat_count must be 0–255"):
+        BroadlinkIRCommand(timings, repeat_count=-1)
+
+    # Test repeat count > 255
+    with pytest.raises(ValueError, match="repeat_count must be 0–255"):
+        BroadlinkIRCommand(timings, repeat_count=256)
+
+    # Test boundary cases that should work
+    BroadlinkIRCommand(timings, repeat_count=0)  # Should not raise
+    BroadlinkIRCommand(timings, repeat_count=255)  # Should not raise


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds infrared transmitter support for Broadlink RM devices (RM4MINI, RM4PRO, RMMINI, RMMINIB, RMPRO) to Home Assistant's native **infrared** platform. This enables standardized IR command handling for Broadlink remotes alongside other IR transmitters.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


### Key implementation details:

- **BroadlinkIRCommand** class extends InfraredCommand for raw Broadlink IR data with hardware repeat counts
- Proper distinction between protocol-level repeats (e.g., NEC repeat codes in timing data) and Broadlink hardware repeats via `isinstance()` check
- Integration with broadlink library's `pulses_to_data()` for accurate microsecond ↔ Broadlink timing unit conversion (32.84 µs per tick)
- Support for both protocol-aware commands (NECCommand, LgTVCommand) and legacy Broadlink-encoded data
- BroadlinkInfraredEntity implements async_send_command() with automatic repeat handling logic

### Example usage - migrating SmartIR Broadlink codes:

```python
import base64
from broadlink.remote import data_to_pulses
from homeassistant.components.broadlink.infrared import BroadlinkIRCommand

# Decode SmartIR base64 code
packet_data = base64.b64decode(b64_code)
repeat_count = packet_data[1]

# Parse to microsecond timings
pulses = data_to_pulses(packet_data)
timings = list(zip(pulses[::2], pulses[1::2]))
if len(pulses) % 2:
    timings.append((pulses[-1], 0))

# Send via infrared platform
cmd = BroadlinkIRCommand(timings, repeat_count=repeat_count)
await infrared.async_send_command(hass, entity_id, cmd)
```

- Tested on: TCL 49C2US TV via Broadlink RM4 remote (power, volume, source commands verified working)

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/44810
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
