### PR TITLE
refactor(hassio): store aiohasupervisor models directly in hass.data using typed HassKey

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -76,7 +76,6 @@ from .auth import async_setup_auth_view
 from .config import HassioConfig
 from .const import (
     ADDONS_COORDINATOR,
-    ATTR_REPOSITORIES,
     DATA_ADDONS_LIST,
     DATA_COMPONENT,
     DATA_CONFIG_STORE,
@@ -343,21 +342,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         except SupervisorError as err:
             _LOGGER.warning("Can't read Supervisor data: %s", err)
         else:
-            hass.data[DATA_INFO] = root_info.to_dict()
-            hass.data[DATA_HOST_INFO] = host_info.to_dict()
-            hass.data[DATA_STORE] = store_info.to_dict()
-            hass.data[DATA_CORE_INFO] = homeassistant_info.to_dict()
-            hass.data[DATA_SUPERVISOR_INFO] = supervisor_info.to_dict()
-            hass.data[DATA_OS_INFO] = os_info.to_dict()
-            hass.data[DATA_NETWORK_INFO] = network_info.to_dict()
-            hass.data[DATA_ADDONS_LIST] = [addon.to_dict() for addon in addons_list]
-
-            # Deprecated 2026.4.0: Folding repositories and addons.list results into supervisor_info for compatibility
-            # Can drop this after removal period
-            hass.data[DATA_SUPERVISOR_INFO]["repositories"] = hass.data[DATA_STORE][
-                ATTR_REPOSITORIES
-            ]
-            hass.data[DATA_SUPERVISOR_INFO]["addons"] = hass.data[DATA_ADDONS_LIST]
+            hass.data[DATA_INFO] = root_info
+            hass.data[DATA_HOST_INFO] = host_info
+            hass.data[DATA_STORE] = store_info
+            hass.data[DATA_CORE_INFO] = homeassistant_info
+            hass.data[DATA_SUPERVISOR_INFO] = supervisor_info
+            hass.data[DATA_OS_INFO] = os_info
+            hass.data[DATA_NETWORK_INFO] = network_info
+            hass.data[DATA_ADDONS_LIST] = addons_list
 
     # Fetch data
     update_info_task = hass.async_create_task(update_info_data(), eager_start=True)

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -9,8 +9,25 @@ from typing import TYPE_CHECKING
 from homeassistant.util.hass_dict import HassKey
 
 if TYPE_CHECKING:
+    from aiohasupervisor.models import (
+        HomeAssistantInfo,
+        HostInfo,
+        InstalledAddon,
+        NetworkInfo,
+        OSInfo,
+        RootInfo,
+        StoreInfo,
+        SupervisorInfo,
+    )
+
     from .config import HassioConfig
+    from .coordinator import (
+        HassioAddOnDataUpdateCoordinator,
+        HassioMainDataUpdateCoordinator,
+        HassioStatsDataUpdateCoordinator,
+    )
     from .handler import HassIO
+    from .issues import SupervisorIssues
 
 
 DOMAIN = "hassio"
@@ -77,25 +94,31 @@ EVENT_JOB = "job"
 UPDATE_KEY_SUPERVISOR = "supervisor"
 STARTUP_COMPLETE = "complete"
 
-MAIN_COORDINATOR = "hassio_main_coordinator"
-ADDONS_COORDINATOR = "hassio_addons_coordinator"
-STATS_COORDINATOR = "hassio_stats_coordinator"
+MAIN_COORDINATOR: HassKey[HassioMainDataUpdateCoordinator] = HassKey(
+    "hassio_main_coordinator"
+)
+ADDONS_COORDINATOR: HassKey[HassioAddOnDataUpdateCoordinator] = HassKey(
+    "hassio_addons_coordinator"
+)
+STATS_COORDINATOR: HassKey[HassioStatsDataUpdateCoordinator] = HassKey(
+    "hassio_stats_coordinator"
+)
 
 
 DATA_COMPONENT: HassKey[HassIO] = HassKey(DOMAIN)
 DATA_CONFIG_STORE: HassKey[HassioConfig] = HassKey("hassio_config_store")
-DATA_CORE_INFO = "hassio_core_info"
+DATA_CORE_INFO: HassKey[HomeAssistantInfo] = HassKey("hassio_core_info")
 DATA_CORE_STATS = "hassio_core_stats"
-DATA_HOST_INFO = "hassio_host_info"
-DATA_STORE = "hassio_store"
-DATA_INFO = "hassio_info"
-DATA_OS_INFO = "hassio_os_info"
-DATA_NETWORK_INFO = "hassio_network_info"
-DATA_SUPERVISOR_INFO = "hassio_supervisor_info"
+DATA_HOST_INFO: HassKey[HostInfo] = HassKey("hassio_host_info")
+DATA_STORE: HassKey[StoreInfo] = HassKey("hassio_store")
+DATA_INFO: HassKey[RootInfo] = HassKey("hassio_info")
+DATA_OS_INFO: HassKey[OSInfo] = HassKey("hassio_os_info")
+DATA_NETWORK_INFO: HassKey[NetworkInfo] = HassKey("hassio_network_info")
+DATA_SUPERVISOR_INFO: HassKey[SupervisorInfo] = HassKey("hassio_supervisor_info")
 DATA_SUPERVISOR_STATS = "hassio_supervisor_stats"
 DATA_ADDONS_INFO = "hassio_addons_info"
 DATA_ADDONS_STATS = "hassio_addons_stats"
-DATA_ADDONS_LIST = "hassio_addons_list"
+DATA_ADDONS_LIST: HassKey[list[InstalledAddon]] = HassKey("hassio_addons_list")
 HASSIO_MAIN_UPDATE_INTERVAL = timedelta(minutes=5)
 HASSIO_ADDON_UPDATE_INTERVAL = timedelta(minutes=15)
 HASSIO_STATS_UPDATE_INTERVAL = timedelta(seconds=60)
@@ -118,7 +141,7 @@ DATA_KEY_OS = "os"
 DATA_KEY_SUPERVISOR = "supervisor"
 DATA_KEY_CORE = "core"
 DATA_KEY_HOST = "host"
-DATA_KEY_SUPERVISOR_ISSUES = "supervisor_issues"
+DATA_KEY_SUPERVISOR_ISSUES: HassKey[SupervisorIssues] = HassKey("supervisor_issues")
 DATA_KEY_MOUNTS = "mounts"
 
 PLACEHOLDER_KEY_ADDON = "addon"

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -665,6 +665,9 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         client = self.supervisor_client
 
         try:
+            # Cast is required here because asyncio.gather only has overloads to
+            # maintain typing for 6 arguments. It falls back to list[<common parent>]
+            # after that which is what mypy sees here since we have 7 API calls.
             (
                 info,
                 core_info,

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -7,16 +7,22 @@ from collections import defaultdict
 from collections.abc import Awaitable
 from copy import deepcopy
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from aiohasupervisor import SupervisorError, SupervisorNotFoundError
 from aiohasupervisor.models import (
     AddonState,
     CIFSMountResponse,
+    HomeAssistantInfo,
+    HostInfo,
     InstalledAddon,
+    NetworkInfo,
     NFSMountResponse,
+    OSInfo,
     ResponseData,
+    RootInfo,
     StoreInfo,
+    SupervisorInfo,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -78,7 +84,8 @@ def get_info(hass: HomeAssistant) -> dict[str, Any] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_INFO)
+    info = hass.data.get(DATA_INFO)
+    return info.to_dict() if info is not None else None
 
 
 @callback
@@ -87,7 +94,8 @@ def get_host_info(hass: HomeAssistant) -> dict[str, Any] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_HOST_INFO)
+    info = hass.data.get(DATA_HOST_INFO)
+    return info.to_dict() if info is not None else None
 
 
 @callback
@@ -96,7 +104,8 @@ def get_store(hass: HomeAssistant) -> dict[str, Any] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_STORE)
+    info = hass.data.get(DATA_STORE)
+    return info.to_dict() if info is not None else None
 
 
 @callback
@@ -105,7 +114,17 @@ def get_supervisor_info(hass: HomeAssistant) -> dict[str, Any] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_SUPERVISOR_INFO)
+    info = hass.data.get(DATA_SUPERVISOR_INFO)
+    if info is None:
+        return None
+    result = info.to_dict()
+    # Deprecated 2026.4.0: Folding repositories and addons into supervisor_info
+    # for backwards compatibility. Can be removed after deprecation period.
+    if (store := hass.data.get(DATA_STORE)) is not None:
+        result[ATTR_REPOSITORIES] = [repo.to_dict() for repo in store.repositories]
+    if (addons_list := hass.data.get(DATA_ADDONS_LIST)) is not None:
+        result["addons"] = [addon.to_dict() for addon in addons_list]
+    return result
 
 
 @callback
@@ -114,7 +133,8 @@ def get_network_info(hass: HomeAssistant) -> dict[str, Any] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_NETWORK_INFO)
+    info = hass.data.get(DATA_NETWORK_INFO)
+    return info.to_dict() if info is not None else None
 
 
 @callback
@@ -132,7 +152,8 @@ def get_addons_list(hass: HomeAssistant) -> list[dict[str, Any]] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_ADDONS_LIST)
+    addons = hass.data.get(DATA_ADDONS_LIST)
+    return [addon.to_dict() for addon in addons] if addons is not None else None
 
 
 @callback
@@ -168,7 +189,8 @@ def get_os_info(hass: HomeAssistant) -> dict[str, Any] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_OS_INFO)
+    info = hass.data.get(DATA_OS_INFO)
+    return info.to_dict() if info is not None else None
 
 
 @callback
@@ -177,7 +199,8 @@ def get_core_info(hass: HomeAssistant) -> dict[str, Any] | None:
 
     Async friendly.
     """
-    return hass.data.get(DATA_CORE_INFO)
+    info = hass.data.get(DATA_CORE_INFO)
+    return info.to_dict() if info is not None else None
 
 
 @callback
@@ -359,11 +382,11 @@ class HassioStatsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data[key] = result.to_dict()
 
         # Fetch addon stats
-        addons_list = get_addons_list(self.hass) or []
+        addons_list: list[InstalledAddon] = self.hass.data.get(DATA_ADDONS_LIST) or []
         started_addons = {
-            addon[ATTR_SLUG]
+            addon.slug
             for addon in addons_list
-            if addon.get("state") in {AddonState.STARTED, AddonState.STARTUP}
+            if addon.state in {AddonState.STARTED, AddonState.STARTUP}
         }
 
         addons_stats: dict[str, Any] = data.setdefault(DATA_ADDONS_STATS, {})
@@ -469,31 +492,23 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Error on Supervisor API: {err}") from err
 
         # Update hass.data for legacy accessor functions
-        data = self.hass.data
-        addons_list_dicts = [addon.to_dict() for addon in installed_addons]
-        data[DATA_ADDONS_LIST] = addons_list_dicts
+        self.hass.data[DATA_ADDONS_LIST] = installed_addons
 
         # Update addon info cache in hass.data
+        data = self.hass.data
         addon_info_cache: dict[str, Any] = data.setdefault(DATA_ADDONS_INFO, {})
         for slug in addon_info_cache.keys() - all_addons:
             del addon_info_cache[slug]
         addon_info_cache.update(addon_info_results)
 
-        # Deprecated 2026.4.0: Folding addons.list results into supervisor_info
-        # for compatibility. Written to hass.data only, not coordinator data.
-        if DATA_SUPERVISOR_INFO in data:
-            data[DATA_SUPERVISOR_INFO]["addons"] = addons_list_dicts
-
         # Build clean coordinator data
-        store_data = get_store(self.hass)
-        if store_data:
-            repositories = {
-                repo.slug: repo.name
-                for repo in StoreInfo.from_dict(store_data).repositories
-            }
+        store = self.hass.data.get(DATA_STORE)
+        if store:
+            repositories = {repo.slug: repo.name for repo in store.repositories}
         else:
             repositories = {}
 
+        addons_list_dicts = [addon.to_dict() for addon in installed_addons]
         new_data: dict[str, Any] = {}
         new_data[DATA_KEY_ADDONS] = {
             (slug := addon[ATTR_SLUG]): {
@@ -635,7 +650,10 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.entry_id = config_entry.entry_id
         self.dev_reg = dev_reg
-        self.is_hass_os = (get_info(self.hass) or {}).get("hassos") is not None
+        if info := self.hass.data.get(DATA_INFO):
+            self.is_hass_os = info.hassos is not None
+        else:
+            self.is_hass_os = False
         self.supervisor_client = get_supervisor_client(hass)
         self.jobs = SupervisorJobs(hass)
 
@@ -653,14 +671,25 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 host_info,
                 store_info,
                 network_info,
-            ) = await asyncio.gather(
-                client.info(),
-                client.homeassistant.info(),
-                client.supervisor.info(),
-                client.os.info(),
-                client.host.info(),
-                client.store.info(),
-                client.network.info(),
+            ) = cast(
+                tuple[
+                    RootInfo,
+                    HomeAssistantInfo,
+                    SupervisorInfo,
+                    OSInfo,
+                    HostInfo,
+                    StoreInfo,
+                    NetworkInfo,
+                ],
+                await asyncio.gather(
+                    client.info(),
+                    client.homeassistant.info(),
+                    client.supervisor.info(),
+                    client.os.info(),
+                    client.host.info(),
+                    client.store.info(),
+                    client.network.info(),
+                ),
             )
             mounts_info = await client.mounts.info()
             await self.jobs.refresh_data(is_first_update)
@@ -677,23 +706,13 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             new_data[DATA_KEY_OS] = os_info.to_dict()
 
         # Update hass.data for legacy accessor functions
-        data = self.hass.data
-        data[DATA_INFO] = info.to_dict()
-        data[DATA_CORE_INFO] = new_data[DATA_KEY_CORE]
-        data[DATA_OS_INFO] = new_data.get(DATA_KEY_OS, os_info.to_dict())
-        data[DATA_HOST_INFO] = new_data[DATA_KEY_HOST]
-        data[DATA_STORE] = store_info.to_dict()
-        data[DATA_NETWORK_INFO] = network_info.to_dict()
-        # Separate dict for hass.data supervisor info since we add deprecated
-        # compat keys that should not be in coordinator data
-        supervisor_info_dict = supervisor_info.to_dict()
-        # Deprecated 2026.4.0: Folding repositories and addons into
-        # supervisor_info for compatibility. Written to hass.data only, not
-        # coordinator data. Preserve the addons key from the addon coordinator.
-        supervisor_info_dict["repositories"] = data[DATA_STORE][ATTR_REPOSITORIES]
-        if (prev := data.get(DATA_SUPERVISOR_INFO)) and "addons" in prev:
-            supervisor_info_dict["addons"] = prev["addons"]
-        data[DATA_SUPERVISOR_INFO] = supervisor_info_dict
+        self.hass.data[DATA_INFO] = info
+        self.hass.data[DATA_CORE_INFO] = core_info
+        self.hass.data[DATA_OS_INFO] = os_info
+        self.hass.data[DATA_HOST_INFO] = host_info
+        self.hass.data[DATA_STORE] = store_info
+        self.hass.data[DATA_NETWORK_INFO] = network_info
+        self.hass.data[DATA_SUPERVISOR_INFO] = supervisor_info
 
         # If this is the initial refresh, register all main components
         if is_first_update:

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -34,6 +34,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    ATTR_ADDONS,
     ATTR_AUTO_UPDATE,
     ATTR_REPOSITORIES,
     ATTR_REPOSITORY,
@@ -123,7 +124,7 @@ def get_supervisor_info(hass: HomeAssistant) -> dict[str, Any] | None:
     if (store := hass.data.get(DATA_STORE)) is not None:
         result[ATTR_REPOSITORIES] = [repo.to_dict() for repo in store.repositories]
     if (addons_list := hass.data.get(DATA_ADDONS_LIST)) is not None:
-        result["addons"] = [addon.to_dict() for addon in addons_list]
+        result[ATTR_ADDONS] = [addon.to_dict() for addon in addons_list]
     return result
 
 
@@ -495,8 +496,9 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.hass.data[DATA_ADDONS_LIST] = installed_addons
 
         # Update addon info cache in hass.data
-        data = self.hass.data
-        addon_info_cache: dict[str, Any] = data.setdefault(DATA_ADDONS_INFO, {})
+        addon_info_cache: dict[str, Any] = self.hass.data.setdefault(
+            DATA_ADDONS_INFO, {}
+        )
         for slug in addon_info_cache.keys() - all_addons:
             del addon_info_cache[slug]
         addon_info_cache.update(addon_info_results)

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -38,6 +38,7 @@ from homeassistant.components.hassio import (
     ADDONS_COORDINATOR,
     DOMAIN,
     get_core_info,
+    get_supervisor_info,
     hostname_from_addon_slug,
 )
 from homeassistant.components.hassio.config import STORAGE_KEY
@@ -1502,3 +1503,22 @@ async def test_mount_reload_selector_matches_device_name(
         ]
         == device.model
     )
+
+
+@pytest.mark.usefixtures("mock_all")
+async def test_get_supervisor_info(hass: HomeAssistant) -> None:
+    """Test get_supervisor_info returns a dict with backwards-compat keys."""
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = get_supervisor_info(hass)
+    assert isinstance(result, dict)
+    # Deprecated backwards-compat keys folded in from store/addons data
+    assert "repositories" in result
+    assert isinstance(result["repositories"], list)
+    assert "addons" in result
+    assert isinstance(result["addons"], list)
+    assert all(isinstance(addon, dict) for addon in result["addons"])

--- a/tests/components/hassio/test_system_health.py
+++ b/tests/components/hassio/test_system_health.py
@@ -1,12 +1,39 @@
 """Test hassio system health."""
 
 import asyncio
+from ipaddress import IPv4Address, IPv4Network
 import os
 from unittest.mock import patch
 
+from aiohasupervisor.models import (
+    AddonStage,
+    AddonState,
+    DockerNetwork,
+    HostInfo,
+    InstalledAddon,
+    InterfaceMethod,
+    InterfaceType,
+    IPv4,
+    LogLevel,
+    NetworkInfo,
+    NetworkInterface,
+    OSInfo,
+    RootInfo,
+    SupervisorInfo,
+    SupervisorState,
+    UpdateChannel,
+)
 from aiohttp import ClientError
 import pytest
 
+from homeassistant.components.hassio.const import (
+    DATA_ADDONS_LIST,
+    DATA_HOST_INFO,
+    DATA_INFO,
+    DATA_NETWORK_INFO,
+    DATA_OS_INFO,
+    DATA_SUPERVISOR_INFO,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -30,47 +57,151 @@ async def test_hassio_system_health(
     assert await async_setup_component(hass, "system_health", {})
     await hass.async_block_till_done()
 
-    hass.data["hassio_info"] = {
-        "channel": "stable",
-        "supervisor": "2020.11.1",
-        "docker": "19.0.3",
-        "hassos": True,
-    }
-    hass.data["hassio_host_info"] = {
-        "operating_system": "Home Assistant OS 5.9",
-        "agent_version": "1337",
-        "disk_total": "32.0",
-        "disk_used": "30.0",
-        "dt_synchronized": True,
-        "virtualization": "qemu",
-    }
-    hass.data["hassio_os_info"] = {"board": "odroid-n2"}
-    hass.data["hassio_supervisor_info"] = {
-        "healthy": True,
-        "supported": True,
-    }
-    hass.data["hassio_addons_info"] = {
-        "test": {
-            "name": "Awesome Addon",
-            "slug": "test",
-            "version": "1.0.0",
-        }
-    }
-    hass.data["hassio_addons_list"] = [
-        {
-            "slug": "test",
-            "name": "Awesome Addon",
-            "version": "1.0.0",
-        }
+    hass.data[DATA_INFO] = RootInfo(
+        supervisor="2020.11.1",
+        homeassistant=None,
+        hassos="5.9",
+        docker="19.0.3",
+        hostname=None,
+        operating_system=None,
+        features=[],
+        machine=None,
+        machine_id=None,
+        arch="aarch64",
+        state=SupervisorState.RUNNING,
+        supported_arch=[],
+        supported=True,
+        channel=UpdateChannel.STABLE,
+        logging=LogLevel.INFO,
+        timezone="Etc/UTC",
+    )
+    hass.data[DATA_HOST_INFO] = HostInfo(
+        agent_version="1337",
+        apparmor_version=None,
+        chassis="vm",
+        virtualization="qemu",
+        cpe=None,
+        deployment=None,
+        disk_free=1.6,
+        disk_total=32.0,
+        disk_used=30.0,
+        disk_life_time=None,
+        features=[],
+        hostname=None,
+        llmnr_hostname=None,
+        kernel="4.19.0",
+        operating_system="Home Assistant OS 5.9",
+        timezone=None,
+        dt_utc=None,
+        dt_synchronized=True,
+        use_ntp=None,
+        startup_time=None,
+        boot_timestamp=None,
+        broadcast_llmnr=None,
+        broadcast_mdns=None,
+    )
+    hass.data[DATA_OS_INFO] = OSInfo(
+        version="5.9",
+        version_latest="5.9",
+        update_available=False,
+        board="odroid-n2",
+        boot=None,
+        data_disk=None,
+        boot_slots={},
+    )
+    hass.data[DATA_SUPERVISOR_INFO] = SupervisorInfo(
+        version="1.0.0",
+        version_latest="1.0.0",
+        update_available=False,
+        channel=UpdateChannel.STABLE,
+        arch="aarch64",
+        supported=True,
+        healthy=True,
+        ip_address=IPv4Address("172.30.32.2"),
+        timezone=None,
+        logging=LogLevel.INFO,
+        debug=False,
+        debug_block=False,
+        diagnostics=None,
+        auto_update=True,
+        country=None,
+        detect_blocking_io=False,
+    )
+    hass.data[DATA_ADDONS_LIST] = [
+        InstalledAddon(
+            detached=False,
+            advanced=False,
+            available=True,
+            build=False,
+            description="",
+            homeassistant=None,
+            icon=False,
+            logo=False,
+            name="Awesome Addon",
+            repository="core",
+            slug="test",
+            stage=AddonStage.STABLE,
+            update_available=False,
+            url=None,
+            version_latest="1.0.0",
+            version="1.0.0",
+            state=AddonState.STARTED,
+        )
     ]
-    hass.data["hassio_network_info"] = {
-        "host_internet": True,
-        "supervisor_internet": True,
-        "interfaces": [
-            {"primary": False, "ipv4": {"nameservers": ["9.9.9.9"]}},
-            {"primary": True, "ipv4": {"nameservers": ["1.1.1.1"]}},
+    hass.data[DATA_NETWORK_INFO] = NetworkInfo(
+        interfaces=[
+            NetworkInterface(
+                interface="eth0",
+                type=InterfaceType.ETHERNET,
+                enabled=True,
+                connected=True,
+                primary=False,
+                mac="aa:bb:cc:dd:ee:01",
+                ipv4=IPv4(
+                    method=InterfaceMethod.AUTO,
+                    ready=True,
+                    address=[],
+                    nameservers=[IPv4Address("9.9.9.9")],
+                    gateway=None,
+                    route_metric=None,
+                ),
+                ipv6=None,
+                wifi=None,
+                vlan=None,
+                mdns=None,
+                llmnr=None,
+            ),
+            NetworkInterface(
+                interface="eth1",
+                type=InterfaceType.ETHERNET,
+                enabled=True,
+                connected=True,
+                primary=True,
+                mac="aa:bb:cc:dd:ee:02",
+                ipv4=IPv4(
+                    method=InterfaceMethod.AUTO,
+                    ready=True,
+                    address=[],
+                    nameservers=[IPv4Address("1.1.1.1")],
+                    gateway=None,
+                    route_metric=None,
+                ),
+                ipv6=None,
+                wifi=None,
+                vlan=None,
+                mdns=None,
+                llmnr=None,
+            ),
         ],
-    }
+        docker=DockerNetwork(
+            interface="hassio",
+            address=IPv4Network("172.30.32.0/23"),
+            gateway=IPv4Address("172.30.32.1"),
+            dns=IPv4Address("172.30.32.3"),
+        ),
+        host_internet=True,
+        supervisor_internet=True,
+    )
 
     with patch.dict(os.environ, MOCK_ENVIRON):
         info = await get_system_health_info(hass, "hassio")
@@ -115,14 +246,87 @@ async def test_hassio_system_health_with_issues(
     assert await async_setup_component(hass, "system_health", {})
     await hass.async_block_till_done()
 
-    hass.data["hassio_info"] = {"channel": "stable"}
-    hass.data["hassio_host_info"] = {}
-    hass.data["hassio_os_info"] = {}
-    hass.data["hassio_supervisor_info"] = {
-        "healthy": False,
-        "supported": False,
-    }
-    hass.data["hassio_network_info"] = {}
+    hass.data[DATA_INFO] = RootInfo(
+        supervisor="1.0.0",
+        homeassistant=None,
+        hassos=None,
+        docker="19.0.3",
+        hostname=None,
+        operating_system=None,
+        features=[],
+        machine=None,
+        machine_id=None,
+        arch="aarch64",
+        state=SupervisorState.RUNNING,
+        supported_arch=[],
+        supported=True,
+        channel=UpdateChannel.STABLE,
+        logging=LogLevel.INFO,
+        timezone="Etc/UTC",
+    )
+    hass.data[DATA_HOST_INFO] = HostInfo(
+        agent_version=None,
+        apparmor_version=None,
+        chassis="vm",
+        virtualization=None,
+        cpe=None,
+        deployment=None,
+        disk_free=1.6,
+        disk_total=100.0,
+        disk_used=98.4,
+        disk_life_time=None,
+        features=[],
+        hostname=None,
+        llmnr_hostname=None,
+        kernel=None,
+        operating_system=None,
+        timezone=None,
+        dt_utc=None,
+        dt_synchronized=None,
+        use_ntp=None,
+        startup_time=None,
+        boot_timestamp=None,
+        broadcast_llmnr=None,
+        broadcast_mdns=None,
+    )
+    hass.data[DATA_OS_INFO] = OSInfo(
+        version=None,
+        version_latest=None,
+        update_available=False,
+        board=None,
+        boot=None,
+        data_disk=None,
+        boot_slots={},
+    )
+    hass.data[DATA_SUPERVISOR_INFO] = SupervisorInfo(
+        version="1.0.0",
+        version_latest="1.0.0",
+        update_available=False,
+        channel=UpdateChannel.STABLE,
+        arch="aarch64",
+        supported=False,
+        healthy=False,
+        ip_address=IPv4Address("172.30.32.2"),
+        timezone=None,
+        logging=LogLevel.INFO,
+        debug=False,
+        debug_block=False,
+        diagnostics=None,
+        auto_update=True,
+        country=None,
+        detect_blocking_io=False,
+    )
+    hass.data[DATA_NETWORK_INFO] = NetworkInfo(
+        interfaces=[],
+        docker=DockerNetwork(
+            interface="hassio",
+            address=IPv4Network("172.30.32.0/23"),
+            gateway=IPv4Address("172.30.32.1"),
+            dns=IPv4Address("172.30.32.3"),
+        ),
+        host_internet=None,
+        supervisor_internet=False,
+    )
 
     with patch.dict(os.environ, MOCK_ENVIRON):
         info = await get_system_health_info(hass, "hassio")


### PR DESCRIPTION
## Proposed change

In the `hassio` integration, `hass.data` entries were using plain string keys and storing `aiohasupervisor` models serialized to dicts via `.to_dict()`. This made internal code unnecessarily verbose and lost type information.

This PR is part of the work tracked in #164680.

Changes:
- Converts 8 info/state data keys (`DATA_INFO`, `DATA_HOST_INFO`, `DATA_STORE`, `DATA_CORE_INFO`, `DATA_SUPERVISOR_INFO`, `DATA_OS_INFO`, `DATA_NETWORK_INFO`, `DATA_ADDONS_LIST`) from plain strings to `HassKey[T]` typed constants, storing raw `aiohasupervisor` model objects directly in `hass.data`
- Converts 4 coordinator/issues keys (`MAIN_COORDINATOR`, `ADDONS_COORDINATOR`, `STATS_COORDINATOR`, `DATA_KEY_SUPERVISOR_ISSUES`) to `HassKey[T]` typed constants so `hass.data` lookups return the correct concrete type without needing a cast
- Public API functions listed in `__all__` (e.g. `get_info`, `get_host_info`) continue to return `dict[str, Any]` for backwards compatibility by calling `.to_dict()` at the boundary

Note: Typing for the coordinator classes themselves (`HassioMainDataUpdateCoordinator` etc.) is still pending as follow-up work in #164680.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #164680
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr