### PR TITLE
Update afsapi to v1.0.0

### DIFF
--- a/homeassistant/components/frontier_silicon/__init__.py
+++ b/homeassistant/components/frontier_silicon/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from afsapi import AFSAPI, ConnectionError as FSConnectionError
+from afsapi import AFSAPI, FSConnectionError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PIN, Platform

--- a/homeassistant/components/frontier_silicon/browse_media.py
+++ b/homeassistant/components/frontier_silicon/browse_media.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from afsapi import AFSAPI, FSApiException, OutOfRangeException, Preset
+from afsapi import AFSAPI, FSApiError, OutOfRangeError, Preset
 
 from homeassistant.components.media_player import (
     BrowseError,
@@ -136,11 +136,11 @@ async def browse_node(
             # Return items in this folder
             children = [
                 _item_payload(key, item, player_mode, parent_keys=parent_keys)
-                async for key, item in await afsapi.nav_list()
+                async for key, item in afsapi.nav_list()
             ]
-    except OutOfRangeException as err:
+    except OutOfRangeError as err:
         raise BrowseError("The requested item is out of range") from err
-    except FSApiException as err:
+    except FSApiError as err:
         raise BrowseError(str(err)) from err
 
     return BrowseMedia(

--- a/homeassistant/components/frontier_silicon/config_flow.py
+++ b/homeassistant/components/frontier_silicon/config_flow.py
@@ -7,12 +7,7 @@ import logging
 from typing import Any
 from urllib.parse import urlparse
 
-from afsapi import (
-    AFSAPI,
-    ConnectionError as FSConnectionError,
-    InvalidPinException,
-    NotImplementedException,
-)
+from afsapi import AFSAPI, FSConnectionError, FSNotImplementedError, InvalidPinError
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
@@ -116,12 +111,12 @@ class FrontierSiliconConfigFlow(ConfigFlow, domain=DOMAIN):
         afsapi = AFSAPI(self._webfsapi_url, DEFAULT_PIN)
         try:
             await afsapi.get_friendly_name()
-        except InvalidPinException:
+        except InvalidPinError:
             return self.async_abort(reason="invalid_auth")
 
         try:
             unique_id = await afsapi.get_radio_id()
-        except NotImplementedException:
+        except FSNotImplementedError:
             unique_id = None
 
         await self.async_set_unique_id(unique_id)
@@ -144,7 +139,7 @@ class FrontierSiliconConfigFlow(ConfigFlow, domain=DOMAIN):
             afsapi = AFSAPI(self._webfsapi_url, DEFAULT_PIN)
 
             self._name = await afsapi.get_friendly_name()
-        except InvalidPinException:
+        except InvalidPinError:
             # Ask for a PIN
             return await self.async_step_device_config()
 
@@ -152,7 +147,7 @@ class FrontierSiliconConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             unique_id = await afsapi.get_radio_id()
-        except NotImplementedException:
+        except FSNotImplementedError:
             unique_id = None
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
@@ -201,7 +196,7 @@ class FrontierSiliconConfigFlow(ConfigFlow, domain=DOMAIN):
 
         except FSConnectionError:
             errors["base"] = "cannot_connect"
-        except InvalidPinException:
+        except InvalidPinError:
             errors["base"] = "invalid_auth"
         except Exception:
             _LOGGER.exception("Unexpected exception")
@@ -215,7 +210,7 @@ class FrontierSiliconConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 unique_id = await afsapi.get_radio_id()
-            except NotImplementedException:
+            except FSNotImplementedError:
                 unique_id = None
             await self.async_set_unique_id(unique_id, raise_on_progress=False)
             self._abort_if_unique_id_configured()

--- a/homeassistant/components/frontier_silicon/manifest.json
+++ b/homeassistant/components/frontier_silicon/manifest.json
@@ -6,7 +6,8 @@
   "documentation": "https://www.home-assistant.io/integrations/frontier_silicon",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["afsapi==0.3.1"],
+  "loggers": ["afsapi"],
+  "requirements": ["afsapi==1.0.0"],
   "ssdp": [
     {
       "st": "urn:schemas-frontier-silicon-com:undok:fsapi:1"

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from afsapi import (
-    AFSAPI,
-    ConnectionError as FSConnectionError,
-    NotImplementedException as FSNotImplementedException,
-    PlayState,
-)
+from afsapi import AFSAPI, FSConnectionError, FSNotImplementedError, PlayState
 
 from homeassistant.components.media_player import (
     BrowseError,
@@ -100,12 +95,13 @@ class AFSAPIDevice(MediaPlayerEntity):
             if await afsapi.get_power():
                 status = await afsapi.get_play_status()
                 self._attr_state = {
+                    PlayState.IDLE: MediaPlayerState.IDLE,
+                    PlayState.BUFFERING: MediaPlayerState.BUFFERING,
                     PlayState.PLAYING: MediaPlayerState.PLAYING,
                     PlayState.PAUSED: MediaPlayerState.PAUSED,
+                    PlayState.REBUFFERING: MediaPlayerState.BUFFERING,
                     PlayState.STOPPED: MediaPlayerState.IDLE,
-                    PlayState.LOADING: MediaPlayerState.BUFFERING,
-                    None: MediaPlayerState.IDLE,
-                }.get(status)
+                }.get(status, MediaPlayerState.IDLE)
             else:
                 self._attr_state = MediaPlayerState.OFF
         except FSConnectionError:
@@ -115,7 +111,9 @@ class AFSAPIDevice(MediaPlayerEntity):
                     self.name or afsapi.webfsapi_endpoint,
                 )
                 self._attr_available = False
-                return
+
+            # Device is not available, stop the update
+            return
 
         if not self._attr_available:
             _LOGGER.warning(
@@ -134,7 +132,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         if not self._attr_sound_mode_list and self._supports_sound_mode:
             try:
                 equalisers = await afsapi.get_equalisers()
-            except FSNotImplementedException:
+            except FSNotImplementedError:
                 self._supports_sound_mode = False
                 # Remove SELECT_SOUND_MODE from the advertised supported features
                 self._attr_supported_features ^= (
@@ -169,7 +167,7 @@ class AFSAPIDevice(MediaPlayerEntity):
             if self._supports_sound_mode:
                 try:
                     eq_preset = await afsapi.get_eq_preset()
-                except FSNotImplementedException:
+                except FSNotImplementedError:
                     self._supports_sound_mode = False
                     # Remove SELECT_SOUND_MODE from the advertised supported features
                     self._attr_supported_features ^= (

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -151,7 +151,7 @@ adguardhome==0.8.1
 advantage-air==0.4.4
 
 # homeassistant.components.frontier_silicon
-afsapi==0.3.1
+afsapi==1.0.0
 
 # homeassistant.components.agent_dvr
 agent-py==0.0.24

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -142,7 +142,7 @@ adguardhome==0.8.1
 advantage-air==0.4.4
 
 # homeassistant.components.frontier_silicon
-afsapi==0.3.1
+afsapi==1.0.0
 
 # homeassistant.components.agent_dvr
 agent-py==0.0.24

--- a/tests/components/frontier_silicon/test_config_flow.py
+++ b/tests/components/frontier_silicon/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-from afsapi import ConnectionError, InvalidPinException, NotImplementedException
+from afsapi import FSConnectionError, FSNotImplementedError, InvalidPinError
 import pytest
 
 from homeassistant import config_entries
@@ -42,7 +42,7 @@ INVALID_MOCK_DISCOVERY = SsdpServiceInfo(
 
 @pytest.mark.parametrize(
     ("radio_id_return_value", "radio_id_side_effect"),
-    [("mock_radio_id", None), (None, NotImplementedException)],
+    [("mock_radio_id", None), (None, FSNotImplementedError)],
 )
 async def test_form_default_pin(
     hass: HomeAssistant,
@@ -80,7 +80,7 @@ async def test_form_default_pin(
 
 @pytest.mark.parametrize(
     ("radio_id_return_value", "radio_id_side_effect"),
-    [("mock_radio_id", None), (None, NotImplementedException)],
+    [("mock_radio_id", None), (None, FSNotImplementedError)],
 )
 async def test_form_nondefault_pin(
     hass: HomeAssistant,
@@ -98,7 +98,7 @@ async def test_form_nondefault_pin(
 
     with patch(
         "homeassistant.components.frontier_silicon.config_flow.AFSAPI.get_friendly_name",
-        side_effect=InvalidPinException,
+        side_effect=InvalidPinError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -133,8 +133,8 @@ async def test_form_nondefault_pin(
 @pytest.mark.parametrize(
     ("friendly_name_error", "result_error"),
     [
-        (ConnectionError, "cannot_connect"),
-        (InvalidPinException, "invalid_auth"),
+        (FSConnectionError, "cannot_connect"),
+        (InvalidPinError, "invalid_auth"),
         (ValueError, "unknown"),
     ],
 )
@@ -154,7 +154,7 @@ async def test_form_nondefault_pin_invalid(
 
     with patch(
         "homeassistant.components.frontier_silicon.config_flow.AFSAPI.get_friendly_name",
-        side_effect=InvalidPinException,
+        side_effect=InvalidPinError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -198,7 +198,7 @@ async def test_form_nondefault_pin_invalid(
 @pytest.mark.parametrize(
     ("webfsapi_endpoint_error", "result_error"),
     [
-        (ConnectionError, "cannot_connect"),
+        (FSConnectionError, "cannot_connect"),
         (ValueError, "unknown"),
     ],
 )
@@ -247,7 +247,7 @@ async def test_invalid_device_url(
 
 @pytest.mark.parametrize(
     ("radio_id_return_value", "radio_id_side_effect"),
-    [("mock_radio_id", None), (None, NotImplementedException)],
+    [("mock_radio_id", None), (None, FSNotImplementedError)],
 )
 async def test_ssdp(
     hass: HomeAssistant,
@@ -321,7 +321,7 @@ async def test_ssdp_already_configured(
 
 @pytest.mark.parametrize(
     ("webfsapi_endpoint_error", "result_error"),
-    [(ValueError, "unknown"), (ConnectionError, "cannot_connect")],
+    [(ValueError, "unknown"), (FSConnectionError, "cannot_connect")],
 )
 async def test_ssdp_fail(
     hass: HomeAssistant, webfsapi_endpoint_error: Exception, result_error: str
@@ -346,7 +346,7 @@ async def test_ssdp_nondefault_pin(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.frontier_silicon.config_flow.AFSAPI.get_friendly_name",
-        side_effect=InvalidPinException,
+        side_effect=InvalidPinError,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -379,8 +379,8 @@ async def test_reauth_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -
 @pytest.mark.parametrize(
     ("exception", "reason"),
     [
-        (ConnectionError, "cannot_connect"),
-        (InvalidPinException, "invalid_auth"),
+        (FSConnectionError, "cannot_connect"),
+        (InvalidPinError, "invalid_auth"),
         (ValueError, "unknown"),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update of afsapi library to v1.0.0.

Release notes: https://github.com/wlcrs/python-afsapi/releases/tag/1.0.0
Changes: https://github.com/wlcrs/python-afsapi/compare/0.3.1...1.0.0

Note: this is a slimmed-down version of PR #168193 . 
Limited to just:
- the exception name changes
- proper conversion of new PlayState enum values
- bugfix when updating while device is unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
