### PR TITLE
husqvarna_automower_ble: Wait for product data

### DIFF
--- a/homeassistant/components/husqvarna_automower_ble/config_flow.py
+++ b/homeassistant/components/husqvarna_automower_ble/config_flow.py
@@ -11,7 +11,8 @@ from automower_ble.protocol import ResponseResult
 from bleak import BleakError
 from bleak_retry_connector import get_device
 from gardena_bluetooth.const import ScanService
-from gardena_bluetooth.parse import ManufacturerData, ProductType
+from gardena_bluetooth.parse import ProductType
+from gardena_bluetooth.scan import async_get_manufacturer_data
 import voluptuous as vol
 
 from homeassistant.components import bluetooth
@@ -37,43 +38,6 @@ USER_SCHEMA = vol.Schema(
 REAUTH_SCHEMA = BLUETOOTH_SCHEMA
 
 
-def _is_supported(discovery_info: BluetoothServiceInfo):
-    """Check if device is supported."""
-    if ScanService not in discovery_info.service_uuids:
-        LOGGER.debug(
-            "Unsupported device, missing service %s: %s", ScanService, discovery_info
-        )
-        return False
-
-    if not (data := discovery_info.manufacturer_data.get(ManufacturerData.company)):
-        LOGGER.debug(
-            "Unsupported device, missing manufacturer data %s: %s",
-            ManufacturerData.company,
-            discovery_info,
-        )
-        return False
-
-    manufacturer_data = ManufacturerData.decode(data)
-    product_type = ProductType.from_manufacturer_data(manufacturer_data)
-
-    # Some mowers only expose the serial number in the manufacturer data
-    # and not the product type, so we allow None here as well.
-    if product_type not in (ProductType.MOWER, ProductType.UNKNOWN):
-        LOGGER.debug("Unsupported device: %s (%s)", manufacturer_data, discovery_info)
-        return False
-
-    if not manufacturer_data.pairable:
-        LOGGER.error(
-            "The mower does not appear to be pairable. "
-            "Ensure the mower is in pairing mode before continuing. "
-            "If the mower isn't pariable you will receive authentication "
-            "errors and be unable to connect"
-        )
-
-    LOGGER.debug("Supported device: %s", manufacturer_data)
-    return True
-
-
 def _pin_valid(pin: str) -> bool:
     """Check if the pin is valid."""
     try:
@@ -91,6 +55,32 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
     address: str | None = None
     mower_name: str = ""
     pin: str | None = None
+    pairable: bool | None = None
+
+    async def _is_supported(self, discovery_info: BluetoothServiceInfo):
+        """Check if device is supported."""
+        if ScanService not in discovery_info.service_uuids:
+            LOGGER.debug(
+                "Unsupported device, missing service %s: %s",
+                ScanService,
+                discovery_info,
+            )
+            return False
+
+        manufacturer_data = (
+            await async_get_manufacturer_data({discovery_info.address})
+        )[discovery_info.address]
+
+        if manufacturer_data.product_type != ProductType.MOWER:
+            LOGGER.debug(
+                "Unsupported device: %s (%s)", manufacturer_data, discovery_info
+            )
+            return False
+
+        self.pairable = manufacturer_data.pairable
+
+        LOGGER.debug("Supported device: %s", manufacturer_data)
+        return True
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfo
@@ -98,7 +88,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the bluetooth discovery step."""
 
         LOGGER.debug("Discovered device: %s", discovery_info)
-        if not _is_supported(discovery_info):
+        if not await self._is_supported(discovery_info):
             return self.async_abort(reason="no_devices_found")
 
         self.context["title_placeholders"] = {
@@ -122,6 +112,13 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_pin"
             else:
                 self.pin = user_input[CONF_PIN]
+                if self.pairable is False:
+                    LOGGER.warning(
+                        "The mower does not appear to be pairable. "
+                        "Ensure the mower is in pairing mode before continuing. "
+                        "If the mower isn't pairable you will receive authentication "
+                        "errors and be unable to connect"
+                    )
                 return await self.check_mower(user_input)
 
         return self.async_show_form(

--- a/tests/components/husqvarna_automower_ble/__init__.py
+++ b/tests/components/husqvarna_automower_ble/__init__.py
@@ -14,7 +14,7 @@ AUTOMOWER_SERVICE_INFO_SERIAL = BluetoothServiceInfo(
     address="00000000-0000-0000-0000-000000000003",
     rssi=-63,
     service_data={},
-    manufacturer_data={1062: b"\x05\x04\xbf\xcf\xbb\r"},
+    manufacturer_data={1062: bytes.fromhex("02050104060a23010504bfcfbb0d")},
     service_uuids=["98bd0001-0b0e-421a-84e5-ddbf75dc6de4"],
     source="local",
 )
@@ -29,12 +29,22 @@ AUTOMOWER_SERVICE_INFO_MOWER = BluetoothServiceInfo(
     source="local",
 )
 
+AUTOMOWER_NOT_PAIRABLE_SERVICE_INFO = BluetoothServiceInfo(
+    name="305",
+    address="00000000-0000-0000-0000-000000000005",
+    rssi=-63,
+    service_data={},
+    manufacturer_data={1062: bytes.fromhex("02050004060a2301")},
+    service_uuids=["98bd0001-0b0e-421a-84e5-ddbf75dc6de4"],
+    source="local",
+)
+
 AUTOMOWER_UNNAMED_SERVICE_INFO = BluetoothServiceInfo(
     name=None,
     address="00000000-0000-0000-0000-000000000004",
     rssi=-63,
     service_data={},
-    manufacturer_data={1062: b"\x05\x04\xbf\xcf\xbb\r"},
+    manufacturer_data={1062: bytes.fromhex("02050104060a23010504bfcfbb0d")},
     service_uuids=["98bd0001-0b0e-421a-84e5-ddbf75dc6de4"],
     source="local",
 )

--- a/tests/components/husqvarna_automower_ble/conftest.py
+++ b/tests/components/husqvarna_automower_ble/conftest.py
@@ -4,8 +4,10 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from automower_ble.protocol import ResponseResult
+from gardena_bluetooth.parse import ManufacturerData
 import pytest
 
+from homeassistant.components.bluetooth import async_last_service_info
 from homeassistant.components.husqvarna_automower_ble.const import DOMAIN
 from homeassistant.const import CONF_ADDRESS, CONF_CLIENT_ID, CONF_PIN
 from homeassistant.core import HomeAssistant
@@ -44,6 +46,32 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         return_value=True,
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture(autouse=True)
+def mock_get_manufacturer_data(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> Generator[None]:
+    """Mock async_get_manufacturer_data to return decoded data from injected service infos."""
+
+    async def _get_manufacturer_data(
+        addresses: set[str], **kwargs
+    ) -> dict[str, ManufacturerData]:
+        result: dict[str, ManufacturerData] = {}
+        for address in addresses:
+            mfg = ManufacturerData()
+            if service_info := async_last_service_info(hass, address):
+                raw = service_info.manufacturer_data.get(ManufacturerData.company)
+                if raw is not None:
+                    mfg.update(raw)
+            result[address] = mfg
+        return result
+
+    with patch(
+        "homeassistant.components.husqvarna_automower_ble.config_flow.async_get_manufacturer_data",
+        new=_get_manufacturer_data,
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/husqvarna_automower_ble/test_config_flow.py
+++ b/tests/components/husqvarna_automower_ble/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from . import (
     AUTOMOWER_MISSING_MANUFACTURER_DATA_SERVICE_INFO,
+    AUTOMOWER_NOT_PAIRABLE_SERVICE_INFO,
     AUTOMOWER_SERVICE_INFO_MOWER,
     AUTOMOWER_SERVICE_INFO_SERIAL,
     AUTOMOWER_UNNAMED_SERVICE_INFO,
@@ -178,14 +179,10 @@ async def test_bluetooth_incorrect_pin(
 ) -> None:
     """Test we can select a device."""
 
+    inject_bluetooth_service_info(hass, AUTOMOWER_SERVICE_INFO_SERIAL)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_BLUETOOTH},
-        data=AUTOMOWER_SERVICE_INFO_SERIAL,
-    )
-    assert result["type"] is FlowResultType.FORM
+    result = hass.config_entries.flow.async_progress_by_handler(DOMAIN)[0]
     assert result["step_id"] == "bluetooth_confirm"
 
     # Try non numeric pin
@@ -235,14 +232,10 @@ async def test_bluetooth_unknown_error(
 ) -> None:
     """Test we can select a device."""
 
+    inject_bluetooth_service_info(hass, AUTOMOWER_SERVICE_INFO_SERIAL)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_BLUETOOTH},
-        data=AUTOMOWER_SERVICE_INFO_SERIAL,
-    )
-    assert result["type"] is FlowResultType.FORM
+    result = hass.config_entries.flow.async_progress_by_handler(DOMAIN)[0]
     assert result["step_id"] == "bluetooth_confirm"
 
     mock_automower_client.connect.return_value = ResponseResult.UNKNOWN_ERROR
@@ -262,14 +255,10 @@ async def test_bluetooth_not_paired(
 ) -> None:
     """Test we can select a device."""
 
+    inject_bluetooth_service_info(hass, AUTOMOWER_SERVICE_INFO_SERIAL)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_BLUETOOTH},
-        data=AUTOMOWER_SERVICE_INFO_SERIAL,
-    )
-    assert result["type"] is FlowResultType.FORM
+    result = hass.config_entries.flow.async_progress_by_handler(DOMAIN)[0]
     assert result["step_id"] == "bluetooth_confirm"
 
     mock_automower_client.connect.return_value = ResponseResult.NOT_ALLOWED
@@ -295,6 +284,44 @@ async def test_bluetooth_not_paired(
 
     assert result["data"] == {
         CONF_ADDRESS: "00000000-0000-0000-0000-000000000003",
+        CONF_CLIENT_ID: 1197489078,
+        CONF_PIN: "1234",
+    }
+
+
+async def test_bluetooth_not_pairable_logs_on_connect(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that the not-pairable warning is logged only when a connection is attempted."""
+
+    inject_bluetooth_service_info(hass, AUTOMOWER_NOT_PAIRABLE_SERVICE_INFO)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    result = hass.config_entries.flow.async_progress_by_handler(DOMAIN)[0]
+    assert result["step_id"] == "bluetooth_confirm"
+
+    # The warning must not be emitted just from showing the form
+    assert "does not appear to be pairable" not in caplog.text
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "1234"},
+    )
+
+    # Now that the user submitted a valid PIN and a connection is attempted,
+    # the warning should appear exactly once
+    assert (
+        sum(
+            "does not appear to be pairable" in record.getMessage()
+            for record in caplog.records
+        )
+        == 1
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == "00000000-0000-0000-0000-000000000005"
+    assert result["data"] == {
+        CONF_ADDRESS: "00000000-0000-0000-0000-000000000005",
         CONF_CLIENT_ID: 1197489078,
         CONF_PIN: "1234",
     }


### PR DESCRIPTION
## Proposed change

Adjust the config flow and to wait for the complete set of product data before continuing, similar to
https://github.com/home-assistant/core/pull/166481.

Also only report that the mower isn't pairable just before we try to connect to it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156482
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
