### PR TITLE
Add reconfigure to Scrape subentry flows

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -137,9 +137,8 @@ RESOURCE_SETUP = vol.Schema(
     }
 )
 
-SENSOR_SETUP = vol.Schema(
+SENSOR_SETTINGS = vol.Schema(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
         vol.Required(CONF_SELECT): TextSelector(),
         vol.Optional(CONF_INDEX, default=0): vol.All(
             NumberSelector(
@@ -188,6 +187,9 @@ SENSOR_SETUP = vol.Schema(
         ),
     }
 )
+SENSOR_SETUP = vol.Schema(
+    {vol.Optional(CONF_NAME, default=DEFAULT_NAME): TextSelector()}
+).extend(SENSOR_SETTINGS.schema)
 
 
 async def validate_rest_setup(
@@ -286,5 +288,21 @@ class ScrapeSubentryFlowHandler(ConfigSubentryFlow):
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
                 SENSOR_SETUP, user_input or {}
+            ),
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """User flow to reconfigure a sensor subentry."""
+        if user_input is not None:
+            self.async_update_and_abort(
+                self._get_entry(), self._get_reconfigure_subentry(), data=user_input
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                SENSOR_SETTINGS, user_input or self._get_reconfigure_subentry().data
             ),
         )

--- a/tests/components/scrape/test_config_flow.py
+++ b/tests/components/scrape/test_config_flow.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     CONF_RESOURCE,
     CONF_TIMEOUT,
     CONF_USERNAME,
+    CONF_VALUE_TEMPLATE,
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
@@ -288,3 +289,36 @@ async def test_options_resource_flow(
     # Check the state of the entity has changed as expected
     state = hass.states.get("sensor.current_version")
     assert state.state == "Hidden Version: 2021.12.10"
+
+
+async def test_reconfigure_sensor_subentry(
+    hass: HomeAssistant, loaded_entry: MockConfigEntry, get_data: MockRestData
+) -> None:
+    """Test reconfiguring a sensor subentry."""
+
+    state = hass.states.get("sensor.current_version")
+    assert state.state == "Current Version: 2021.12.10"
+
+    subentry_id = list(loaded_entry.subentries)[0]
+
+    result = await loaded_entry.start_subentry_reconfigure_flow(
+        hass, subentry_id=subentry_id
+    )
+    with patch(
+        "homeassistant.components.rest.RestData",
+        return_value=get_data,
+    ):
+        await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {
+                CONF_ADVANCED: {
+                    CONF_VALUE_TEMPLATE: "{{ value.split(':')[1] }}",
+                },
+                CONF_INDEX: 0,
+                CONF_SELECT: ".current-version h1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.current_version")
+    assert state.state == "2021.12.10"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Adds `reconfigure` option to Scrape subentry flows.
Previous PR: #141389

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 