### PR TITLE
Version checking of Transmission

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -25,7 +25,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -34,8 +38,9 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DEFAULT_PATH, DEFAULT_SSL, DOMAIN
+from .const import DEFAULT_PATH, DEFAULT_SSL, DOMAIN, MIN_REQUIRED_TRANSMISSION_VERSION
 from .coordinator import TransmissionConfigEntry, TransmissionDataUpdateCoordinator
+from .helpers import create_version
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,6 +101,17 @@ async def async_setup_entry(
         raise ConfigEntryAuthFailed from err
     except (TransmissionConnectError, TransmissionError) as err:
         raise ConfigEntryNotReady from err
+
+    version = create_version(api.server_version)
+    if version.valid and version < MIN_REQUIRED_TRANSMISSION_VERSION:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="version_error",
+            translation_placeholders={
+                "transmission_version": api.server_version,
+                "min_version": MIN_REQUIRED_TRANSMISSION_VERSION,
+            },
+        )
 
     protocol: Final = "https" if config_entry.data[CONF_SSL] else "http"
     device_registry = dr.async_get(hass)

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -40,8 +40,10 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_SSL,
     DOMAIN,
+    MIN_REQUIRED_TRANSMISSION_VERSION,
     SUPPORTED_ORDER_MODES,
 )
+from .helpers import create_version
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -80,13 +82,17 @@ class TransmissionFlowHandler(ConfigFlow, domain=DOMAIN):
                 {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
             )
             try:
-                await get_api(self.hass, user_input)
+                api = await get_api(self.hass, user_input)
 
             except TransmissionAuthError:
                 errors[CONF_USERNAME] = "invalid_auth"
                 errors[CONF_PASSWORD] = "invalid_auth"
             except TransmissionConnectError, TransmissionError:
                 errors["base"] = "cannot_connect"
+            else:
+                version = create_version(api.server_version)
+                if version.valid and version < MIN_REQUIRED_TRANSMISSION_VERSION:
+                    errors["base"] = "transmission_version"
 
             if not errors:
                 return self.async_create_entry(
@@ -115,14 +121,20 @@ class TransmissionFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             user_input = {**reauth_entry.data, **user_input}
             try:
-                await get_api(self.hass, user_input)
+                api = await get_api(self.hass, user_input)
 
             except TransmissionAuthError:
                 errors[CONF_PASSWORD] = "invalid_auth"
             except TransmissionConnectError, TransmissionError:
                 errors["base"] = "cannot_connect"
             else:
-                return self.async_update_reload_and_abort(reauth_entry, data=user_input)
+                version = create_version(api.server_version)
+                if version.valid and version < MIN_REQUIRED_TRANSMISSION_VERSION:
+                    errors["base"] = "transmission_version"
+                else:
+                    return self.async_update_reload_and_abort(
+                        reauth_entry, data=user_input
+                    )
 
         return self.async_show_form(
             description_placeholders={

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from awesomeversion import AwesomeVersion
 from transmission_rpc import Torrent
 
 DOMAIN = "transmission"
+
+MIN_REQUIRED_TRANSMISSION_VERSION = AwesomeVersion("4.0.0")
 
 ORDER_NEWEST_FIRST = "newest_first"
 ORDER_OLDEST_FIRST = "oldest_first"

--- a/homeassistant/components/transmission/helpers.py
+++ b/homeassistant/components/transmission/helpers.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from awesomeversion import AwesomeVersion
 from transmission_rpc.torrent import Torrent
 
 
@@ -43,3 +44,8 @@ def format_torrents(
         value[torrent.name] = format_torrent(torrent)
 
     return value
+
+
+def create_version(version: str) -> AwesomeVersion:
+    """Convert versions, transmission has x.x.x (build)."""
+    return AwesomeVersion(version.split(" ", 1)[0])

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -125,7 +125,7 @@
       "message": "Could not add torrent: unsupported type or no permission."
     },
     "version_error": {
-      "message": "You are running {transmission_version} of Transmission. Minimum required version is {min_version}. Please upgrade Transmission and then retry."
+      "message": "You are running {transmission_version} of Transmission. Minimum required version is {min_version}. Please upgrade Transmission and then restart Home Assistant."
     }
   },
   "options": {

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -6,7 +6,8 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "transmission_version": "Minimum required version is 4.0.0. Please upgrade Transmission and then retry."
     },
     "step": {
       "reauth_confirm": {
@@ -122,6 +123,9 @@
   "exceptions": {
     "could_not_add_torrent": {
       "message": "Could not add torrent: unsupported type or no permission."
+    },
+    "version_error": {
+      "message": "You are running {transmission_version} of Transmission. Minimum required version is {min_version}. Please upgrade Transmission and then retry."
     }
   },
   "options": {

--- a/tests/components/transmission/conftest.py
+++ b/tests/components/transmission/conftest.py
@@ -47,7 +47,7 @@ def mock_transmission_client() -> Generator[AsyncMock]:
     ):
         client = mock_client_class.return_value
 
-        client.server_version = "4.0.5 (a6fe2a64aa)"
+        client.server_version = "4.1.1 (56442e2929)"
 
         session_stats_data = {
             "uploadSpeed": 1,

--- a/tests/components/transmission/conftest.py
+++ b/tests/components/transmission/conftest.py
@@ -47,7 +47,7 @@ def mock_transmission_client() -> Generator[AsyncMock]:
     ):
         client = mock_client_class.return_value
 
-        client.server_version = "4.1.1 (56442e2929)"
+        client.server_version = "4.0.5 (a6fe2a64aa)"
 
         session_stats_data = {
             "uploadSpeed": 1,

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -174,7 +174,7 @@ async def test_flow_version_error(
     hass: HomeAssistant,
     mock_transmission_client: AsyncMock,
     mock_setup_entry: AsyncMock,
-    version,
+    version: str,
 ) -> None:
     """Test flow version error."""
     mock_transmission_client.return_value.server_version = version
@@ -294,7 +294,7 @@ async def test_reauth_version_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_transmission_client: AsyncMock,
-    version: str | None,
+    version: str,
 ) -> None:
     """Test reauth version error."""
     mock_transmission_client.return_value.server_version = version

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -193,6 +193,13 @@ async def test_flow_version_error(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "transmission_version"}
 
+    mock_transmission_client.return_value.server_version = "4.0.5 (a6fe2a64aa)"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        MOCK_CONFIG_DATA,
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
 
 async def test_reauth_success(
     hass: HomeAssistant,
@@ -314,3 +321,13 @@ async def test_reauth_version_error(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "transmission_version"}
+
+    mock_transmission_client.return_value.server_version = "4.0.5 (a6fe2a64aa)"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "password": "test-password",
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -160,6 +160,40 @@ async def test_flow_errors(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(
+    ("version"),
+    [
+        ("v1.0.0-RC2"),
+        ("v0.1.0"),
+        ("v1.9.0"),
+        ("3.0.0"),
+        ("3.0.0 (123798)"),
+    ],
+)
+async def test_flow_version_error(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    version,
+) -> None:
+    """Test flow version error."""
+    mock_transmission_client.return_value.server_version = version
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MOCK_CONFIG_DATA
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "transmission_version"}
+
+
 async def test_reauth_success(
     hass: HomeAssistant,
     mock_transmission_client: AsyncMock,
@@ -244,3 +278,39 @@ async def test_reauth_flow_errors(
         },
     )
     assert result["type"] is FlowResultType.ABORT
+
+
+@pytest.mark.parametrize(
+    ("version"),
+    [
+        ("v1.0.0-RC2"),
+        ("v0.1.0"),
+        ("v1.9.0"),
+        ("3.0.0"),
+        ("3.0.0 (123798)"),
+    ],
+)
+async def test_reauth_version_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_transmission_client: AsyncMock,
+    version: str | None,
+) -> None:
+    """Test reauth version error."""
+    mock_transmission_client.return_value.server_version = version
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "password": "test-password",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "transmission_version"}

--- a/tests/components/transmission/test_init.py
+++ b/tests/components/transmission/test_init.py
@@ -83,7 +83,6 @@ async def test_setup_failed_auth_error(
 @pytest.mark.parametrize(
     ("version"),
     [
-        (None),
         ("v1.0.0-RC2"),
         ("v0.1.0"),
         ("v1.9.0"),

--- a/tests/components/transmission/test_init.py
+++ b/tests/components/transmission/test_init.py
@@ -80,6 +80,33 @@ async def test_setup_failed_auth_error(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
+@pytest.mark.parametrize(
+    ("version"),
+    [
+        (None),
+        ("v1.0.0-RC2"),
+        ("v0.1.0"),
+        ("v1.9.0"),
+        ("3.0.0"),
+        ("3.0.0 (123798)"),
+    ],
+)
+async def test_setup_failed_too_old(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    version,
+) -> None:
+    """Test setup of Transmission entry with too old version of Transmission."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_transmission_client.return_value.server_version = version
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
 async def test_setup_failed_unexpected_error(
     hass: HomeAssistant,
     mock_transmission_client: AsyncMock,

--- a/tests/components/transmission/test_init.py
+++ b/tests/components/transmission/test_init.py
@@ -95,7 +95,7 @@ async def test_setup_failed_too_old(
     hass: HomeAssistant,
     mock_transmission_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    version,
+    version: str,
 ) -> None:
     """Test setup of Transmission entry with too old version of Transmission."""
     mock_config_entry.add_to_hass(hass)


### PR DESCRIPTION
## Breaking change
Transmission versions prior to version 4.0.0 (released in Feb 2023) are no longer supported as we are unable to test these.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The latest 4.1 transmission version has deprecated certain methods, to cater for future version differences implement check in config flow and init.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
