### PR TITLE
Bump victron-mqtt to 2026.4.17

### DIFF
--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "silver",
-  "requirements": ["victron-mqtt==2026.4.16"],
+  "requirements": ["victron-mqtt==2026.4.17"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "silver",
-  "requirements": ["victron-mqtt==2026.4.3"],
+  "requirements": ["victron-mqtt==2026.4.16"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -1,4 +1,101 @@
 {
+  "common": {
+    "absorption": "Absorption",
+    "active_ac_input": "Active AC input",
+    "alarm": "Alarm",
+    "auto_equalize_recondition": "Auto equalize / recondition",
+    "battery_safe": "Battery Safe",
+    "battery_voltage_too_high": "Battery voltage too high",
+    "bms_connection_lost": "BMS connection lost",
+    "bulk": "Bulk",
+    "bulk_time_limit_exceeded": "Bulk time limit exceeded",
+    "charger_current_reversed": "Charger current reversed",
+    "charger_only": "Charger only",
+    "charger_over_current": "Charger over current",
+    "charger_temperature_too_high": "Charger temperature too high",
+    "consumption": "Consumption",
+    "consumption_on_phase": "Consumption on {phase}",
+    "converter_issue": "Converter issue",
+    "current": "Current",
+    "current_limit": "Current limit",
+    "current_on_phase": "Current on {phase}",
+    "current_phase": "Current {phase}",
+    "current_sensor_issue": "Current sensor issue",
+    "dc_output_current": "DC output current",
+    "dc_output_power": "DC output power",
+    "dc_output_voltage": "DC output voltage",
+    "dc_temperature": "DC temperature",
+    "equalize": "Equalize",
+    "error_code": "Error code",
+    "ess_mode": "ESS mode",
+    "external_control": "External control",
+    "factory_calibration_data_lost": "Factory calibration data lost",
+    "float": "Float",
+    "frequency": "Frequency",
+    "generator": "Generator",
+    "grid": "Grid",
+    "high_temperature_alarm": "High temperature alarm",
+    "input_current": "Input current",
+    "input_current_too_high_solar_panel": "Input current too high (solar panel)",
+    "input_power": "Input power",
+    "input_shutdown_battery_voltage_too_high": "Input shutdown (battery voltage too high)",
+    "input_shutdown_reverse_current": "Input shutdown (reverse current)",
+    "input_voltage": "Input voltage",
+    "input_voltage_too_high_solar_panel": "Input voltage too high (solar panel)",
+    "invalid_incompatible_firmware": "Invalid/incompatible firmware",
+    "inverter_only": "Inverter only",
+    "inverting": "Inverting",
+    "lost_communication_with_device": "Lost communication with device",
+    "low_power": "Low power",
+    "max_power_today": "Max power today",
+    "max_power_yesterday": "Max power yesterday",
+    "mppt_active": "MPPT active",
+    "network_misconfigured": "Network misconfigured",
+    "no_alarm": "No alarm",
+    "no_error": "No error",
+    "not_available": "Not available",
+    "not_connected": "Not connected",
+    "ok": "Ok",
+    "output_apparent_power_phase": "Output apparent power {phase}",
+    "output_current_phase": "Output current {phase}",
+    "output_power_phase": "Output power {phase}",
+    "output_voltage_phase": "Output voltage {phase}",
+    "overload_alarm": "Overload alarm",
+    "passthrough": "Passthrough",
+    "power": "Power",
+    "power_assist": "Power Assist",
+    "power_on_phase": "Power on {phase}",
+    "power_phase": "Power {phase}",
+    "power_supply": "Power supply",
+    "pv_bus_voltage": "PV bus voltage",
+    "pv_power_total": "PV power total",
+    "recharging": "Recharging",
+    "repeated_absorption": "Repeated absorption",
+    "reserved": "Reserved",
+    "ripple_alarm": "Ripple alarm",
+    "scheduled_recharging": "Scheduled recharging",
+    "self_consumption": "Self-consumption",
+    "sensor_battery_voltage": "Sensor battery voltage",
+    "shore_power": "Shore power",
+    "starting_up": "Starting up",
+    "state": "State",
+    "storage": "Storage",
+    "sustain": "Sustain",
+    "sustain_alt": "Sustain alt",
+    "synchronized_charging_config_issue": "Synchronized charging config issue",
+    "temperature": "Temperature",
+    "terminals_overheated": "Terminals overheated",
+    "total_pv_yield_user": "Total PV yield user",
+    "total_yield": "Total yield",
+    "unknown": "Unknown",
+    "user_settings_invalid": "User settings invalid",
+    "voltage": "Voltage",
+    "voltage_current_limited": "Voltage/current limited",
+    "voltage_on_phase": "Voltage on {phase}",
+    "warning": "Warning",
+    "yield_today": "Yield today",
+    "yield_yesterday": "Yield yesterday"
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -63,41 +160,14 @@
   },
   "entity": {
     "binary_sensor": {
-      "digitalinput_settings_invert_translation": {
-        "name": "Invert digital input"
-      },
-      "evcharger_charge": {
-        "name": "EV charging"
-      },
       "evcharger_connected": {
-        "name": "Connected"
-      },
-      "generator_autorun": {
-        "name": "Auto-start enabled"
-      },
-      "generator_gen_id_quiet_hours_enabled": {
-        "name": "Generator quiet hours enabled"
-      },
-      "generator_gen_id_start_on_soc_enabled": {
-        "name": "Generator start on SOC enabled"
-      },
-      "generator_gen_id_start_on_temp_enabled": {
-        "name": "Generator start on high temp enabled"
-      },
-      "generator_gen_id_start_on_voltage_enabled": {
-        "name": "Generator start on voltage enabled"
-      },
-      "generator_manual_start": {
-        "name": "Manual start"
+        "name": "[%key:common::state::connected%]"
       },
       "gps_connected": {
-        "name": "Connected"
-      },
-      "gps_fix": {
-        "name": "Fix"
+        "name": "[%key:common::state::connected%]"
       },
       "inverter_alarm_high_temperature": {
-        "name": "High temperature alarm"
+        "name": "[%key:component::victron_gx::common::high_temperature_alarm%]"
       },
       "inverter_alarm_high_voltage": {
         "name": "High voltage alarm"
@@ -115,31 +185,13 @@
         "name": "Low voltage AC-out alarm"
       },
       "inverter_alarm_overload": {
-        "name": "Overload alarm"
+        "name": "[%key:component::victron_gx::common::overload_alarm%]"
       },
       "inverter_alarm_ripple": {
-        "name": "Ripple alarm"
-      },
-      "multi_disable_charge": {
-        "name": "ESS disable charge"
-      },
-      "multi_disable_feed_in": {
-        "name": "ESS disable feed-in"
-      },
-      "multi_relay0_state": {
-        "name": "Relay on Multi RS state"
+        "name": "[%key:component::victron_gx::common::ripple_alarm%]"
       },
       "solarcharger_load_state": {
         "name": "Load state"
-      },
-      "solarcharger_relay_state": {
-        "name": "Relay state"
-      },
-      "switch_output_state": {
-        "name": "Switch {output} state"
-      },
-      "switchable_output_output_state": {
-        "name": "Switchable output {output} state"
       },
       "system_dynamicess_active": {
         "name": "Dynamic ESS active"
@@ -150,29 +202,8 @@
       "system_dynamicess_available": {
         "name": "Dynamic ESS available"
       },
-      "system_ess_battery_use": {
-        "name": "ESS only critical loads from battery"
-      },
-      "system_ess_schedule_charge_slot_enabled": {
-        "name": "ESS BatteryLife schedule charge {slot} enabled"
-      },
-      "system_relay_relay": {
-        "name": "Relay {relay} state"
-      },
-      "system_settings_overvoltage_feedin": {
-        "name": "PV DC overvoltage feed-in"
-      },
-      "vebus_device_device_number_power_assist_enabled": {
-        "name": "{device_number} PowerAssist enabled"
-      },
       "vebus_inverter_connected": {
-        "name": "Connected"
-      },
-      "vebus_inverter_ignoreacin1_onoff_control": {
-        "name": "Control ignore AC-in-1"
-      },
-      "vebus_inverter_setting_alarm_grid_lost": {
-        "name": "Grid lost alarm setting"
+        "name": "[%key:common::state::connected%]"
       }
     },
     "number": {
@@ -252,7 +283,7 @@
         "name": "Assist current boost factor"
       },
       "switch_output_dimming": {
-        "name": "{output} dimming"
+        "name": "Dimming"
       },
       "system_ac_export_limit": {
         "name": "AC export limit"
@@ -300,21 +331,21 @@
         "name": "AC power setpoint {phase}"
       },
       "vebus_inverter_current_limit": {
-        "name": "Current limit"
+        "name": "[%key:component::victron_gx::common::current_limit%]"
       }
     },
     "select": {
       "acsystem_mode": {
         "state": {
-          "charger_only": "Charger only",
-          "inverter_only": "Inverter only",
+          "charger_only": "[%key:component::victron_gx::common::charger_only%]",
+          "inverter_only": "[%key:component::victron_gx::common::inverter_only%]",
           "off": "[%key:common::state::off%]",
           "on": "[%key:common::state::on%]",
-          "passthrough": "Passthrough"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]"
         }
       },
       "evcharger_mode": {
-        "name": "Mode",
+        "name": "[%key:common::config_flow::data::mode%]",
         "state": {
           "auto": "[%key:common::state::auto%]",
           "manual": "[%key:common::state::manual%]",
@@ -334,7 +365,7 @@
           "keep_batteries_charged": "'Keep batteries charged' mode enabled",
           "recharge": "Recharge, SoC dropped 5% or more below minimum SoC",
           "recharge_no_battery_life": "Recharge, SoC dropped 5% or more below minimum SoC (No BatteryLife)",
-          "self_consumption": "Self-consumption",
+          "self_consumption": "[%key:component::victron_gx::common::self_consumption%]",
           "self_consumption_soc_above_min": "Self-consumption, SoC at or above minimum SoC",
           "self_consumption_soc_at_100": "Self-consumption, SoC at 100%",
           "self_consumption_soc_below_min": "Self-consumption, SoC is below minimum SoC",
@@ -348,7 +379,7 @@
       "system_ess_mode": {
         "name": "ESS mode (Hub4)",
         "state": {
-          "external_control": "External control",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "phase_compensation_disabled": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
           "phase_compensation_enabled": "Optimized mode or 'keep batteries charged' and phase compensation enabled"
         }
@@ -390,8 +421,8 @@
       },
       "vebus_inverter_mode": {
         "state": {
-          "charger_only": "Charger only",
-          "inverter_only": "Inverter only",
+          "charger_only": "[%key:component::victron_gx::common::charger_only%]",
+          "inverter_only": "[%key:component::victron_gx::common::inverter_only%]",
           "off": "[%key:common::state::off%]",
           "on": "[%key:common::state::on%]"
         }
@@ -402,72 +433,72 @@
         "name": "Load current"
       },
       "acload_current_phase": {
-        "name": "Current on {phase}"
+        "name": "[%key:component::victron_gx::common::current_on_phase%]"
       },
       "acload_energy_forward": {
-        "name": "Consumption"
+        "name": "[%key:component::victron_gx::common::consumption%]"
       },
       "acload_energy_forward_phase": {
-        "name": "Consumption on {phase}"
+        "name": "[%key:component::victron_gx::common::consumption_on_phase%]"
       },
       "acload_frequency": {
-        "name": "Frequency"
+        "name": "[%key:component::victron_gx::common::frequency%]"
       },
       "acload_power": {
-        "name": "Power"
+        "name": "[%key:component::victron_gx::common::power%]"
       },
       "acload_power_phase": {
-        "name": "Power on {phase}"
+        "name": "[%key:component::victron_gx::common::power_on_phase%]"
       },
       "acload_voltage": {
-        "name": "Voltage"
+        "name": "[%key:component::victron_gx::common::voltage%]"
       },
       "acload_voltage_phase": {
-        "name": "Voltage on {phase}"
+        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
       },
       "alternator_dc_current": {
-        "name": "DC output current"
+        "name": "[%key:component::victron_gx::common::dc_output_current%]"
       },
       "alternator_dc_power": {
-        "name": "DC output power"
+        "name": "[%key:component::victron_gx::common::dc_output_power%]"
       },
       "alternator_dc_voltage": {
-        "name": "DC output voltage"
+        "name": "[%key:component::victron_gx::common::dc_output_voltage%]"
       },
       "alternator_input_current": {
-        "name": "Input current"
+        "name": "[%key:component::victron_gx::common::input_current%]"
       },
       "alternator_input_power": {
-        "name": "Input power"
+        "name": "[%key:component::victron_gx::common::input_power%]"
       },
       "alternator_input_voltage": {
-        "name": "Input voltage"
+        "name": "[%key:component::victron_gx::common::input_voltage%]"
       },
       "alternator_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
       "auxiliary_battery_voltage": {
@@ -490,9 +521,9 @@
       "battery_cell_imbalance": {
         "name": "Cell imbalance",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "battery_cell_voltage_deviation": {
@@ -521,25 +552,25 @@
       "battery_high_charge_current": {
         "name": "High charge current",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "battery_high_charge_temperature": {
         "name": "High charge temperature",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "battery_high_discharge_current": {
         "name": "High discharge current",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "battery_installed_capacity": {
@@ -549,9 +580,9 @@
       "battery_internal_failure": {
         "name": "Internal failure",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "battery_last_discharge": {
@@ -560,17 +591,17 @@
       "battery_low_cell_voltage": {
         "name": "Low cell voltage",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "battery_low_charge_temperature": {
         "name": "Low charge temperature",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "battery_max_cell_temperature": {
@@ -635,7 +666,7 @@
         "unit_of_measurement": "modules"
       },
       "battery_power": {
-        "name": "Power"
+        "name": "[%key:component::victron_gx::common::power%]"
       },
       "battery_soc": {
         "name": "Charge"
@@ -644,7 +675,7 @@
         "name": "State of health"
       },
       "battery_temperature": {
-        "name": "Temperature"
+        "name": "[%key:component::victron_gx::common::temperature%]"
       },
       "battery_time_since_last_full_charge": {
         "name": "Time since last full charge",
@@ -663,35 +694,38 @@
       "charge_mode": {
         "name": "Charge mode"
       },
-      "charger_dc_current": {
-        "name": "DC output current"
+      "charger_ac_in_current_phase": {
+        "name": "AC input current {phase}"
       },
-      "charger_dc_voltage": {
-        "name": "DC output voltage"
+      "charger_dc_current_output": {
+        "name": "DC output {output} current"
+      },
+      "charger_dc_voltage_output": {
+        "name": "DC output {output} voltage"
       },
       "charger_error_code": {
-        "name": "Error code",
+        "name": "[%key:component::victron_gx::common::error_code%]",
         "state": {
-          "battery_voltage_too_high": "Battery voltage too high",
-          "bms_connection_lost": "BMS connection lost",
-          "bulk_time_limit_exceeded": "Bulk time limit exceeded",
-          "charger_current_reversed": "Charger current reversed",
-          "charger_over_current": "Charger over current",
-          "charger_temperature_too_high": "Charger temperature too high",
-          "converter_issue": "Converter issue",
-          "current_sensor_issue": "Current sensor issue",
-          "factory_calibration_data_lost": "Factory calibration data lost",
-          "input_current_too_high": "Input current too high (solar panel)",
-          "input_shutdown_battery_voltage_too_high": "Input shutdown (battery voltage too high)",
-          "input_shutdown_reverse_current": "Input shutdown (reverse current)",
-          "input_voltage_too_high": "Input voltage too high (solar panel)",
-          "invalid_incompatible_firmware": "Invalid/incompatible firmware",
-          "lost_communication_with_device": "Lost communication with device",
-          "network_misconfigured": "Network misconfigured",
-          "no_error": "No error",
-          "synchronized_charging_config_issue": "Synchronized charging config issue",
-          "terminals_overheated": "Terminals overheated",
-          "user_settings_invalid": "User settings invalid"
+          "battery_voltage_too_high": "[%key:component::victron_gx::common::battery_voltage_too_high%]",
+          "bms_connection_lost": "[%key:component::victron_gx::common::bms_connection_lost%]",
+          "bulk_time_limit_exceeded": "[%key:component::victron_gx::common::bulk_time_limit_exceeded%]",
+          "charger_current_reversed": "[%key:component::victron_gx::common::charger_current_reversed%]",
+          "charger_over_current": "[%key:component::victron_gx::common::charger_over_current%]",
+          "charger_temperature_too_high": "[%key:component::victron_gx::common::charger_temperature_too_high%]",
+          "converter_issue": "[%key:component::victron_gx::common::converter_issue%]",
+          "current_sensor_issue": "[%key:component::victron_gx::common::current_sensor_issue%]",
+          "factory_calibration_data_lost": "[%key:component::victron_gx::common::factory_calibration_data_lost%]",
+          "input_current_too_high": "[%key:component::victron_gx::common::input_current_too_high_solar_panel%]",
+          "input_shutdown_battery_voltage_too_high": "[%key:component::victron_gx::common::input_shutdown_battery_voltage_too_high%]",
+          "input_shutdown_reverse_current": "[%key:component::victron_gx::common::input_shutdown_reverse_current%]",
+          "input_voltage_too_high": "[%key:component::victron_gx::common::input_voltage_too_high_solar_panel%]",
+          "invalid_incompatible_firmware": "[%key:component::victron_gx::common::invalid_incompatible_firmware%]",
+          "lost_communication_with_device": "[%key:component::victron_gx::common::lost_communication_with_device%]",
+          "network_misconfigured": "[%key:component::victron_gx::common::network_misconfigured%]",
+          "no_error": "[%key:component::victron_gx::common::no_error%]",
+          "synchronized_charging_config_issue": "[%key:component::victron_gx::common::synchronized_charging_config_issue%]",
+          "terminals_overheated": "[%key:component::victron_gx::common::terminals_overheated%]",
+          "user_settings_invalid": "[%key:component::victron_gx::common::user_settings_invalid%]"
         }
       },
       "charger_nr_of_outputs": {
@@ -699,123 +733,123 @@
         "unit_of_measurement": "outputs"
       },
       "charger_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
       "dcdc_dc_current": {
-        "name": "DC output current"
+        "name": "[%key:component::victron_gx::common::dc_output_current%]"
       },
       "dcdc_dc_power": {
-        "name": "DC output power"
+        "name": "[%key:component::victron_gx::common::dc_output_power%]"
       },
       "dcdc_dc_voltage": {
-        "name": "DC output voltage"
+        "name": "[%key:component::victron_gx::common::dc_output_voltage%]"
       },
       "dcdc_input_current": {
-        "name": "Input current"
+        "name": "[%key:component::victron_gx::common::input_current%]"
       },
       "dcdc_input_power": {
-        "name": "Input power"
+        "name": "[%key:component::victron_gx::common::input_power%]"
       },
       "dcdc_input_voltage": {
-        "name": "Input voltage"
+        "name": "[%key:component::victron_gx::common::input_voltage%]"
       },
       "dcdc_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
       "dcload_current": {
-        "name": "Current"
+        "name": "[%key:component::victron_gx::common::current%]"
       },
       "dcload_power": {
-        "name": "Power"
+        "name": "[%key:component::victron_gx::common::power%]"
       },
       "dcload_voltage": {
-        "name": "Voltage"
+        "name": "[%key:component::victron_gx::common::voltage%]"
       },
       "dcsystem_aux_voltage": {
         "name": "Auxiliary voltage"
       },
       "dcsystem_current": {
-        "name": "Current"
+        "name": "[%key:component::victron_gx::common::current%]"
       },
       "dcsystem_power": {
-        "name": "Power"
+        "name": "[%key:component::victron_gx::common::power%]"
       },
       "dcsystem_voltage": {
-        "name": "Voltage"
+        "name": "[%key:component::victron_gx::common::voltage%]"
       },
       "digitalinput_alarm": {
-        "name": "Alarm",
+        "name": "[%key:component::victron_gx::common::alarm%]",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "digitalinput_input_state_raw": {
         "name": "Raw state",
         "state": {
-          "high_open": "High/Open",
-          "low_closed": "Low/Closed"
+          "high_open": "High/open",
+          "low_closed": "Low/closed"
         }
       },
       "digitalinput_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "alarm": "Alarm",
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
           "closed": "[%key:common::state::closed%]",
           "high": "[%key:common::state::high%]",
           "low": "[%key:common::state::low%]",
           "no": "[%key:common::state::no%]",
           "off": "[%key:common::state::off%]",
-          "ok": "Ok",
+          "ok": "[%key:component::victron_gx::common::ok%]",
           "on": "[%key:common::state::on%]",
           "open": "[%key:common::state::open%]",
           "running": "Running",
@@ -833,14 +867,14 @@
           "disabled": "[%key:common::state::disabled%]",
           "door_alarm": "Door alarm",
           "fire_alarm": "Fire alarm",
-          "generator": "Generator",
+          "generator": "[%key:component::victron_gx::common::generator%]",
           "pulse_meter": "Pulse meter",
           "smoke_alarm": "Smoke alarm",
           "touch_input_control": "Touch input control"
         }
       },
       "evcharger_current": {
-        "name": "Current"
+        "name": "[%key:component::victron_gx::common::current%]"
       },
       "evcharger_max_set_current": {
         "name": "Maximum set current"
@@ -851,15 +885,15 @@
       "evcharger_position": {
         "name": "Position",
         "state": {
-          "ac_input": "AC Input",
-          "ac_out": "AC Out"
+          "ac_input": "AC input",
+          "ac_out": "AC out"
         }
       },
       "evcharger_power": {
-        "name": "Power"
+        "name": "[%key:component::victron_gx::common::power%]"
       },
       "evcharger_power_phase": {
-        "name": "Power {phase}"
+        "name": "[%key:component::victron_gx::common::power_phase%]"
       },
       "evcharger_session_cost": {
         "name": "Last session cost",
@@ -884,11 +918,11 @@
           "low_soc": "Low SoC",
           "overheating_detected": "Overheating detected",
           "overvoltage_detected": "Overvoltage detected",
-          "reserved15": "Reserved",
-          "reserved16": "Reserved",
-          "reserved17": "Reserved",
-          "reserved18": "Reserved",
-          "reserved19": "reserved",
+          "reserved15": "[%key:component::victron_gx::common::reserved%]",
+          "reserved16": "[%key:component::victron_gx::common::reserved%]",
+          "reserved17": "[%key:component::victron_gx::common::reserved%]",
+          "reserved18": "[%key:component::victron_gx::common::reserved%]",
+          "reserved19": "[%key:component::victron_gx::common::reserved%]",
           "residual_current_detected": "Residual current detected",
           "start_charging": "Start charging",
           "switching_to_1_phase": "Switching to 1 phase",
@@ -906,17 +940,17 @@
       "generator_run_state": {
         "name": "Run state",
         "state": {
-          "ac_load": "AC Load",
-          "battery_current": "Battery Current",
-          "battery_volts": "Battery Volts",
-          "inv_overload": "Inv Overload",
-          "inv_temp": "Inv Temp",
-          "lost_comms": "Lost Comms",
+          "ac_load": "AC load",
+          "battery_current": "Battery current",
+          "battery_volts": "Battery volts",
+          "inv_overload": "Inverter overload",
+          "inv_temp": "Inverter temperature",
+          "lost_comms": "Lost comms",
           "manual": "[%key:common::state::manual%]",
           "soc": "SoC",
-          "stop_on_ac1": "Stop On AC1",
+          "stop_on_ac1": "Stop on AC1",
           "stopped": "[%key:common::state::stopped%]",
-          "test_run": "Test Run"
+          "test_run": "Test run"
         }
       },
       "generator_service_counter": {
@@ -928,40 +962,21 @@
       "generator_total_runtime": {
         "name": "Total runtime"
       },
-      "gps_altitude": {
-        "name": "Altitude",
-        "unit_of_measurement": "m"
-      },
-      "gps_course": {
-        "name": "Course",
-        "unit_of_measurement": "°"
-      },
-      "gps_latitude": {
-        "name": "Latitude",
-        "unit_of_measurement": "lat"
-      },
-      "gps_longitude": {
-        "name": "Longitude",
-        "unit_of_measurement": "long"
-      },
       "gps_nrofsatellites": {
         "name": "Number of satellites",
         "unit_of_measurement": "satellites"
       },
-      "gps_speed": {
-        "name": "Speed"
-      },
       "grid_current": {
-        "name": "Current"
+        "name": "[%key:component::victron_gx::common::current%]"
       },
       "grid_current_n": {
         "name": "Current on N"
       },
       "grid_current_phase": {
-        "name": "Current on {phase}"
+        "name": "[%key:component::victron_gx::common::current_on_phase%]"
       },
       "grid_energy_forward": {
-        "name": "Consumption"
+        "name": "[%key:component::victron_gx::common::consumption%]"
       },
       "grid_energy_forward_phase": {
         "name": "Grid consumption on {phase}"
@@ -973,111 +988,109 @@
         "name": "Feed-in on {phase}"
       },
       "grid_frequency": {
-        "name": "Frequency"
+        "name": "[%key:component::victron_gx::common::frequency%]"
       },
       "grid_power": {
-        "name": "Power"
+        "name": "[%key:component::victron_gx::common::power%]"
       },
       "grid_power_factor": {
-        "name": "Power factor",
-        "unit_of_measurement": "factor"
+        "name": "Power factor"
       },
       "grid_power_factor_phase": {
-        "name": "Power factor on {phase}",
-        "unit_of_measurement": "factor"
+        "name": "Power factor on {phase}"
       },
       "grid_power_phase": {
-        "name": "Power on {phase}"
+        "name": "[%key:component::victron_gx::common::power_on_phase%]"
       },
       "grid_voltage": {
-        "name": "Voltage"
+        "name": "[%key:component::victron_gx::common::voltage%]"
       },
       "grid_voltage_pen": {
         "name": "Voltage on PEN"
       },
       "grid_voltage_phase": {
-        "name": "Voltage on {phase}"
+        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
       },
       "grid_voltage_phase_next_phase": {
         "name": "Voltage {phase} to {next_phase}"
       },
       "heatpump_current": {
-        "name": "Current"
+        "name": "[%key:component::victron_gx::common::current%]"
       },
       "heatpump_current_phase": {
-        "name": "Current on {phase}"
+        "name": "[%key:component::victron_gx::common::current_on_phase%]"
       },
       "heatpump_energy_forward": {
-        "name": "Consumption"
+        "name": "[%key:component::victron_gx::common::consumption%]"
       },
       "heatpump_energy_forward_phase": {
-        "name": "Consumption on {phase}"
+        "name": "[%key:component::victron_gx::common::consumption_on_phase%]"
       },
       "heatpump_frequency": {
-        "name": "Frequency"
+        "name": "[%key:component::victron_gx::common::frequency%]"
       },
       "heatpump_power": {
-        "name": "Power"
+        "name": "[%key:component::victron_gx::common::power%]"
       },
       "heatpump_power_phase": {
-        "name": "Power on {phase}"
+        "name": "[%key:component::victron_gx::common::power_on_phase%]"
       },
       "heatpump_voltage": {
-        "name": "Voltage"
+        "name": "[%key:component::victron_gx::common::voltage%]"
       },
       "heatpump_voltage_phase": {
-        "name": "Voltage on {phase}"
+        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
       },
       "inverter_output_apparent_power_phase": {
-        "name": "Output apparent power {phase}"
+        "name": "[%key:component::victron_gx::common::output_apparent_power_phase%]"
       },
       "inverter_output_current_phase": {
-        "name": "Output current {phase}"
+        "name": "[%key:component::victron_gx::common::output_current_phase%]"
       },
       "inverter_output_power_phase": {
-        "name": "Output power {phase}"
+        "name": "[%key:component::victron_gx::common::output_power_phase%]"
       },
       "inverter_output_voltage_phase": {
-        "name": "Output voltage {phase}"
+        "name": "[%key:component::victron_gx::common::output_voltage_phase%]"
       },
       "inverter_pv_power_total": {
-        "name": "PV power total"
+        "name": "[%key:component::victron_gx::common::pv_power_total%]"
       },
       "inverter_pv_voltage": {
-        "name": "PV bus voltage"
+        "name": "[%key:component::victron_gx::common::pv_bus_voltage%]"
       },
       "inverter_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
       "inverter_total_pv_yield_system": {
         "name": "Total PV yield system"
       },
       "inverter_total_pv_yield_user": {
-        "name": "Total PV yield user"
+        "name": "[%key:component::victron_gx::common::total_pv_yield_user%]"
       },
       "multi_acin1_to_acout": {
         "name": "AC-in-1 to AC-out"
@@ -1086,13 +1099,13 @@
         "name": "AC-in-1 to inverter"
       },
       "multi_acin_current_phase": {
-        "name": "Current {phase}"
+        "name": "[%key:component::victron_gx::common::current_phase%]"
       },
       "multi_acin_power_phase": {
-        "name": "Power on {phase}"
+        "name": "[%key:component::victron_gx::common::power_on_phase%]"
       },
       "multi_acin_voltage_phase": {
-        "name": "Voltage on {phase}"
+        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
       },
       "multi_acout_output_current_phase": {
         "name": "AC-out-{output} current on {phase}"
@@ -1110,20 +1123,23 @@
         "name": "AC-out to inverter"
       },
       "multi_active_input": {
-        "name": "Active AC input",
+        "name": "[%key:component::victron_gx::common::active_ac_input%]",
         "state": {
-          "ac_input_1": "AC Input 1",
-          "ac_input_2": "AC Input 2",
+          "ac_input_1": "AC input 1",
+          "ac_input_2": "AC input 2",
           "disconnected": "[%key:common::state::disconnected%]"
         }
       },
+      "multi_dc_temperature": {
+        "name": "[%key:component::victron_gx::common::dc_temperature%]"
+      },
       "multi_ess_mode": {
-        "name": "ESS mode",
+        "name": "[%key:component::victron_gx::common::ess_mode%]",
         "state": {
-          "external_control": "External control",
-          "keep_charged": "keep charged",
-          "self_consumption": "Self-consumption",
-          "self_consumption_batterylife": "Self-consumption (batterylife)"
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "keep_charged": "Keep charged",
+          "self_consumption": "[%key:component::victron_gx::common::self_consumption%]",
+          "self_consumption_batterylife": "Self-consumption (BatteryLife)"
         }
       },
       "multi_inverter_power_setpoint": {
@@ -1136,10 +1152,10 @@
         "name": "Inverter to AC-out"
       },
       "multi_max_power_today": {
-        "name": "Max power today"
+        "name": "[%key:component::victron_gx::common::max_power_today%]"
       },
       "multi_max_power_yesterday": {
-        "name": "Max power yesterday"
+        "name": "[%key:component::victron_gx::common::max_power_yesterday%]"
       },
       "multi_mppt_mppt_id_yield_today": {
         "name": "MPPT {mppt_id} yield today"
@@ -1152,10 +1168,10 @@
       },
       "multi_mppt_mpptnumber_state": {
         "state": {
-          "mppt_active": "MPPT active",
-          "not_available": "Not available",
+          "mppt_active": "[%key:component::victron_gx::common::mppt_active%]",
+          "not_available": "[%key:component::victron_gx::common::not_available%]",
           "off": "[%key:common::state::off%]",
-          "voltage_current_limited": "Voltage/current limited"
+          "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
         }
       },
       "multi_mppt_mpptnumber_voltage": {
@@ -1166,7 +1182,7 @@
         "unit_of_measurement": "phases"
       },
       "multi_pv_power_total": {
-        "name": "PV power total"
+        "name": "[%key:component::victron_gx::common::pv_power_total%]"
       },
       "multi_solar_to_acin1": {
         "name": "Solar to AC-in-1"
@@ -1178,40 +1194,40 @@
         "name": "Solar to battery"
       },
       "multi_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
       "multi_total_pv_yield": {
-        "name": "Total PV yield user"
+        "name": "[%key:component::victron_gx::common::total_pv_yield_user%]"
       },
       "multi_yield_today": {
-        "name": "Yield today"
+        "name": "[%key:component::victron_gx::common::yield_today%]"
       },
       "multi_yield_yesterday": {
-        "name": "Yield yesterday"
+        "name": "[%key:component::victron_gx::common::yield_yesterday%]"
       },
       "platform_venus_firmware_available_version": {
         "name": "Available version"
@@ -1220,10 +1236,10 @@
         "name": "Installed version"
       },
       "pvinverter_current_phase": {
-        "name": "Current {phase}"
+        "name": "[%key:component::victron_gx::common::current_phase%]"
       },
       "pvinverter_power_phase": {
-        "name": "Power {phase}"
+        "name": "[%key:component::victron_gx::common::power_phase%]"
       },
       "pvinverter_power_total": {
         "name": "Power total"
@@ -1235,7 +1251,7 @@
         "name": "Yield {phase}"
       },
       "pvinverter_yield_total": {
-        "name": "Total yield"
+        "name": "[%key:component::victron_gx::common::total_yield%]"
       },
       "solarcharger_current": {
         "name": "PV bus current"
@@ -1254,9 +1270,9 @@
           "engine_shutdown": "Engine shutdown on low input voltage",
           "low_temperature": "Low temperature",
           "need_token": "Need token for operation",
-          "no_battery_power": "No/Low battery power",
-          "no_input_power": "No/Low input power",
-          "no_panel_power": "No/Low panel power",
+          "no_battery_power": "No/low battery power",
+          "no_input_power": "No/low input power",
+          "no_panel_power": "No/low panel power",
           "none": "-",
           "protective_action": "Protection active",
           "remote_input": "Remote input",
@@ -1266,28 +1282,28 @@
         }
       },
       "solarcharger_error_code": {
-        "name": "Error code",
+        "name": "[%key:component::victron_gx::common::error_code%]",
         "state": {
-          "battery_voltage_too_high": "Battery voltage too high",
-          "bms_connection_lost": "BMS connection lost",
-          "bulk_time_limit_exceeded": "Bulk time limit exceeded",
-          "charger_current_reversed": "Charger current reversed",
-          "charger_over_current": "Charger over current",
-          "charger_temperature_too_high": "Charger temperature too high",
-          "converter_issue": "Converter issue",
-          "current_sensor_issue": "Current sensor issue",
-          "factory_calibration_data_lost": "Factory calibration data lost",
-          "input_current_too_high": "Input current too high (solar panel)",
-          "input_shutdown_battery_voltage_too_high": "Input shutdown (battery voltage too high)",
-          "input_shutdown_reverse_current": "Input shutdown (reverse current)",
-          "input_voltage_too_high": "Input voltage too high (solar panel)",
-          "invalid_incompatible_firmware": "Invalid/incompatible firmware",
-          "lost_communication_with_device": "Lost communication with device",
-          "network_misconfigured": "Network misconfigured",
-          "no_error": "No error",
-          "synchronized_charging_config_issue": "Synchronized charging config issue",
-          "terminals_overheated": "Terminals overheated",
-          "user_settings_invalid": "User settings invalid"
+          "battery_voltage_too_high": "[%key:component::victron_gx::common::battery_voltage_too_high%]",
+          "bms_connection_lost": "[%key:component::victron_gx::common::bms_connection_lost%]",
+          "bulk_time_limit_exceeded": "[%key:component::victron_gx::common::bulk_time_limit_exceeded%]",
+          "charger_current_reversed": "[%key:component::victron_gx::common::charger_current_reversed%]",
+          "charger_over_current": "[%key:component::victron_gx::common::charger_over_current%]",
+          "charger_temperature_too_high": "[%key:component::victron_gx::common::charger_temperature_too_high%]",
+          "converter_issue": "[%key:component::victron_gx::common::converter_issue%]",
+          "current_sensor_issue": "[%key:component::victron_gx::common::current_sensor_issue%]",
+          "factory_calibration_data_lost": "[%key:component::victron_gx::common::factory_calibration_data_lost%]",
+          "input_current_too_high": "[%key:component::victron_gx::common::input_current_too_high_solar_panel%]",
+          "input_shutdown_battery_voltage_too_high": "[%key:component::victron_gx::common::input_shutdown_battery_voltage_too_high%]",
+          "input_shutdown_reverse_current": "[%key:component::victron_gx::common::input_shutdown_reverse_current%]",
+          "input_voltage_too_high": "[%key:component::victron_gx::common::input_voltage_too_high_solar_panel%]",
+          "invalid_incompatible_firmware": "[%key:component::victron_gx::common::invalid_incompatible_firmware%]",
+          "lost_communication_with_device": "[%key:component::victron_gx::common::lost_communication_with_device%]",
+          "network_misconfigured": "[%key:component::victron_gx::common::network_misconfigured%]",
+          "no_error": "[%key:component::victron_gx::common::no_error%]",
+          "synchronized_charging_config_issue": "[%key:component::victron_gx::common::synchronized_charging_config_issue%]",
+          "terminals_overheated": "[%key:component::victron_gx::common::terminals_overheated%]",
+          "user_settings_invalid": "[%key:component::victron_gx::common::user_settings_invalid%]"
         }
       },
       "solarcharger_load_current": {
@@ -1297,10 +1313,10 @@
         "name": "Max battery voltage today"
       },
       "solarcharger_max_power_today": {
-        "name": "Max power today"
+        "name": "[%key:component::victron_gx::common::max_power_today%]"
       },
       "solarcharger_max_power_yesterday": {
-        "name": "Max power yesterday"
+        "name": "[%key:component::victron_gx::common::max_power_yesterday%]"
       },
       "solarcharger_min_battery_voltage_today": {
         "name": "Min battery voltage today"
@@ -1308,37 +1324,37 @@
       "solarcharger_mppt_operation_mode": {
         "name": "MPPT operation mode",
         "state": {
-          "mppt_active": "MPPT active",
-          "not_available": "Not available",
+          "mppt_active": "[%key:component::victron_gx::common::mppt_active%]",
+          "not_available": "[%key:component::victron_gx::common::not_available%]",
           "off": "[%key:common::state::off%]",
-          "voltage_current_limited": "Voltage/current limited"
+          "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
         }
       },
       "solarcharger_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
       "solarcharger_time_in_absorption_today": {
@@ -1362,10 +1378,10 @@
       "solarcharger_tracker_tracker_operation_mode": {
         "name": "PV tracker {tracker} operation mode",
         "state": {
-          "mppt_active": "MPPT active",
-          "not_available": "Not available",
+          "mppt_active": "[%key:component::victron_gx::common::mppt_active%]",
+          "not_available": "[%key:component::victron_gx::common::not_available%]",
           "off": "[%key:common::state::off%]",
-          "voltage_current_limited": "Voltage/current limited"
+          "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
         }
       },
       "solarcharger_tracker_tracker_power": {
@@ -1378,34 +1394,28 @@
         "name": "Tracker {tracker} yield today"
       },
       "solarcharger_voltage": {
-        "name": "PV bus voltage"
+        "name": "[%key:component::victron_gx::common::pv_bus_voltage%]"
       },
       "solarcharger_yield_power": {
         "name": "PV yield power"
       },
       "solarcharger_yield_today": {
-        "name": "Yield today"
+        "name": "[%key:component::victron_gx::common::yield_today%]"
       },
       "solarcharger_yield_total": {
-        "name": "Total yield"
+        "name": "[%key:component::victron_gx::common::total_yield%]"
       },
       "solarcharger_yield_yesterday": {
-        "name": "Yield yesterday"
-      },
-      "switch_output_custom_name": {
-        "name": "{output} custom name"
-      },
-      "switchable_output_output_custom_name": {
-        "name": "Switchable output {output} custom name"
+        "name": "[%key:component::victron_gx::common::yield_yesterday%]"
       },
       "system_ac_active_input_source": {
         "name": "AC active input source",
         "state": {
-          "generator": "Generator",
-          "grid": "Grid",
-          "not_connected": "Not connected",
-          "shore_power": "Shore power",
-          "unknown": "Unknown"
+          "generator": "[%key:component::victron_gx::common::generator%]",
+          "grid": "[%key:component::victron_gx::common::grid%]",
+          "not_connected": "[%key:component::victron_gx::common::not_connected%]",
+          "shore_power": "[%key:component::victron_gx::common::shore_power%]",
+          "unknown": "[%key:component::victron_gx::common::unknown%]"
         }
       },
       "system_ac_loads_phase": {
@@ -1481,11 +1491,11 @@
       "system_dynamicess_error": {
         "name": "Dynamic ESS error",
         "state": {
-          "battry_capacity_not_configured": "Battery Capacity Not Configured",
-          "ess_mode": "ESS Mode",
-          "no_error": "No Error",
+          "battry_capacity_not_configured": "Battery capacity not configured",
+          "ess_mode": "[%key:component::victron_gx::common::ess_mode%]",
+          "no_error": "[%key:component::victron_gx::common::no_error%]",
           "no_ess": "No ESS",
-          "no_schedule": "No Matching Schedule",
+          "no_schedule": "No matching schedule",
           "soc_low": "SoC low"
         }
       },
@@ -1501,33 +1511,33 @@
       "system_dynamicess_reactive_strategy": {
         "name": "Dynamic ESS reactive strategy",
         "state": {
-          "dess_disabled": "DESS Disabled",
-          "ess_low_soc": "ESS Low SoC",
-          "idle_maintain_surplus": "Idle Maintain Surplus",
-          "idle_maintain_targetsoc": "Idle Maintain Target SoC",
-          "idle_no_opportunity": "Idle No Opportunity",
-          "idle_scheduled_feedin": "Idle Scheduled Feed-In",
-          "keep_battery_charged": "Keep Battery Charged",
-          "no_window": "No Window",
-          "scheduled_charge_allow_grid": "Scheduled Charge Allow Grid",
-          "scheduled_charge_enhanced": "Scheduled Charge Enhanced",
-          "scheduled_charge_feedin": "Scheduled Charge Feed-In",
-          "scheduled_charge_no_grid": "Scheduled Charge No Grid",
-          "scheduled_charge_smooth_transition": "Scheduled Charge Smooth Transition",
-          "scheduled_discharge": "Scheduled Discharge",
-          "scheduled_discharge_smooth_transition": "Scheduled Discharge Smooth Transition",
-          "scheduled_minimum_discharge": "Scheduled Minimum Discharge",
-          "scheduled_selfconsume": "Scheduled Self-Consume",
-          "selfconsume_accept_charge": "Self-Consume Accept Charge",
-          "selfconsume_accept_discharge": "Self-Consume Accept Discharge",
-          "selfconsume_faulty_chargerate": "Self-Consume Faulty Charge Rate",
-          "selfconsume_increased_discharge": "Self-Consume Increased Discharge",
-          "selfconsume_no_grid": "Self-Consume No Grid",
-          "selfconsume_unexpected_exception": "Self-Consume Unexpected Exception",
-          "selfconsume_unmapped_state": "Self-Consume Unmapped State",
-          "selfconsume_unpredicted": "Self-Consume Unpredicted",
-          "unknown_operating_mode": "Unknown Operating Mode",
-          "unscheduled_charge_catchup_targetsoc": "Unscheduled Charge Catch-Up Target SoC"
+          "dess_disabled": "DESS disabled",
+          "ess_low_soc": "ESS low SoC",
+          "idle_maintain_surplus": "Idle maintain surplus",
+          "idle_maintain_targetsoc": "Idle maintain target SoC",
+          "idle_no_opportunity": "Idle no opportunity",
+          "idle_scheduled_feedin": "Idle scheduled feed-in",
+          "keep_battery_charged": "Keep battery charged",
+          "no_window": "No window",
+          "scheduled_charge_allow_grid": "Scheduled charge allow grid",
+          "scheduled_charge_enhanced": "Scheduled charge enhanced",
+          "scheduled_charge_feedin": "Scheduled charge feed-in",
+          "scheduled_charge_no_grid": "Scheduled charge no grid",
+          "scheduled_charge_smooth_transition": "Scheduled charge smooth transition",
+          "scheduled_discharge": "Scheduled discharge",
+          "scheduled_discharge_smooth_transition": "Scheduled discharge smooth transition",
+          "scheduled_minimum_discharge": "Scheduled minimum discharge",
+          "scheduled_selfconsume": "Scheduled self-consume",
+          "selfconsume_accept_charge": "Self-consume accept charge",
+          "selfconsume_accept_discharge": "Self-consume accept discharge",
+          "selfconsume_faulty_chargerate": "Self-consume faulty charge rate",
+          "selfconsume_increased_discharge": "Self-consume increased discharge",
+          "selfconsume_no_grid": "Self-consume no grid",
+          "selfconsume_unexpected_exception": "Self-consume unexpected exception",
+          "selfconsume_unmapped_state": "Self-consume unmapped state",
+          "selfconsume_unpredicted": "Self-consume unpredicted",
+          "unknown_operating_mode": "Unknown operating mode",
+          "unscheduled_charge_catchup_targetsoc": "Unscheduled charge catch-up target SoC"
         }
       },
       "system_dynamicess_restrictions": {
@@ -1536,7 +1546,7 @@
           "battery_to_grid_restricted": "Battery to grid energy flow restricted",
           "grid_to_battery_restricted": "Grid to battery energy flow restricted",
           "no_flow": "No energy flow between battery and grid",
-          "no_restrictions": "No Restrictions between battery and the grid"
+          "no_restrictions": "No restrictions between battery and the grid"
         }
       },
       "system_dynamicess_schedule_count": {
@@ -1546,9 +1556,9 @@
       "system_dynamicess_strategy": {
         "name": "Dynamic ESS strategy",
         "state": {
-          "probattery": "Pro Battery",
-          "progrid": "Pro Grid",
-          "selfconsume": "Self-Consume",
+          "probattery": "Pro battery",
+          "progrid": "Pro grid",
+          "selfconsume": "Self-consume",
           "targetsoc": "Target SoC"
         }
       },
@@ -1587,48 +1597,48 @@
       "system_state": {
         "name": "System state",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
       "tank_battery_voltage": {
-        "name": "Sensor battery voltage"
+        "name": "[%key:component::victron_gx::common::sensor_battery_voltage%]"
       },
       "tank_fluid_type": {
         "name": "Fluid type",
         "state": {
           "black_water": "Black water (sewage)",
           "diesel": "Diesel",
-          "fresh_water": "Fresh Water",
+          "fresh_water": "Fresh water",
           "fuel": "Fuel",
           "gasoline": "Gasoline",
           "hydraulic_oil": "Hydraulic oil",
-          "live_well": "Live Well",
-          "lng": "Liquid Natural Gas (LNG)",
-          "lpg": "Liquid  Petroleum Gas (LPG)",
+          "live_well": "Live well",
+          "lng": "Liquid natural gas (LNG)",
+          "lpg": "Liquid petroleum gas (LPG)",
           "oil": "Oil",
           "raw_water": "Raw water",
-          "waste_water": "Waste Water"
+          "waste_water": "Waste water"
         }
       },
       "tank_level": {
@@ -1638,30 +1648,29 @@
         "name": "Remaining"
       },
       "tank_temperature": {
-        "name": "Temperature"
+        "name": "[%key:component::victron_gx::common::temperature%]"
       },
       "temperature_battery_voltage": {
-        "name": "Sensor battery voltage"
+        "name": "[%key:component::victron_gx::common::sensor_battery_voltage%]"
       },
       "temperature_humidity": {
         "name": "Humidity"
       },
       "temperature_pressure": {
-        "name": "Pressure",
-        "unit_of_measurement": "hPa"
+        "name": "Pressure"
       },
       "temperature_status": {
         "name": "Sensor status",
         "state": {
           "disconnected": "[%key:common::state::disconnected%]",
-          "ok": "Ok",
+          "ok": "[%key:component::victron_gx::common::ok%]",
           "reverse_polarity": "Reverse polarity",
           "short_circuited": "Short circuited",
-          "unknown": "Unknown"
+          "unknown": "[%key:component::victron_gx::common::unknown%]"
         }
       },
       "temperature_temperature": {
-        "name": "Temperature"
+        "name": "[%key:component::victron_gx::common::temperature%]"
       },
       "temperature_type": {
         "name": "Sensor type",
@@ -1672,7 +1681,7 @@
           "generic": "Generic",
           "outdoor": "Outdoor",
           "room": "Room",
-          "water_heater": "Water Heater"
+          "water_heater": "Water heater"
         }
       },
       "vebus_device_device_number_input_power_l1": {
@@ -1721,97 +1730,97 @@
         "name": "Energy from out to inverter"
       },
       "vebus_inverter_active_input": {
-        "name": "Active AC input",
+        "name": "[%key:component::victron_gx::common::active_ac_input%]",
         "state": {
-          "generator": "Generator",
-          "grid": "Grid",
-          "not_connected": "Not connected",
-          "shore_power": "Shore power",
-          "unknown": "Unknown"
+          "generator": "[%key:component::victron_gx::common::generator%]",
+          "grid": "[%key:component::victron_gx::common::grid%]",
+          "not_connected": "[%key:component::victron_gx::common::not_connected%]",
+          "shore_power": "[%key:component::victron_gx::common::shore_power%]",
+          "unknown": "[%key:component::victron_gx::common::unknown%]"
         }
       },
       "vebus_inverter_alarm_grid_lost": {
         "name": "Grid lost alarm",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_high_dc_current": {
         "name": "High DC current alarm",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_high_dc_voltage": {
         "name": "High DC voltage alarm",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_high_temperature": {
-        "name": "High temperature alarm",
+        "name": "[%key:component::victron_gx::common::high_temperature_alarm%]",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_low_battery": {
         "name": "Low battery alarm",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_overload": {
-        "name": "Overload alarm",
+        "name": "[%key:component::victron_gx::common::overload_alarm%]",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_phase_rotation": {
         "name": "Phase rotation alarm",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_ripple": {
-        "name": "Ripple alarm",
+        "name": "[%key:component::victron_gx::common::ripple_alarm%]",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_temperature_sensor": {
         "name": "Temperature sensor alarm",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_alarm_voltage_sensor": {
         "name": "Voltage sensor alarm",
         "state": {
-          "alarm": "Alarm",
-          "no_alarm": "No Alarm",
-          "warning": "Warning"
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
         }
       },
       "vebus_inverter_current_limit": {
-        "name": "Current limit"
+        "name": "[%key:component::victron_gx::common::current_limit%]"
       },
       "vebus_inverter_dc_current": {
         "name": "DC current"
@@ -1820,7 +1829,7 @@
         "name": "DC power"
       },
       "vebus_inverter_dc_temperature": {
-        "name": "DC temperature"
+        "name": "[%key:component::victron_gx::common::dc_temperature%]"
       },
       "vebus_inverter_dc_voltage": {
         "name": "DC voltage"
@@ -1848,51 +1857,54 @@
         "name": "Input voltage {phase}"
       },
       "vebus_inverter_output_apparent_power_phase": {
-        "name": "Output apparent power {phase}"
+        "name": "[%key:component::victron_gx::common::output_apparent_power_phase%]"
       },
       "vebus_inverter_output_current_phase": {
-        "name": "Output current {phase}"
+        "name": "[%key:component::victron_gx::common::output_current_phase%]"
       },
       "vebus_inverter_output_frequency_phase": {
         "name": "Output frequency {phase}"
       },
       "vebus_inverter_output_power_phase": {
-        "name": "Output power {phase}"
+        "name": "[%key:component::victron_gx::common::output_power_phase%]"
       },
       "vebus_inverter_output_voltage_phase": {
-        "name": "Output voltage {phase}"
+        "name": "[%key:component::victron_gx::common::output_voltage_phase%]"
       },
       "vebus_inverter_state": {
-        "name": "State",
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "absorption": "Absorption",
-          "auto_equalize": "Auto Equalize / Recondition",
-          "battery_safe": "Battery Safe",
-          "bulk": "Bulk",
+          "absorption": "[%key:component::victron_gx::common::absorption%]",
+          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
+          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
+          "bulk": "[%key:component::victron_gx::common::bulk%]",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "Equalize",
-          "external_control": "External Control",
+          "equalize": "[%key:component::victron_gx::common::equalize%]",
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
           "fault": "[%key:common::state::fault%]",
-          "float": "Float",
-          "inverting": "Inverting",
-          "low_power": "Low Power",
+          "float": "[%key:component::victron_gx::common::float%]",
+          "inverting": "[%key:component::victron_gx::common::inverting%]",
+          "low_power": "[%key:component::victron_gx::common::low_power%]",
           "off": "[%key:common::state::off%]",
-          "passthrough": "Passthrough",
-          "power_assist": "Power Assist",
-          "power_supply": "Power Supply",
-          "recharging": "Recharging",
-          "repeated_absorption": "Repeated Absorption",
-          "scheduled_recharging": "Scheduled Recharging",
-          "starting_up": "Starting Up",
-          "storage": "Storage",
-          "sustain": "Sustain",
-          "sustain_alt": "Sustain Alt"
+          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
+          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
+          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
+          "recharging": "[%key:component::victron_gx::common::recharging%]",
+          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
+          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
+          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
+          "storage": "[%key:component::victron_gx::common::storage%]",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       }
     },
     "switch": {
       "digitalinput_settings_invert_translation": {
         "name": "Invert digital input"
+      },
+      "evcharger_auto_start": {
+        "name": "Auto start"
       },
       "evcharger_charge": {
         "name": "EV charging"
@@ -1928,10 +1940,10 @@
         "name": "Relay state"
       },
       "switch_output_state": {
-        "name": "Switch {output} state"
+        "name": "[%key:component::victron_gx::common::state%]"
       },
       "switchable_output_output_state": {
-        "name": "Switchable output {output} state"
+        "name": "[%key:component::victron_gx::common::state%]"
       },
       "system_ess_battery_use": {
         "name": "ESS only critical loads from battery"

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -1,101 +1,4 @@
 {
-  "common": {
-    "absorption": "Absorption",
-    "active_ac_input": "Active AC input",
-    "alarm": "Alarm",
-    "auto_equalize_recondition": "Auto equalize / recondition",
-    "battery_safe": "Battery Safe",
-    "battery_voltage_too_high": "Battery voltage too high",
-    "bms_connection_lost": "BMS connection lost",
-    "bulk": "Bulk",
-    "bulk_time_limit_exceeded": "Bulk time limit exceeded",
-    "charger_current_reversed": "Charger current reversed",
-    "charger_only": "Charger only",
-    "charger_over_current": "Charger over current",
-    "charger_temperature_too_high": "Charger temperature too high",
-    "consumption": "Consumption",
-    "consumption_on_phase": "Consumption on {phase}",
-    "converter_issue": "Converter issue",
-    "current": "Current",
-    "current_limit": "Current limit",
-    "current_on_phase": "Current on {phase}",
-    "current_phase": "Current {phase}",
-    "current_sensor_issue": "Current sensor issue",
-    "dc_output_current": "DC output current",
-    "dc_output_power": "DC output power",
-    "dc_output_voltage": "DC output voltage",
-    "dc_temperature": "DC temperature",
-    "equalize": "Equalize",
-    "error_code": "Error code",
-    "ess_mode": "ESS mode",
-    "external_control": "External control",
-    "factory_calibration_data_lost": "Factory calibration data lost",
-    "float": "Float",
-    "frequency": "Frequency",
-    "generator": "Generator",
-    "grid": "Grid",
-    "high_temperature_alarm": "High temperature alarm",
-    "input_current": "Input current",
-    "input_current_too_high_solar_panel": "Input current too high (solar panel)",
-    "input_power": "Input power",
-    "input_shutdown_battery_voltage_too_high": "Input shutdown (battery voltage too high)",
-    "input_shutdown_reverse_current": "Input shutdown (reverse current)",
-    "input_voltage": "Input voltage",
-    "input_voltage_too_high_solar_panel": "Input voltage too high (solar panel)",
-    "invalid_incompatible_firmware": "Invalid/incompatible firmware",
-    "inverter_only": "Inverter only",
-    "inverting": "Inverting",
-    "lost_communication_with_device": "Lost communication with device",
-    "low_power": "Low power",
-    "max_power_today": "Max power today",
-    "max_power_yesterday": "Max power yesterday",
-    "mppt_active": "MPPT active",
-    "network_misconfigured": "Network misconfigured",
-    "no_alarm": "No alarm",
-    "no_error": "No error",
-    "not_available": "Not available",
-    "not_connected": "Not connected",
-    "ok": "Ok",
-    "output_apparent_power_phase": "Output apparent power {phase}",
-    "output_current_phase": "Output current {phase}",
-    "output_power_phase": "Output power {phase}",
-    "output_voltage_phase": "Output voltage {phase}",
-    "overload_alarm": "Overload alarm",
-    "passthrough": "Passthrough",
-    "power": "Power",
-    "power_assist": "Power Assist",
-    "power_on_phase": "Power on {phase}",
-    "power_phase": "Power {phase}",
-    "power_supply": "Power supply",
-    "pv_bus_voltage": "PV bus voltage",
-    "pv_power_total": "PV power total",
-    "recharging": "Recharging",
-    "repeated_absorption": "Repeated absorption",
-    "reserved": "Reserved",
-    "ripple_alarm": "Ripple alarm",
-    "scheduled_recharging": "Scheduled recharging",
-    "self_consumption": "Self-consumption",
-    "sensor_battery_voltage": "Sensor battery voltage",
-    "shore_power": "Shore power",
-    "starting_up": "Starting up",
-    "state": "State",
-    "storage": "Storage",
-    "sustain": "Sustain",
-    "sustain_alt": "Sustain alt",
-    "synchronized_charging_config_issue": "Synchronized charging config issue",
-    "temperature": "Temperature",
-    "terminals_overheated": "Terminals overheated",
-    "total_pv_yield_user": "Total PV yield user",
-    "total_yield": "Total yield",
-    "unknown": "Unknown",
-    "user_settings_invalid": "User settings invalid",
-    "voltage": "Voltage",
-    "voltage_current_limited": "Voltage/current limited",
-    "voltage_on_phase": "Voltage on {phase}",
-    "warning": "Warning",
-    "yield_today": "Yield today",
-    "yield_yesterday": "Yield yesterday"
-  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -167,7 +70,7 @@
         "name": "[%key:common::state::connected%]"
       },
       "inverter_alarm_high_temperature": {
-        "name": "[%key:component::victron_gx::common::high_temperature_alarm%]"
+        "name": "High temperature alarm"
       },
       "inverter_alarm_high_voltage": {
         "name": "High voltage alarm"
@@ -185,10 +88,10 @@
         "name": "Low voltage AC-out alarm"
       },
       "inverter_alarm_overload": {
-        "name": "[%key:component::victron_gx::common::overload_alarm%]"
+        "name": "Overload alarm"
       },
       "inverter_alarm_ripple": {
-        "name": "[%key:component::victron_gx::common::ripple_alarm%]"
+        "name": "Ripple alarm"
       },
       "solarcharger_load_state": {
         "name": "Load state"
@@ -331,17 +234,17 @@
         "name": "AC power setpoint {phase}"
       },
       "vebus_inverter_current_limit": {
-        "name": "[%key:component::victron_gx::common::current_limit%]"
+        "name": "Current limit"
       }
     },
     "select": {
       "acsystem_mode": {
         "state": {
-          "charger_only": "[%key:component::victron_gx::common::charger_only%]",
-          "inverter_only": "[%key:component::victron_gx::common::inverter_only%]",
+          "charger_only": "Charger only",
+          "inverter_only": "Inverter only",
           "off": "[%key:common::state::off%]",
           "on": "[%key:common::state::on%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]"
+          "passthrough": "Passthrough"
         }
       },
       "evcharger_mode": {
@@ -365,7 +268,7 @@
           "keep_batteries_charged": "'Keep batteries charged' mode enabled",
           "recharge": "Recharge, SoC dropped 5% or more below minimum SoC",
           "recharge_no_battery_life": "Recharge, SoC dropped 5% or more below minimum SoC (No BatteryLife)",
-          "self_consumption": "[%key:component::victron_gx::common::self_consumption%]",
+          "self_consumption": "Self-consumption",
           "self_consumption_soc_above_min": "Self-consumption, SoC at or above minimum SoC",
           "self_consumption_soc_at_100": "Self-consumption, SoC at 100%",
           "self_consumption_soc_below_min": "Self-consumption, SoC is below minimum SoC",
@@ -379,7 +282,7 @@
       "system_ess_mode": {
         "name": "ESS mode (Hub4)",
         "state": {
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "external_control": "External control",
           "phase_compensation_disabled": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
           "phase_compensation_enabled": "Optimized mode or 'keep batteries charged' and phase compensation enabled"
         }
@@ -421,8 +324,8 @@
       },
       "vebus_inverter_mode": {
         "state": {
-          "charger_only": "[%key:component::victron_gx::common::charger_only%]",
-          "inverter_only": "[%key:component::victron_gx::common::inverter_only%]",
+          "charger_only": "Charger only",
+          "inverter_only": "Inverter only",
           "off": "[%key:common::state::off%]",
           "on": "[%key:common::state::on%]"
         }
@@ -433,72 +336,72 @@
         "name": "Load current"
       },
       "acload_current_phase": {
-        "name": "[%key:component::victron_gx::common::current_on_phase%]"
+        "name": "Current on {phase}"
       },
       "acload_energy_forward": {
-        "name": "[%key:component::victron_gx::common::consumption%]"
+        "name": "Consumption"
       },
       "acload_energy_forward_phase": {
-        "name": "[%key:component::victron_gx::common::consumption_on_phase%]"
+        "name": "Consumption on {phase}"
       },
       "acload_frequency": {
-        "name": "[%key:component::victron_gx::common::frequency%]"
+        "name": "Frequency"
       },
       "acload_power": {
-        "name": "[%key:component::victron_gx::common::power%]"
+        "name": "Power"
       },
       "acload_power_phase": {
-        "name": "[%key:component::victron_gx::common::power_on_phase%]"
+        "name": "Power on {phase}"
       },
       "acload_voltage": {
-        "name": "[%key:component::victron_gx::common::voltage%]"
+        "name": "Voltage"
       },
       "acload_voltage_phase": {
-        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
+        "name": "Voltage on {phase}"
       },
       "alternator_dc_current": {
-        "name": "[%key:component::victron_gx::common::dc_output_current%]"
+        "name": "DC output current"
       },
       "alternator_dc_power": {
-        "name": "[%key:component::victron_gx::common::dc_output_power%]"
+        "name": "DC output power"
       },
       "alternator_dc_voltage": {
-        "name": "[%key:component::victron_gx::common::dc_output_voltage%]"
+        "name": "DC output voltage"
       },
       "alternator_input_current": {
-        "name": "[%key:component::victron_gx::common::input_current%]"
+        "name": "Input current"
       },
       "alternator_input_power": {
-        "name": "[%key:component::victron_gx::common::input_power%]"
+        "name": "Input power"
       },
       "alternator_input_voltage": {
-        "name": "[%key:component::victron_gx::common::input_voltage%]"
+        "name": "Input voltage"
       },
       "alternator_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       },
       "auxiliary_battery_voltage": {
@@ -521,9 +424,9 @@
       "battery_cell_imbalance": {
         "name": "Cell imbalance",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "battery_cell_voltage_deviation": {
@@ -552,25 +455,25 @@
       "battery_high_charge_current": {
         "name": "High charge current",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "battery_high_charge_temperature": {
         "name": "High charge temperature",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "battery_high_discharge_current": {
         "name": "High discharge current",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "battery_installed_capacity": {
@@ -580,9 +483,9 @@
       "battery_internal_failure": {
         "name": "Internal failure",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "battery_last_discharge": {
@@ -591,17 +494,17 @@
       "battery_low_cell_voltage": {
         "name": "Low cell voltage",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "battery_low_charge_temperature": {
         "name": "Low charge temperature",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "battery_max_cell_temperature": {
@@ -666,7 +569,7 @@
         "unit_of_measurement": "modules"
       },
       "battery_power": {
-        "name": "[%key:component::victron_gx::common::power%]"
+        "name": "Power"
       },
       "battery_soc": {
         "name": "Charge"
@@ -675,7 +578,7 @@
         "name": "State of health"
       },
       "battery_temperature": {
-        "name": "[%key:component::victron_gx::common::temperature%]"
+        "name": "Temperature"
       },
       "battery_time_since_last_full_charge": {
         "name": "Time since last full charge",
@@ -704,28 +607,28 @@
         "name": "DC output {output} voltage"
       },
       "charger_error_code": {
-        "name": "[%key:component::victron_gx::common::error_code%]",
+        "name": "Error code",
         "state": {
-          "battery_voltage_too_high": "[%key:component::victron_gx::common::battery_voltage_too_high%]",
-          "bms_connection_lost": "[%key:component::victron_gx::common::bms_connection_lost%]",
-          "bulk_time_limit_exceeded": "[%key:component::victron_gx::common::bulk_time_limit_exceeded%]",
-          "charger_current_reversed": "[%key:component::victron_gx::common::charger_current_reversed%]",
-          "charger_over_current": "[%key:component::victron_gx::common::charger_over_current%]",
-          "charger_temperature_too_high": "[%key:component::victron_gx::common::charger_temperature_too_high%]",
-          "converter_issue": "[%key:component::victron_gx::common::converter_issue%]",
-          "current_sensor_issue": "[%key:component::victron_gx::common::current_sensor_issue%]",
-          "factory_calibration_data_lost": "[%key:component::victron_gx::common::factory_calibration_data_lost%]",
-          "input_current_too_high": "[%key:component::victron_gx::common::input_current_too_high_solar_panel%]",
-          "input_shutdown_battery_voltage_too_high": "[%key:component::victron_gx::common::input_shutdown_battery_voltage_too_high%]",
-          "input_shutdown_reverse_current": "[%key:component::victron_gx::common::input_shutdown_reverse_current%]",
-          "input_voltage_too_high": "[%key:component::victron_gx::common::input_voltage_too_high_solar_panel%]",
-          "invalid_incompatible_firmware": "[%key:component::victron_gx::common::invalid_incompatible_firmware%]",
-          "lost_communication_with_device": "[%key:component::victron_gx::common::lost_communication_with_device%]",
-          "network_misconfigured": "[%key:component::victron_gx::common::network_misconfigured%]",
-          "no_error": "[%key:component::victron_gx::common::no_error%]",
-          "synchronized_charging_config_issue": "[%key:component::victron_gx::common::synchronized_charging_config_issue%]",
-          "terminals_overheated": "[%key:component::victron_gx::common::terminals_overheated%]",
-          "user_settings_invalid": "[%key:component::victron_gx::common::user_settings_invalid%]"
+          "battery_voltage_too_high": "Battery voltage too high",
+          "bms_connection_lost": "BMS connection lost",
+          "bulk_time_limit_exceeded": "Bulk time limit exceeded",
+          "charger_current_reversed": "Charger current reversed",
+          "charger_over_current": "Charger over current",
+          "charger_temperature_too_high": "Charger temperature too high",
+          "converter_issue": "Converter issue",
+          "current_sensor_issue": "Current sensor issue",
+          "factory_calibration_data_lost": "Factory calibration data lost",
+          "input_current_too_high": "Input current too high (solar panel)",
+          "input_shutdown_battery_voltage_too_high": "Input shutdown (battery voltage too high)",
+          "input_shutdown_reverse_current": "Input shutdown (reverse current)",
+          "input_voltage_too_high": "Input voltage too high (solar panel)",
+          "invalid_incompatible_firmware": "Invalid/incompatible firmware",
+          "lost_communication_with_device": "Lost communication with device",
+          "network_misconfigured": "Network misconfigured",
+          "no_error": "No error",
+          "synchronized_charging_config_issue": "Synchronized charging config issue",
+          "terminals_overheated": "Terminals overheated",
+          "user_settings_invalid": "User settings invalid"
         }
       },
       "charger_nr_of_outputs": {
@@ -733,104 +636,104 @@
         "unit_of_measurement": "outputs"
       },
       "charger_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       },
       "dcdc_dc_current": {
-        "name": "[%key:component::victron_gx::common::dc_output_current%]"
+        "name": "DC output current"
       },
       "dcdc_dc_power": {
-        "name": "[%key:component::victron_gx::common::dc_output_power%]"
+        "name": "DC output power"
       },
       "dcdc_dc_voltage": {
-        "name": "[%key:component::victron_gx::common::dc_output_voltage%]"
+        "name": "DC output voltage"
       },
       "dcdc_input_current": {
-        "name": "[%key:component::victron_gx::common::input_current%]"
+        "name": "Input current"
       },
       "dcdc_input_power": {
-        "name": "[%key:component::victron_gx::common::input_power%]"
+        "name": "Input power"
       },
       "dcdc_input_voltage": {
-        "name": "[%key:component::victron_gx::common::input_voltage%]"
+        "name": "Input voltage"
       },
       "dcdc_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       },
       "dcload_current": {
-        "name": "[%key:component::victron_gx::common::current%]"
+        "name": "Current"
       },
       "dcload_power": {
-        "name": "[%key:component::victron_gx::common::power%]"
+        "name": "Power"
       },
       "dcload_voltage": {
-        "name": "[%key:component::victron_gx::common::voltage%]"
+        "name": "Voltage"
       },
       "dcsystem_aux_voltage": {
         "name": "Auxiliary voltage"
       },
       "dcsystem_current": {
-        "name": "[%key:component::victron_gx::common::current%]"
+        "name": "Current"
       },
       "dcsystem_power": {
-        "name": "[%key:component::victron_gx::common::power%]"
+        "name": "Power"
       },
       "dcsystem_voltage": {
-        "name": "[%key:component::victron_gx::common::voltage%]"
+        "name": "Voltage"
       },
       "digitalinput_alarm": {
-        "name": "[%key:component::victron_gx::common::alarm%]",
+        "name": "Alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "digitalinput_input_state_raw": {
@@ -841,15 +744,15 @@
         }
       },
       "digitalinput_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "alarm": "Alarm",
           "closed": "[%key:common::state::closed%]",
           "high": "[%key:common::state::high%]",
           "low": "[%key:common::state::low%]",
           "no": "[%key:common::state::no%]",
           "off": "[%key:common::state::off%]",
-          "ok": "[%key:component::victron_gx::common::ok%]",
+          "ok": "Ok",
           "on": "[%key:common::state::on%]",
           "open": "[%key:common::state::open%]",
           "running": "Running",
@@ -867,14 +770,14 @@
           "disabled": "[%key:common::state::disabled%]",
           "door_alarm": "Door alarm",
           "fire_alarm": "Fire alarm",
-          "generator": "[%key:component::victron_gx::common::generator%]",
+          "generator": "Generator",
           "pulse_meter": "Pulse meter",
           "smoke_alarm": "Smoke alarm",
           "touch_input_control": "Touch input control"
         }
       },
       "evcharger_current": {
-        "name": "[%key:component::victron_gx::common::current%]"
+        "name": "Current"
       },
       "evcharger_max_set_current": {
         "name": "Maximum set current"
@@ -890,10 +793,10 @@
         }
       },
       "evcharger_power": {
-        "name": "[%key:component::victron_gx::common::power%]"
+        "name": "Power"
       },
       "evcharger_power_phase": {
-        "name": "[%key:component::victron_gx::common::power_phase%]"
+        "name": "Power {phase}"
       },
       "evcharger_session_cost": {
         "name": "Last session cost",
@@ -918,11 +821,11 @@
           "low_soc": "Low SoC",
           "overheating_detected": "Overheating detected",
           "overvoltage_detected": "Overvoltage detected",
-          "reserved15": "[%key:component::victron_gx::common::reserved%]",
-          "reserved16": "[%key:component::victron_gx::common::reserved%]",
-          "reserved17": "[%key:component::victron_gx::common::reserved%]",
-          "reserved18": "[%key:component::victron_gx::common::reserved%]",
-          "reserved19": "[%key:component::victron_gx::common::reserved%]",
+          "reserved15": "Reserved",
+          "reserved16": "Reserved",
+          "reserved17": "Reserved",
+          "reserved18": "Reserved",
+          "reserved19": "Reserved",
           "residual_current_detected": "Residual current detected",
           "start_charging": "Start charging",
           "switching_to_1_phase": "Switching to 1 phase",
@@ -967,16 +870,16 @@
         "unit_of_measurement": "satellites"
       },
       "grid_current": {
-        "name": "[%key:component::victron_gx::common::current%]"
+        "name": "Current"
       },
       "grid_current_n": {
         "name": "Current on N"
       },
       "grid_current_phase": {
-        "name": "[%key:component::victron_gx::common::current_on_phase%]"
+        "name": "Current on {phase}"
       },
       "grid_energy_forward": {
-        "name": "[%key:component::victron_gx::common::consumption%]"
+        "name": "Consumption"
       },
       "grid_energy_forward_phase": {
         "name": "Grid consumption on {phase}"
@@ -988,10 +891,10 @@
         "name": "Feed-in on {phase}"
       },
       "grid_frequency": {
-        "name": "[%key:component::victron_gx::common::frequency%]"
+        "name": "Frequency"
       },
       "grid_power": {
-        "name": "[%key:component::victron_gx::common::power%]"
+        "name": "Power"
       },
       "grid_power_factor": {
         "name": "Power factor"
@@ -1000,97 +903,97 @@
         "name": "Power factor on {phase}"
       },
       "grid_power_phase": {
-        "name": "[%key:component::victron_gx::common::power_on_phase%]"
+        "name": "Power on {phase}"
       },
       "grid_voltage": {
-        "name": "[%key:component::victron_gx::common::voltage%]"
+        "name": "Voltage"
       },
       "grid_voltage_pen": {
         "name": "Voltage on PEN"
       },
       "grid_voltage_phase": {
-        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
+        "name": "Voltage on {phase}"
       },
       "grid_voltage_phase_next_phase": {
         "name": "Voltage {phase} to {next_phase}"
       },
       "heatpump_current": {
-        "name": "[%key:component::victron_gx::common::current%]"
+        "name": "Current"
       },
       "heatpump_current_phase": {
-        "name": "[%key:component::victron_gx::common::current_on_phase%]"
+        "name": "Current on {phase}"
       },
       "heatpump_energy_forward": {
-        "name": "[%key:component::victron_gx::common::consumption%]"
+        "name": "Consumption"
       },
       "heatpump_energy_forward_phase": {
-        "name": "[%key:component::victron_gx::common::consumption_on_phase%]"
+        "name": "Consumption on {phase}"
       },
       "heatpump_frequency": {
-        "name": "[%key:component::victron_gx::common::frequency%]"
+        "name": "Frequency"
       },
       "heatpump_power": {
-        "name": "[%key:component::victron_gx::common::power%]"
+        "name": "Power"
       },
       "heatpump_power_phase": {
-        "name": "[%key:component::victron_gx::common::power_on_phase%]"
+        "name": "Power on {phase}"
       },
       "heatpump_voltage": {
-        "name": "[%key:component::victron_gx::common::voltage%]"
+        "name": "Voltage"
       },
       "heatpump_voltage_phase": {
-        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
+        "name": "Voltage on {phase}"
       },
       "inverter_output_apparent_power_phase": {
-        "name": "[%key:component::victron_gx::common::output_apparent_power_phase%]"
+        "name": "Output apparent power {phase}"
       },
       "inverter_output_current_phase": {
-        "name": "[%key:component::victron_gx::common::output_current_phase%]"
+        "name": "Output current {phase}"
       },
       "inverter_output_power_phase": {
-        "name": "[%key:component::victron_gx::common::output_power_phase%]"
+        "name": "Output power {phase}"
       },
       "inverter_output_voltage_phase": {
-        "name": "[%key:component::victron_gx::common::output_voltage_phase%]"
+        "name": "Output voltage {phase}"
       },
       "inverter_pv_power_total": {
-        "name": "[%key:component::victron_gx::common::pv_power_total%]"
+        "name": "PV power total"
       },
       "inverter_pv_voltage": {
-        "name": "[%key:component::victron_gx::common::pv_bus_voltage%]"
+        "name": "PV bus voltage"
       },
       "inverter_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       },
       "inverter_total_pv_yield_system": {
         "name": "Total PV yield system"
       },
       "inverter_total_pv_yield_user": {
-        "name": "[%key:component::victron_gx::common::total_pv_yield_user%]"
+        "name": "Total PV yield user"
       },
       "multi_acin1_to_acout": {
         "name": "AC-in-1 to AC-out"
@@ -1099,13 +1002,13 @@
         "name": "AC-in-1 to inverter"
       },
       "multi_acin_current_phase": {
-        "name": "[%key:component::victron_gx::common::current_phase%]"
+        "name": "Current {phase}"
       },
       "multi_acin_power_phase": {
-        "name": "[%key:component::victron_gx::common::power_on_phase%]"
+        "name": "Power on {phase}"
       },
       "multi_acin_voltage_phase": {
-        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
+        "name": "Voltage on {phase}"
       },
       "multi_acout_output_current_phase": {
         "name": "AC-out-{output} current on {phase}"
@@ -1123,7 +1026,7 @@
         "name": "AC-out to inverter"
       },
       "multi_active_input": {
-        "name": "[%key:component::victron_gx::common::active_ac_input%]",
+        "name": "Active AC input",
         "state": {
           "ac_input_1": "AC input 1",
           "ac_input_2": "AC input 2",
@@ -1131,14 +1034,14 @@
         }
       },
       "multi_dc_temperature": {
-        "name": "[%key:component::victron_gx::common::dc_temperature%]"
+        "name": "DC temperature"
       },
       "multi_ess_mode": {
-        "name": "[%key:component::victron_gx::common::ess_mode%]",
+        "name": "ESS mode",
         "state": {
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "external_control": "External control",
           "keep_charged": "Keep charged",
-          "self_consumption": "[%key:component::victron_gx::common::self_consumption%]",
+          "self_consumption": "Self-consumption",
           "self_consumption_batterylife": "Self-consumption (BatteryLife)"
         }
       },
@@ -1152,10 +1055,10 @@
         "name": "Inverter to AC-out"
       },
       "multi_max_power_today": {
-        "name": "[%key:component::victron_gx::common::max_power_today%]"
+        "name": "Max power today"
       },
       "multi_max_power_yesterday": {
-        "name": "[%key:component::victron_gx::common::max_power_yesterday%]"
+        "name": "Max power yesterday"
       },
       "multi_mppt_mppt_id_yield_today": {
         "name": "MPPT {mppt_id} yield today"
@@ -1168,10 +1071,10 @@
       },
       "multi_mppt_mpptnumber_state": {
         "state": {
-          "mppt_active": "[%key:component::victron_gx::common::mppt_active%]",
-          "not_available": "[%key:component::victron_gx::common::not_available%]",
+          "mppt_active": "MPPT active",
+          "not_available": "Not available",
           "off": "[%key:common::state::off%]",
-          "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
+          "voltage_current_limited": "Voltage/current limited"
         }
       },
       "multi_mppt_mpptnumber_voltage": {
@@ -1182,7 +1085,7 @@
         "unit_of_measurement": "phases"
       },
       "multi_pv_power_total": {
-        "name": "[%key:component::victron_gx::common::pv_power_total%]"
+        "name": "PV power total"
       },
       "multi_solar_to_acin1": {
         "name": "Solar to AC-in-1"
@@ -1194,40 +1097,40 @@
         "name": "Solar to battery"
       },
       "multi_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       },
       "multi_total_pv_yield": {
-        "name": "[%key:component::victron_gx::common::total_pv_yield_user%]"
+        "name": "Total PV yield user"
       },
       "multi_yield_today": {
-        "name": "[%key:component::victron_gx::common::yield_today%]"
+        "name": "Yield today"
       },
       "multi_yield_yesterday": {
-        "name": "[%key:component::victron_gx::common::yield_yesterday%]"
+        "name": "Yield yesterday"
       },
       "platform_venus_firmware_available_version": {
         "name": "Available version"
@@ -1236,10 +1139,10 @@
         "name": "Installed version"
       },
       "pvinverter_current_phase": {
-        "name": "[%key:component::victron_gx::common::current_phase%]"
+        "name": "Current {phase}"
       },
       "pvinverter_power_phase": {
-        "name": "[%key:component::victron_gx::common::power_phase%]"
+        "name": "Power {phase}"
       },
       "pvinverter_power_total": {
         "name": "Power total"
@@ -1251,7 +1154,7 @@
         "name": "Yield {phase}"
       },
       "pvinverter_yield_total": {
-        "name": "[%key:component::victron_gx::common::total_yield%]"
+        "name": "Total yield"
       },
       "solarcharger_current": {
         "name": "PV bus current"
@@ -1282,28 +1185,28 @@
         }
       },
       "solarcharger_error_code": {
-        "name": "[%key:component::victron_gx::common::error_code%]",
+        "name": "Error code",
         "state": {
-          "battery_voltage_too_high": "[%key:component::victron_gx::common::battery_voltage_too_high%]",
-          "bms_connection_lost": "[%key:component::victron_gx::common::bms_connection_lost%]",
-          "bulk_time_limit_exceeded": "[%key:component::victron_gx::common::bulk_time_limit_exceeded%]",
-          "charger_current_reversed": "[%key:component::victron_gx::common::charger_current_reversed%]",
-          "charger_over_current": "[%key:component::victron_gx::common::charger_over_current%]",
-          "charger_temperature_too_high": "[%key:component::victron_gx::common::charger_temperature_too_high%]",
-          "converter_issue": "[%key:component::victron_gx::common::converter_issue%]",
-          "current_sensor_issue": "[%key:component::victron_gx::common::current_sensor_issue%]",
-          "factory_calibration_data_lost": "[%key:component::victron_gx::common::factory_calibration_data_lost%]",
-          "input_current_too_high": "[%key:component::victron_gx::common::input_current_too_high_solar_panel%]",
-          "input_shutdown_battery_voltage_too_high": "[%key:component::victron_gx::common::input_shutdown_battery_voltage_too_high%]",
-          "input_shutdown_reverse_current": "[%key:component::victron_gx::common::input_shutdown_reverse_current%]",
-          "input_voltage_too_high": "[%key:component::victron_gx::common::input_voltage_too_high_solar_panel%]",
-          "invalid_incompatible_firmware": "[%key:component::victron_gx::common::invalid_incompatible_firmware%]",
-          "lost_communication_with_device": "[%key:component::victron_gx::common::lost_communication_with_device%]",
-          "network_misconfigured": "[%key:component::victron_gx::common::network_misconfigured%]",
-          "no_error": "[%key:component::victron_gx::common::no_error%]",
-          "synchronized_charging_config_issue": "[%key:component::victron_gx::common::synchronized_charging_config_issue%]",
-          "terminals_overheated": "[%key:component::victron_gx::common::terminals_overheated%]",
-          "user_settings_invalid": "[%key:component::victron_gx::common::user_settings_invalid%]"
+          "battery_voltage_too_high": "Battery voltage too high",
+          "bms_connection_lost": "BMS connection lost",
+          "bulk_time_limit_exceeded": "Bulk time limit exceeded",
+          "charger_current_reversed": "Charger current reversed",
+          "charger_over_current": "Charger over current",
+          "charger_temperature_too_high": "Charger temperature too high",
+          "converter_issue": "Converter issue",
+          "current_sensor_issue": "Current sensor issue",
+          "factory_calibration_data_lost": "Factory calibration data lost",
+          "input_current_too_high": "Input current too high (solar panel)",
+          "input_shutdown_battery_voltage_too_high": "Input shutdown (battery voltage too high)",
+          "input_shutdown_reverse_current": "Input shutdown (reverse current)",
+          "input_voltage_too_high": "Input voltage too high (solar panel)",
+          "invalid_incompatible_firmware": "Invalid/incompatible firmware",
+          "lost_communication_with_device": "Lost communication with device",
+          "network_misconfigured": "Network misconfigured",
+          "no_error": "No error",
+          "synchronized_charging_config_issue": "Synchronized charging config issue",
+          "terminals_overheated": "Terminals overheated",
+          "user_settings_invalid": "User settings invalid"
         }
       },
       "solarcharger_load_current": {
@@ -1313,10 +1216,10 @@
         "name": "Max battery voltage today"
       },
       "solarcharger_max_power_today": {
-        "name": "[%key:component::victron_gx::common::max_power_today%]"
+        "name": "Max power today"
       },
       "solarcharger_max_power_yesterday": {
-        "name": "[%key:component::victron_gx::common::max_power_yesterday%]"
+        "name": "Max power yesterday"
       },
       "solarcharger_min_battery_voltage_today": {
         "name": "Min battery voltage today"
@@ -1324,37 +1227,37 @@
       "solarcharger_mppt_operation_mode": {
         "name": "MPPT operation mode",
         "state": {
-          "mppt_active": "[%key:component::victron_gx::common::mppt_active%]",
-          "not_available": "[%key:component::victron_gx::common::not_available%]",
+          "mppt_active": "MPPT active",
+          "not_available": "Not available",
           "off": "[%key:common::state::off%]",
-          "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
+          "voltage_current_limited": "Voltage/current limited"
         }
       },
       "solarcharger_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       },
       "solarcharger_time_in_absorption_today": {
@@ -1378,10 +1281,10 @@
       "solarcharger_tracker_tracker_operation_mode": {
         "name": "PV tracker {tracker} operation mode",
         "state": {
-          "mppt_active": "[%key:component::victron_gx::common::mppt_active%]",
-          "not_available": "[%key:component::victron_gx::common::not_available%]",
+          "mppt_active": "MPPT active",
+          "not_available": "Not available",
           "off": "[%key:common::state::off%]",
-          "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
+          "voltage_current_limited": "Voltage/current limited"
         }
       },
       "solarcharger_tracker_tracker_power": {
@@ -1394,28 +1297,28 @@
         "name": "Tracker {tracker} yield today"
       },
       "solarcharger_voltage": {
-        "name": "[%key:component::victron_gx::common::pv_bus_voltage%]"
+        "name": "PV bus voltage"
       },
       "solarcharger_yield_power": {
         "name": "PV yield power"
       },
       "solarcharger_yield_today": {
-        "name": "[%key:component::victron_gx::common::yield_today%]"
+        "name": "Yield today"
       },
       "solarcharger_yield_total": {
-        "name": "[%key:component::victron_gx::common::total_yield%]"
+        "name": "Total yield"
       },
       "solarcharger_yield_yesterday": {
-        "name": "[%key:component::victron_gx::common::yield_yesterday%]"
+        "name": "Yield yesterday"
       },
       "system_ac_active_input_source": {
         "name": "AC active input source",
         "state": {
-          "generator": "[%key:component::victron_gx::common::generator%]",
-          "grid": "[%key:component::victron_gx::common::grid%]",
-          "not_connected": "[%key:component::victron_gx::common::not_connected%]",
-          "shore_power": "[%key:component::victron_gx::common::shore_power%]",
-          "unknown": "[%key:component::victron_gx::common::unknown%]"
+          "generator": "Generator",
+          "grid": "Grid",
+          "not_connected": "Not connected",
+          "shore_power": "Shore power",
+          "unknown": "Unknown"
         }
       },
       "system_ac_loads_phase": {
@@ -1492,8 +1395,8 @@
         "name": "Dynamic ESS error",
         "state": {
           "battry_capacity_not_configured": "Battery capacity not configured",
-          "ess_mode": "[%key:component::victron_gx::common::ess_mode%]",
-          "no_error": "[%key:component::victron_gx::common::no_error%]",
+          "ess_mode": "ESS mode",
+          "no_error": "No error",
           "no_ess": "No ESS",
           "no_schedule": "No matching schedule",
           "soc_low": "SoC low"
@@ -1597,32 +1500,32 @@
       "system_state": {
         "name": "System state",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       },
       "tank_battery_voltage": {
-        "name": "[%key:component::victron_gx::common::sensor_battery_voltage%]"
+        "name": "Sensor battery voltage"
       },
       "tank_fluid_type": {
         "name": "Fluid type",
@@ -1648,10 +1551,10 @@
         "name": "Remaining"
       },
       "tank_temperature": {
-        "name": "[%key:component::victron_gx::common::temperature%]"
+        "name": "Temperature"
       },
       "temperature_battery_voltage": {
-        "name": "[%key:component::victron_gx::common::sensor_battery_voltage%]"
+        "name": "Sensor battery voltage"
       },
       "temperature_humidity": {
         "name": "Humidity"
@@ -1663,14 +1566,14 @@
         "name": "Sensor status",
         "state": {
           "disconnected": "[%key:common::state::disconnected%]",
-          "ok": "[%key:component::victron_gx::common::ok%]",
+          "ok": "Ok",
           "reverse_polarity": "Reverse polarity",
           "short_circuited": "Short circuited",
-          "unknown": "[%key:component::victron_gx::common::unknown%]"
+          "unknown": "Unknown"
         }
       },
       "temperature_temperature": {
-        "name": "[%key:component::victron_gx::common::temperature%]"
+        "name": "Temperature"
       },
       "temperature_type": {
         "name": "Sensor type",
@@ -1730,97 +1633,97 @@
         "name": "Energy from out to inverter"
       },
       "vebus_inverter_active_input": {
-        "name": "[%key:component::victron_gx::common::active_ac_input%]",
+        "name": "Active AC input",
         "state": {
-          "generator": "[%key:component::victron_gx::common::generator%]",
-          "grid": "[%key:component::victron_gx::common::grid%]",
-          "not_connected": "[%key:component::victron_gx::common::not_connected%]",
-          "shore_power": "[%key:component::victron_gx::common::shore_power%]",
-          "unknown": "[%key:component::victron_gx::common::unknown%]"
+          "generator": "Generator",
+          "grid": "Grid",
+          "not_connected": "Not connected",
+          "shore_power": "Shore power",
+          "unknown": "Unknown"
         }
       },
       "vebus_inverter_alarm_grid_lost": {
         "name": "Grid lost alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_high_dc_current": {
         "name": "High DC current alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_high_dc_voltage": {
         "name": "High DC voltage alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_high_temperature": {
-        "name": "[%key:component::victron_gx::common::high_temperature_alarm%]",
+        "name": "High temperature alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_low_battery": {
         "name": "Low battery alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_overload": {
-        "name": "[%key:component::victron_gx::common::overload_alarm%]",
+        "name": "Overload alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_phase_rotation": {
         "name": "Phase rotation alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_ripple": {
-        "name": "[%key:component::victron_gx::common::ripple_alarm%]",
+        "name": "Ripple alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_temperature_sensor": {
         "name": "Temperature sensor alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_alarm_voltage_sensor": {
         "name": "Voltage sensor alarm",
         "state": {
-          "alarm": "[%key:component::victron_gx::common::alarm%]",
-          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
-          "warning": "[%key:component::victron_gx::common::warning%]"
+          "alarm": "Alarm",
+          "no_alarm": "No alarm",
+          "warning": "Warning"
         }
       },
       "vebus_inverter_current_limit": {
-        "name": "[%key:component::victron_gx::common::current_limit%]"
+        "name": "Current limit"
       },
       "vebus_inverter_dc_current": {
         "name": "DC current"
@@ -1829,7 +1732,7 @@
         "name": "DC power"
       },
       "vebus_inverter_dc_temperature": {
-        "name": "[%key:component::victron_gx::common::dc_temperature%]"
+        "name": "DC temperature"
       },
       "vebus_inverter_dc_voltage": {
         "name": "DC voltage"
@@ -1857,45 +1760,45 @@
         "name": "Input voltage {phase}"
       },
       "vebus_inverter_output_apparent_power_phase": {
-        "name": "[%key:component::victron_gx::common::output_apparent_power_phase%]"
+        "name": "Output apparent power {phase}"
       },
       "vebus_inverter_output_current_phase": {
-        "name": "[%key:component::victron_gx::common::output_current_phase%]"
+        "name": "Output current {phase}"
       },
       "vebus_inverter_output_frequency_phase": {
         "name": "Output frequency {phase}"
       },
       "vebus_inverter_output_power_phase": {
-        "name": "[%key:component::victron_gx::common::output_power_phase%]"
+        "name": "Output power {phase}"
       },
       "vebus_inverter_output_voltage_phase": {
-        "name": "[%key:component::victron_gx::common::output_voltage_phase%]"
+        "name": "Output voltage {phase}"
       },
       "vebus_inverter_state": {
-        "name": "[%key:component::victron_gx::common::state%]",
+        "name": "State",
         "state": {
-          "absorption": "[%key:component::victron_gx::common::absorption%]",
-          "auto_equalize": "[%key:component::victron_gx::common::auto_equalize_recondition%]",
-          "battery_safe": "[%key:component::victron_gx::common::battery_safe%]",
-          "bulk": "[%key:component::victron_gx::common::bulk%]",
+          "absorption": "Absorption",
+          "auto_equalize": "Auto equalize / recondition",
+          "battery_safe": "Battery Safe",
+          "bulk": "Bulk",
           "discharging": "[%key:common::state::discharging%]",
-          "equalize": "[%key:component::victron_gx::common::equalize%]",
-          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "equalize": "Equalize",
+          "external_control": "External control",
           "fault": "[%key:common::state::fault%]",
-          "float": "[%key:component::victron_gx::common::float%]",
-          "inverting": "[%key:component::victron_gx::common::inverting%]",
-          "low_power": "[%key:component::victron_gx::common::low_power%]",
+          "float": "Float",
+          "inverting": "Inverting",
+          "low_power": "Low power",
           "off": "[%key:common::state::off%]",
-          "passthrough": "[%key:component::victron_gx::common::passthrough%]",
-          "power_assist": "[%key:component::victron_gx::common::power_assist%]",
-          "power_supply": "[%key:component::victron_gx::common::power_supply%]",
-          "recharging": "[%key:component::victron_gx::common::recharging%]",
-          "repeated_absorption": "[%key:component::victron_gx::common::repeated_absorption%]",
-          "scheduled_recharging": "[%key:component::victron_gx::common::scheduled_recharging%]",
-          "starting_up": "[%key:component::victron_gx::common::starting_up%]",
-          "storage": "[%key:component::victron_gx::common::storage%]",
-          "sustain": "[%key:component::victron_gx::common::sustain%]",
-          "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
+          "passthrough": "Passthrough",
+          "power_assist": "Power Assist",
+          "power_supply": "Power supply",
+          "recharging": "Recharging",
+          "repeated_absorption": "Repeated absorption",
+          "scheduled_recharging": "Scheduled recharging",
+          "starting_up": "Starting up",
+          "storage": "Storage",
+          "sustain": "Sustain",
+          "sustain_alt": "Sustain alt"
         }
       }
     },
@@ -1940,10 +1843,10 @@
         "name": "Relay state"
       },
       "switch_output_state": {
-        "name": "[%key:component::victron_gx::common::state%]"
+        "name": "State"
       },
       "switchable_output_output_state": {
-        "name": "[%key:component::victron_gx::common::state%]"
+        "name": "State"
       },
       "system_ess_battery_use": {
         "name": "ESS only critical loads from battery"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3236,7 +3236,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.16
+victron-mqtt==2026.4.17
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3236,7 +3236,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.3
+victron-mqtt==2026.4.16
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2742,7 +2742,7 @@ venstarcolortouch==0.21
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.16
+victron-mqtt==2026.4.17
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2742,7 +2742,7 @@ venstarcolortouch==0.21
 victron-ble-ha-parser==0.6.3
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.3
+victron-mqtt==2026.4.16
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moving to latest version of the library and aligning strings

Diff between the last and current versions: https://github.com/tomer-w/victron_mqtt/compare/v2026.4.4...v2026.4.17

# victron_mqtt Changelog (2026.4.5 – 2026.4.17)

## 2026.4.17 (April 17, 2026)

- **Remove empty devices from the device chain** — Parent devices with no metrics of their own (e.g., a switch device that only groups SwitchableOutput sub-devices) are now automatically skipped in the device hierarchy. Sub-devices connect directly to the nearest ancestor with metrics. ([#350](https://github.com/tomer-w/ha-victron-mqtt/issues/350))

## 2026.4.16 (April 16, 2026)

- **Fix publish workflow** — CI/CD pipeline fix for automated releases.

## 2026.4.15 (April 16, 2026)

- **Auto bump versions** — Automated version bumping infrastructure.
- **Add EV charger autostart metric** ([#358](https://github.com/tomer-w/ha-victron-mqtt/issues/358))
- **Fix GPS with partial attributes** — GPS location formula now handles cases where some attributes (altitude, course, speed) are missing. ([#354](https://github.com/tomer-w/ha-victron-mqtt/issues/354))

## 2026.4.13 (April 16, 2026)

- **Add better step values** for writable number entities. ([Discussion #356](https://github.com/tomer-w/ha-victron-mqtt/discussions/356))
- **Improved view_metrics tool** — Split screen between devices and metrics panes.
- **Fix regression with sub-devices** — Sub-device keys with non-numerical IDs (e.g., `output_1`) now work correctly. ([#350](https://github.com/tomer-w/ha-victron-mqtt/issues/350))

## 2026.4.9 (April 14, 2026)

- **Add more device classes** for better HA entity categorization.
- **Remove unneeded measurements** — Cleaned up redundant metrics. ([#347](https://github.com/tomer-w/ha-victron-mqtt/issues/347))

## 2026.4.7 (April 13, 2026)

- **Skip devices with no visible metrics** from notification callbacks.
- **SwitchableOutput sub-device support** — Switch and system `SwitchableOutput` topics now create separate sub-devices per output, linked to a parent device via `sub_device_key`. ([#350](https://github.com/tomer-w/ha-victron-mqtt/issues/350))
- **`on_new_device` callback** — New callback with topological ordering (parent devices notified before children).
- **GPS device tracker support** — GPS location formula creates a `device_tracker` entity.
- **Modernized view_metrics tool** — Improved UX with search, live updates, and color-coded metric kinds.
- **`main_topic` support** — Topics can be marked as the main entity for a device.
- **New `MetricType` values** — Added `RESTART` for buttons, additional binary sensor states.
- **Comprehensive README and CONTRIBUTING.md rewrite**.

## 2026.4.5 (April 11, 2026)

- **Support all outputs of IP43 Charger** ([#337](https://github.com/tomer-w/ha-victron-mqtt/issues/337))
- **Multi RS Solar DC temperature metric** ([#88](https://github.com/tomer-w/victron_mqtt/issues/88))
- **Device tracker support** for GPS devices.
- **Centralized device name logic** in the library.
- **HA Core update workflow** — Automated workflow to generate `strings.json` for HA Core integration.
- **Remove unit_of_measurement from time entities**.
- **Remove phases as units**.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
