### PR TITLE
Automatically start subentry flow when creating a scrape config entry

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -23,11 +23,14 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import (
+    SOURCE_USER,
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
     ConfigSubentryFlow,
+    FlowType,
     OptionsFlow,
+    SubentryFlowContext,
     SubentryFlowResult,
 )
 from homeassistant.const import (
@@ -246,6 +249,18 @@ class ScrapeConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
+        """Start subentry flow after creating main entry."""
+        subentry_result = await self.hass.config_entries.subentries.async_init(
+            (result["result"].entry_id, "entity"),
+            context=SubentryFlowContext(source=SOURCE_USER),
+        )
+        result["next_flow"] = (
+            FlowType.CONFIG_SUBENTRIES_FLOW,
+            subentry_result["flow_id"],
+        )
+        return result
 
 
 class ScrapeOptionFlow(OptionsFlow):

--- a/tests/components/scrape/test_config_flow.py
+++ b/tests/components/scrape/test_config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.components.scrape.const import (
 )
 from homeassistant.const import (
     CONF_METHOD,
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_PAYLOAD,
     CONF_RESOURCE,
@@ -82,21 +83,23 @@ async def test_entry_and_subentry(
 
     assert len(mock_data.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-    entry_id = result["result"].entry_id
-
-    result = await hass.config_entries.subentries.async_init(
-        (entry_id, "entity"), context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["step_id"] == "user"
-    assert result["type"] is FlowResultType.FORM
+    subentry_flows = hass.config_entries.subentries.async_progress()
+    assert len(subentry_flows) == 1
 
     result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"],
-        {CONF_INDEX: 0, CONF_SELECT: ".current-version h1", CONF_ADVANCED: {}},
+        subentry_flows[0]["flow_id"],
+        {
+            CONF_NAME: "Current version",
+            CONF_INDEX: 0,
+            CONF_SELECT: ".current-version h1",
+            CONF_ADVANCED: {},
+        },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Current version"
     assert result["data"] == {
         CONF_INDEX: 0,
         CONF_SELECT: ".current-version h1",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
automatically start a subentry from once the config entry has been created in `scrape`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 