### PR TITLE
Add pending dataset visibility and cancellation to OTBR WebSocket API

### DIFF
--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -153,6 +153,11 @@ class OTBRData:
         await self.api.set_channel(channel, delay=int(delay * 1000))
 
     @_handle_otbr_error
+    async def delete_pending_dataset(self) -> None:
+        """Delete the pending operational dataset."""
+        await self.api.delete_pending_dataset()
+
+    @_handle_otbr_error
     async def get_extended_address(self) -> bytes:
         """Get extended address (EUI-64)."""
         return await self.api.get_extended_address()

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -170,17 +170,24 @@ class OTBRData:
 
         try:
             dataset = await self.api.get_active_dataset()
-            if dataset is None:
-                raise HomeAssistantError(
-                    "Failed to cancel pending dataset: no active dataset"
-                )
-            if (
-                dataset.active_timestamp
-                and dataset.active_timestamp.seconds is not None
-            ):
-                dataset.active_timestamp.seconds += 1
-            else:
-                dataset.active_timestamp = python_otbr_api.Timestamp(False, 1, 0)
+        except (
+            python_otbr_api.OTBRError,
+            aiohttp.ClientError,
+            TimeoutError,
+        ) as exc:
+            raise HomeAssistantError("Failed to call OTBR API") from exc
+
+        if dataset is None:
+            raise HomeAssistantError(
+                "Failed to cancel pending dataset: no active dataset"
+            )
+
+        if dataset.active_timestamp and dataset.active_timestamp.seconds is not None:
+            dataset.active_timestamp.seconds += 1
+        else:
+            dataset.active_timestamp = python_otbr_api.Timestamp(False, 1, 0)
+
+        try:
             await self.api.create_pending_dataset(
                 python_otbr_api.PendingDataSet(active_dataset=dataset, delay=0)
             )
@@ -188,8 +195,8 @@ class OTBRData:
             python_otbr_api.OTBRError,
             aiohttp.ClientError,
             TimeoutError,
-        ) as fallback_exc:
-            raise HomeAssistantError("Failed to call OTBR API") from fallback_exc
+        ) as exc:
+            raise HomeAssistantError("Failed to call OTBR API") from exc
 
     @_handle_otbr_error
     async def get_extended_address(self) -> bytes:

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -165,28 +165,31 @@ class OTBRData:
             _LOGGER.debug(
                 "DELETE pending dataset not supported, using fallback: %s", exc
             )
-            try:
-                dataset = await self.api.get_active_dataset()
-                if dataset is None:
-                    raise HomeAssistantError(
-                        "Failed to cancel pending dataset: no active dataset"
-                    ) from exc
-                if (
-                    dataset.active_timestamp
-                    and dataset.active_timestamp.seconds is not None
-                ):
-                    dataset.active_timestamp.seconds += 1
-                else:
-                    dataset.active_timestamp = python_otbr_api.Timestamp(False, 1, 0)
-                await self.api.create_pending_dataset(
-                    python_otbr_api.PendingDataSet(active_dataset=dataset, delay=0)
+        else:
+            return
+
+        try:
+            dataset = await self.api.get_active_dataset()
+            if dataset is None:
+                raise HomeAssistantError(
+                    "Failed to cancel pending dataset: no active dataset"
                 )
-            except (
-                python_otbr_api.OTBRError,
-                aiohttp.ClientError,
-                TimeoutError,
-            ) as fallback_exc:
-                raise HomeAssistantError("Failed to call OTBR API") from fallback_exc
+            if (
+                dataset.active_timestamp
+                and dataset.active_timestamp.seconds is not None
+            ):
+                dataset.active_timestamp.seconds += 1
+            else:
+                dataset.active_timestamp = python_otbr_api.Timestamp(False, 1, 0)
+            await self.api.create_pending_dataset(
+                python_otbr_api.PendingDataSet(active_dataset=dataset, delay=0)
+            )
+        except (
+            python_otbr_api.OTBRError,
+            aiohttp.ClientError,
+            TimeoutError,
+        ) as fallback_exc:
+            raise HomeAssistantError("Failed to call OTBR API") from fallback_exc
 
     @_handle_otbr_error
     async def get_extended_address(self) -> bytes:

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -159,6 +159,9 @@ class OTBRData:
         dataset with the current active dataset and delay=0, which immediately
         applies the current state and clears the pending migration.
         """
+        # Try the spec-compliant DELETE first; if it succeeds, return early.
+        # If it fails (e.g. 405 on older firmware), fall through to the
+        # fallback which overwrites the pending dataset instead.
         try:
             await self.api.delete_pending_dataset()
         except (python_otbr_api.OTBRError, aiohttp.ClientError, TimeoutError) as exc:
@@ -168,6 +171,8 @@ class OTBRData:
         else:
             return
 
+        # Fallback: set a pending dataset matching the current active dataset
+        # with delay=0, which immediately applies and clears the pending state.
         try:
             dataset = await self.api.get_active_dataset()
         except (

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -160,14 +160,19 @@ class OTBRData:
         applies the current state and clears the pending migration.
         """
         # Try the spec-compliant DELETE first; if it succeeds, return early.
-        # If it fails (e.g. 405 on older firmware), fall through to the
+        # If it fails with 405 on older firmware, fall through to the
         # fallback which overwrites the pending dataset instead.
+        # Re-raise any other error (connectivity, server errors, etc.).
         try:
             await self.api.delete_pending_dataset()
-        except (python_otbr_api.OTBRError, aiohttp.ClientError, TimeoutError) as exc:
+        except python_otbr_api.OTBRError as exc:
+            if "405" not in str(exc):
+                raise HomeAssistantError("Failed to call OTBR API") from exc
             _LOGGER.debug(
                 "DELETE pending dataset not supported, using fallback: %s", exc
             )
+        except (aiohttp.ClientError, TimeoutError) as exc:
+            raise HomeAssistantError("Failed to call OTBR API") from exc
         else:
             return
 

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -152,10 +152,41 @@ class OTBRData:
         """Set current channel."""
         await self.api.set_channel(channel, delay=int(delay * 1000))
 
-    @_handle_otbr_error
     async def delete_pending_dataset(self) -> None:
-        """Delete the pending operational dataset."""
-        await self.api.delete_pending_dataset()
+        """Delete the pending operational dataset.
+
+        Tries DELETE first (spec-compliant). Falls back to creating a pending
+        dataset with the current active dataset and delay=0, which immediately
+        applies the current state and clears the pending migration.
+        """
+        try:
+            await self.api.delete_pending_dataset()
+        except (python_otbr_api.OTBRError, aiohttp.ClientError, TimeoutError) as exc:
+            _LOGGER.debug(
+                "DELETE pending dataset not supported, using fallback: %s", exc
+            )
+            try:
+                dataset = await self.api.get_active_dataset()
+                if dataset is None:
+                    raise HomeAssistantError(
+                        "Failed to cancel pending dataset: no active dataset"
+                    ) from exc
+                if (
+                    dataset.active_timestamp
+                    and dataset.active_timestamp.seconds is not None
+                ):
+                    dataset.active_timestamp.seconds += 1
+                else:
+                    dataset.active_timestamp = python_otbr_api.Timestamp(False, 1, 0)
+                await self.api.create_pending_dataset(
+                    python_otbr_api.PendingDataSet(active_dataset=dataset, delay=0)
+                )
+            except (
+                python_otbr_api.OTBRError,
+                aiohttp.ClientError,
+                TimeoutError,
+            ) as fallback_exc:
+                raise HomeAssistantError("Failed to call OTBR API") from fallback_exc
 
     @_handle_otbr_error
     async def get_extended_address(self) -> bytes:

--- a/homeassistant/components/otbr/websocket_api.py
+++ b/homeassistant/components/otbr/websocket_api.py
@@ -305,7 +305,6 @@ async def websocket_set_channel(
         vol.Required("extended_address"): str,
     }
 )
-@websocket_api.require_admin
 @websocket_api.async_response
 @async_get_otbr_data
 async def websocket_get_pending_dataset(

--- a/homeassistant/components/otbr/websocket_api.py
+++ b/homeassistant/components/otbr/websocket_api.py
@@ -35,6 +35,8 @@ def async_setup(hass: HomeAssistant) -> None:
     """Set up the OTBR Websocket API."""
     websocket_api.async_register_command(hass, websocket_info)
     websocket_api.async_register_command(hass, websocket_create_network)
+    websocket_api.async_register_command(hass, websocket_get_pending_dataset)
+    websocket_api.async_register_command(hass, websocket_delete_pending_dataset)
     websocket_api.async_register_command(hass, websocket_set_channel)
     websocket_api.async_register_command(hass, websocket_set_network)
 
@@ -295,3 +297,75 @@ async def websocket_set_channel(
         return
 
     connection.send_result(msg["id"], {"delay": delay})
+
+
+@websocket_api.websocket_command(
+    {
+        "type": "otbr/get_pending_dataset",
+        vol.Required("extended_address"): str,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+@async_get_otbr_data
+async def websocket_get_pending_dataset(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+    data: OTBRData,
+) -> None:
+    """Get pending dataset info."""
+    try:
+        pending_tlvs = await data.get_pending_dataset_tlvs()
+    except HomeAssistantError as exc:
+        connection.send_error(msg["id"], "get_pending_dataset_failed", str(exc))
+        return
+
+    if pending_tlvs is None:
+        connection.send_result(msg["id"], None)
+        return
+
+    dataset = tlv_parser.parse_tlv(pending_tlvs.hex())
+
+    channel_tlv = dataset.get(MeshcopTLVType.CHANNEL)
+    delay_tlv = dataset.get(MeshcopTLVType.DELAYTIMER)
+
+    if channel_tlv is None or delay_tlv is None:
+        connection.send_result(msg["id"], None)
+        return
+
+    pending_channel = cast(tlv_parser.Channel, channel_tlv).channel
+    delay_ms = int.from_bytes(delay_tlv.data, "big")
+
+    connection.send_result(
+        msg["id"],
+        {
+            "pending_channel": pending_channel,
+            "pending_dataset_delay": delay_ms / 1000,
+        },
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        "type": "otbr/delete_pending_dataset",
+        vol.Required("extended_address"): str,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+@async_get_otbr_data
+async def websocket_delete_pending_dataset(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+    data: OTBRData,
+) -> None:
+    """Delete pending dataset."""
+    try:
+        await data.delete_pending_dataset()
+    except HomeAssistantError as exc:
+        connection.send_error(msg["id"], "delete_pending_dataset_failed", str(exc))
+        return
+
+    connection.send_result(msg["id"])

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -20,6 +20,28 @@ from . import (
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
+# Pending dataset with CHANNEL=15 and DELAYTIMER=26265ms (0x00006699)
+PENDING_DATASET_CH15 = bytes.fromhex(
+    "0E080000000000020000"  # ACTIVETIMESTAMP
+    "340400006699"  # DELAYTIMER
+    "000300000F"  # CHANNEL
+    "35060004001FFFE0"  # CHANNELMASK
+    "0208F642646DA209B1C0"  # EXTPANID
+    "0708FDF57B5A0FE2AAF6"  # MESHLOCALPREFIX
+    "0510DE98B5BA1A528FEE049D4B4B01835375"  # NETWORKKEY
+    "030D4F70656E546872656164204841"  # NETWORKNAME
+    "010225A4"  # PANID
+    "0410F5DD18371BFD29E1A601EF6FFAD94C03"  # PSKC
+    "0C0402A0F7F8"  # SECURITYPOLICY
+)
+
+# Pending dataset with no CHANNEL or DELAYTIMER fields
+PENDING_DATASET_NO_CHANNEL = bytes.fromhex(
+    "0E080000000000020000"  # ACTIVETIMESTAMP
+    "35060004001FFFE0"  # CHANNELMASK
+    "0208F642646DA209B1C0"  # EXTPANID
+)
+
 
 @pytest.fixture
 async def websocket_client(
@@ -697,6 +719,183 @@ async def test_set_network_fails_5(
 
     assert not msg["success"]
     assert msg["error"]["code"] == "unknown_router"
+
+
+async def test_get_pending_dataset(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test get pending dataset returns channel and delay."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.get_pending_dataset_tlvs",
+            return_value=PENDING_DATASET_CH15,
+        ),
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/get_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] == {
+        "pending_channel": 15,
+        "pending_dataset_delay": 26.265,
+    }
+
+
+async def test_get_pending_dataset_none(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test get pending dataset returns None when no pending dataset."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.get_pending_dataset_tlvs",
+            return_value=None,
+        ),
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/get_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] is None
+
+
+async def test_get_pending_dataset_missing_fields(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test get pending dataset returns None when TLV lacks CHANNEL or DELAYTIMER."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.get_pending_dataset_tlvs",
+            return_value=PENDING_DATASET_NO_CHANNEL,
+        ),
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/get_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] is None
+
+
+async def test_get_pending_dataset_api_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test get pending dataset error handling."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.get_pending_dataset_tlvs",
+            side_effect=python_otbr_api.OTBRError,
+        ),
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/get_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "get_pending_dataset_failed"
+
+
+async def test_delete_pending_dataset(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test delete pending dataset success."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.delete_pending_dataset",
+        ) as mock_delete,
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/delete_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] is None
+    mock_delete.assert_called_once()
+
+
+async def test_delete_pending_dataset_api_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test delete pending dataset error handling."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.delete_pending_dataset",
+            side_effect=python_otbr_api.OTBRError,
+        ),
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/delete_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "delete_pending_dataset_failed"
 
 
 async def test_set_channel(

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -869,13 +869,13 @@ async def test_delete_pending_dataset(
     mock_delete.assert_called_once()
 
 
-async def test_delete_pending_dataset_api_error(
+async def test_delete_pending_dataset_fallback(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     otbr_config_entry_thread,
     websocket_client: MockHAClientWebSocket,
 ) -> None:
-    """Test delete pending dataset error handling."""
+    """Test delete pending dataset falls back when DELETE is not supported."""
     with (
         patch(
             "python_otbr_api.OTBR.get_extended_address",
@@ -883,7 +883,87 @@ async def test_delete_pending_dataset_api_error(
         ),
         patch(
             "python_otbr_api.OTBR.delete_pending_dataset",
+            side_effect=python_otbr_api.OTBRError("unexpected http status 405"),
+        ),
+        patch(
+            "python_otbr_api.OTBR.get_active_dataset",
+            return_value=python_otbr_api.ActiveDataSet(
+                channel=15,
+                active_timestamp=python_otbr_api.Timestamp(False, 1, 0),
+            ),
+        ),
+        patch(
+            "python_otbr_api.OTBR.create_pending_dataset",
+        ) as mock_create_pending,
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/delete_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert msg["success"]
+    assert msg["result"] is None
+    mock_create_pending.assert_called_once()
+    pending_dataset = mock_create_pending.call_args[0][0]
+    assert pending_dataset.delay == 0
+    assert pending_dataset.active_dataset.active_timestamp.seconds == 2
+
+
+async def test_delete_pending_dataset_fallback_fails(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test delete pending dataset when both DELETE and fallback fail."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.delete_pending_dataset",
+            side_effect=python_otbr_api.OTBRError("unexpected http status 405"),
+        ),
+        patch(
+            "python_otbr_api.OTBR.get_active_dataset",
             side_effect=python_otbr_api.OTBRError,
+        ),
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/delete_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "delete_pending_dataset_failed"
+
+
+async def test_delete_pending_dataset_fallback_no_dataset(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test delete pending dataset fallback when no active dataset exists."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.delete_pending_dataset",
+            side_effect=python_otbr_api.OTBRError("unexpected http status 405"),
+        ),
+        patch(
+            "python_otbr_api.OTBR.get_active_dataset",
+            return_value=None,
         ),
     ):
         await websocket_client.send_json_auto_id(

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -912,6 +912,35 @@ async def test_delete_pending_dataset_fallback(
     assert pending_dataset.active_dataset.active_timestamp.seconds == 2
 
 
+async def test_delete_pending_dataset_non_405_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry_thread,
+    websocket_client: MockHAClientWebSocket,
+) -> None:
+    """Test delete pending dataset raises on non-405 errors instead of falling back."""
+    with (
+        patch(
+            "python_otbr_api.OTBR.get_extended_address",
+            return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS,
+        ),
+        patch(
+            "python_otbr_api.OTBR.delete_pending_dataset",
+            side_effect=python_otbr_api.OTBRError("unexpected http status 500"),
+        ),
+    ):
+        await websocket_client.send_json_auto_id(
+            {
+                "type": "otbr/delete_pending_dataset",
+                "extended_address": TEST_BORDER_AGENT_EXTENDED_ADDRESS.hex(),
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "delete_pending_dataset_failed"
+
+
 async def test_delete_pending_dataset_fallback_fails(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,


### PR DESCRIPTION
## Proposed change

The frontend exposes a "change channel" action which triggers a channel migration with a 5-minute delay on the OTBR. Once initiated, users have no way of knowing a channel change is in flight without checking the logs. These new WebSocket commands provide the backend support needed to improve the frontend UX so users can see when a channel migration is pending and how much time remains. As a bonus, we can also let users cancel a pending change if they made a mistake.

Changes:
- `otbr/get_pending_dataset` — returns the pending target channel and remaining delay (in seconds), or `None` if no migration is pending. Available to all authenticated users so the frontend can display pending migration status.
- `otbr/delete_pending_dataset` (admin-only) — cancels a pending channel migration. Includes a fallback for OTBR firmware that doesn't support `DELETE /node/dataset/pending` (405 only — other errors are raised immediately): creates a pending dataset with the current active dataset and delay=0, which immediately clears the pending migration.
- `OTBRData.delete_pending_dataset()` wrapper in `util.py` with DELETE + fallback logic

Tested against a live OTBR (official HA addon + ZBT-2).

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/51608

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr