### PR TITLE
Handle specific connection errors for Satel Integra

### DIFF
--- a/homeassistant/components/satel_integra/client.py
+++ b/homeassistant/components/satel_integra/client.py
@@ -88,21 +88,18 @@ class SatelClient:
             await self.controller.connect(raise_exceptions=True)
         except SatelConnectFailedError as ex:
             raise ConfigEntryNotReady(
-                translation_domain=DOMAIN, translation_key="cannot_connect"
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
             ) from ex
         except SatelPanelBusyError as ex:
             raise ConfigEntryNotReady(
-                translation_domain=DOMAIN, translation_key="panel_busy"
+                translation_domain=DOMAIN,
+                translation_key="panel_busy",
             ) from ex
         except SatelConnectionInitializationError as ex:
             raise ConfigEntryError(
                 translation_domain=DOMAIN,
                 translation_key="connection_initialization_failed",
-            ) from ex
-        except Exception as ex:
-            raise ConfigEntryError(
-                translation_domain=DOMAIN,
-                translation_key="unknown",
             ) from ex
 
         self.controller.register_callbacks(

--- a/homeassistant/components/satel_integra/client.py
+++ b/homeassistant/components/satel_integra/client.py
@@ -3,11 +3,16 @@
 from collections.abc import Callable
 
 from satel_integra import AsyncSatel
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelPanelBusyError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
 from .const import (
     CONF_ENCRYPTION_KEY,
@@ -78,9 +83,18 @@ class SatelClient:
         partitions_update_callback: Callable[[], None],
     ) -> None:
         """Start controller connection."""
-        result = await self.controller.connect()
-        if not result:
-            raise ConfigEntryNotReady("Controller failed to connect")
+        try:
+            await self.controller.connect(raise_exceptions=True)
+        except SatelConnectFailedError as ex:
+            raise ConfigEntryNotReady("Failed to connect to the panel") from ex
+        except SatelPanelBusyError as ex:
+            raise ConfigEntryNotReady("Panel is busy, please try again later") from ex
+        except SatelConnectionInitializationError as ex:
+            raise ConfigEntryError(
+                "Failed to initialize connection with the panel"
+            ) from ex
+        except Exception as ex:
+            raise ConfigEntryError("Controller failed to connect") from ex
 
         self.controller.register_callbacks(
             alarm_status_callback=partitions_update_callback,

--- a/homeassistant/components/satel_integra/client.py
+++ b/homeassistant/components/satel_integra/client.py
@@ -88,27 +88,21 @@ class SatelClient:
             await self.controller.connect(raise_exceptions=True)
         except SatelConnectFailedError as ex:
             raise ConfigEntryNotReady(
-                translation_domain=DOMAIN,
-                translation_key="cannot_connect",
-                translation_placeholders={"error": repr(ex)},
+                translation_domain=DOMAIN, translation_key="cannot_connect"
             ) from ex
         except SatelPanelBusyError as ex:
             raise ConfigEntryNotReady(
-                translation_domain=DOMAIN,
-                translation_key="panel_busy",
-                translation_placeholders={"error": repr(ex)},
+                translation_domain=DOMAIN, translation_key="panel_busy"
             ) from ex
         except SatelConnectionInitializationError as ex:
             raise ConfigEntryError(
                 translation_domain=DOMAIN,
                 translation_key="connection_initialization_failed",
-                translation_placeholders={"error": repr(ex)},
             ) from ex
         except Exception as ex:
             raise ConfigEntryError(
                 translation_domain=DOMAIN,
                 translation_key="unknown",
-                translation_placeholders={"error": repr(ex)},
             ) from ex
 
         self.controller.register_callbacks(

--- a/homeassistant/components/satel_integra/client.py
+++ b/homeassistant/components/satel_integra/client.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_PARTITION_NUMBER,
     CONF_SWITCHABLE_OUTPUT_NUMBER,
     CONF_ZONE_NUMBER,
+    DOMAIN,
     SUBENTRY_TYPE_OUTPUT,
     SUBENTRY_TYPE_PARTITION,
     SUBENTRY_TYPE_SWITCHABLE_OUTPUT,
@@ -86,15 +87,29 @@ class SatelClient:
         try:
             await self.controller.connect(raise_exceptions=True)
         except SatelConnectFailedError as ex:
-            raise ConfigEntryNotReady("Failed to connect to the panel") from ex
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                translation_placeholders={"error": repr(ex)},
+            ) from ex
         except SatelPanelBusyError as ex:
-            raise ConfigEntryNotReady("Panel is busy, please try again later") from ex
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="panel_busy",
+                translation_placeholders={"error": repr(ex)},
+            ) from ex
         except SatelConnectionInitializationError as ex:
             raise ConfigEntryError(
-                "Failed to initialize connection with the panel"
+                translation_domain=DOMAIN,
+                translation_key="connection_initialization_failed",
+                translation_placeholders={"error": repr(ex)},
             ) from ex
         except Exception as ex:
-            raise ConfigEntryError("Controller failed to connect") from ex
+            raise ConfigEntryError(
+                translation_domain=DOMAIN,
+                translation_key="unknown",
+                translation_placeholders={"error": repr(ex)},
+            ) from ex
 
         self.controller.register_callbacks(
             alarm_status_callback=partitions_update_callback,

--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -6,6 +6,11 @@ import logging
 from typing import Any
 
 from satel_integra import AsyncSatel
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelPanelBusyError,
+)
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -127,19 +132,19 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
 
-            if await self.test_connection(
+            errors = await self.test_connection(
                 user_input[CONF_HOST],
                 user_input[CONF_PORT],
                 user_input.get(CONF_ENCRYPTION_KEY),
-            ):
+            )
+
+            if not errors:
                 self.connection_data = {
                     CONF_HOST: user_input[CONF_HOST],
                     CONF_PORT: user_input[CONF_PORT],
                     CONF_ENCRYPTION_KEY: user_input.get(CONF_ENCRYPTION_KEY),
                 }
                 return await self.async_step_code()
-
-            errors["base"] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",
@@ -180,12 +185,11 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
                 reconfigure_entry.state is not ConfigEntryState.LOADED
                 or reconfigure_entry.data != normalized_input
             ):
-                if not await self.test_connection(
+                errors = await self.test_connection(
                     normalized_input[CONF_HOST],
                     normalized_input[CONF_PORT],
                     normalized_input.get(CONF_ENCRYPTION_KEY),
-                ):
-                    errors["base"] = "cannot_connect"
+                )
 
             if not errors:
                 return self.async_update_reload_and_abort(
@@ -213,21 +217,30 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def test_connection(
         self, host: str, port: int, integration_key: str | None = None
-    ) -> bool:
+    ) -> dict[str, str]:
         """Test a connection to the Satel alarm."""
+        errors: dict[str, str] = {}
         controller = AsyncSatel(host, port, integration_key=integration_key)
 
         try:
-            return await controller.connect()
+            await controller.connect(raise_exceptions=True)
+        except SatelPanelBusyError:
+            errors["base"] = "panel_busy"
+        except SatelConnectionInitializationError:
+            errors["base"] = "connection_initialization_failed"
+        except SatelConnectFailedError:
+            errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception(
                 "Unexpected error during connection test to %s:%s",
                 host,
                 port,
             )
-            return False
+            errors["base"] = "unknown"
         finally:
             await controller.close()
+
+        return errors
 
 
 class SatelOptionsFlow(OptionsFlow):

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -11,7 +11,10 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "connection_initialization_failed": "Successfully connected, but failed to read data from the panel. Please check the integration encryption key is correct if your panel requires encryption.",
+      "panel_busy": "Successfully connected, but alarm panel reports it's busy. Please check no other connections are active.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "code": {

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -189,8 +189,17 @@
     }
   },
   "exceptions": {
+    "cannot_connect": {
+      "message": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "connection_initialization_failed": {
+      "message": "[%key:component::satel_integra::config::error::connection_initialization_failed%]"
+    },
     "missing_output_access_code": {
       "message": "Cannot control switchable outputs because no user code is configured for this Satel Integra entry. Configure a code in the integration options to enable output control."
+    },
+    "panel_busy": {
+      "message": "[%key:component::satel_integra::config::error::panel_busy%]"
     }
   },
   "options": {

--- a/tests/components/satel_integra/test_config_flow.py
+++ b/tests/components/satel_integra/test_config_flow.py
@@ -4,6 +4,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from satel_integra import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelPanelBusyError,
+)
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.satel_integra.const import (
@@ -98,8 +103,21 @@ async def test_setup_flow(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (SatelConnectFailedError, "cannot_connect"),
+        (SatelPanelBusyError, "panel_busy"),
+        (SatelConnectionInitializationError, "connection_initialization_failed"),
+        (Exception, "unknown"),
+    ],
+)
 async def test_setup_connection_failed(
-    hass: HomeAssistant, mock_satel: AsyncMock, mock_setup_entry: AsyncMock
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    exception: Exception,
+    error: str,
 ) -> None:
     """Test the setup flow when connection fails."""
     user_input = MOCK_CONFIG_DATA
@@ -108,7 +126,7 @@ async def test_setup_connection_failed(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    mock_satel.connect.return_value = False
+    mock_satel.connect.side_effect = exception
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -116,9 +134,9 @@ async def test_setup_connection_failed(
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": error}
 
-    mock_satel.connect.return_value = True
+    mock_satel.connect.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -428,13 +446,25 @@ async def test_reconfigure_flow_config_unchanged_not_loaded(
     assert mock_setup_entry.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (SatelConnectFailedError, "cannot_connect"),
+        (SatelPanelBusyError, "panel_busy"),
+        (SatelConnectionInitializationError, "connection_initialization_failed"),
+        (Exception, "unknown"),
+    ],
+)
 async def test_reconfigure_connection_failed(
     hass: HomeAssistant,
     mock_satel: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    error: str,
 ) -> None:
     """Failure path for the reconfigure flow."""
-    mock_satel.connect.return_value = False
+
+    mock_satel.connect.side_effect = exception
 
     mock_config_entry.add_to_hass(hass)
 
@@ -450,9 +480,9 @@ async def test_reconfigure_connection_failed(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": error}
 
-    mock_satel.connect.return_value = True
+    mock_satel.connect.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -4,6 +4,11 @@ from copy import deepcopy
 from unittest.mock import AsyncMock
 
 import pytest
+from satel_integra import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelPanelBusyError,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_PANEL_DOMAIN
@@ -11,7 +16,7 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAI
 from homeassistant.components.satel_integra.config_flow import SatelConfigFlow
 from homeassistant.components.satel_integra.const import CONF_ENCRYPTION_KEY, DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import ConfigSubentry
+from homeassistant.config_entries import ConfigEntryState, ConfigSubentry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
@@ -164,3 +169,24 @@ async def test_parent_device_exists(
         identifiers={(DOMAIN, MOCK_ENTRY_ID)}
     )
     assert device_entry == snapshot(name="parent-device")
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_state"),
+    [
+        (SatelConnectFailedError, ConfigEntryState.SETUP_RETRY),
+        (SatelPanelBusyError, ConfigEntryState.SETUP_RETRY),
+        (SatelConnectionInitializationError, ConfigEntryState.SETUP_ERROR),
+    ],
+)
+async def test_setup_exceptions(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    expected_state: ConfigEntryState,
+) -> None:
+    """Test the client async_connect."""
+    mock_satel.connect.side_effect = exception
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In a [previous PR](https://github.com/home-assistant/core/pull/167372) I added support for encrypted connections. Since then the [library has been updated](https://github.com/home-assistant/core/pull/168416) to opt into raising exceptions from the connect calls, allowing for targeted error messages during configuration.

This PR opts in to raising and handles those exceptions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
