### PR TITLE
Add Honeywell String Lights integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -758,6 +758,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/homewizard/ @DCSBL
 /homeassistant/components/honeywell/ @rdfurman @mkmer
 /tests/components/honeywell/ @rdfurman @mkmer
+/homeassistant/components/honeywell_string_lights/ @balloob
+/tests/components/honeywell_string_lights/ @balloob
 /homeassistant/components/hr_energy_qube/ @MattieGit
 /tests/components/hr_energy_qube/ @MattieGit
 /homeassistant/components/html5/ @alexyao2015 @tr4nt0r

--- a/homeassistant/brands/honeywell.json
+++ b/homeassistant/brands/honeywell.json
@@ -1,5 +1,5 @@
 {
   "domain": "honeywell",
   "name": "Honeywell",
-  "integrations": ["lyric", "evohome", "honeywell"]
+  "integrations": ["lyric", "evohome", "honeywell", "honeywell_string_lights"]
 }

--- a/homeassistant/components/honeywell_string_lights/__init__.py
+++ b/homeassistant/components/honeywell_string_lights/__init__.py
@@ -1,0 +1,20 @@
+"""The Honeywell String Lights integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS: list[Platform] = [Platform.LIGHT]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Honeywell String Lights from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/honeywell_string_lights/config_flow.py
+++ b/homeassistant/components/honeywell_string_lights/config_flow.py
@@ -1,0 +1,61 @@
+"""Config flow for the Honeywell String Lights integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rf_protocols import RadioFrequencyCommand
+import voluptuous as vol
+
+from homeassistant.components.radio_frequency import async_get_transmitters
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er, selector
+
+from .const import CONF_TRANSMITTER, DOMAIN
+from .light import COMMANDS
+
+
+class HoneywellStringLightsConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Honeywell String Lights."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        sample_command: RadioFrequencyCommand = await self.hass.async_add_executor_job(
+            COMMANDS.load_command, "turn_on"
+        )
+        try:
+            transmitters = async_get_transmitters(
+                self.hass, sample_command.frequency, sample_command.modulation
+            )
+        except HomeAssistantError:
+            return self.async_abort(reason="no_transmitters")
+
+        if not transmitters:
+            return self.async_abort(reason="no_compatible_transmitters")
+
+        if user_input is not None:
+            registry = er.async_get(self.hass)
+            entity_entry = registry.async_get(user_input[CONF_TRANSMITTER])
+            assert entity_entry is not None
+            await self.async_set_unique_id(entity_entry.id)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title="Honeywell String Lights",
+                data={CONF_TRANSMITTER: entity_entry.id},
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TRANSMITTER): selector.EntitySelector(
+                        selector.EntitySelectorConfig(include_entities=transmitters),
+                    ),
+                }
+            ),
+        )

--- a/homeassistant/components/honeywell_string_lights/const.py
+++ b/homeassistant/components/honeywell_string_lights/const.py
@@ -1,0 +1,9 @@
+"""Constants for the Honeywell String Lights integration."""
+
+from __future__ import annotations
+
+from typing import Final
+
+DOMAIN: Final = "honeywell_string_lights"
+
+CONF_TRANSMITTER: Final = "transmitter"

--- a/homeassistant/components/honeywell_string_lights/entity.py
+++ b/homeassistant/components/honeywell_string_lights/entity.py
@@ -1,0 +1,77 @@
+"""Common entity for Honeywell String Lights integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import Event, EventStateChangedData, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import CONF_TRANSMITTER, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HoneywellStringLightsEntity(Entity):
+    """Honeywell String Lights base entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the entity."""
+        self._transmitter = entry.data[CONF_TRANSMITTER]
+        self._attr_unique_id = entry.entry_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            manufacturer="Honeywell",
+            model="String Lights",
+            name=entry.title,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to transmitter entity state changes."""
+        await super().async_added_to_hass()
+
+        transmitter_entity_id = er.async_validate_entity_id(
+            er.async_get(self.hass), self._transmitter
+        )
+
+        @callback
+        def _async_transmitter_state_changed(
+            event: Event[EventStateChangedData],
+        ) -> None:
+            """Handle transmitter entity state changes."""
+            new_state = event.data["new_state"]
+            transmitter_available = (
+                new_state is not None and new_state.state != STATE_UNAVAILABLE
+            )
+            if transmitter_available != self.available:
+                _LOGGER.info(
+                    "Transmitter %s used by %s is %s",
+                    transmitter_entity_id,
+                    self.entity_id,
+                    "available" if transmitter_available else "unavailable",
+                )
+
+                self._attr_available = transmitter_available
+                self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                [transmitter_entity_id],
+                _async_transmitter_state_changed,
+            )
+        )
+
+        # Set initial availability based on current transmitter entity state
+        transmitter_state = self.hass.states.get(transmitter_entity_id)
+        self._attr_available = (
+            transmitter_state is not None
+            and transmitter_state.state != STATE_UNAVAILABLE
+        )

--- a/homeassistant/components/honeywell_string_lights/entity.py
+++ b/homeassistant/components/honeywell_string_lights/entity.py
@@ -30,7 +30,6 @@ class HoneywellStringLightsEntity(Entity):
             identifiers={(DOMAIN, entry.entry_id)},
             manufacturer="Honeywell",
             model="String Lights",
-            name=entry.title,
         )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/honeywell_string_lights/light.py
+++ b/homeassistant/components/honeywell_string_lights/light.py
@@ -59,7 +59,7 @@ class HoneywellStringLight(HoneywellStringLightsEntity, LightEntity, RestoreEnti
 
     async def _async_send_command(self, name: str) -> None:
         """Load the named command and send it via the configured transmitter."""
-        command = await self.hass.async_add_executor_job(COMMANDS.load_command, name)
+        command = await COMMANDS.async_load_command(name)
         await async_send_command(
             self.hass, self._transmitter, command, context=self._context
         )

--- a/homeassistant/components/honeywell_string_lights/light.py
+++ b/homeassistant/components/honeywell_string_lights/light.py
@@ -1,0 +1,64 @@
+"""Light platform for Honeywell String Lights."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rf_protocols import get_codes
+
+from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.components.radio_frequency import async_send_command
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .entity import HoneywellStringLightsEntity
+
+PARALLEL_UPDATES = 1
+
+COMMANDS = get_codes("honeywell/string_lights")
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Honeywell String Lights light platform."""
+    async_add_entities([HoneywellStringLight(config_entry)])
+
+
+class HoneywellStringLight(HoneywellStringLightsEntity, LightEntity, RestoreEntity):
+    """Representation of a Honeywell String Lights set controlled via RF."""
+
+    _attr_assumed_state = True
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+    _attr_is_on = False
+    _attr_name = None
+    _attr_should_poll = False
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known state."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light."""
+        await self._async_send_command("turn_on")
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the light."""
+        await self._async_send_command("turn_off")
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    async def _async_send_command(self, name: str) -> None:
+        """Load the named command and send it via the configured transmitter."""
+        command = await self.hass.async_add_executor_job(COMMANDS.load_command, name)
+        await async_send_command(self.hass, self._transmitter, command)

--- a/homeassistant/components/honeywell_string_lights/light.py
+++ b/homeassistant/components/honeywell_string_lights/light.py
@@ -36,7 +36,6 @@ class HoneywellStringLight(HoneywellStringLightsEntity, LightEntity, RestoreEnti
     _attr_assumed_state = True
     _attr_color_mode = ColorMode.ONOFF
     _attr_supported_color_modes = {ColorMode.ONOFF}
-    _attr_is_on = False
     _attr_name = None
     _attr_should_poll = False
 
@@ -61,4 +60,6 @@ class HoneywellStringLight(HoneywellStringLightsEntity, LightEntity, RestoreEnti
     async def _async_send_command(self, name: str) -> None:
         """Load the named command and send it via the configured transmitter."""
         command = await self.hass.async_add_executor_job(COMMANDS.load_command, name)
-        await async_send_command(self.hass, self._transmitter, command)
+        await async_send_command(
+            self.hass, self._transmitter, command, context=self._context
+        )

--- a/homeassistant/components/honeywell_string_lights/manifest.json
+++ b/homeassistant/components/honeywell_string_lights/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "honeywell_string_lights",
+  "name": "Honeywell String Lights",
+  "codeowners": ["@balloob"],
+  "config_flow": true,
+  "dependencies": ["radio_frequency"],
+  "documentation": "https://www.home-assistant.io/integrations/honeywell_string_lights",
+  "integration_type": "device",
+  "iot_class": "assumed_state",
+  "quality_scale": "bronze",
+  "requirements": ["rf-protocols==2.0.0"]
+}

--- a/homeassistant/components/honeywell_string_lights/manifest.json
+++ b/homeassistant/components/honeywell_string_lights/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "device",
   "iot_class": "assumed_state",
   "quality_scale": "bronze",
-  "requirements": ["rf-protocols==2.0.0"]
+  "requirements": ["rf-protocols==2.1.0"]
 }

--- a/homeassistant/components/honeywell_string_lights/quality_scale.yaml
+++ b/homeassistant/components/honeywell_string_lights/quality_scale.yaml
@@ -1,0 +1,124 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not register custom service actions.
+  appropriate-polling:
+    status: exempt
+    comment: |
+      This integration transmits RF commands and does not poll.
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not register custom service actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data:
+    status: exempt
+    comment: |
+      This integration does not use runtime data.
+  test-before-configure:
+    status: exempt
+    comment: |
+      RF transmission is a one-way broadcast with no device to contact.
+  test-before-setup:
+    status: exempt
+    comment: |
+      RF transmission is a one-way broadcast with no device to contact.
+  unique-config-entry: done
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      This integration has no options.
+  docs-installation-parameters: todo
+  entity-unavailable:
+    status: exempt
+    comment: |
+      RF transmission is a one-way broadcast; the light uses assumed state.
+  integration-owner: done
+  log-when-unavailable:
+    status: exempt
+    comment: |
+      RF transmission is a one-way broadcast; the light uses assumed state.
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      This integration does not authenticate.
+  test-coverage: todo
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: |
+      This integration does not support discovery.
+  discovery:
+    status: exempt
+    comment: |
+      RF devices cannot be discovered.
+  docs-data-update:
+    status: exempt
+    comment: |
+      RF transmission is one-way; there is no data update.
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      Each config entry represents a single static device.
+  entity-category:
+    status: exempt
+    comment: |
+      The single entity represents the primary device function.
+  entity-device-class:
+    status: exempt
+    comment: |
+      Light entities do not have device classes.
+  entity-disabled-by-default:
+    status: exempt
+    comment: |
+      The single entity represents the primary device function.
+  entity-translations:
+    status: exempt
+    comment: |
+      The entity uses the device name.
+  exception-translations: todo
+  icon-translations:
+    status: exempt
+    comment: |
+      Light uses the default icon for its state.
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      No known repairable issues.
+  stale-devices:
+    status: exempt
+    comment: |
+      Each config entry represents a single static device.
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: |
+      This integration does not use a web session.
+  strict-typing: todo

--- a/homeassistant/components/honeywell_string_lights/strings.json
+++ b/homeassistant/components/honeywell_string_lights/strings.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "no_compatible_transmitters": "No radio frequency transmitter supports 433.92 MHz OOK transmissions. Please add a compatible transmitter first.",
+      "no_transmitters": "No radio frequency transmitters are available. Please set up a transmitter first."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "transmitter": "Radio frequency transmitter"
+        },
+        "data_description": {
+          "transmitter": "The radio frequency transmitter used to control the Honeywell String Lights."
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -311,6 +311,7 @@ FLOWS = {
         "homewizard",
         "homeworks",
         "honeywell",
+        "honeywell_string_lights",
         "hr_energy_qube",
         "html5",
         "huawei_lte",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2975,6 +2975,12 @@
           "config_flow": true,
           "iot_class": "cloud_polling",
           "name": "Honeywell Total Connect Comfort (US)"
+        },
+        "honeywell_string_lights": {
+          "integration_type": "device",
+          "config_flow": true,
+          "iot_class": "assumed_state",
+          "name": "Honeywell String Lights"
         }
       }
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2840,6 +2840,7 @@ renson-endura-delta==1.7.2
 # homeassistant.components.reolink
 reolink-aio==0.19.1
 
+# homeassistant.components.honeywell_string_lights
 # homeassistant.components.radio_frequency
 rf-protocols==2.1.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2840,8 +2840,10 @@ renson-endura-delta==1.7.2
 # homeassistant.components.reolink
 reolink-aio==0.19.1
 
-# homeassistant.components.honeywell_string_lights
 # homeassistant.components.radio_frequency
+rf-protocols==2.1.0
+
+# homeassistant.components.honeywell_string_lights
 rf-protocols==2.1.0
 
 # homeassistant.components.idteck_prox

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2840,10 +2840,8 @@ renson-endura-delta==1.7.2
 # homeassistant.components.reolink
 reolink-aio==0.19.1
 
-# homeassistant.components.radio_frequency
-rf-protocols==2.1.0
-
 # homeassistant.components.honeywell_string_lights
+# homeassistant.components.radio_frequency
 rf-protocols==2.1.0
 
 # homeassistant.components.idteck_prox

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2424,6 +2424,7 @@ renson-endura-delta==1.7.2
 # homeassistant.components.reolink
 reolink-aio==0.19.1
 
+# homeassistant.components.honeywell_string_lights
 # homeassistant.components.radio_frequency
 rf-protocols==2.1.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2424,8 +2424,10 @@ renson-endura-delta==1.7.2
 # homeassistant.components.reolink
 reolink-aio==0.19.1
 
-# homeassistant.components.honeywell_string_lights
 # homeassistant.components.radio_frequency
+rf-protocols==2.1.0
+
+# homeassistant.components.honeywell_string_lights
 rf-protocols==2.1.0
 
 # homeassistant.components.rflink

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2424,10 +2424,8 @@ renson-endura-delta==1.7.2
 # homeassistant.components.reolink
 reolink-aio==0.19.1
 
-# homeassistant.components.radio_frequency
-rf-protocols==2.1.0
-
 # homeassistant.components.honeywell_string_lights
+# homeassistant.components.radio_frequency
 rf-protocols==2.1.0
 
 # homeassistant.components.rflink

--- a/tests/components/honeywell_string_lights/__init__.py
+++ b/tests/components/honeywell_string_lights/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Honeywell String Lights integration."""

--- a/tests/components/honeywell_string_lights/conftest.py
+++ b/tests/components/honeywell_string_lights/conftest.py
@@ -1,0 +1,56 @@
+"""Common fixtures for the Honeywell String Lights tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.honeywell_string_lights.const import (
+    CONF_TRANSMITTER,
+    DOMAIN,
+)
+from homeassistant.components.radio_frequency import DATA_COMPONENT, DOMAIN as RF_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
+
+
+@pytest.fixture
+async def mock_transmitter(hass: HomeAssistant) -> MockRadioFrequencyEntity:
+    """Set up the radio_frequency component and register a mock transmitter."""
+    assert await async_setup_component(hass, RF_DOMAIN, {})
+    await hass.async_block_till_done()
+
+    entity = MockRadioFrequencyEntity("test_rf_transmitter")
+    component = hass.data[DATA_COMPONENT]
+    await component.async_add_entities([entity])
+    return entity
+
+
+@pytest.fixture
+def mock_config_entry(
+    hass: HomeAssistant, mock_transmitter: MockRadioFrequencyEntity
+) -> MockConfigEntry:
+    """Return a mock config entry for Honeywell String Lights."""
+    entity_registry = er.async_get(hass)
+    entity_entry = entity_registry.async_get(mock_transmitter.entity_id)
+    assert entity_entry is not None
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Honeywell String Lights",
+        data={CONF_TRANSMITTER: entity_entry.id},
+        unique_id=entity_entry.id,
+    )
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> MockConfigEntry:
+    """Set up the Honeywell String Lights integration."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/honeywell_string_lights/conftest.py
+++ b/tests/components/honeywell_string_lights/conftest.py
@@ -8,35 +8,27 @@ from homeassistant.components.honeywell_string_lights.const import (
     CONF_TRANSMITTER,
     DOMAIN,
 )
-from homeassistant.components.radio_frequency import DATA_COMPONENT, DOMAIN as RF_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
-from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
+from tests.components.radio_frequency.conftest import (
+    MockRadioFrequencyEntity,
+    init_integration,  # noqa: F401
+    mock_rf_entity,  # noqa: F401
+)
 
-
-@pytest.fixture
-async def mock_transmitter(hass: HomeAssistant) -> MockRadioFrequencyEntity:
-    """Set up the radio_frequency component and register a mock transmitter."""
-    assert await async_setup_component(hass, RF_DOMAIN, {})
-    await hass.async_block_till_done()
-
-    entity = MockRadioFrequencyEntity("test_rf_transmitter")
-    component = hass.data[DATA_COMPONENT]
-    await component.async_add_entities([entity])
-    return entity
+TRANSMITTER_ENTITY_ID = "radio_frequency.test_rf_transmitter"
 
 
 @pytest.fixture
 def mock_config_entry(
-    hass: HomeAssistant, mock_transmitter: MockRadioFrequencyEntity
+    hass: HomeAssistant,
+    mock_rf_entity: MockRadioFrequencyEntity,  # noqa: F811
 ) -> MockConfigEntry:
     """Return a mock config entry for Honeywell String Lights."""
     entity_registry = er.async_get(hass)
-    entity_entry = entity_registry.async_get(mock_transmitter.entity_id)
-    assert entity_entry is not None
+    entity_entry = entity_registry.async_get(TRANSMITTER_ENTITY_ID)
     return MockConfigEntry(
         domain=DOMAIN,
         title="Honeywell String Lights",
@@ -46,7 +38,7 @@ def mock_config_entry(
 
 
 @pytest.fixture
-async def init_integration(
+async def init_string_lights(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> MockConfigEntry:
     """Set up the Honeywell String Lights integration."""

--- a/tests/components/honeywell_string_lights/test_config_flow.py
+++ b/tests/components/honeywell_string_lights/test_config_flow.py
@@ -1,0 +1,89 @@
+"""Test the Honeywell String Lights config flow."""
+
+from __future__ import annotations
+
+from homeassistant.components.honeywell_string_lights.const import (
+    CONF_TRANSMITTER,
+    DOMAIN,
+)
+from homeassistant.components.radio_frequency import DATA_COMPONENT, DOMAIN as RF_DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
+
+
+async def test_user_flow(
+    hass: HomeAssistant, mock_transmitter: MockRadioFrequencyEntity
+) -> None:
+    """Test the user config flow creates an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_TRANSMITTER: mock_transmitter.entity_id},
+    )
+
+    entity_registry = er.async_get(hass)
+    entity_entry = entity_registry.async_get(mock_transmitter.entity_id)
+    assert entity_entry is not None
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Honeywell String Lights"
+    assert result["data"] == {CONF_TRANSMITTER: entity_entry.id}
+    assert result["result"].unique_id == entity_entry.id
+
+
+async def test_unique_id_already_configured(
+    hass: HomeAssistant,
+    mock_transmitter: MockRadioFrequencyEntity,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test aborting when the same transmitter is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_TRANSMITTER: mock_transmitter.entity_id},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_no_transmitters(hass: HomeAssistant) -> None:
+    """Test the flow aborts when no RF transmitters are registered at all."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_transmitters"
+
+
+async def test_no_compatible_transmitters(hass: HomeAssistant) -> None:
+    """Test aborting when transmitters exist but none support 433.92 MHz OOK."""
+    assert await async_setup_component(hass, RF_DOMAIN, {})
+    await hass.async_block_till_done()
+    incompatible = MockRadioFrequencyEntity(
+        "incompatible", frequency_ranges=[(868_000_000, 869_000_000)]
+    )
+    await hass.data[DATA_COMPONENT].async_add_entities([incompatible])
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_compatible_transmitters"

--- a/tests/components/honeywell_string_lights/test_config_flow.py
+++ b/tests/components/honeywell_string_lights/test_config_flow.py
@@ -20,7 +20,9 @@ from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
 
 
 async def test_user_flow(
-    hass: HomeAssistant, mock_rf_entity: MockRadioFrequencyEntity
+    hass: HomeAssistant,
+    mock_rf_entity: MockRadioFrequencyEntity,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the user config flow creates an entry."""
     result = await hass.config_entries.flow.async_init(
@@ -34,7 +36,6 @@ async def test_user_flow(
         user_input={CONF_TRANSMITTER: TRANSMITTER_ENTITY_ID},
     )
 
-    entity_registry = er.async_get(hass)
     entity_entry = entity_registry.async_get(TRANSMITTER_ENTITY_ID)
 
     assert result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/honeywell_string_lights/test_config_flow.py
+++ b/tests/components/honeywell_string_lights/test_config_flow.py
@@ -13,12 +13,14 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
+from .conftest import TRANSMITTER_ENTITY_ID
+
 from tests.common import MockConfigEntry
 from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
 
 
 async def test_user_flow(
-    hass: HomeAssistant, mock_transmitter: MockRadioFrequencyEntity
+    hass: HomeAssistant, mock_rf_entity: MockRadioFrequencyEntity
 ) -> None:
     """Test the user config flow creates an entry."""
     result = await hass.config_entries.flow.async_init(
@@ -29,12 +31,11 @@ async def test_user_flow(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_TRANSMITTER: mock_transmitter.entity_id},
+        user_input={CONF_TRANSMITTER: TRANSMITTER_ENTITY_ID},
     )
 
     entity_registry = er.async_get(hass)
-    entity_entry = entity_registry.async_get(mock_transmitter.entity_id)
-    assert entity_entry is not None
+    entity_entry = entity_registry.async_get(TRANSMITTER_ENTITY_ID)
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Honeywell String Lights"
@@ -44,7 +45,6 @@ async def test_user_flow(
 
 async def test_unique_id_already_configured(
     hass: HomeAssistant,
-    mock_transmitter: MockRadioFrequencyEntity,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test aborting when the same transmitter is already configured."""
@@ -55,7 +55,7 @@ async def test_unique_id_already_configured(
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_TRANSMITTER: mock_transmitter.entity_id},
+        user_input={CONF_TRANSMITTER: TRANSMITTER_ENTITY_ID},
     )
 
     assert result["type"] is FlowResultType.ABORT

--- a/tests/components/honeywell_string_lights/test_light.py
+++ b/tests/components/honeywell_string_lights/test_light.py
@@ -1,0 +1,87 @@
+"""Tests for the Honeywell String Lights light platform."""
+
+from __future__ import annotations
+
+from homeassistant.components.honeywell_string_lights.light import COMMANDS
+from homeassistant.components.light import (
+    DOMAIN as LIGHT_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    ATTR_ENTITY_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant, State
+
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
+
+ENTITY_ID = "light.honeywell_string_lights"
+
+
+async def test_turn_on_off_sends_commands(
+    hass: HomeAssistant,
+    mock_transmitter: MockRadioFrequencyEntity,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test turning the light on and off sends the correct RF commands."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_ASSUMED_STATE] is True
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    assert hass.states.get(ENTITY_ID).state == STATE_ON
+    assert len(mock_transmitter.send_command_calls) == 1
+    assert mock_transmitter.send_command_calls[0] is COMMANDS.load_command("turn_on")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    assert hass.states.get(ENTITY_ID).state == STATE_OFF
+    assert len(mock_transmitter.send_command_calls) == 2
+    assert mock_transmitter.send_command_calls[1] is COMMANDS.load_command("turn_off")
+
+
+async def test_restore_state(
+    hass: HomeAssistant,
+    mock_transmitter: MockRadioFrequencyEntity,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the light restores its previous on state."""
+    mock_restore_cache(hass, [State(ENTITY_ID, STATE_ON)])
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_unload_entry(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
+    """Test unloading the config entry removes the entity."""
+    assert hass.states.get(ENTITY_ID) is not None
+
+    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/honeywell_string_lights/test_light.py
+++ b/tests/components/honeywell_string_lights/test_light.py
@@ -25,8 +25,8 @@ ENTITY_ID = "light.honeywell_string_lights"
 
 async def test_turn_on_off_sends_commands(
     hass: HomeAssistant,
-    mock_transmitter: MockRadioFrequencyEntity,
-    init_integration: MockConfigEntry,
+    mock_rf_entity: MockRadioFrequencyEntity,
+    init_string_lights: MockConfigEntry,
 ) -> None:
     """Test turning the light on and off sends the correct RF commands."""
     state = hass.states.get(ENTITY_ID)
@@ -42,8 +42,8 @@ async def test_turn_on_off_sends_commands(
     )
 
     assert hass.states.get(ENTITY_ID).state == STATE_ON
-    assert len(mock_transmitter.send_command_calls) == 1
-    assert mock_transmitter.send_command_calls[0] is COMMANDS.load_command("turn_on")
+    assert len(mock_rf_entity.send_command_calls) == 1
+    assert mock_rf_entity.send_command_calls[0] is COMMANDS.load_command("turn_on")
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -53,13 +53,13 @@ async def test_turn_on_off_sends_commands(
     )
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
-    assert len(mock_transmitter.send_command_calls) == 2
-    assert mock_transmitter.send_command_calls[1] is COMMANDS.load_command("turn_off")
+    assert len(mock_rf_entity.send_command_calls) == 2
+    assert mock_rf_entity.send_command_calls[1] is COMMANDS.load_command("turn_off")
 
 
 async def test_restore_state(
     hass: HomeAssistant,
-    mock_transmitter: MockRadioFrequencyEntity,
+    mock_rf_entity: MockRadioFrequencyEntity,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the light restores its previous on state."""
@@ -74,12 +74,12 @@ async def test_restore_state(
 
 
 async def test_unload_entry(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant, init_string_lights: MockConfigEntry
 ) -> None:
     """Test unloading the config entry removes the entity."""
     assert hass.states.get(ENTITY_ID) is not None
 
-    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    assert await hass.config_entries.async_unload(init_string_lights.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_ID)

--- a/tests/components/honeywell_string_lights/test_light.py
+++ b/tests/components/honeywell_string_lights/test_light.py
@@ -14,8 +14,9 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import Context, HomeAssistant, State
 
 from tests.common import MockConfigEntry, mock_restore_cache
 from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
@@ -31,30 +32,44 @@ async def test_turn_on_off_sends_commands(
     """Test turning the light on and off sends the correct RF commands."""
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes[ATTR_ASSUMED_STATE] is True
+
+    context = Context()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: ENTITY_ID},
+        context=context,
         blocking=True,
     )
 
-    assert hass.states.get(ENTITY_ID).state == STATE_ON
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.context is context
     assert len(mock_rf_entity.send_command_calls) == 1
-    assert mock_rf_entity.send_command_calls[0] is COMMANDS.load_command("turn_on")
+    command = mock_rf_entity.send_command_calls[0]
+    assert command.command is COMMANDS.load_command("turn_on")
+    assert command.context is context
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: ENTITY_ID},
+        context=context,
         blocking=True,
     )
 
-    assert hass.states.get(ENTITY_ID).state == STATE_OFF
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.context is context
     assert len(mock_rf_entity.send_command_calls) == 2
-    assert mock_rf_entity.send_command_calls[1] is COMMANDS.load_command("turn_off")
+    command = mock_rf_entity.send_command_calls[1]
+    assert command.command is COMMANDS.load_command("turn_off")
+    assert command.context is context
 
 
 async def test_restore_state(

--- a/tests/components/radio_frequency/conftest.py
+++ b/tests/components/radio_frequency/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Radio Frequency tests."""
 
-from typing import override
+from typing import NamedTuple, override
 
 import pytest
 from rf_protocols import ModulationType, RadioFrequencyCommand
@@ -19,6 +19,13 @@ async def init_integration(hass: HomeAssistant) -> None:
     """Set up the Radio Frequency integration for testing."""
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
+
+
+class MockCommand(NamedTuple):
+    """Data structure to store calls to async_send_command."""
+
+    command: RadioFrequencyCommand
+    context: object | None
 
 
 class MockRadioFrequencyCommand(RadioFrequencyCommand):
@@ -60,7 +67,7 @@ class MockRadioFrequencyEntity(RadioFrequencyTransmitterEntity):
             if frequency_ranges is None
             else frequency_ranges
         )
-        self.send_command_calls: list[RadioFrequencyCommand] = []
+        self.send_command_calls: list[MockCommand] = []
 
     @property
     def supported_frequency_ranges(self) -> list[tuple[int, int]]:
@@ -69,7 +76,9 @@ class MockRadioFrequencyEntity(RadioFrequencyTransmitterEntity):
 
     async def async_send_command(self, command: RadioFrequencyCommand) -> None:
         """Mock send command."""
-        self.send_command_calls.append(command)
+        self.send_command_calls.append(
+            MockCommand(command=command, context=self._context)
+        )
 
 
 @pytest.fixture

--- a/tests/components/radio_frequency/test_init.py
+++ b/tests/components/radio_frequency/test_init.py
@@ -80,7 +80,7 @@ async def test_async_send_command_success(
     await async_send_command(hass, ENTITY_ID, command)
 
     assert len(mock_rf_entity.send_command_calls) == 1
-    assert mock_rf_entity.send_command_calls[0] is command
+    assert mock_rf_entity.send_command_calls[0].command is command
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new `honeywell_string_lights` integration that drives a Honeywell String Lights set via the `radio_frequency` entity platform. All protocol details (frequency, modulation, timings, repeat count) are provided by the [`rf-protocols`](https://github.com/home-assistant-libs/rf-protocols) library — this integration contains no hard-coded RF constants.

This PR **relies on** https://github.com/home-assistant/core/pull/168447 — the `radio_frequency` entity platform. This PR is currently stacked on top of that branch.

Opened as a **draft** until the parent PR lands.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44829
- Link to brands pull request: https://github.com/home-assistant/brands/pull/10164
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr