### PR TITLE
Add reconfiguration flow to Duco integration

### DIFF
--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -57,6 +57,7 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
         except DucoConnectionError:
             return self.async_abort(reason="cannot_connect")
         except DucoError:
+            _LOGGER.exception("Unexpected error discovering Duco box via zeroconf")
             return self.async_abort(reason="unknown")
 
         await self.async_set_unique_id(format_mac(mac))

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from duco import DucoClient
@@ -18,6 +19,11 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+# Duco boxes advertise themselves as "DUCO [<12 hex MAC chars>]" over mDNS.
+# Reject anything that doesn't match this pattern to avoid false positives
+# (e.g. a laptop named "ducotje").
+_DUCO_MDNS_NAME_RE = re.compile(r"^DUCO \[[0-9a-f]{12}\]", re.IGNORECASE)
 
 STEP_USER_SCHEMA = vol.Schema(
     {
@@ -41,6 +47,9 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
+        if not _DUCO_MDNS_NAME_RE.match(discovery_info.name):
+            return self.async_abort(reason="not_duco_device")
+
         host = discovery_info.host
 
         try:

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -40,8 +40,8 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self._host: str = ""
-        self._box_name: str = ""
+        self._host: str | None = None
+        self._box_name: str | None = None
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
@@ -71,6 +71,8 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm discovery."""
+        assert self._host is not None
+        assert self._box_name is not None
         if user_input is not None:
             return self.async_create_entry(
                 title=self._box_name,

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -21,7 +21,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 # Duco boxes advertise themselves as "DUCO [<12 hex MAC chars>]" over mDNS.
-# Reject anything that doesn't match this pattern to avoid false positives
+# Reject anything that doesn't match this pattern to avoid false positives.
 # (e.g. a laptop named "ducotje").
 _DUCO_MDNS_NAME_RE = re.compile(r"^DUCO \[[0-9a-f]{12}\]", re.IGNORECASE)
 

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -21,7 +21,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 # Duco boxes advertise themselves as "DUCO [<12 hex MAC chars>]" over mDNS.
-# Reject anything that doesn't match this pattern to avoid false positives.
+# Reject anything that doesn't match this pattern to avoid false positives
 # (e.g. a laptop named "ducotje").
 _DUCO_MDNS_NAME_RE = re.compile(r"^DUCO \[[0-9a-f]{12}\]", re.IGNORECASE)
 

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -85,6 +85,42 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"name": self._box_name},
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                box_name, mac = await self._validate_input(user_input[CONF_HOST])
+            except DucoConnectionError:
+                errors["base"] = "cannot_connect"
+            except DucoError:
+                _LOGGER.exception("Unexpected error connecting to Duco box")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(format_mac(mac))
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    title=box_name,
+                    data_updates={CONF_HOST: user_input[CONF_HOST]},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST, default=reconfigure_entry.data[CONF_HOST]
+                    ): str,
+                }
+            ),
+            errors=errors,
+        )
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 
@@ -31,6 +32,49 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
 
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._host: str = ""
+        self._box_name: str = ""
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        host = discovery_info.host
+
+        try:
+            box_name, mac = await self._validate_input(host)
+        except DucoConnectionError:
+            return self.async_abort(reason="cannot_connect")
+        except DucoError:
+            return self.async_abort(reason="unknown")
+
+        await self.async_set_unique_id(format_mac(mac))
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
+        self._host = host
+        self._box_name = box_name
+        self.context["title_placeholders"] = {"name": box_name}
+
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm discovery."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._box_name,
+                data={CONF_HOST: self._host},
+            )
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="discovery_confirm",
+            description_placeholders={"name": self._box_name},
+        )
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -46,7 +90,7 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected error connecting to Duco box")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(format_mac(mac))
+                await self.async_set_unique_id(format_mac(mac), raise_on_progress=False)
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -50,10 +50,8 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
         if not _DUCO_MDNS_NAME_RE.match(discovery_info.name):
             return self.async_abort(reason="not_duco_device")
 
-        host = discovery_info.host
-
         try:
-            box_name, mac = await self._validate_input(host)
+            box_name, mac = await self._validate_input(discovery_info.host)
         except DucoConnectionError:
             return self.async_abort(reason="cannot_connect")
         except DucoError:
@@ -61,9 +59,9 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="unknown")
 
         await self.async_set_unique_id(format_mac(mac))
-        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
 
-        self._host = host
+        self._host = discovery_info.host
         self._box_name = box_name
         self.context["title_placeholders"] = {"name": box_name}
 

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -85,42 +85,6 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"name": self._box_name},
         )
 
-    async def async_step_reconfigure(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reconfiguration of the integration."""
-        errors: dict[str, str] = {}
-        reconfigure_entry = self._get_reconfigure_entry()
-
-        if user_input is not None:
-            try:
-                box_name, mac = await self._validate_input(user_input[CONF_HOST])
-            except DucoConnectionError:
-                errors["base"] = "cannot_connect"
-            except DucoError:
-                _LOGGER.exception("Unexpected error connecting to Duco box")
-                errors["base"] = "unknown"
-            else:
-                await self.async_set_unique_id(format_mac(mac))
-                self._abort_if_unique_id_mismatch(reason="wrong_device")
-                return self.async_update_reload_and_abort(
-                    reconfigure_entry,
-                    title=box_name,
-                    data_updates={CONF_HOST: user_input[CONF_HOST]},
-                )
-
-        return self.async_show_form(
-            step_id="reconfigure",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST, default=reconfigure_entry.data[CONF_HOST]
-                    ): str,
-                }
-            ),
-            errors=errors,
-        )
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -75,6 +75,42 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"name": self._box_name},
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                box_name, mac = await self._validate_input(user_input[CONF_HOST])
+            except DucoConnectionError:
+                errors["base"] = "cannot_connect"
+            except DucoError:
+                _LOGGER.exception("Unexpected error connecting to Duco box")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(format_mac(mac))
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    title=box_name,
+                    data_updates={CONF_HOST: user_input[CONF_HOST]},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST, default=reconfigure_entry.data[CONF_HOST]
+                    ): str,
+                }
+            ),
+            errors=errors,
+        )
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -8,5 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["duco"],
   "quality_scale": "bronze",
-  "requirements": ["python-duco-client==0.3.1"]
+  "requirements": ["python-duco-client==0.3.1"],
+  "zeroconf": [{ "name": "duco*", "type": "_http._tcp.local." }]
 }

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -46,18 +46,8 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info:
-    status: todo
-    comment: >-
-      DHCP host updating to be implemented in a follow-up PR.
-      The device hostname follows the pattern duco_<last 6 chars of MAC>
-      (e.g. duco_061293), which can be used for DHCP hostname matching.
-  discovery:
-    status: todo
-    comment: >-
-      Device can be discovered via DHCP. The hostname follows the pattern
-      duco_<last 6 chars of MAC> (e.g. duco_061293). To be implemented
-      in a follow-up PR together with discovery-update-info.
+  discovery-update-info: done
+  discovery: done
   docs-data-update: done
   docs-examples: done
   docs-known-limitations: done

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -66,7 +66,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: done
+  reconfiguration-flow: todo
   repair-issues: todo
   stale-devices:
     status: todo

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -66,7 +66,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices:
     status: todo

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "not_duco_device": "The discovered device is not a Duco ventilation box.",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -3,7 +3,9 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "wrong_device": "The device you entered belongs to a different Duco box."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -12,6 +14,14 @@
     "step": {
       "discovery_confirm": {
         "description": "Do you want to set up {name}?"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "IP address or hostname of your Duco ventilation box."
+        }
       },
       "user": {
         "data": {

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -5,9 +5,7 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "not_duco_device": "The discovered device is not a Duco ventilation box.",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]",
-      "wrong_device": "The device you entered belongs to a different Duco box."
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -16,14 +14,6 @@
     "step": {
       "discovery_confirm": {
         "description": "Do you want to set up {name}?"
-      },
-      "reconfigure": {
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]"
-        },
-        "data_description": {
-          "host": "IP address or hostname of your Duco ventilation box."
-        }
       },
       "user": {
         "data": {

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -1,13 +1,18 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "discovery_confirm": {
+        "description": "Do you want to set up {name}?"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -5,7 +5,9 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "not_duco_device": "The discovered device is not a Duco ventilation box.",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "wrong_device": "The device you entered belongs to a different Duco box."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -14,6 +16,14 @@
     "step": {
       "discovery_confirm": {
         "description": "Do you want to set up {name}?"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "IP address or hostname of your Duco ventilation box."
+        }
       },
       "user": {
         "data": {

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -3,6 +3,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "not_duco_device": "The discovered device is not a Duco ventilation box.",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "wrong_device": "The device you entered belongs to a different Duco box."

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -584,6 +584,10 @@ ZEROCONF = {
             "name": "bsb-lan*",
         },
         {
+            "domain": "duco",
+            "name": "duco*",
+        },
+        {
             "domain": "eheimdigital",
             "name": "eheimdigital._http._tcp.local.",
         },

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -6,7 +6,6 @@ from ipaddress import IPv4Address
 from unittest.mock import AsyncMock
 
 from duco.exceptions import DucoConnectionError, DucoError
-from duco.models import LanInfo
 import pytest
 
 from homeassistant.components.duco.const import DOMAIN
@@ -279,94 +278,3 @@ async def test_zeroconf_discovery_accepts_valid_names(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
-
-
-async def test_reconfigure_flow_success(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test a successful reconfigure flow updates host and reloads."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await mock_config_entry.start_reconfigure_flow(hass)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-
-    new_host = "192.168.1.200"
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: new_host}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-    assert mock_config_entry.data[CONF_HOST] == new_host
-
-
-async def test_reconfigure_flow_wrong_device(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test reconfigure flow aborts when pointing to a different device."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await mock_config_entry.start_reconfigure_flow(hass)
-
-    # Simulate a different MAC returned by the new host
-    different_mac = "11:22:33:44:55:66"
-    mock_duco_client.async_get_lan_info.return_value = LanInfo(
-        mode="WIFI_CLIENT",
-        ip="192.168.1.200",
-        net_mask="255.255.255.0",
-        default_gateway="192.168.1.1",
-        dns="8.8.8.8",
-        mac=different_mac,
-        host_name="duco-other",
-        rssi_wifi=-60,
-    )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: "192.168.1.200"}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "wrong_device"
-
-
-@pytest.mark.parametrize(
-    ("exception", "expected_error"),
-    [
-        (DucoConnectionError("Connection refused"), "cannot_connect"),
-        (DucoError("Unexpected error"), "unknown"),
-    ],
-)
-async def test_reconfigure_flow_error(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    exception: Exception,
-    expected_error: str,
-) -> None:
-    """Test reconfigure flow shows error on connection failure."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await mock_config_entry.start_reconfigure_flow(hass)
-
-    mock_duco_client.async_get_board_info.side_effect = exception
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: "192.168.1.200"}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-    assert result["errors"] == {"base": expected_error}
-
-    mock_duco_client.async_get_board_info.side_effect = None
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: "192.168.1.200"}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -145,8 +145,8 @@ async def test_zeroconf_discovery_updates_host(
 
     new_ip = "192.168.1.200"
     discovery = ZeroconfServiceInfo(
-        ip_address=new_ip,
-        ip_addresses=[new_ip],
+        ip_address=IPv4Address(new_ip),
+        ip_addresses=[IPv4Address(new_ip)],
         port=80,
         hostname="duco_061293.local.",
         type="_http._tcp.local.",
@@ -227,8 +227,8 @@ async def test_zeroconf_discovery_rejects_invalid_names(
 ) -> None:
     """Test zeroconf discovery rejects devices that don't match Duco naming pattern."""
     invalid_discovery = ZeroconfServiceInfo(
-        ip_address=TEST_HOST,
-        ip_addresses=[TEST_HOST],
+        ip_address=IPv4Address(TEST_HOST),
+        ip_addresses=[IPv4Address(TEST_HOST)],
         port=80,
         hostname="device.local.",
         type="_http._tcp.local.",
@@ -262,8 +262,8 @@ async def test_zeroconf_discovery_accepts_valid_names(
 ) -> None:
     """Test zeroconf discovery accepts valid Duco device names."""
     valid_discovery = ZeroconfServiceInfo(
-        ip_address=TEST_HOST,
-        ip_addresses=[TEST_HOST],
+        ip_address=IPv4Address(TEST_HOST),
+        ip_addresses=[IPv4Address(TEST_HOST)],
         port=80,
         hostname="duco.local.",
         type="_http._tcp.local.",

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -9,12 +9,24 @@ import pytest
 
 from homeassistant.components.duco.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .conftest import TEST_MAC, USER_INPUT
+from .conftest import TEST_HOST, TEST_MAC, USER_INPUT
 
 from tests.common import MockConfigEntry
+
+ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
+    ip_address=TEST_HOST,
+    ip_addresses=[TEST_HOST],
+    port=80,
+    hostname="duco_061293.local.",
+    type="_http._tcp.local.",
+    name="DUCO [a0dd6c061293]._http._tcp.local.",
+    properties={},
+)
 
 
 async def test_user_flow_success(
@@ -94,3 +106,102 @@ async def test_user_flow_duplicate(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_discovery_new_device(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test zeroconf discovery of a new device shows confirmation form and creates entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=ZEROCONF_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "SILENT_CONNECT"
+    assert result["data"] == USER_INPUT
+    assert result["result"].unique_id == TEST_MAC
+
+
+async def test_zeroconf_discovery_updates_host(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zeroconf discovery updates the host of an existing entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    new_ip = "192.168.1.200"
+    discovery = ZeroconfServiceInfo(
+        ip_address=new_ip,
+        ip_addresses=[new_ip],
+        port=80,
+        hostname="duco_061293.local.",
+        type="_http._tcp.local.",
+        name="DUCO [a0dd6c061293]._http._tcp.local.",
+        properties={},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=discovery,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == new_ip
+
+
+async def test_zeroconf_discovery_already_configured_same_ip(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zeroconf discovery with unchanged IP aborts as already_configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=ZEROCONF_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_reason"),
+    [
+        (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (DucoError("Unexpected error"), "unknown"),
+    ],
+)
+async def test_zeroconf_discovery_connection_error(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    exception: Exception,
+    expected_reason: str,
+) -> None:
+    """Test zeroconf discovery aborts on connection and unknown errors."""
+    mock_duco_client.async_get_board_info.side_effect = exception
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=ZEROCONF_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == expected_reason

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 from duco.exceptions import DucoConnectionError, DucoError
+from duco.models import LanInfo
 import pytest
 
 from homeassistant.components.duco.const import DOMAIN
@@ -205,3 +206,94 @@ async def test_zeroconf_discovery_connection_error(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
+
+
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a successful reconfigure flow updates host and reloads."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_host = "192.168.1.200"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: new_host}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == new_host
+
+
+async def test_reconfigure_flow_wrong_device(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow aborts when pointing to a different device."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    # Simulate a different MAC returned by the new host
+    different_mac = "11:22:33:44:55:66"
+    mock_duco_client.async_get_lan_info.return_value = LanInfo(
+        mode="WIFI_CLIENT",
+        ip="192.168.1.200",
+        net_mask="255.255.255.0",
+        default_gateway="192.168.1.1",
+        dns="8.8.8.8",
+        mac=different_mac,
+        host_name="duco-other",
+        rssi_wifi=-60,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.200"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (DucoError("Unexpected error"), "unknown"),
+    ],
+)
+async def test_reconfigure_flow_error(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    expected_error: str,
+) -> None:
+    """Test reconfigure flow shows error on connection failure."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_duco_client.async_get_board_info.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.200"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": expected_error}
+
+    mock_duco_client.async_get_board_info.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.200"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -216,7 +216,6 @@ async def test_zeroconf_discovery_connection_error(
         "something_duco._http._tcp.local.",
         "DUCO [invalid]._http._tcp.local.",
         "DUCO [a0dd6c06129]._http._tcp.local.",  # Wrong MAC length
-        "duco [a0dd6c061293]._http._tcp.local.",  # Wrong case
         "My Duco Device._http._tcp.local.",
     ],
 )

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -208,6 +208,79 @@ async def test_zeroconf_discovery_connection_error(
     assert result["reason"] == expected_reason
 
 
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "ducotje._http._tcp.local.",
+        "DUCO Box._http._tcp.local.",
+        "something_duco._http._tcp.local.",
+        "DUCO [invalid]._http._tcp.local.",
+        "DUCO [a0dd6c06129]._http._tcp.local.",  # Wrong MAC length
+        "duco [a0dd6c061293]._http._tcp.local.",  # Wrong case
+        "My Duco Device._http._tcp.local.",
+    ],
+)
+async def test_zeroconf_discovery_rejects_invalid_names(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    invalid_name: str,
+) -> None:
+    """Test zeroconf discovery rejects devices that don't match Duco naming pattern."""
+    invalid_discovery = ZeroconfServiceInfo(
+        ip_address=TEST_HOST,
+        ip_addresses=[TEST_HOST],
+        port=80,
+        hostname="device.local.",
+        type="_http._tcp.local.",
+        name=invalid_name,
+        properties={},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=invalid_discovery,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_duco_device"
+
+
+@pytest.mark.parametrize(
+    "valid_name",
+    [
+        "DUCO [a0dd6c061293]._http._tcp.local.",
+        "duco [123abc456def]._http._tcp.local.",  # Lowercase should work with IGNORECASE
+        "DUCO [ABCDEF123456]._http._tcp.local.",  # Uppercase hex
+    ],
+)
+async def test_zeroconf_discovery_accepts_valid_names(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    valid_name: str,
+) -> None:
+    """Test zeroconf discovery accepts valid Duco device names."""
+    valid_discovery = ZeroconfServiceInfo(
+        ip_address=TEST_HOST,
+        ip_addresses=[TEST_HOST],
+        port=80,
+        hostname="duco.local.",
+        type="_http._tcp.local.",
+        name=valid_name,
+        properties={},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=valid_discovery,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+
 async def test_reconfigure_flow_success(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -6,6 +6,7 @@ from ipaddress import IPv4Address
 from unittest.mock import AsyncMock
 
 from duco.exceptions import DucoConnectionError, DucoError
+from duco.models import LanInfo
 import pytest
 
 from homeassistant.components.duco.const import DOMAIN
@@ -278,3 +279,94 @@ async def test_zeroconf_discovery_accepts_valid_names(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
+
+
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a successful reconfigure flow updates host and reloads."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_host = "192.168.1.200"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: new_host}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == new_host
+
+
+async def test_reconfigure_flow_wrong_device(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow aborts when pointing to a different device."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    # Simulate a different MAC returned by the new host
+    different_mac = "11:22:33:44:55:66"
+    mock_duco_client.async_get_lan_info.return_value = LanInfo(
+        mode="WIFI_CLIENT",
+        ip="192.168.1.200",
+        net_mask="255.255.255.0",
+        default_gateway="192.168.1.1",
+        dns="8.8.8.8",
+        mac=different_mac,
+        host_name="duco-other",
+        rssi_wifi=-60,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.200"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (DucoError("Unexpected error"), "unknown"),
+    ],
+)
+async def test_reconfigure_flow_error(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    expected_error: str,
+) -> None:
+    """Test reconfigure flow shows error on connection failure."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_duco_client.async_get_board_info.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.200"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": expected_error}
+
+    mock_duco_client.async_get_board_info.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.200"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ipaddress import IPv4Address
 from unittest.mock import AsyncMock
 
 from duco.exceptions import DucoConnectionError, DucoError
@@ -20,8 +21,8 @@ from .conftest import TEST_HOST, TEST_MAC, USER_INPUT
 from tests.common import MockConfigEntry
 
 ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
-    ip_address=TEST_HOST,
-    ip_addresses=[TEST_HOST],
+    ip_address=IPv4Address(TEST_HOST),
+    ip_addresses=[IPv4Address(TEST_HOST)],
     port=80,
     hostname="duco_061293.local.",
     type="_http._tcp.local.",


### PR DESCRIPTION
## Proposed change

Add a reconfiguration flow to the Duco integration so users can update the IP address or hostname of an already-configured Duco ventilation box without removing and re-adding the integration.

Changes:
- `async_step_reconfigure` in the config flow
- Aborts with `wrong_device` if the new host responds with a different MAC address
- Translations for `reconfigure_successful` and `wrong_device` abort reasons and the `reconfigure` step
- Tests covering success, wrong-device, and error paths
- `quality_scale.yaml`: `reconfiguration-flow: done`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR depends on: home-assistant/core#168439 (Add zeroconf discovery to Duco integration)
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect_pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest