### PR TITLE
Add ability to filter GetLiveContext tool

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1220,6 +1220,8 @@ class GetLiveContextTool(Tool):
 
         if isinstance(domain_filter, str):
             domain_filter = [domain_filter]
+        if domain_filter is not None:
+            domain_filter = [domain.casefold() for domain in domain_filter]
 
         if name_filter is not None:
             name_filter_norm = name_filter.casefold()
@@ -1245,7 +1247,9 @@ class GetLiveContextTool(Tool):
             ]
 
         if domain_filter is not None:
-            entities = [info for info in entities if info["domain"] in domain_filter]
+            entities = [
+                info for info in entities if info["domain"].casefold() in domain_filter
+            ]
 
         if not entities:
             return {

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1174,7 +1174,8 @@ class GetLiveContextTool(Tool):
         "Use this tool for: "
         "1. Answering questions about current conditions (e.g., 'Is the light on?'). "
         "2. As the first step in conditional actions (e.g., 'If the weather is rainy, turn off sprinklers' requires checking the weather first). "
-        "Optionally filter the response by entity name, domain, and/or area to reduce the amount of context returned."
+        "You may filter for devices by any combination of arguments from the static context. "
+        "Prefer filtering by domain when searching for multiple devices of the same type."
     )
     parameters = vol.Schema(
         {

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1173,7 +1173,24 @@ class GetLiveContextTool(Tool):
         "Provides real-time information about the CURRENT state, value, or mode of devices, sensors, entities, or areas. "
         "Use this tool for: "
         "1. Answering questions about current conditions (e.g., 'Is the light on?'). "
-        "2. As the first step in conditional actions (e.g., 'If the weather is rainy, turn off sprinklers' requires checking the weather first)."
+        "2. As the first step in conditional actions (e.g., 'If the weather is rainy, turn off sprinklers' requires checking the weather first). "
+        "Optionally filter the response by entity name, domain, and/or area to reduce the amount of context returned."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Optional(
+                "name",
+                description="Filter entities by name or alias (case-insensitive).",
+            ): cv.string,
+            vol.Optional(
+                "domain",
+                description="Filter entities by domain (e.g. 'light', 'sensor'). Accepts a single domain or a list.",
+            ): vol.Any(cv.string, [cv.string]),
+            vol.Optional(
+                "area",
+                description="Filter entities by area name or alias (case-insensitive).",
+            ): cv.string,
+        }
     )
 
     async def async_call(
@@ -1188,12 +1205,55 @@ class GetLiveContextTool(Tool):
             # exposed if no assistant is configured.
             return {"success": False, "error": "No assistant configured"}
 
+        args = self.parameters(tool_input.tool_args)
         exposed_entities = _get_exposed_entities(hass, llm_context.assistant)
+
         if not exposed_entities["entities"]:
             return {"success": False, "error": NO_ENTITIES_PROMPT}
+
+        entities = list(exposed_entities["entities"].values())
+
+        name_filter = args.get("name")
+        area_filter = args.get("area")
+        domain_filter = args.get("domain")
+
+        if isinstance(domain_filter, str):
+            domain_filter = [domain_filter]
+
+        if name_filter is not None:
+            name_filter_norm = name_filter.casefold()
+            entities = [
+                info
+                for info in entities
+                if any(
+                    name_filter_norm == alias.casefold()
+                    for alias in info["names"].split(", ")
+                )
+            ]
+
+        if area_filter is not None:
+            area_filter_norm = area_filter.casefold()
+            entities = [
+                info
+                for info in entities
+                if "areas" in info
+                and any(
+                    area_filter_norm == area.casefold()
+                    for area in info["areas"].split(", ")
+                )
+            ]
+
+        if domain_filter is not None:
+            entities = [info for info in entities if info["domain"] in domain_filter]
+
+        if not entities:
+            return {
+                "success": False,
+                "error": "No entities matched the provided filter",
+            }
         prompt = [
             "Live Context: An overview of the areas and the devices in this smart home:",
-            yaml_util.dump(list(exposed_entities["entities"].values())),
+            yaml_util.dump(entities),
         ]
         return {
             "success": True,

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1174,7 +1174,7 @@ class GetLiveContextTool(Tool):
         "Use this tool for: "
         "1. Answering questions about current conditions (e.g., 'Is the light on?'). "
         "2. As the first step in conditional actions (e.g., 'If the weather is rainy, turn off sprinklers' requires checking the weather first). "
-        "You may filter for devices by any combination of arguments from the static context. "
+        "You may filter for devices by name, domain, and area, including combining those filters. "
         "Prefer filtering by domain when searching for multiple devices of the same type."
     )
     parameters = vol.Schema(

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1223,14 +1223,19 @@ class GetLiveContextTool(Tool):
             domain_filter = [domain.lower() for domain in domain_filter]
 
         if name_filter or area_filter or domain_filter:
+            exposed_states = [
+                state
+                for entity_id in exposed_entities["entities"]
+                if (state := hass.states.get(entity_id)) is not None
+            ]
             match_result = intent.async_match_targets(
                 hass,
                 intent.MatchTargetsConstraints(
                     name=name_filter,
                     area_name=area_filter,
                     domains=domain_filter,
-                    assistant=llm_context.assistant,
                 ),
+                states=exposed_states,
             )
 
             if not match_result.is_match:

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1212,44 +1212,41 @@ class GetLiveContextTool(Tool):
         if not exposed_entities["entities"]:
             return {"success": False, "error": NO_ENTITIES_PROMPT}
 
-        entities = list(exposed_entities["entities"].values())
-
         name_filter = args.get("name")
         area_filter = args.get("area")
         domain_filter = args.get("domain")
 
         if isinstance(domain_filter, str):
             domain_filter = [domain_filter]
-        if domain_filter is not None:
-            domain_filter = [domain.casefold() for domain in domain_filter]
-
-        if name_filter is not None:
-            name_filter_norm = name_filter.casefold()
-            entities = [
-                info
-                for info in entities
-                if any(
-                    name_filter_norm == alias.casefold()
-                    for alias in info["names"].split(", ")
-                )
-            ]
-
-        if area_filter is not None:
-            area_filter_norm = area_filter.casefold()
-            entities = [
-                info
-                for info in entities
-                if "areas" in info
-                and any(
-                    area_filter_norm == area.casefold()
-                    for area in info["areas"].split(", ")
-                )
-            ]
 
         if domain_filter is not None:
+            domain_filter = [domain.lower() for domain in domain_filter]
+
+        if name_filter or area_filter or domain_filter:
+            match_result = intent.async_match_targets(
+                hass,
+                intent.MatchTargetsConstraints(
+                    name=name_filter,
+                    area_name=area_filter,
+                    domains=domain_filter,
+                    assistant=llm_context.assistant,
+                ),
+            )
+
+            if not match_result.is_match:
+                return {
+                    "success": False,
+                    "error": "No entities matched the provided filter",
+                }
+
+            matched_ids = {state.entity_id for state in match_result.states}
             entities = [
-                info for info in entities if info["domain"].casefold() in domain_filter
+                info
+                for entity_id, info in exposed_entities["entities"].items()
+                if entity_id in matched_ids
             ]
+        else:
+            entities = list(exposed_entities["entities"].values())
 
         if not entities:
             return {

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1240,7 +1240,11 @@ class GetLiveContextTool(Tool):
             domain_filter = [domain_filter]
 
         if domain_filter is not None:
-            domain_filter = [domain.lower() for domain in domain_filter]
+            domain_filter = [
+                normalized_domain
+                for domain in domain_filter
+                if (normalized_domain := domain.strip().lower())
+            ]
 
         if name_filter or area_filter or domain_filter:
             exposed_states = [

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1160,6 +1160,26 @@ class TodoGetItemsTool(Tool):
         return {"success": True, "result": items}
 
 
+def _live_context_match_error(
+    match_result: intent.MatchTargetsResult,
+    name_filter: str | None,
+    area_filter: str | None,
+    domain_filter: list[str] | None,
+) -> str:
+    """Build an actionable error message for a failed GetLiveContext match."""
+    reason = match_result.no_match_reason
+    if reason is intent.MatchFailedReason.INVALID_AREA:
+        return f"Area '{match_result.no_match_name}' does not exist"
+    if reason is intent.MatchFailedReason.NAME:
+        return f"No exposed entities matched name '{name_filter}'"
+    if reason is intent.MatchFailedReason.AREA:
+        return f"No exposed entities found in area '{area_filter}'"
+    if reason is intent.MatchFailedReason.DOMAIN:
+        domains = ", ".join(domain_filter) if domain_filter else ""
+        return f"No exposed entities found in domain(s): {domains}"
+    return "No entities matched the provided filter"
+
+
 class GetLiveContextTool(Tool):
     """Tool for getting the current state of exposed entities.
 
@@ -1241,7 +1261,9 @@ class GetLiveContextTool(Tool):
             if not match_result.is_match:
                 return {
                     "success": False,
-                    "error": "No entities matched the provided filter",
+                    "error": _live_context_match_error(
+                        match_result, name_filter, area_filter, domain_filter
+                    ),
                 }
 
             matched_ids = {state.entity_id for state in match_result.states}

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1279,11 +1279,6 @@ class GetLiveContextTool(Tool):
         else:
             entities = list(exposed_entities["entities"].values())
 
-        if not entities:
-            return {
-                "success": False,
-                "error": "No entities matched the provided filter",
-            }
         prompt = [
             "Live Context: An overview of the areas and the devices in this smart home:",
             yaml_util.dump(entities),

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -750,6 +750,174 @@ For general knowledge questions not about the home: Answer truthfully from inter
     )
 
 
+async def test_get_live_context_tool_filter(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test the filter parameters of the GetLiveContext tool."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "intent", {})
+    context = Context()
+    llm_context = llm.LLMContext(
+        platform="test_platform",
+        context=context,
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+    entry = MockConfigEntry(title=None)
+    entry.add_to_hass(hass)
+
+    office = area_registry.async_create("Office")
+    area_registry.async_update(office.id, aliases=["Workspace"])
+    kitchen = area_registry.async_create("Kitchen")
+
+    office_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={("test", "office-1")},
+        suggested_area="Office",
+    )
+    kitchen_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={("test", "kitchen-1")},
+        suggested_area="Kitchen",
+    )
+
+    office_light = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "office_light",
+        original_name="Office Light",
+        device_id=office_device.id,
+        suggested_object_id="office_light",
+    )
+    kitchen_light = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "kitchen_light",
+        original_name="Kitchen Light",
+        device_id=kitchen_device.id,
+        suggested_object_id="kitchen_light",
+    )
+    office_switch = entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "office_switch",
+        original_name="Office Switch",
+        device_id=office_device.id,
+        suggested_object_id="office_switch",
+    )
+    front_door = entity_registry.async_get_or_create(
+        "lock",
+        "test",
+        "front_door",
+        original_name="Front Door",
+        suggested_object_id="front_door",
+    )
+
+    for entity_id in (
+        office_light.entity_id,
+        kitchen_light.entity_id,
+        office_switch.entity_id,
+        front_door.entity_id,
+    ):
+        async_expose_entity(hass, "conversation", entity_id, True)
+
+    hass.states.async_set(office_light.entity_id, "on")
+    hass.states.async_set(kitchen_light.entity_id, "off")
+    hass.states.async_set(office_switch.entity_id, "on")
+    hass.states.async_set(front_door.entity_id, "locked")
+
+    api = await llm.async_get_api(hass, "assist", llm_context)
+
+    # Filter by area and domain (example 1)
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"area": "Office", "domain": "light"},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Kitchen Light" not in result["result"]
+    assert "Office Switch" not in result["result"]
+    assert "Front Door" not in result["result"]
+
+    # Filter by name (example 2)
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "Front Door"},
+        )
+    )
+    assert result["success"] is True
+    assert "Front Door" in result["result"]
+    assert "Office Light" not in result["result"]
+    assert "Kitchen Light" not in result["result"]
+    assert "Office Switch" not in result["result"]
+
+    # Name filter is case insensitive
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "front door"},
+        )
+    )
+    assert result["success"] is True
+    assert "Front Door" in result["result"]
+
+    # Area filter matches area aliases
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"area": "workspace"},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Office Switch" in result["result"]
+    assert "Kitchen Light" not in result["result"]
+    assert "Front Door" not in result["result"]
+
+    # Domain filter accepts a list
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"domain": ["switch", "lock"]},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Switch" in result["result"]
+    assert "Front Door" in result["result"]
+    assert "Office Light" not in result["result"]
+    assert "Kitchen Light" not in result["result"]
+
+    # No filters returns all exposed entities
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="GetLiveContext", tool_args={})
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Kitchen Light" in result["result"]
+    assert "Office Switch" in result["result"]
+    assert "Front Door" in result["result"]
+
+    # Filter that matches nothing returns a descriptive error
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "Does Not Exist"},
+        )
+    )
+    assert result == {
+        "success": False,
+        "error": "No entities matched the provided filter",
+    }
+
+
 async def test_script_tool(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -895,6 +895,19 @@ async def test_get_live_context_tool_filter(
     assert "Office Light" not in result["result"]
     assert "Kitchen Light" not in result["result"]
 
+    # Domain filter is case insensitive
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"domain": "Light"},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Kitchen Light" in result["result"]
+    assert "Office Switch" not in result["result"]
+    assert "Front Door" not in result["result"]
+
     # No filters returns all exposed entities
     result = await api.async_call_tool(
         llm.ToolInput(tool_name="GetLiveContext", tool_args={})

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -773,7 +773,7 @@ async def test_get_live_context_tool_filter(
 
     office = area_registry.async_create("Office")
     area_registry.async_update(office.id, aliases=["Workspace"])
-    kitchen = area_registry.async_create("Kitchen")
+    area_registry.async_create("Kitchen")
 
     office_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -818,7 +818,7 @@ async def test_get_live_context_tool_filter(
         suggested_object_id="front_door",
     )
     entity_registry.async_update_entity(
-        kitchen_light.entity_id, aliases={"Cooking Lamp"}
+        kitchen_light.entity_id, aliases=[er.COMPUTED_NAME, "Cooking Lamp"]
     )
 
     for entity_id in (

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -930,7 +930,7 @@ async def test_get_live_context_tool_filter(
     )
     assert result == {
         "success": False,
-        "error": "No entities matched the provided filter",
+        "error": "No exposed entities matched name 'Does Not Exist'",
     }
 
     # Name filter strips surrounding whitespace
@@ -1002,7 +1002,7 @@ async def test_get_live_context_tool_filter(
     assert "Office Light" in result["result"]
     assert "Office Switch" not in result["result"]
 
-    # Combining name + area returns nothing when they do not intersect
+    # Combining name + area returns the failing constraint in the error
     result = await api.async_call_tool(
         llm.ToolInput(
             tool_name="GetLiveContext",
@@ -1011,10 +1011,10 @@ async def test_get_live_context_tool_filter(
     )
     assert result == {
         "success": False,
-        "error": "No entities matched the provided filter",
+        "error": "No exposed entities found in area 'Kitchen'",
     }
 
-    # Unknown area returns the descriptive error rather than ignoring the filter
+    # Unknown area distinguishes "invalid area" from "no entities in area"
     result = await api.async_call_tool(
         llm.ToolInput(
             tool_name="GetLiveContext",
@@ -1023,7 +1023,19 @@ async def test_get_live_context_tool_filter(
     )
     assert result == {
         "success": False,
-        "error": "No entities matched the provided filter",
+        "error": "Area 'Garage' does not exist",
+    }
+
+    # Unknown domain reports which domain(s) failed
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"domain": "climate"},
+        )
+    )
+    assert result == {
+        "success": False,
+        "error": "No exposed entities found in domain(s): climate",
     }
 
 

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -772,7 +772,7 @@ async def test_get_live_context_tool_filter(
     entry.add_to_hass(hass)
 
     office = area_registry.async_create("Office")
-    area_registry.async_update(office.id, aliases=["Workspace"])
+    area_registry.async_update(office.id, aliases={"Workspace"})
     area_registry.async_create("Kitchen")
 
     office_device = device_registry.async_get_or_create(

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -817,6 +817,9 @@ async def test_get_live_context_tool_filter(
         original_name="Front Door",
         suggested_object_id="front_door",
     )
+    entity_registry.async_update_entity(
+        kitchen_light.entity_id, aliases={"Cooking Lamp"}
+    )
 
     for entity_id in (
         office_light.entity_id,
@@ -923,6 +926,99 @@ async def test_get_live_context_tool_filter(
         llm.ToolInput(
             tool_name="GetLiveContext",
             tool_args={"name": "Does Not Exist"},
+        )
+    )
+    assert result == {
+        "success": False,
+        "error": "No entities matched the provided filter",
+    }
+
+    # Name filter strips surrounding whitespace
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "  Front Door  "},
+        )
+    )
+    assert result["success"] is True
+    assert "Front Door" in result["result"]
+
+    # Area filter strips surrounding whitespace
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"area": "  Office  "},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Office Switch" in result["result"]
+    assert "Kitchen Light" not in result["result"]
+
+    # Name filter accepts entity_id
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": office_light.entity_id},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Kitchen Light" not in result["result"]
+    assert "Office Switch" not in result["result"]
+
+    # Area filter accepts area_id
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"area": office.id},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Office Switch" in result["result"]
+    assert "Kitchen Light" not in result["result"]
+    assert "Front Door" not in result["result"]
+
+    # Name filter matches entity aliases
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "cooking lamp"},
+        )
+    )
+    assert result["success"] is True
+    assert "Kitchen Light" in result["result"]
+    assert "Office Light" not in result["result"]
+
+    # Combining name + area narrows the result
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "Office Light", "area": "Office"},
+        )
+    )
+    assert result["success"] is True
+    assert "Office Light" in result["result"]
+    assert "Office Switch" not in result["result"]
+
+    # Combining name + area returns nothing when they do not intersect
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "Office Light", "area": "Kitchen"},
+        )
+    )
+    assert result == {
+        "success": False,
+        "error": "No entities matched the provided filter",
+    }
+
+    # Unknown area returns the descriptive error rather than ignoring the filter
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"area": "Garage"},
         )
     )
     assert result == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the GetLiveContext tool is often used by LLMs but it provides a significant amount of unnecessary information. A question about a specific device or area (ex: "Is the front door locked?" or "are the upstairs lights on?") includes information about all exposed entities and their state. Depending on the number of exposed entities this can have affects from multiple seconds to minutes of delay, and a lot of tokens consumed that is unnecessary.

This PR adds an area, domain, and name filter which the LLM can use to get more specific results for the question the user asked. This could look like the below:

<img width="601" height="754" alt="Screenshot 2026-04-17 at 2 47 28 PM" src="https://github.com/user-attachments/assets/cee5874e-7039-4fda-8953-c87fb79ce7af" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
