### PR TITLE
Victron GX: bug fix for missing translation key

### DIFF
--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -35,14 +35,14 @@ class VictronBaseEntity(Entity):
         self._attr_device_info = device_info
         self._attr_unique_id = f"{installation_id}_{metric.unique_id}"
         self._attr_suggested_display_precision = metric.precision
-        # When main_topic is set, omit translation_key/name so HA uses the device name (via _attr_has_entity_name).
+        # Always set translation_key so HA can resolve state/option translations (e.g. select options).
+        self._attr_translation_key = metric.generic_short_id.replace("{", "").replace(
+            "}", ""
+        )
+        self._attr_translation_placeholders = metric.key_values
+        # When main_topic is set, override name to None so HA uses the device name (via _attr_has_entity_name).
         if metric.main_topic:
             self._attr_name = None
-        else:
-            self._attr_translation_key = metric.generic_short_id.replace(
-                "{", ""
-            ).replace("}", "")
-            self._attr_translation_placeholders = metric.key_values
 
         # Special case for "%" as it should not be coming from the localization file
         self._attr_native_unit_of_measurement = (

--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -135,9 +135,12 @@ class Hub:
             model=device.model,
             serial_number=device.serial_number,
         )
-        # Don't set via_device for the GX device itself
-        if device.unique_id != "system_0":
-            device_info["via_device"] = (DOMAIN, f"{installation_id}_system_0")
+        # Set via_device based on parent_device relationship
+        if device.parent_device is not None:
+            device_info["via_device"] = (
+                DOMAIN,
+                f"{installation_id}_{device.parent_device.unique_id}",
+            )
         return device_info
 
     def register_new_metric_callback(

--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -135,12 +135,9 @@ class Hub:
             model=device.model,
             serial_number=device.serial_number,
         )
-        # Set via_device based on parent_device relationship
-        if device.parent_device is not None:
-            device_info["via_device"] = (
-                DOMAIN,
-                f"{installation_id}_{device.parent_device.unique_id}",
-            )
+        # Don't set via_device for the GX device itself
+        if device.unique_id != "system_0":
+            device_info["via_device"] = (DOMAIN, f"{installation_id}_system_0")
         return device_info
 
     def register_new_metric_callback(

--- a/tests/components/victron_gx/test_select.py
+++ b/tests/components/victron_gx/test_select.py
@@ -137,5 +137,5 @@ async def test_select_main_topic_has_translation_key(
         "main_topic entity must have translation_key"
     )
     assert entity.translation_key == "vebus_inverter_mode"
-    # name should be None (uses device name via has_entity_name)
-    assert entity.name is None
+    # original_name should be None (uses device name via has_entity_name)
+    assert entity.original_name is None

--- a/tests/components/victron_gx/test_select.py
+++ b/tests/components/victron_gx/test_select.py
@@ -103,3 +103,39 @@ async def test_victron_select_actions(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == "auto"
+
+
+async def test_select_main_topic_has_translation_key(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that select entities with main_topic=True still have translation_key set.
+
+    Regression test: previously main_topic entities skipped setting translation_key,
+    breaking HA state/option translations.
+    """
+    victron_hub, mock_config_entry = init_integration
+
+    # vebus Mode has main_topic=True
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/vebus/289/Mode",
+        '{"value": 3}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    assert len(entities) == 1
+    entity = entities[0]
+    # translation_key must be set even for main_topic entities
+    assert entity.translation_key is not None, (
+        "main_topic entity must have translation_key"
+    )
+    assert entity.translation_key == "vebus_inverter_mode"
+    # name should be None (uses device name via has_entity_name)
+    assert entity.name is None

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -24,6 +24,22 @@ async def test_victron_battery_sensor(
     """Test SENSOR MetricKind - battery current sensor is created and updated."""
     victron_hub, mock_config_entry = init_integration
 
+    # Inject a system metric first so the gateway device (system_0) is registered
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/system/0/SystemState/State",
+        '{"value": 1}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    # Verify system device has no via_device (it IS the gateway)
+    system_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    )
+    assert system_device is not None
+    assert system_device.via_device_id is None
+
     # Inject a sensor metric (battery current)
     await inject_message(
         victron_hub,
@@ -38,10 +54,9 @@ async def test_victron_battery_sensor(
         entity_registry, mock_config_entry.entry_id
     )
 
-    # Exactly one entity is expected for this injected metric.
-    assert len(entities) == 1
-    entity = entities[0]
-    assert entity.entity_id == "sensor.battery_dc_bus_current"
+    # Exactly two entities are expected: system state + battery current
+    assert len(entities) == 2
+    entity = next(e for e in entities if e.entity_id == "sensor.battery_dc_bus_current")
     assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_battery_0_battery_current"
     assert entity.original_device_class is SensorDeviceClass.CURRENT
     assert entity.unit_of_measurement == "A"
@@ -61,6 +76,8 @@ async def test_victron_battery_sensor(
     assert device is not None
     assert device.manufacturer == "Victron Energy"
     assert device.name == "Battery"
+    # Verify battery device has via_device pointing to system_0 (gateway)
+    assert device.via_device_id == system_device.id
 
     # Update the same metric to exercise the entity update callback path.
     await inject_message(

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -111,7 +111,7 @@ async def test_victron_main_topic_sensor(
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test sensor whose metric has main_topic=True uses name instead of translation key."""
+    """Test sensor whose metric has main_topic=True keeps translation key and uses device name."""
     victron_hub, mock_config_entry = init_integration
 
     # Multi RS MPPT MppOperationMode is a main_topic metric
@@ -130,8 +130,7 @@ async def test_victron_main_topic_sensor(
     assert len(entities) == 1
     entity = entities[0]
     assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_multi_0_multi_mppt_1_state"
-    # main_topic entities get their name from the device, not a translation key
-    assert entity.translation_key is None
+    assert entity.translation_key == "multi_mppt_mpptnumber_state"
 
     state = hass.states.get(entity.entity_id)
     assert state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixing a bug I introduced while fixing CR comments. Main entities still need translation key so in the case of selects or enum sensor they will still have the list of options.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
