### PR TITLE
Get deprecated Anthropic models from SDK

### DIFF
--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from anthropic.resources.messages.messages import DEPRECATED_MODELS
+
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
@@ -13,13 +15,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_CHAT_MODEL,
-    DEFAULT_CONVERSATION_NAME,
-    DEPRECATED_MODELS,
-    DOMAIN,
-    LOGGER,
-)
+from .const import CONF_CHAT_MODEL, DEFAULT_CONVERSATION_NAME, DOMAIN, LOGGER
 from .coordinator import AnthropicConfigEntry, AnthropicCoordinator
 
 PLATFORMS = (Platform.AI_TASK, Platform.CONVERSATION)
@@ -44,9 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AnthropicConfigEntry) ->
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     for subentry in entry.subentries.values():
-        if (model := subentry.data.get(CONF_CHAT_MODEL)) and model.startswith(
-            tuple(DEPRECATED_MODELS)
-        ):
+        if (model := subentry.data.get(CONF_CHAT_MODEL)) and model in DEPRECATED_MODELS:
             ir.async_create_issue(
                 hass,
                 DOMAIN,

--- a/homeassistant/components/anthropic/const.py
+++ b/homeassistant/components/anthropic/const.py
@@ -99,7 +99,3 @@ TOOL_SEARCH_UNSUPPORTED_MODELS = [
     "claude-3",
     "claude-haiku",
 ]
-
-DEPRECATED_MODELS = [
-    "claude-3",
-]

--- a/homeassistant/components/anthropic/repairs.py
+++ b/homeassistant/components/anthropic/repairs.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import anthropic
+from anthropic.resources.messages.messages import DEPRECATED_MODELS
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
@@ -19,7 +20,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
 )
 
-from .const import CONF_CHAT_MODEL, DEPRECATED_MODELS, DOMAIN
+from .const import CONF_CHAT_MODEL, DOMAIN
 from .coordinator import model_alias
 
 if TYPE_CHECKING:
@@ -63,7 +64,7 @@ class ModelDeprecatedRepairFlow(RepairsFlow):
             model_list = [
                 model_option
                 for model_option in await self.get_model_list(client)
-                if not model_option["value"].startswith(tuple(DEPRECATED_MODELS))
+                if model_option["value"] not in DEPRECATED_MODELS
             ]
             self._model_list_cache[entry.entry_id] = model_list
 
@@ -105,6 +106,7 @@ class ModelDeprecatedRepairFlow(RepairsFlow):
                 "model": model,
                 "subentry_name": subentry.title,
                 "subentry_type": self._format_subentry_type(subentry.subentry_type),
+                "retirement_date": DEPRECATED_MODELS[model],
             },
         )
 
@@ -131,7 +133,7 @@ class ModelDeprecatedRepairFlow(RepairsFlow):
                 continue
             for subentry in entry.subentries.values():
                 model = subentry.data.get(CONF_CHAT_MODEL)
-                if model and model.startswith(tuple(DEPRECATED_MODELS)):
+                if model and model in DEPRECATED_MODELS:
                     yield entry.entry_id, subentry.subentry_id
 
     async def _async_next_target(
@@ -158,7 +160,7 @@ class ModelDeprecatedRepairFlow(RepairsFlow):
                 continue
 
             model = subentry.data.get(CONF_CHAT_MODEL)
-            if not model or not model.startswith(tuple(DEPRECATED_MODELS)):
+            if not model or model not in DEPRECATED_MODELS:
                 continue
 
             self._current_entry_id = entry_id

--- a/homeassistant/components/anthropic/strings.json
+++ b/homeassistant/components/anthropic/strings.json
@@ -219,7 +219,7 @@
             "data_description": {
               "chat_model": "Select the new model to use."
             },
-            "description": "You are updating {subentry_name} ({subentry_type}) in {entry_name}. The current model {model} is deprecated. Select a supported model to continue.",
+            "description": "You are updating {subentry_name} ({subentry_type}) in {entry_name}. The current model {model} is deprecated and will reach end-of-life on {retirement_date}. Select a supported model to continue.",
             "title": "Update model"
           }
         }

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -21,7 +21,11 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.device_registry import DeviceEntryDisabler
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.setup import async_setup_component
@@ -82,6 +86,34 @@ async def test_init_auth_error(
         assert await async_setup_component(hass, "anthropic", {})
         await hass.async_block_till_done()
         assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_init_no_repair_issue(
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test successful init."""
+
+    assert issue_registry.async_get_issue(DOMAIN, "model_deprecated") is None
+
+
+async def test_init_repair_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test that repair issue is created on deprecated model."""
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        next(iter(mock_config_entry.subentries.values())),
+        data={
+            "chat_model": "claude-3-opus-20240229",
+        },
+    )
+
+    assert issue_registry.async_get_issue(DOMAIN, "model_deprecated")
 
 
 @pytest.mark.usefixtures("mock_setup_entry")

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -112,6 +112,7 @@ async def test_init_repair_issue(
             "chat_model": "claude-3-opus-20240229",
         },
     )
+    await hass.async_block_till_done()
 
     assert issue_registry.async_get_issue(DOMAIN, "model_deprecated")
 

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -88,16 +88,6 @@ async def test_init_auth_error(
         assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_init_no_repair_issue(
-    mock_config_entry: MockConfigEntry,
-    mock_init_component,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Test successful init."""
-
-    assert issue_registry.async_get_issue(DOMAIN, "model_deprecated") is None
-
-
 async def test_init_repair_issue(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/anthropic/test_repairs.py
+++ b/tests/components/anthropic/test_repairs.py
@@ -128,6 +128,7 @@ async def test_repair_flow_iterates_subentries(
     assert placeholders["entry_name"] == entry_one.title
     assert placeholders["subentry_name"] == "Conversation One"
     assert placeholders["subentry_type"] == "Conversation agent"
+    assert placeholders["retirement_date"] == "February 19th, 2026"
 
     flow_id = result["flow_id"]
 
@@ -146,6 +147,7 @@ async def test_repair_flow_iterates_subentries(
     assert placeholders["entry_name"] == entry_one.title
     assert placeholders["subentry_name"] == "AI task One"
     assert placeholders["subentry_type"] == "AI task"
+    assert placeholders["retirement_date"] == "February 19th, 2026"
 
     result = await process_repair_fix_flow(
         client,
@@ -166,6 +168,7 @@ async def test_repair_flow_iterates_subentries(
     assert placeholders["entry_name"] == entry_two.title
     assert placeholders["subentry_name"] == "Conversation Two"
     assert placeholders["subentry_type"] == "Conversation agent"
+    assert placeholders["retirement_date"] == "January 5th, 2026"
 
     result = await process_repair_fix_flow(
         client,

--- a/tests/components/anthropic/test_repairs.py
+++ b/tests/components/anthropic/test_repairs.py
@@ -87,7 +87,7 @@ async def test_repair_flow_iterates_subentries(
                 "unique_id": None,
             },
             {
-                "data": {CONF_CHAT_MODEL: "claude-3-5-sonnet-20241022"},
+                "data": {CONF_CHAT_MODEL: "claude-3-7-sonnet-20250219"},
                 "subentry_type": "ai_task_data",
                 "title": "AI task One",
                 "unique_id": None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the list of deprecated models from the anthropic python library instead of maintaining our own list.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
