### PR TITLE
Add optional filter arguments to GetLiveContext LLM tool

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -620,6 +620,41 @@ class AssistAPI(API):
         return tools
 
 
+def _entity_area_names(
+    entity_id: str,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> set[str]:
+    """Return lowercased area name + aliases associated with an entity.
+
+    Mirrors the lookup used in :func:`_get_exposed_entities` so that callers
+    can match against canonical area registry data instead of re-parsing the
+    comma-joined string stored under ``info["areas"]`` (which is lossy when an
+    area name or alias contains a comma).
+    """
+    entity_entry = entity_registry.async_get(entity_id)
+    if entity_entry is None:
+        return set()
+
+    area_id = entity_entry.area_id
+    if area_id is None and entity_entry.device_id is not None:
+        device_entry = device_registry.async_get(entity_entry.device_id)
+        if device_entry is not None:
+            area_id = device_entry.area_id
+
+    if area_id is None:
+        return set()
+
+    area_entry = area_registry.async_get_area(area_id)
+    if area_entry is None:
+        return set()
+
+    names = {area_entry.name.strip().casefold()}
+    names.update(alias.strip().casefold() for alias in area_entry.aliases)
+    return names
+
+
 def _get_exposed_entities(
     hass: HomeAssistant,
     assistant: str,
@@ -1175,6 +1210,38 @@ class GetLiveContextTool(Tool):
         "1. Answering questions about current conditions (e.g., 'Is the light on?'). "
         "2. As the first step in conditional actions (e.g., 'If the weather is rainy, turn off sprinklers' requires checking the weather first)."
     )
+    parameters = vol.Schema(
+        {
+            vol.Optional(
+                "domains",
+                description=(
+                    "Optional. Only include entities whose domain is in this"
+                    " list (case-insensitive, e.g. ['light', 'climate'])."
+                ),
+            ): [str],
+            vol.Optional(
+                "areas",
+                description=(
+                    "Optional. Only include entities whose area name or alias"
+                    " matches one of these values (case-insensitive)."
+                ),
+            ): [str],
+            vol.Optional(
+                "entity_ids",
+                description=(
+                    "Optional. Only include these specific entity_ids"
+                    " (e.g. ['light.kitchen'])."
+                ),
+            ): [str],
+            vol.Optional(
+                "name_contains",
+                description=(
+                    "Optional. Only include entities whose name or alias"
+                    " contains this substring (case-insensitive)."
+                ),
+            ): str,
+        }
+    )
 
     async def async_call(
         self,
@@ -1188,12 +1255,79 @@ class GetLiveContextTool(Tool):
             # exposed if no assistant is configured.
             return {"success": False, "error": "No assistant configured"}
 
+        args = self.parameters(tool_input.tool_args)
+
         exposed_entities = _get_exposed_entities(hass, llm_context.assistant)
-        if not exposed_entities["entities"]:
+        entities = exposed_entities["entities"]
+        if not entities:
             return {"success": False, "error": NO_ENTITIES_PROMPT}
+
+        domains = (
+            {d.strip().casefold() for d in args["domains"]}
+            if "domains" in args
+            else None
+        )
+        areas = (
+            {a.strip().casefold() for a in args["areas"]} if "areas" in args else None
+        )
+        entity_ids = set(args["entity_ids"]) if "entity_ids" in args else None
+        name_contains = (
+            args["name_contains"].strip().casefold()
+            if "name_contains" in args
+            else None
+        )
+
+        if (
+            domains is not None
+            or areas is not None
+            or entity_ids is not None
+            or (name_contains is not None)
+        ):
+            area_registry = ar.async_get(hass) if areas is not None else None
+            entity_registry = er.async_get(hass) if areas is not None else None
+            device_registry = dr.async_get(hass) if areas is not None else None
+
+            filtered: dict[str, dict[str, Any]] = {}
+            for entity_id, info in entities.items():
+                if entity_ids is not None and entity_id not in entity_ids:
+                    continue
+                if (
+                    domains is not None
+                    and info.get("domain", "").casefold() not in domains
+                ):
+                    continue
+                if areas is not None:
+                    # Re-derive area names from the registries instead of
+                    # parsing info["areas"], because area names/aliases may
+                    # legally contain commas which would break a string split.
+                    assert area_registry is not None
+                    assert entity_registry is not None
+                    assert device_registry is not None
+                    entity_areas = _entity_area_names(
+                        entity_id,
+                        area_registry,
+                        entity_registry,
+                        device_registry,
+                    )
+                    if not entity_areas & areas:
+                        continue
+                if (
+                    name_contains is not None
+                    and name_contains not in str(info.get("names", "")).casefold()
+                ):
+                    continue
+                filtered[entity_id] = info
+            entities = filtered
+
+        if not entities:
+            return {
+                "success": False,
+                "error": "No exposed entities matched the provided filters.",
+            }
+
         prompt = [
             "Live Context: An overview of the areas and the devices in this smart home:",
-            yaml_util.dump(list(exposed_entities["entities"].values())),
+            yaml_util.dump(list(entities.values())),
         ]
         return {
             "success": True,

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -388,6 +388,72 @@ async def test_mcp_tools_list(
     properties = tool.inputSchema.get("properties")
     assert properties.get("name") == {"type": "string"}
 
+    # GetLiveContext exposes the optional filter arguments through the schema.
+    live_context_tool = next(
+        iter(tool for tool in result.tools if tool.name == "GetLiveContext")
+    )
+    live_properties = live_context_tool.inputSchema.get("properties")
+    assert live_properties is not None
+    assert live_properties.get("domains") == {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": (
+            "Optional. Only include entities whose domain is in this list"
+            " (case-insensitive, e.g. ['light', 'climate'])."
+        ),
+    }
+    assert live_properties.get("areas", {}).get("type") == "array"
+    assert live_properties.get("entity_ids", {}).get("type") == "array"
+    assert live_properties.get("name_contains", {}).get("type") == "string"
+    # All filter arguments must remain optional.
+    assert "required" not in live_context_tool.inputSchema or not (
+        live_context_tool.inputSchema.get("required")
+    )
+
+
+@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+async def test_mcp_get_live_context_filters(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test that GetLiveContext honors filter arguments over MCP."""
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        # Calling with no arguments returns the kitchen light snapshot.
+        result_no_args = await session.call_tool(
+            name="GetLiveContext",
+            arguments={},
+        )
+        # Calling with a domain that matches returns the same snapshot.
+        result_matching = await session.call_tool(
+            name="GetLiveContext",
+            arguments={"domains": ["light"]},
+        )
+        # Calling with a domain that matches nothing yields a filtered error.
+        result_filtered_out = await session.call_tool(
+            name="GetLiveContext",
+            arguments={"domains": ["climate"]},
+        )
+
+    assert not result_no_args.isError
+    payload_no_args = json.loads(result_no_args.content[0].text)
+    assert payload_no_args["success"] is True
+    assert "Kitchen Light" in payload_no_args["result"]
+
+    assert not result_matching.isError
+    payload_matching = json.loads(result_matching.content[0].text)
+    assert payload_matching == payload_no_args
+
+    assert not result_filtered_out.isError
+    payload_filtered = json.loads(result_filtered_out.content[0].text)
+    assert payload_filtered == {
+        "success": False,
+        "error": "No exposed entities matched the provided filters.",
+    }
+
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
 async def test_mcp_tool_call(

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -706,6 +706,82 @@ For general knowledge questions not about the home: Answer truthfully from inter
         "result": exposed_entities_prompt,
     }
 
+    # GetLiveContext: filter by entity_ids returns only that entity.
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"entity_ids": [entry1.entity_id]},
+        )
+    )
+    assert result["success"] is True
+    assert "Kitchen" in result["result"]
+    assert "Living Room" not in result["result"]
+
+    # GetLiveContext: filter by domains matches when domain is in list.
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="GetLiveContext", tool_args={"domains": ["light"]})
+    )
+    assert result == {"success": True, "result": exposed_entities_prompt}
+
+    # GetLiveContext: domain matching is case-insensitive.
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="GetLiveContext", tool_args={"domains": ["LiGhT"]})
+    )
+    assert result == {"success": True, "result": exposed_entities_prompt}
+
+    # GetLiveContext: filter by domain that matches nothing returns an error.
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="GetLiveContext", tool_args={"domains": ["climate"]})
+    )
+    assert result == {
+        "success": False,
+        "error": "No exposed entities matched the provided filters.",
+    }
+
+    # GetLiveContext: filter by area name (case-insensitive).
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="GetLiveContext", tool_args={"areas": ["test area 2"]})
+    )
+    assert result["success"] is True
+    assert "Test Device 2" in result["result"]
+    assert "Living Room" not in result["result"]
+
+    # GetLiveContext: area filter also matches against aliases.
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext", tool_args={"areas": ["alternative name"]}
+        )
+    )
+    assert result["success"] is True
+    assert "Living Room" in result["result"]
+    assert "Test Device 2" not in result["result"]
+
+    # GetLiveContext: name_contains filter is a case-insensitive substring match.
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext", tool_args={"name_contains": "kitchen"}
+        )
+    )
+    assert result["success"] is True
+    assert "Kitchen" in result["result"]
+    assert "Living Room" not in result["result"]
+
+    # GetLiveContext: combined filters are AND-ed together.
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={
+                "domains": ["light"],
+                "areas": ["test area 2"],
+                "name_contains": "test device 2",
+            },
+        )
+    )
+    assert result["success"] is True
+    assert "Test Device 2" in result["result"]
+    assert "Test Device 3" not in result["result"]
+    assert "Living Room" not in result["result"]
+
     # Fake that request is made from a specific device ID with an area
     llm_context.device_id = device.id
     area_prompt = (


### PR DESCRIPTION
## Proposed change

Add four optional filter arguments to the `GetLiveContext` LLM tool so callers (LLMs, MCP clients, integrations) can request a subset of exposed entities instead of always retrieving the full snapshot:

- `domains` (`list[str]`) — only include entities whose domain is in this list (case-insensitive).
- `areas` (`list[str]`) — only include entities whose area name or alias matches one of these values (case-insensitive).
- `entity_ids` (`list[str]`) — only include these specific entity_ids.
- `name_contains` (`str`) — only include entities whose name or alias contains this substring (case-insensitive).

All arguments are optional and AND-ed together. When no arguments are provided the tool returns the same output as before, so the change is fully backward compatible for every consumer (Anthropic, OpenAI, Google, Ollama, the built-in conversation agent, and the MCP server). When filters match no exposed entity, the tool returns `{"success": false, "error": "No exposed entities matched the provided filters."}` (consistent with the existing empty-snapshot branch).

The MCP server picks up the new schema automatically through `voluptuous_openapi.convert`, so no MCP-side code change was required.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
