### PR TITLE
Bump velbusaio to 2026.4.1

### DIFF
--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -14,7 +14,7 @@
     "velbus-protocol"
   ],
   "quality_scale": "silver",
-  "requirements": ["velbus-aio==2026.4.0"],
+  "requirements": ["velbus-aio==2026.4.1"],
   "usb": [
     {
       "pid": "0B1B",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3233,7 +3233,7 @@ vegehub==0.1.26
 vehicle==2.2.2
 
 # homeassistant.components.velbus
-velbus-aio==2026.4.0
+velbus-aio==2026.4.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.21

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2742,7 +2742,7 @@ vegehub==0.1.26
 vehicle==2.2.2
 
 # homeassistant.components.velbus
-velbus-aio==2026.4.0
+velbus-aio==2026.4.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.21


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump velbus-aio tot 2026.4.1

https://github.com/cereal2nd/velbus-aio/releases/tag/2026.4.1
https://github.com/cereal2nd/velbus-aio/compare/2026.4.0...2026.4.1

* fix: ButtonCounter sensor category for VMB8IN-20 CounterValueMessage by @WilliamCoenen in https://github.com/cereal2nd/velbus-aio/pull/178
* Use human-readable name for properties from module spec by @StefCoene in https://github.com/cereal2nd/velbus-aio/pull/181
* parse_specs: check that all JSON keys are sorted alphabetically by @StefCoene in https://github.com/cereal2nd/velbus-aio/pull/179
* Fix/vmb8in counter sensor category by @WilliamCoenen in https://github.com/cereal2nd/velbus-aio/pull/182
* Fix channel number translation for modules with ChannelNumbers.Name.Map by @StefCoene in https://github.com/cereal2nd/velbus-aio/pull/180
* velbus: handle corrupt cache per module instead of clearing all by @StefCoene in https://github.com/cereal2nd/velbus-aio/pull/184
* velbus: add get_property_key_map helper function by @StefCoene in https://github.com/cereal2nd/velbus-aio/pull/183
* Swith from pyserial to serialx @cereal2nd 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
