### PR TITLE
Add scheduled events and scene/cover cross-references to PowerView

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from aiopvapi.resources.model import PowerviewData
 from aiopvapi.resources.shade_data import PowerviewShadeData
 from aiopvapi.rooms import Rooms
+from aiopvapi.scene_members import SceneMembers
 from aiopvapi.scenes import Scenes
 from aiopvapi.shades import Shades
 
@@ -91,6 +92,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
             f"Connection error to PowerView hub {hub_address}: {err}"
         ) from err
 
+    scene_member_data: PowerviewData | None = None
+    if hub.api_version == 2:
+        try:
+            scene_members = SceneMembers(pv_request)
+            scene_member_data = await scene_members.get_scene_members()
+        except HUB_EXCEPTIONS as err:
+            raise ConfigEntryNotReady(
+                f"Connection error to PowerView hub {hub_address}: {err}"
+            ) from err
+
+    scene_to_shade_ids: dict[int, list[int]] = {}
+    shade_to_scene_ids: dict[int, list[int]] = {}
+    if scene_member_data:
+        for member in scene_member_data.raw:
+            s_id = member["sceneId"]
+            sh_id = member["shadeId"]
+            scene_to_shade_ids.setdefault(s_id, []).append(sh_id)
+            shade_to_scene_ids.setdefault(sh_id, []).append(s_id)
+    elif hub.api_version >= 3:
+        # Gen3 embeds shadeIds directly in scene data; no separate API call needed
+        for scene in scene_data.processed.values():
+            for sh_id in scene.raw_data.get("shadeIds", []):
+                scene_to_shade_ids.setdefault(scene.id, []).append(sh_id)
+                shade_to_scene_ids.setdefault(sh_id, []).append(scene.id)
+
     if not device_info:
         raise ConfigEntryNotReady(f"Unable to initialize PowerView hub: {hub_address}")
 
@@ -116,9 +142,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
         shade_data=shade_data.processed,
         coordinator=coordinator,
         device_info=device_info,
+        scene_to_shade_ids=scene_to_shade_ids,
+        shade_to_scene_ids=shade_to_scene_ids,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # All platforms (including scene) are now set up. Fire coordinator listeners so
+    # cover entities can resolve scene entity IDs from the now-populated entity registry.
+    coordinator.async_update_listeners()
 
     return True
 

--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -3,6 +3,7 @@
 import logging
 from typing import TYPE_CHECKING
 
+from aiopvapi.automations import Automations
 from aiopvapi.resources.model import PowerviewData
 from aiopvapi.resources.shade_data import PowerviewShadeData
 from aiopvapi.rooms import Rooms
@@ -30,6 +31,7 @@ PLATFORMS = [
     Platform.SCENE,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,11 +94,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
             f"Connection error to PowerView hub {hub_address}: {err}"
         ) from err
 
+    automation_data: PowerviewData | None = None
     scene_member_data: PowerviewData | None = None
-    if hub.api_version == 2:
+    if hub.api_version >= 2:
         try:
-            scene_members = SceneMembers(pv_request)
-            scene_member_data = await scene_members.get_scene_members()
+            automations = Automations(pv_request)
+            automation_data = await automations.get_automations(fetch_scene_data=False)
+            if hub.api_version == 2:
+                scene_members = SceneMembers(pv_request)
+                scene_member_data = await scene_members.get_scene_members()
         except HUB_EXCEPTIONS as err:
             raise ConfigEntryNotReady(
                 f"Connection error to PowerView hub {hub_address}: {err}"
@@ -116,6 +122,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
             for sh_id in scene.raw_data.get("shadeIds", []):
                 scene_to_shade_ids.setdefault(scene.id, []).append(sh_id)
                 shade_to_scene_ids.setdefault(sh_id, []).append(scene.id)
+
+    scene_to_automation_ids: dict[int, list[int]] = {}
+    if automation_data:
+        for automation in automation_data.processed.values():
+            if automation.scene_id is not None:
+                scene_to_automation_ids.setdefault(automation.scene_id, []).append(
+                    automation.id
+                )
 
     if not device_info:
         raise ConfigEntryNotReady(f"Unable to initialize PowerView hub: {hub_address}")
@@ -140,10 +154,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
         room_data=room_data.processed,
         scene_data=scene_data.processed,
         shade_data=shade_data.processed,
+        automation_data=automation_data.processed if automation_data else {},
         coordinator=coordinator,
         device_info=device_info,
         scene_to_shade_ids=scene_to_shade_ids,
         shade_to_scene_ids=shade_to_scene_ids,
+        scene_to_automation_ids=scene_to_automation_ids,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -7,7 +7,7 @@ from aiopvapi.automations import Automations
 from aiopvapi.resources.model import PowerviewData
 from aiopvapi.resources.shade_data import PowerviewShadeData
 from aiopvapi.rooms import Rooms
-from aiopvapi.scene_members import SceneMembers
+from aiopvapi.scene_members import SceneMembers, build_shade_scene_mapping
 from aiopvapi.scenes import Scenes
 from aiopvapi.shades import Shades
 
@@ -108,20 +108,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
                 f"Connection error to PowerView hub {hub_address}: {err}"
             ) from err
 
-    scene_to_shade_ids: dict[int, list[int]] = {}
-    shade_to_scene_ids: dict[int, list[int]] = {}
-    if scene_member_data:
-        for member in scene_member_data.raw:
-            s_id = member["sceneId"]
-            sh_id = member["shadeId"]
-            scene_to_shade_ids.setdefault(s_id, []).append(sh_id)
-            shade_to_scene_ids.setdefault(sh_id, []).append(s_id)
-    elif hub.api_version >= 3:
-        # Gen3 embeds shadeIds directly in scene data; no separate API call needed
-        for scene in scene_data.processed.values():
-            for sh_id in scene.raw_data.get("shadeIds", []):
-                scene_to_shade_ids.setdefault(scene.id, []).append(sh_id)
-                shade_to_scene_ids.setdefault(sh_id, []).append(scene.id)
+    scene_to_shade_ids, shade_to_scene_ids = build_shade_scene_mapping(
+        scene_data, scene_member_data
+    )
 
     scene_to_automation_ids: dict[int, list[int]] = {}
     if automation_data:

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -25,11 +25,13 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
+from homeassistant.const import Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
-from .const import STATE_ATTRIBUTE_ROOM_NAME
+from .const import DOMAIN, STATE_ATTRIBUTE_ROOM_NAME
 from .coordinator import PowerviewShadeUpdateCoordinator
 from .entity import ShadeEntity
 from .model import PowerviewConfigEntry, PowerviewDeviceInfo
@@ -114,6 +116,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         if self._shade.is_supported(MOTION_STOP):
             self._attr_supported_features |= CoverEntityFeature.STOP
         self._forced_resync: Callable[[], None] | None = None
+        self._scene_ids: list[int] = []
 
     @property
     def assumed_state(self) -> bool:
@@ -136,9 +139,23 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return self._is_hard_wired
 
     @property
-    def extra_state_attributes(self) -> dict[str, str]:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
+        scene_entity_ids: list[str] = []
+        if self._scene_ids:
+            entity_registry = er.async_get(self.hass)
+            serial = self._device_info.serial_number
+            for scene_id in self._scene_ids:
+                entity_id = entity_registry.async_get_entity_id(
+                    Platform.SCENE, DOMAIN, f"{serial}_{scene_id}"
+                )
+                if entity_id:
+                    scene_entity_ids.append(entity_id)
+        return {
+            STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
+            "scene_ids": self._scene_ids,
+            "scene_entity_ids": scene_entity_ids,
+        }
 
     @property
     def is_closed(self) -> bool:
@@ -294,6 +311,8 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self.async_on_remove(
             self.coordinator.async_add_listener(self._async_update_shade_from_group)
         )
+        pv_entry = self.coordinator.config_entry.runtime_data
+        self._scene_ids = pv_entry.shade_to_scene_ids.get(self._shade.id, [])
 
     async def async_will_remove_from_hass(self) -> None:
         """Cancel any pending refreshes."""

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -156,8 +156,8 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
                     scene_entity_ids.append(entity_id)
         return {
             STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
-            "scene_ids": self._scene_ids,
-            "scene_entity_ids": scene_entity_ids,
+            "scene_ids": sorted(set(self._scene_ids)),
+            "scene_entity_ids": sorted(set(scene_entity_ids)),
         }
 
     @property

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -137,16 +137,12 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return self._is_hard_wired
 
     @property
-<<<<<<< HEAD
     def available(self) -> bool:
         """Return True if shade position data is available."""
         return super().available and self.positions.primary is not None
 
     @property
-    def extra_state_attributes(self) -> dict[str, str]:
-=======
     def extra_state_attributes(self) -> dict[str, Any]:
->>>>>>> 76557c9d467 (Add scene/cover cross-references to PowerView)
         """Return the state attributes."""
         scene_entity_ids: list[str] = []
         if self._scene_ids:

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -23,11 +23,13 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
+from homeassistant.const import Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
-from .const import STATE_ATTRIBUTE_ROOM_NAME
+from .const import DOMAIN, STATE_ATTRIBUTE_ROOM_NAME
 from .coordinator import PowerviewShadeUpdateCoordinator
 from .entity import ShadeEntity
 from .model import PowerviewConfigEntry, PowerviewDeviceInfo
@@ -112,6 +114,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         if self._shade.is_supported(MOTION_STOP):
             self._attr_supported_features |= CoverEntityFeature.STOP
         self._forced_resync: Callable[[], None] | None = None
+        self._scene_ids: list[int] = []
 
     @property
     def assumed_state(self) -> bool:
@@ -134,14 +137,32 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return self._is_hard_wired
 
     @property
+<<<<<<< HEAD
     def available(self) -> bool:
         """Return True if shade position data is available."""
         return super().available and self.positions.primary is not None
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:
+=======
+    def extra_state_attributes(self) -> dict[str, Any]:
+>>>>>>> 76557c9d467 (Add scene/cover cross-references to PowerView)
         """Return the state attributes."""
-        return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
+        scene_entity_ids: list[str] = []
+        if self._scene_ids:
+            entity_registry = er.async_get(self.hass)
+            serial = self._device_info.serial_number
+            for scene_id in self._scene_ids:
+                entity_id = entity_registry.async_get_entity_id(
+                    Platform.SCENE, DOMAIN, f"{serial}_{scene_id}"
+                )
+                if entity_id:
+                    scene_entity_ids.append(entity_id)
+        return {
+            STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
+            "scene_ids": self._scene_ids,
+            "scene_entity_ids": scene_entity_ids,
+        }
 
     @property
     def is_closed(self) -> bool:
@@ -297,6 +318,8 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self.async_on_remove(
             self.coordinator.async_add_listener(self._async_update_shade_from_group)
         )
+        pv_entry = self.coordinator.config_entry.runtime_data
+        self._scene_ids = pv_entry.shade_to_scene_ids.get(self._shade.id, [])
 
     async def async_will_remove_from_hass(self) -> None:
         """Cancel any pending refreshes."""

--- a/homeassistant/components/hunterdouglas_powerview/model.py
+++ b/homeassistant/components/hunterdouglas_powerview/model.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from aiopvapi.helpers.aiorequest import AioRequest
 from aiopvapi.hub import Hub
+from aiopvapi.resources.automation import Automation
 from aiopvapi.resources.room import Room
 from aiopvapi.resources.scene import Scene
 from aiopvapi.resources.shade import BaseShade
@@ -29,8 +30,10 @@ class PowerviewEntryData:
     shade_data: dict[str, BaseShade]
     coordinator: PowerviewShadeUpdateCoordinator
     device_info: PowerviewDeviceInfo
+    automation_data: dict[str, Automation]
     scene_to_shade_ids: dict[int, list[int]]
     shade_to_scene_ids: dict[int, list[int]]
+    scene_to_automation_ids: dict[int, list[int]]
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/hunterdouglas_powerview/model.py
+++ b/homeassistant/components/hunterdouglas_powerview/model.py
@@ -29,6 +29,8 @@ class PowerviewEntryData:
     shade_data: dict[str, BaseShade]
     coordinator: PowerviewShadeUpdateCoordinator
     device_info: PowerviewDeviceInfo
+    scene_to_shade_ids: dict[int, list[int]]
+    shade_to_scene_ids: dict[int, list[int]]
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/hunterdouglas_powerview/model.py
+++ b/homeassistant/components/hunterdouglas_powerview/model.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from aiopvapi.helpers.aiorequest import AioRequest
 from aiopvapi.hub import Hub
+from aiopvapi.resources.automation import Automation
 from aiopvapi.resources.room import Room
 from aiopvapi.resources.scene import Scene
 from aiopvapi.resources.shade import BaseShade
@@ -27,8 +28,10 @@ class PowerviewEntryData:
     shade_data: dict[str, BaseShade]
     coordinator: PowerviewShadeUpdateCoordinator
     device_info: PowerviewDeviceInfo
+    automation_data: dict[str, Automation]
     scene_to_shade_ids: dict[int, list[int]]
     shade_to_scene_ids: dict[int, list[int]]
+    scene_to_automation_ids: dict[int, list[int]]
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/hunterdouglas_powerview/model.py
+++ b/homeassistant/components/hunterdouglas_powerview/model.py
@@ -27,6 +27,8 @@ class PowerviewEntryData:
     shade_data: dict[str, BaseShade]
     coordinator: PowerviewShadeUpdateCoordinator
     device_info: PowerviewDeviceInfo
+    scene_to_shade_ids: dict[int, list[int]]
+    shade_to_scene_ids: dict[int, list[int]]
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import STATE_ATTRIBUTE_ROOM_NAME
+from .const import DOMAIN, STATE_ATTRIBUTE_ROOM_NAME
 from .coordinator import PowerviewShadeUpdateCoordinator
 from .entity import HDEntity
 from .model import PowerviewConfigEntry, PowerviewDeviceInfo
@@ -41,6 +41,7 @@ async def async_setup_entry(
                 room_name,
                 scene,
                 pv_entry.scene_to_shade_ids.get(scene.id, []),
+                pv_entry.scene_to_automation_ids.get(scene.id, []),
             )
         )
     async_add_entities(pvscenes)
@@ -58,11 +59,13 @@ class PowerViewScene(HDEntity, Scene):
         room_name: str,
         scene: PvScene,
         shade_ids: list[int],
+        automation_ids: list[int],
     ) -> None:
         """Initialize the scene."""
         super().__init__(coordinator, device_info, room_name, scene.id)
         self._scene: PvScene = scene
         self._shade_ids = shade_ids
+        self._automation_ids = automation_ids
         self._attr_name = scene.name
 
     @property
@@ -85,10 +88,22 @@ class PowerViewScene(HDEntity, Scene):
                 and (e.unique_id == prefix or e.unique_id.startswith(f"{prefix}_"))
             )
 
+        automation_entity_ids = [
+            entity_id
+            for automation_id in self._automation_ids
+            if (
+                entity_id := entity_registry.async_get_entity_id(
+                    Platform.SWITCH, DOMAIN, f"{serial}_{automation_id}"
+                )
+            )
+        ]
+
         return {
             STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
             "shade_ids": self._shade_ids,
             "shade_entity_ids": shade_entity_ids,
+            "scheduled_event_ids": self._automation_ids,
+            "scheduled_event_entity_ids": automation_entity_ids,
         }
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -9,7 +9,9 @@ from aiopvapi.helpers.constants import ATTR_NAME
 from aiopvapi.resources.scene import Scene as PvScene
 
 from homeassistant.components.scene import Scene
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import STATE_ATTRIBUTE_ROOM_NAME
@@ -33,7 +35,13 @@ async def async_setup_entry(
     for scene in pv_entry.scene_data.values():
         room_name = getattr(pv_entry.room_data.get(scene.room_id), ATTR_NAME, "")
         pvscenes.append(
-            PowerViewScene(pv_entry.coordinator, pv_entry.device_info, room_name, scene)
+            PowerViewScene(
+                pv_entry.coordinator,
+                pv_entry.device_info,
+                room_name,
+                scene,
+                pv_entry.scene_to_shade_ids.get(scene.id, []),
+            )
         )
     async_add_entities(pvscenes)
 
@@ -49,12 +57,39 @@ class PowerViewScene(HDEntity, Scene):
         device_info: PowerviewDeviceInfo,
         room_name: str,
         scene: PvScene,
+        shade_ids: list[int],
     ) -> None:
         """Initialize the scene."""
         super().__init__(coordinator, device_info, room_name, scene.id)
         self._scene: PvScene = scene
+        self._shade_ids = shade_ids
         self._attr_name = scene.name
-        self._attr_extra_state_attributes = {STATE_ATTRIBUTE_ROOM_NAME: room_name}
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return state attributes, resolving cross-platform entity IDs dynamically."""
+        entity_registry = er.async_get(self.hass)
+        config_entry_id = self.coordinator.config_entry.entry_id
+        all_entries = er.async_entries_for_config_entry(
+            entity_registry, config_entry_id
+        )
+        serial = self._device_info.serial_number
+
+        shade_entity_ids: list[str] = []
+        for shade_id in self._shade_ids:
+            prefix = f"{serial}_{shade_id}"
+            shade_entity_ids.extend(
+                e.entity_id
+                for e in all_entries
+                if e.domain == Platform.COVER
+                and (e.unique_id == prefix or e.unique_id.startswith(f"{prefix}_"))
+            )
+
+        return {
+            STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
+            "shade_ids": self._shade_ids,
+            "shade_entity_ids": shade_entity_ids,
+        }
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import STATE_ATTRIBUTE_ROOM_NAME
+from .const import DOMAIN, STATE_ATTRIBUTE_ROOM_NAME
 from .coordinator import PowerviewShadeUpdateCoordinator
 from .entity import HDEntity
 from .model import PowerviewConfigEntry, PowerviewDeviceInfo
@@ -39,6 +39,7 @@ async def async_setup_entry(
                 room_name,
                 scene,
                 pv_entry.scene_to_shade_ids.get(scene.id, []),
+                pv_entry.scene_to_automation_ids.get(scene.id, []),
             )
         )
     async_add_entities(pvscenes)
@@ -56,11 +57,13 @@ class PowerViewScene(HDEntity, Scene):
         room_name: str,
         scene: PvScene,
         shade_ids: list[int],
+        automation_ids: list[int],
     ) -> None:
         """Initialize the scene."""
         super().__init__(coordinator, device_info, room_name, scene.id)
         self._scene: PvScene = scene
         self._shade_ids = shade_ids
+        self._automation_ids = automation_ids
         self._attr_name = scene.name
 
     @property
@@ -83,10 +86,22 @@ class PowerViewScene(HDEntity, Scene):
                 and (e.unique_id == prefix or e.unique_id.startswith(f"{prefix}_"))
             )
 
+        automation_entity_ids = [
+            entity_id
+            for automation_id in self._automation_ids
+            if (
+                entity_id := entity_registry.async_get_entity_id(
+                    Platform.SWITCH, DOMAIN, f"{serial}_{automation_id}"
+                )
+            )
+        ]
+
         return {
             STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
             "shade_ids": self._shade_ids,
             "shade_entity_ids": shade_entity_ids,
+            "scheduled_event_ids": self._automation_ids,
+            "scheduled_event_entity_ids": automation_entity_ids,
         }
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -101,10 +101,10 @@ class PowerViewScene(HDEntity, Scene):
 
         return {
             STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
-            "shade_ids": self._shade_ids,
-            "shade_entity_ids": shade_entity_ids,
-            "scheduled_event_ids": self._automation_ids,
-            "scheduled_event_entity_ids": automation_entity_ids,
+            "shade_ids": sorted(set(self._shade_ids)),
+            "shade_entity_ids": sorted(set(shade_entity_ids)),
+            "scheduled_event_ids": sorted(set(self._automation_ids)),
+            "scheduled_event_entity_ids": sorted(set(automation_entity_ids)),
         }
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -31,7 +31,10 @@ async def async_setup_entry(
     pv_entry = entry.runtime_data
     pvscenes: list[PowerViewScene] = []
     for scene in pv_entry.scene_data.values():
-        room_name = getattr(pv_entry.room_data.get(scene.room_id), ATTR_NAME, "")
+        room_ids = scene.room_id
+        room_name = getattr(
+            pv_entry.room_data.get(room_ids[0]) if room_ids else None, ATTR_NAME, ""
+        )
         pvscenes.append(
             PowerViewScene(
                 pv_entry.coordinator,

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -7,7 +7,9 @@ from aiopvapi.helpers.constants import ATTR_NAME
 from aiopvapi.resources.scene import Scene as PvScene
 
 from homeassistant.components.scene import Scene
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import STATE_ATTRIBUTE_ROOM_NAME
@@ -31,7 +33,13 @@ async def async_setup_entry(
     for scene in pv_entry.scene_data.values():
         room_name = getattr(pv_entry.room_data.get(scene.room_id), ATTR_NAME, "")
         pvscenes.append(
-            PowerViewScene(pv_entry.coordinator, pv_entry.device_info, room_name, scene)
+            PowerViewScene(
+                pv_entry.coordinator,
+                pv_entry.device_info,
+                room_name,
+                scene,
+                pv_entry.scene_to_shade_ids.get(scene.id, []),
+            )
         )
     async_add_entities(pvscenes)
 
@@ -47,12 +55,39 @@ class PowerViewScene(HDEntity, Scene):
         device_info: PowerviewDeviceInfo,
         room_name: str,
         scene: PvScene,
+        shade_ids: list[int],
     ) -> None:
         """Initialize the scene."""
         super().__init__(coordinator, device_info, room_name, scene.id)
         self._scene: PvScene = scene
+        self._shade_ids = shade_ids
         self._attr_name = scene.name
-        self._attr_extra_state_attributes = {STATE_ATTRIBUTE_ROOM_NAME: room_name}
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return state attributes, resolving cross-platform entity IDs dynamically."""
+        entity_registry = er.async_get(self.hass)
+        config_entry_id = self.coordinator.config_entry.entry_id
+        all_entries = er.async_entries_for_config_entry(
+            entity_registry, config_entry_id
+        )
+        serial = self._device_info.serial_number
+
+        shade_entity_ids: list[str] = []
+        for shade_id in self._shade_ids:
+            prefix = f"{serial}_{shade_id}"
+            shade_entity_ids.extend(
+                e.entity_id
+                for e in all_entries
+                if e.domain == Platform.COVER
+                and (e.unique_id == prefix or e.unique_id.startswith(f"{prefix}_"))
+            )
+
+        return {
+            STATE_ATTRIBUTE_ROOM_NAME: self._room_name,
+            "shade_ids": self._shade_ids,
+            "shade_entity_ids": shade_entity_ids,
+        }
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""

--- a/homeassistant/components/hunterdouglas_powerview/switch.py
+++ b/homeassistant/components/hunterdouglas_powerview/switch.py
@@ -1,0 +1,132 @@
+"""Support for Hunter Douglas PowerView scheduled events."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiopvapi.helpers.constants import ATTR_NAME
+from aiopvapi.resources.automation import Automation
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN, STATE_ATTRIBUTE_ROOM_NAME
+from .coordinator import PowerviewShadeUpdateCoordinator
+from .entity import HDEntity
+from .model import PowerviewConfigEntry, PowerviewDeviceInfo
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PowerviewConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up PowerView schedule switches."""
+    pv_entry = entry.runtime_data
+
+    # Count automations per scene to determine if an index suffix is needed
+    scene_automation_counts: dict = {}
+    for automation in pv_entry.automation_data.values():
+        key = automation.scene_id
+        scene_automation_counts[key] = scene_automation_counts.get(key, 0) + 1
+
+    scene_automation_index: dict = {}
+    entities: list[PowerViewScheduleSwitch] = []
+
+    for automation in sorted(pv_entry.automation_data.values(), key=lambda a: a.id):
+        key = automation.scene_id
+        scene = pv_entry.scene_data.get(key)
+        scene_name = scene.name if scene is not None else str(key)
+        room_name = getattr(
+            pv_entry.room_data.get(getattr(scene, "room_id", None)), ATTR_NAME, ""
+        )
+
+        scene_automation_index[key] = scene_automation_index.get(key, 0) + 1
+        schedule_index = (
+            scene_automation_index[key]
+            if scene_automation_counts[key] > 1
+            else None
+        )
+
+        entities.append(
+            PowerViewScheduleSwitch(
+                pv_entry.coordinator,
+                pv_entry.device_info,
+                room_name,
+                automation,
+                scene_name,
+                schedule_index,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class PowerViewScheduleSwitch(HDEntity, SwitchEntity):
+    """Representation of a PowerView scheduled event."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:calendar-clock"
+
+    def __init__(
+        self,
+        coordinator: PowerviewShadeUpdateCoordinator,
+        device_info: PowerviewDeviceInfo,
+        room_name: str,
+        automation: Automation,
+        scene_name: str,
+        schedule_index: int | None,
+    ) -> None:
+        """Initialize the schedule switch."""
+        super().__init__(coordinator, device_info, room_name, str(automation.id))
+        self._automation = automation
+        name = f"{scene_name} Schedule"
+        if schedule_index is not None:
+            name = f"{name} {schedule_index}"
+        self._attr_name = name
+        self._attr_extra_state_attributes = {
+            STATE_ATTRIBUTE_ROOM_NAME: room_name,
+            "scene_name": scene_name,
+            "scene_id": automation.scene_id,
+            "scene_entity_id": None,
+            "execution_time": automation.get_execution_time(),
+            "execution_days": automation.get_execution_days(),
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Resolve scene PowerView ID to HA entity ID once registered."""
+        await super().async_added_to_hass()
+        entity_registry = er.async_get(self.hass)
+        serial = self._device_info.serial_number
+        entity_id = entity_registry.async_get_entity_id(
+            Platform.SCENE, DOMAIN, f"{serial}_{self._automation.scene_id}"
+        )
+        if entity_id:
+            self._attr_extra_state_attributes = {
+                **self._attr_extra_state_attributes,
+                "scene_entity_id": entity_id,
+            }
+            self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the schedule is enabled."""
+        return self._automation.enabled
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the schedule."""
+        await self._automation.set_state(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the schedule."""
+        await self._automation.set_state(False)
+        self.async_write_ha_state()

--- a/homeassistant/components/hunterdouglas_powerview/switch.py
+++ b/homeassistant/components/hunterdouglas_powerview/switch.py
@@ -88,29 +88,23 @@ class PowerViewScheduleSwitch(HDEntity, SwitchEntity):
         if schedule_index is not None:
             name = f"{name} {schedule_index}"
         self._attr_name = name
-        self._attr_extra_state_attributes = {
+        self._static_attributes = {
             STATE_ATTRIBUTE_ROOM_NAME: room_name,
             "scene_name": scene_name,
             "scene_id": automation.scene_id,
-            "scene_entity_id": None,
             "execution_time": automation.get_execution_time(),
             "execution_days": automation.get_execution_days(),
         }
 
-    async def async_added_to_hass(self) -> None:
-        """Resolve scene PowerView ID to HA entity ID once registered."""
-        await super().async_added_to_hass()
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return schedule attributes with scene entity ID resolved dynamically."""
         entity_registry = er.async_get(self.hass)
         serial = self._device_info.serial_number
         entity_id = entity_registry.async_get_entity_id(
             Platform.SCENE, DOMAIN, f"{serial}_{self._automation.scene_id}"
         )
-        if entity_id:
-            self._attr_extra_state_attributes = {
-                **self._attr_extra_state_attributes,
-                "scene_entity_id": entity_id,
-            }
-            self.async_write_ha_state()
+        return {**self._static_attributes, "scene_entity_id": entity_id}
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/hunterdouglas_powerview/switch.py
+++ b/homeassistant/components/hunterdouglas_powerview/switch.py
@@ -1,7 +1,5 @@
 """Support for Hunter Douglas PowerView scheduled events."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 
@@ -45,15 +43,13 @@ async def async_setup_entry(
         key = automation.scene_id
         scene = pv_entry.scene_data.get(key)
         scene_name = scene.name if scene is not None else str(key)
-        room_name = getattr(
-            pv_entry.room_data.get(getattr(scene, "room_id", None)), ATTR_NAME, ""
-        )
+        room_ids = scene.room_id if scene is not None else []
+        room = pv_entry.room_data.get(room_ids[0]) if room_ids else None
+        room_name = getattr(room, ATTR_NAME, "")
 
         scene_automation_index[key] = scene_automation_index.get(key, 0) + 1
         schedule_index = (
-            scene_automation_index[key]
-            if scene_automation_counts[key] > 1
-            else None
+            scene_automation_index[key] if scene_automation_counts[key] > 1 else None
         )
 
         entities.append(

--- a/tests/components/hunterdouglas_powerview/conftest.py
+++ b/tests/components/hunterdouglas_powerview/conftest.py
@@ -1,6 +1,7 @@
 """Common fixtures for Hunter Douglas Powerview tests."""
 
 from collections.abc import Generator
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 from aiopvapi.resources.shade import ShadePosition
@@ -23,15 +24,17 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 @pytest.fixture
 def mock_hunterdouglas_hub(
+    api_version: int,
     device_json: str,
     home_json: str,
     firmware_json: str,
     rooms_json: str,
     scenes_json: str,
     shades_json: str,
+    scenemembers_json: str | None,
 ) -> Generator[None]:
     """Return a mocked Powerview Hub with all data populated."""
-    with (
+    patches = [
         patch(
             "homeassistant.components.hunterdouglas_powerview.util.Hub.request_raw_data",
             return_value=load_json_object_fixture(device_json, DOMAIN),
@@ -64,7 +67,18 @@ def mock_hunterdouglas_hub(
             new_callable=PropertyMock,
             return_value=ShadePosition(primary=0, secondary=0, tilt=0, velocity=0),
         ),
-    ):
+    ]
+    if api_version == 2 and scenemembers_json is not None:
+        patches.append(
+            patch(
+                "homeassistant.components.hunterdouglas_powerview.SceneMembers.get_resources",
+                return_value=load_json_value_fixture(scenemembers_json, DOMAIN),
+            ),
+        )
+
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
         yield
 
 
@@ -144,3 +158,11 @@ def shades_json(api_version: int) -> str:
         return "gen3/home/shades.json"
     # Add more conditions for different api_versions if needed
     raise ValueError(f"Unsupported api_version: {api_version}")
+
+
+@pytest.fixture
+def scenemembers_json(api_version: int) -> str | None:
+    """Return the get_resources fixture for scene members, or None if unsupported."""
+    if api_version == 2:
+        return "gen2/scenemembers.json"
+    return None

--- a/tests/components/hunterdouglas_powerview/conftest.py
+++ b/tests/components/hunterdouglas_powerview/conftest.py
@@ -31,6 +31,7 @@ def mock_hunterdouglas_hub(
     rooms_json: str,
     scenes_json: str,
     shades_json: str,
+    scheduledevents_json: str | None,
     scenemembers_json: str | None,
 ) -> Generator[None]:
     """Return a mocked Powerview Hub with all data populated."""
@@ -68,6 +69,13 @@ def mock_hunterdouglas_hub(
             return_value=ShadePosition(primary=0, secondary=0, tilt=0, velocity=0),
         ),
     ]
+    if api_version >= 2 and scheduledevents_json is not None:
+        patches.append(
+            patch(
+                "homeassistant.components.hunterdouglas_powerview.Automations.get_resources",
+                return_value=load_json_value_fixture(scheduledevents_json, DOMAIN),
+            ),
+        )
     if api_version == 2 and scenemembers_json is not None:
         patches.append(
             patch(
@@ -158,6 +166,16 @@ def shades_json(api_version: int) -> str:
         return "gen3/home/shades.json"
     # Add more conditions for different api_versions if needed
     raise ValueError(f"Unsupported api_version: {api_version}")
+
+
+@pytest.fixture
+def scheduledevents_json(api_version: int) -> str | None:
+    """Return the get_resources fixture for scheduled events, or None if unsupported."""
+    if api_version == 2:
+        return "gen2/scheduledevents.json"
+    if api_version == 3:
+        return "gen3/home/automations.json"
+    return None
 
 
 @pytest.fixture

--- a/tests/components/hunterdouglas_powerview/test_cover.py
+++ b/tests/components/hunterdouglas_powerview/test_cover.py
@@ -1,0 +1,85 @@
+"""Test the Hunter Douglas PowerView cover platform."""
+
+import pytest
+
+from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from .const import MOCK_MAC
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_cover_scene_cross_references_v2(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test cover entities expose scene PV IDs and HA entity IDs for v2."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Shade 40458 ("Kitchen Roller") appears in 4 scenes:
+    # 61648 (Open All), 64679 (Open Kitchen), 24626 (Close All), 51159 (Close Kitchen)
+    state = hass.states.get("cover.kitchen_roller")
+    assert state is not None
+
+    scene_ids = state.attributes["scene_ids"]
+    assert set(scene_ids) == {61648, 64679, 24626, 51159}
+
+    scene_entity_ids = state.attributes["scene_entity_ids"]
+    assert set(scene_entity_ids) == {
+        "scene.powerview_generation_2_open_all",
+        "scene.powerview_generation_2_open_kitchen",
+        "scene.powerview_generation_2_close_all",
+        "scene.powerview_generation_2_close_kitchen",
+    }
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [3])
+async def test_cover_scene_cross_references_v3(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test cover entities expose scene PV IDs and HA entity IDs for v3."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Shade 173 ("Bed 4") appears in 4 scenes:
+    # 220 (Close Bed 4), 255 (Open Bed 4), 299 (Open All), 301 (Close All)
+    state = hass.states.get("cover.bed_4")
+    assert state is not None
+
+    scene_ids = state.attributes["scene_ids"]
+    assert set(scene_ids) == {220, 255, 299, 301}
+
+    scene_entity_ids = state.attributes["scene_entity_ids"]
+    assert "scene.powerview_generation_3_close_bed_4" in scene_entity_ids
+    assert "scene.powerview_generation_3_open_bed_4" in scene_entity_ids
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [1])
+async def test_cover_scene_cross_references_empty_for_v1(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that cover scene cross-reference attributes are empty lists on v1."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover_ids = hass.states.async_entity_ids("cover")
+    assert len(cover_ids) > 0
+
+    for entity_id in cover_ids:
+        state = hass.states.get(entity_id)
+        assert state.attributes["scene_ids"] == [], entity_id
+        assert state.attributes["scene_entity_ids"] == [], entity_id

--- a/tests/components/hunterdouglas_powerview/test_cover.py
+++ b/tests/components/hunterdouglas_powerview/test_cover.py
@@ -24,7 +24,7 @@ async def test_cover_scene_cross_references_v2(
 
     # Shade 40458 ("Kitchen Roller") appears in 4 scenes:
     # 61648 (Open All), 64679 (Open Kitchen), 24626 (Close All), 51159 (Close Kitchen)
-    state = hass.states.get("cover.kitchen_roller")
+    state = hass.states.get("cover.kitchen_kitchen_roller")
     assert state is not None
 
     scene_ids = state.attributes["scene_ids"]
@@ -53,7 +53,7 @@ async def test_cover_scene_cross_references_v3(
 
     # Shade 173 ("Bed 4") appears in 4 scenes:
     # 220 (Close Bed 4), 255 (Open Bed 4), 299 (Open All), 301 (Close All)
-    state = hass.states.get("cover.bed_4")
+    state = hass.states.get("cover.bedroom_4_bed_4")
     assert state is not None
 
     scene_ids = state.attributes["scene_ids"]

--- a/tests/components/hunterdouglas_powerview/test_scene.py
+++ b/tests/components/hunterdouglas_powerview/test_scene.py
@@ -181,3 +181,48 @@ async def test_scene_shade_cross_references_empty_for_v1(
     assert state is not None
     assert state.attributes["shade_ids"] == []
     assert state.attributes["shade_entity_ids"] == []
+    assert state.attributes["scheduled_event_ids"] == []
+    assert state.attributes["scheduled_event_entity_ids"] == []
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_scene_scheduled_event_cross_references_v2(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test scene entities expose scheduled event PV IDs and HA entity IDs for v2."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("scene.powerview_generation_2_open_kitchen")
+    assert state is not None
+    assert 37484 in state.attributes["scheduled_event_ids"]
+    assert (
+        "switch.powerview_generation_2_open_kitchen_schedule"
+        in state.attributes["scheduled_event_entity_ids"]
+    )
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [3])
+async def test_scene_scheduled_event_cross_references_v3(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test scene entities expose scheduled event PV IDs and HA entity IDs for v3."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Automation 437 references scene 220 ("Close Bed 4")
+    state = hass.states.get("scene.powerview_generation_3_close_bed_4")
+    assert state is not None
+    assert 437 in state.attributes["scheduled_event_ids"]
+    assert (
+        "switch.powerview_generation_3_close_bed_4_schedule"
+        in state.attributes["scheduled_event_entity_ids"]
+    )

--- a/tests/components/hunterdouglas_powerview/test_scene.py
+++ b/tests/components/hunterdouglas_powerview/test_scene.py
@@ -120,3 +120,64 @@ async def test_scenes(
         await hass.async_block_till_done()
 
     mock_activate.assert_called_once()
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_scene_shade_cross_references_v2(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test scene entities expose shade PV IDs and HA entity IDs for v2."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # "Open Kitchen" (scene id 64679) has exactly one shade: 40458 ("Kitchen Roller")
+    # Kitchen Roller is a DualOverlappedTilt90 (type 9), which creates 3 cover entities.
+    state = hass.states.get("scene.powerview_generation_2_open_kitchen")
+    assert state is not None
+    assert state.attributes["shade_ids"] == [40458]
+    assert set(state.attributes["shade_entity_ids"]) == {
+        "cover.kitchen_roller",
+        "cover.kitchen_roller_front",
+        "cover.kitchen_roller_rear",
+    }
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [3])
+async def test_scene_shade_cross_references_v3(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test scene entities expose shade PV IDs and HA entity IDs for v3."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # "Close Bed 4" (scene id 220) has exactly one shade: 173 ("Bed 4")
+    state = hass.states.get("scene.powerview_generation_3_close_bed_4")
+    assert state is not None
+    assert state.attributes["shade_ids"] == [173]
+    assert "cover.bed_4" in state.attributes["shade_entity_ids"]
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [1])
+async def test_scene_shade_cross_references_empty_for_v1(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that scene shade cross-reference attributes are empty lists on v1."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("scene.powerview_generation_1_open_kitchen")
+    assert state is not None
+    assert state.attributes["shade_ids"] == []
+    assert state.attributes["shade_entity_ids"] == []

--- a/tests/components/hunterdouglas_powerview/test_scene.py
+++ b/tests/components/hunterdouglas_powerview/test_scene.py
@@ -140,9 +140,9 @@ async def test_scene_shade_cross_references_v2(
     assert state is not None
     assert state.attributes["shade_ids"] == [40458]
     assert set(state.attributes["shade_entity_ids"]) == {
-        "cover.kitchen_roller",
-        "cover.kitchen_roller_front",
-        "cover.kitchen_roller_rear",
+        "cover.kitchen_kitchen_roller",
+        "cover.kitchen_kitchen_roller_front",
+        "cover.kitchen_kitchen_roller_rear",
     }
 
 
@@ -162,7 +162,7 @@ async def test_scene_shade_cross_references_v3(
     state = hass.states.get("scene.powerview_generation_3_close_bed_4")
     assert state is not None
     assert state.attributes["shade_ids"] == [173]
-    assert "cover.bed_4" in state.attributes["shade_entity_ids"]
+    assert "cover.bedroom_4_bed_4" in state.attributes["shade_entity_ids"]
 
 
 @pytest.mark.usefixtures("mock_hunterdouglas_hub")

--- a/tests/components/hunterdouglas_powerview/test_schedule.py
+++ b/tests/components/hunterdouglas_powerview/test_schedule.py
@@ -1,0 +1,217 @@
+"""Test the Hunter Douglas PowerView schedule switch platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+
+from .const import MOCK_MAC
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_schedule_switches_created_v2(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that schedule switches are created for Gen2."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # 12 scheduled events in the Gen2 fixture
+    switch_ids = hass.states.async_entity_ids("switch")
+    assert len(switch_ids) == 12
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [3])
+async def test_schedule_switches_created_v3(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that schedule switches are created for Gen3."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # 9 automations in the Gen3 fixture
+    switch_ids = hass.states.async_entity_ids("switch")
+    assert len(switch_ids) == 9
+
+
+def _find_switch_by_scene(hass: HomeAssistant, scene_name: str) -> list:
+    """Return all switch states whose scene_name attribute matches."""
+    return [
+        state
+        for entity_id in hass.states.async_entity_ids("switch")
+        if (state := hass.states.get(entity_id)) is not None
+        and state.attributes.get("scene_name") == scene_name
+    ]
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_schedule_switch_state(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test switch state reflects the enabled field."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Event 37484 is the only enabled=true event (Open Kitchen scene)
+    enabled_switches = _find_switch_by_scene(hass, "Open Kitchen")
+    assert len(enabled_switches) == 1
+    assert enabled_switches[0].state == STATE_ON
+
+    # Open Bed 4 has 3 scheduled events, all disabled
+    disabled_switches = _find_switch_by_scene(hass, "Open Bed 4")
+    assert len(disabled_switches) == 3
+    assert all(s.state == STATE_OFF for s in disabled_switches)
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_schedule_switch_attributes(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that schedule switches expose execution time and days attributes."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    switches = _find_switch_by_scene(hass, "Open Kitchen")
+    assert len(switches) == 1
+    state = switches[0]
+    assert "execution_time" in state.attributes
+    assert "execution_days" in state.attributes
+    assert state.attributes["scene_name"] == "Open Kitchen"
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_schedule_switch_turn_on(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test turning on a schedule switch enables the scheduled event."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    switches = _find_switch_by_scene(hass, "Open Kitchen")
+    assert len(switches) == 1
+    entity_id = switches[0].entity_id
+
+    with patch(
+        "homeassistant.components.hunterdouglas_powerview.switch.Automation.set_state",
+        new_callable=AsyncMock,
+    ) as mock_set_state:
+        await hass.services.async_call(
+            "switch",
+            "turn_on",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_set_state.assert_called_once_with(True)
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_schedule_switch_turn_off(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test turning off a schedule switch disables the scheduled event."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    switches = _find_switch_by_scene(hass, "Open Kitchen")
+    assert len(switches) == 1
+    entity_id = switches[0].entity_id
+
+    with patch(
+        "homeassistant.components.hunterdouglas_powerview.switch.Automation.set_state",
+        new_callable=AsyncMock,
+    ) as mock_set_state:
+        await hass.services.async_call(
+            "switch",
+            "turn_off",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_set_state.assert_called_once_with(False)
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [2])
+async def test_schedule_switch_scene_reference(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that schedule switches expose scene PV ID and HA entity ID."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Event 37484 references scene 64679 ("Open Kitchen")
+    switches = _find_switch_by_scene(hass, "Open Kitchen")
+    assert len(switches) == 1
+    state = switches[0]
+    assert state.attributes["scene_id"] == 64679
+    assert state.attributes["scene_entity_id"] == "scene.powerview_generation_2_open_kitchen"
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [3])
+async def test_schedule_switch_scene_reference_v3(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that Gen3 schedule switches expose scene PV ID and HA entity ID."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Automation 437 references scene 220 ("Close Bed 4")
+    switches = _find_switch_by_scene(hass, "Close Bed 4")
+    assert len(switches) == 1
+    state = switches[0]
+    assert state.attributes["scene_id"] == 220
+    assert state.attributes["scene_entity_id"] == "scene.powerview_generation_3_close_bed_4"
+
+
+@pytest.mark.usefixtures("mock_hunterdouglas_hub")
+@pytest.mark.parametrize("api_version", [1])
+async def test_no_schedule_switches_for_v1(
+    hass: HomeAssistant,
+    api_version: int,
+) -> None:
+    """Test that no schedule switches are created for Gen1."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"}, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.async_entity_ids_count("switch") == 0


### PR DESCRIPTION
## Proposed change

Adds two new features to the Hunter Douglas PowerView integration:

**Scheduled event switches:** Exposes each scheduled event (automation) on Gen2 and Gen3 hubs as a `switch` entity, allowing users to enable or disable individual scheduled events from Home Assistant. Gen2 uses the `scheduledevents` API endpoint; Gen3 uses the `automations` endpoint — both handled transparently by `aiopvapi`'s `Automations` class.

**Scene/cover cross-references:** Cover entities gain a `scene_entity_ids` attribute listing the scenes they belong to, and scene entities gain `shade_ids` / `shade_entity_ids` attributes listing the covers they control. Scene entities also gain `scheduled_event_ids` / `scheduled_event_entity_ids` attributes cross-referencing their corresponding switch entities. Entity IDs are resolved dynamically from the entity registry so they survive entity renames.

Gen2 uses the `SceneMembers` API endpoint to build shade↔scene mappings. Gen3 embeds `shadeIds` directly in scene data, so no extra API call is needed.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: fixes #165651
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr