### PR TITLE
Fix KeyError in Growatt server login response handling

### DIFF
--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -256,11 +256,13 @@ class GrowattServerConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.error("Invalid response format during login: %s", ex)
             return self._async_show_password_form({"base": ERROR_CANNOT_CONNECT})
 
-        if (
-            not login_response["success"]
-            and login_response["msg"] == LOGIN_INVALID_AUTH_CODE
-        ):
-            return self._async_show_password_form({"base": ERROR_INVALID_AUTH})
+        if not login_response.get("success"):
+            if login_response.get("msg") == LOGIN_INVALID_AUTH_CODE:
+                return self._async_show_password_form({"base": ERROR_INVALID_AUTH})
+            _LOGGER.debug(
+                "Growatt login failed: %s", login_response.get("msg", "Unknown error")
+            )
+            return self._async_show_password_form({"base": ERROR_CANNOT_CONNECT})
 
         self.user_id = login_response["user"]["id"]
         self.data = user_input

--- a/tests/components/growatt_server/test_config_flow.py
+++ b/tests/components/growatt_server/test_config_flow.py
@@ -183,6 +183,42 @@ async def test_password_auth_incorrect_login(
     assert result["data"][CONF_AUTH_TYPE] == AUTH_PASSWORD
 
 
+async def test_password_auth_account_locked(
+    hass: HomeAssistant, mock_growatt_classic_api: MagicMock, mock_setup_entry: None
+) -> None:
+    """Test password authentication when account is locked out."""
+    mock_growatt_classic_api.login.return_value = {
+        "success": False,
+        "msg": "Account locked",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "password_auth"}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], FIXTURE_USER_INPUT_PASSWORD
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "password_auth"
+    assert result["errors"] == {"base": ERROR_CANNOT_CONNECT}
+
+    # Test recovery after lockout expires
+    mock_growatt_classic_api.login.return_value = GROWATT_LOGIN_RESPONSE
+    mock_growatt_classic_api.plant_list.return_value = GROWATT_PLANT_LIST_RESPONSE
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], FIXTURE_USER_INPUT_PASSWORD
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
 async def test_password_auth_no_plants(
     hass: HomeAssistant, mock_growatt_classic_api
 ) -> None:


### PR DESCRIPTION

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix `KeyError` in the Growatt server config flow login handling. The login response fields (`success`, `msg`) were accessed via direct dictionary key lookup, which raises `KeyError` when the API returns an unexpected response format. This change uses `dict.get()` for safe access.

Additionally, non-auth login failures (e.g., account lockout) were not handled - the code would fall through and attempt to access `login_response["user"]`, causing another `KeyError`. Now these failures return an appropriate error to the user.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
