### PR TITLE
Refactor how Evohome allocates names and IDs

### DIFF
--- a/homeassistant/components/evohome/button.py
+++ b/homeassistant/components/evohome/button.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import EVOHOME_DATA
 from .coordinator import EvoDataUpdateCoordinator
-from .entity import EvoEntity, is_valid_zone
+from .entity import EvoEntity, is_valid_zone, unique_zone_id
 
 
 async def async_setup_platform(
@@ -45,27 +45,10 @@ async def async_setup_platform(
 
 
 class EvoResetButtonBase(EvoEntity, ButtonEntity):
-    """Button entity for system reset."""
+    """Base for reset button entities."""
 
     _attr_entity_category = EntityCategory.CONFIG
-
     _evo_state_attr_names = ()
-
-    def __init__(
-        self,
-        coordinator: EvoDataUpdateCoordinator,
-        evo_device: evo.ControlSystem | evo.HotWater | evo.Zone,
-    ) -> None:
-        """Initialize the system reset button."""
-        super().__init__(coordinator, evo_device)
-
-        # zones can be renamed, so set name in their property method
-        if isinstance(evo_device, evo.ControlSystem):
-            self._attr_name = f"Reset {evo_device.location.name}"
-        elif not isinstance(evo_device, evo.Zone):
-            self._attr_name = f"Reset {evo_device.name}"
-
-        self._attr_unique_id = f"{evo_device.id}_reset"
 
     async def async_press(self) -> None:
         """Reset the Evohome entity to its base operating mode."""
@@ -80,6 +63,17 @@ class EvoResetSystemButton(EvoResetButtonBase):
     _evo_device: evo.ControlSystem
     _evo_id_attr = "system_id"
 
+    def __init__(
+        self,
+        coordinator: EvoDataUpdateCoordinator,
+        evo_device: evo.ControlSystem,
+    ) -> None:
+        """Initialize the system reset button."""
+        super().__init__(coordinator, evo_device)
+
+        self._attr_unique_id = f"{evo_device.id}_reset"
+        self._attr_name = f"Reset {evo_device.location.name}"
+
 
 class EvoResetDhwButton(EvoResetButtonBase):
     """Button entity for DHW override reset."""
@@ -88,6 +82,17 @@ class EvoResetDhwButton(EvoResetButtonBase):
 
     _evo_device: evo.HotWater
     _evo_id_attr = "dhw_id"
+
+    def __init__(
+        self,
+        coordinator: EvoDataUpdateCoordinator,
+        evo_device: evo.HotWater,
+    ) -> None:
+        """Initialize the DHW reset button."""
+        super().__init__(coordinator, evo_device)
+
+        self._attr_unique_id = f"{evo_device.id}_reset"
+        self._attr_name = f"Reset {evo_device.name}"
 
 
 class EvoResetZoneButton(EvoResetButtonBase):
@@ -105,12 +110,9 @@ class EvoResetZoneButton(EvoResetButtonBase):
     ) -> None:
         """Initialize the zone reset button."""
         super().__init__(coordinator, evo_device)
-
-        if evo_device.id == evo_device.tcs.id:
-            # this system does not have a distinct ID for the zone
-            self._attr_unique_id = f"{evo_device.id}z_reset"
+        self._attr_unique_id = f"{unique_zone_id(evo_device)}_reset"
 
     @property
     def name(self) -> str:
-        """Return the name of the evohome entity."""
+        """Return the name, dynamically following any zone rename."""
         return f"Reset {self._evo_device.name}"

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -49,7 +49,7 @@ from .const import (
     EvoService,
 )
 from .coordinator import EvoDataUpdateCoordinator
-from .entity import EvoChild, EvoEntity, is_valid_zone
+from .entity import EvoChild, EvoEntity, is_valid_zone, unique_zone_id
 from .helpers import async_create_deprecation_issue_once
 
 _LOGGER = logging.getLogger(__name__)
@@ -170,13 +170,8 @@ class EvoZone(EvoChild, EvoClimateEntity):
         """Initialize an evohome-compatible heating zone."""
 
         super().__init__(coordinator, evo_device)
-        self._evo_id = evo_device.id
 
-        if evo_device.id == evo_device.tcs.id:
-            # this system does not have a distinct ID for the zone
-            self._attr_unique_id = f"{evo_device.id}z"
-        else:
-            self._attr_unique_id = evo_device.id
+        self._attr_unique_id = unique_zone_id(evo_device)
 
         if coordinator.client_v1:
             self._attr_precision = PRECISION_TENTHS
@@ -352,7 +347,6 @@ class EvoController(EvoClimateEntity):
         """Initialize an evohome-compatible controller."""
 
         super().__init__(coordinator, evo_device)
-        self._evo_id = evo_device.id
 
         self._attr_unique_id = evo_device.id
         self._attr_name = evo_device.location.name

--- a/homeassistant/components/evohome/entity.py
+++ b/homeassistant/components/evohome/entity.py
@@ -28,6 +28,17 @@ def is_valid_zone(zone: evo.Zone) -> bool:
     )
 
 
+def unique_zone_id(evo_device: evo.Zone) -> str:
+    """Return a unique identifier for a zone-based entity.
+
+    Some systems assign the zone the same ID as its parent TCS; in that case
+    we append 'z' so the zone entity doesn't collide with the controller entity.
+    """
+    if evo_device.id == evo_device.tcs.id:
+        return f"{evo_device.id}z"
+    return evo_device.id
+
+
 class EvoEntity(CoordinatorEntity[EvoDataUpdateCoordinator]):
     """Base for any evohome-compatible entity (controller, DHW, zone).
 
@@ -86,6 +97,7 @@ class EvoChild(EvoEntity):
         """Initialize an evohome-compatible child entity (DHW, zone)."""
         super().__init__(coordinator, evo_device)
 
+        self._evo_id = evo_device.id
         self._evo_tcs = evo_device.tcs
 
         self._schedule: list[DayOfWeekDhwT] | None = None

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -70,7 +70,6 @@ async def async_setup_platform(
 class EvoDHW(EvoChild, WaterHeaterEntity):
     """Base for any evohome-compatible DHW controller."""
 
-    _attr_name = "DHW controller"
     _attr_operation_list = list(HA_STATE_TO_EVO)
     _attr_supported_features = (
         WaterHeaterEntityFeature.AWAY_MODE
@@ -89,7 +88,6 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
         """Initialize an evohome-compatible DHW controller."""
 
         super().__init__(coordinator, evo_device)
-        self._evo_id = evo_device.id
 
         self._attr_unique_id = evo_device.id
         self._attr_name = evo_device.name  # is static


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up the technical debt of `name` and `unique_id` allocation logic that accumulated as new platforms were added to Evohome.

Work to add a fourth platform to Evohome has made clear the need to refactor this code.

No names or IDs change value. All existing tests pass unmodified.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
