### PR TITLE
Remove Temperature parameter from Anthropic integration

### DIFF
--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -230,6 +230,19 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AnthropicConfigEntry) 
                 )
         hass.config_entries.async_update_entry(entry, minor_version=3)
 
+    if entry.version == 2 and entry.minor_version == 3:
+        # Remove Temperature parameter
+        CONF_TEMPERATURE = "temperature"
+
+        for subentry in entry.subentries.values():
+            data = subentry.data.copy()
+            if CONF_TEMPERATURE not in data:
+                continue
+            data.pop(CONF_TEMPERATURE, None)
+            hass.config_entries.async_update_subentry(entry, subentry, data=data)
+
+        hass.config_entries.async_update_entry(entry, minor_version=4)
+
     LOGGER.debug(
         "Migration to version %s:%s successful", entry.version, entry.minor_version
     )

--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -108,7 +108,7 @@ class AnthropicConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Anthropic."""
 
     VERSION = 2
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -50,7 +50,6 @@ from .const import (
     CONF_PROMPT,
     CONF_PROMPT_CACHING,
     CONF_RECOMMENDED,
-    CONF_TEMPERATURE,
     CONF_THINKING_BUDGET,
     CONF_THINKING_EFFORT,
     CONF_TOOL_SEARCH,
@@ -324,10 +323,6 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
             ): SelectSelector(
                 SelectSelectorConfig(options=self._get_model_list(), custom_value=True)
             ),
-            vol.Optional(
-                CONF_TEMPERATURE,
-                default=DEFAULT[CONF_TEMPERATURE],
-            ): NumberSelector(NumberSelectorConfig(min=0, max=1, step=0.05)),
             vol.Optional(
                 CONF_PROMPT_CACHING,
                 default=DEFAULT[CONF_PROMPT_CACHING],

--- a/homeassistant/components/anthropic/const.py
+++ b/homeassistant/components/anthropic/const.py
@@ -15,7 +15,6 @@ CONF_CHAT_MODEL = "chat_model"
 CONF_CODE_EXECUTION = "code_execution"
 CONF_MAX_TOKENS = "max_tokens"
 CONF_PROMPT_CACHING = "prompt_caching"
-CONF_TEMPERATURE = "temperature"
 CONF_THINKING_BUDGET = "thinking_budget"
 CONF_THINKING_EFFORT = "thinking_effort"
 CONF_TOOL_SEARCH = "tool_search"
@@ -43,7 +42,6 @@ DEFAULT = {
     CONF_CODE_EXECUTION: False,
     CONF_MAX_TOKENS: 3000,
     CONF_PROMPT_CACHING: PromptCaching.PROMPT.value,
-    CONF_TEMPERATURE: 1.0,
     CONF_THINKING_BUDGET: MIN_THINKING_BUDGET,
     CONF_THINKING_EFFORT: "low",
     CONF_TOOL_SEARCH: False,

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -98,7 +98,6 @@ from .const import (
     CONF_CODE_EXECUTION,
     CONF_MAX_TOKENS,
     CONF_PROMPT_CACHING,
-    CONF_TEMPERATURE,
     CONF_THINKING_BUDGET,
     CONF_THINKING_EFFORT,
     CONF_TOOL_SEARCH,
@@ -768,9 +767,6 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                 model_args["output_config"] = OutputConfigParam(effort=thinking_effort)
             else:
                 model_args["thinking"] = ThinkingConfigDisabledParam(type="disabled")
-                model_args["temperature"] = options.get(
-                    CONF_TEMPERATURE, DEFAULT[CONF_TEMPERATURE]
-                )
         else:
             thinking_budget = options.get(
                 CONF_THINKING_BUDGET, DEFAULT[CONF_THINKING_BUDGET]
@@ -785,9 +781,6 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                 )
             else:
                 model_args["thinking"] = ThinkingConfigDisabledParam(type="disabled")
-                model_args["temperature"] = options.get(
-                    CONF_TEMPERATURE, DEFAULT[CONF_TEMPERATURE]
-                )
 
             if (
                 self.model_info.capabilities

--- a/tests/components/anthropic/snapshots/test_ai_task.ambr
+++ b/tests/components/anthropic/snapshots/test_ai_task.ambr
@@ -82,7 +82,6 @@
         'type': 'text',
       }),
     ]),
-    'temperature': 1.0,
     'thinking': dict({
       'type': 'disabled',
     }),
@@ -288,7 +287,6 @@
         'type': 'text',
       }),
     ]),
-    'temperature': 1.0,
     'thinking': dict({
       'type': 'disabled',
     }),

--- a/tests/components/anthropic/snapshots/test_conversation.ambr
+++ b/tests/components/anthropic/snapshots/test_conversation.ambr
@@ -254,7 +254,6 @@
         'type': 'text',
       }),
     ]),
-    'temperature': 1.0,
     'thinking': dict({
       'type': 'disabled',
     }),
@@ -319,7 +318,6 @@
         'type': 'text',
       }),
     ]),
-    'temperature': 1.0,
     'thinking': dict({
       'type': 'disabled',
     }),

--- a/tests/components/anthropic/snapshots/test_diagnostics.ambr
+++ b/tests/components/anthropic/snapshots/test_diagnostics.ambr
@@ -64,7 +64,7 @@
         'translation_key': 'conversation',
       }),
     }),
-    'entry_version': '2.3',
+    'entry_version': '2.4',
     'options': dict({
     }),
     'state': 'loaded',

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -30,7 +30,6 @@ from homeassistant.components.anthropic.const import (
     CONF_PROMPT,
     CONF_PROMPT_CACHING,
     CONF_RECOMMENDED,
-    CONF_TEMPERATURE,
     CONF_THINKING_BUDGET,
     CONF_THINKING_EFFORT,
     CONF_TOOL_SEARCH,
@@ -276,10 +275,7 @@ async def test_subentry_options_thinking_budget_more_than_max(
     # Configure advanced step
     options = await hass.config_entries.subentries.async_configure(
         options["flow_id"],
-        {
-            "chat_model": "claude-sonnet-4-5",
-            "temperature": 1,
-        },
+        {"chat_model": "claude-sonnet-4-5"},
     )
     assert options["type"] is FlowResultType.FORM
     assert options["step_id"] == "model"
@@ -390,7 +386,6 @@ async def test_subentry_web_search_user_location(
         "prompt_caching": "prompt",
         "recommended": False,
         "region": "California",
-        "temperature": 1.0,
         "thinking_budget": 1024,
         "timezone": "America/Los_Angeles",
         "tool_search": False,
@@ -574,7 +569,6 @@ async def test_invalid_model(
                 },
                 {
                     CONF_CHAT_MODEL: "claude-haiku-4-5",
-                    CONF_TEMPERATURE: 1.0,
                     CONF_PROMPT_CACHING: "off",
                 },
                 {
@@ -588,7 +582,6 @@ async def test_invalid_model(
                 CONF_RECOMMENDED: False,
                 CONF_PROMPT: "Speak like a pirate",
                 CONF_PROMPT_CACHING: "off",
-                CONF_TEMPERATURE: 1.0,
                 CONF_CHAT_MODEL: "claude-haiku-4-5",
                 CONF_MAX_TOKENS: DEFAULT[CONF_MAX_TOKENS],
                 CONF_THINKING_BUDGET: DEFAULT[CONF_THINKING_BUDGET],
@@ -619,7 +612,6 @@ async def test_invalid_model(
                 },
                 {
                     CONF_CHAT_MODEL: "claude-sonnet-4-5",
-                    CONF_TEMPERATURE: 1.0,
                     CONF_PROMPT_CACHING: "automatic",
                 },
                 {
@@ -635,7 +627,6 @@ async def test_invalid_model(
                 CONF_RECOMMENDED: False,
                 CONF_PROMPT: "Speak like a pirate",
                 CONF_PROMPT_CACHING: "automatic",
-                CONF_TEMPERATURE: 1.0,
                 CONF_CHAT_MODEL: "claude-sonnet-4-5",
                 CONF_MAX_TOKENS: DEFAULT[CONF_MAX_TOKENS],
                 CONF_THINKING_BUDGET: 2048,
@@ -667,7 +658,6 @@ async def test_invalid_model(
                 },
                 {
                     CONF_CHAT_MODEL: "claude-opus-4-7",
-                    CONF_TEMPERATURE: 1.0,
                     CONF_PROMPT_CACHING: "prompt",
                 },
                 {
@@ -683,7 +673,6 @@ async def test_invalid_model(
                 CONF_RECOMMENDED: False,
                 CONF_PROMPT: "Speak like a pirate",
                 CONF_PROMPT_CACHING: "prompt",
-                CONF_TEMPERATURE: 1.0,
                 CONF_CHAT_MODEL: "claude-opus-4-7",
                 CONF_MAX_TOKENS: DEFAULT[CONF_MAX_TOKENS],
                 CONF_THINKING_EFFORT: "xhigh",
@@ -707,7 +696,6 @@ async def test_invalid_model(
                 },
                 {
                     CONF_CHAT_MODEL: "claude-3-haiku-20240307",
-                    CONF_TEMPERATURE: 0.3,
                     CONF_PROMPT_CACHING: "automatic",
                 },
                 {},
@@ -716,7 +704,6 @@ async def test_invalid_model(
                 CONF_RECOMMENDED: False,
                 CONF_PROMPT: "Speak like a pirate",
                 CONF_PROMPT_CACHING: "automatic",
-                CONF_TEMPERATURE: 0.3,
                 CONF_CHAT_MODEL: "claude-3-haiku-20240307",
                 CONF_MAX_TOKENS: DEFAULT[CONF_MAX_TOKENS],
             },
@@ -726,7 +713,6 @@ async def test_invalid_model(
                 CONF_RECOMMENDED: False,
                 CONF_PROMPT: "Speak like a pirate",
                 CONF_PROMPT_CACHING: "off",
-                CONF_TEMPERATURE: 0.3,
                 CONF_CHAT_MODEL: DEFAULT[CONF_CHAT_MODEL],
                 CONF_MAX_TOKENS: DEFAULT[CONF_MAX_TOKENS],
                 CONF_THINKING_BUDGET: DEFAULT[CONF_THINKING_BUDGET],
@@ -888,7 +874,6 @@ async def test_creating_ai_task_subentry_advanced(
         result["flow_id"],
         {
             CONF_CHAT_MODEL: "claude-sonnet-4-5",
-            CONF_TEMPERATURE: 0.5,
         },
     )
 
@@ -910,7 +895,6 @@ async def test_creating_ai_task_subentry_advanced(
         CONF_RECOMMENDED: False,
         CONF_CHAT_MODEL: "claude-sonnet-4-5",
         CONF_MAX_TOKENS: 1200,
-        CONF_TEMPERATURE: 0.5,
         CONF_TOOL_SEARCH: False,
         CONF_WEB_SEARCH: False,
         CONF_WEB_SEARCH_MAX_USES: 5,

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -210,7 +210,7 @@ async def test_migration_from_v1_to_v2(
     await hass.async_block_till_done()
 
     assert mock_config_entry.version == 2
-    assert mock_config_entry.minor_version == 3
+    assert mock_config_entry.minor_version == 4
     assert mock_config_entry.data == {"api_key": "1234"}
     assert mock_config_entry.options == {}
 
@@ -409,7 +409,9 @@ async def test_migration_from_v1_disabled(
     entry = entries[0]
     assert entry.disabled_by is merged_config_entry_disabled_by
     assert entry.version == 2
-    assert entry.minor_version == 3
+    assert (
+        entry.minor_version == 3 if merged_config_entry_disabled_by is not None else 4
+    )
     assert not entry.options
     assert entry.title == "Claude conversation"
     assert len(entry.subentries) == 2
@@ -529,7 +531,7 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
 
     for idx, entry in enumerate(entries):
         assert entry.version == 2
-        assert entry.minor_version == 3
+        assert entry.minor_version == 4
         assert not entry.options
         assert len(entry.subentries) == 1
         subentry = list(entry.subentries.values())[0]
@@ -620,7 +622,7 @@ async def test_migration_from_v1_to_v2_with_same_keys(
 
     entry = entries[0]
     assert entry.version == 2
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
     assert not entry.options
     assert len(entry.subentries) == 2  # Two subentries from the two original entries
 
@@ -740,7 +742,7 @@ async def test_migration_from_v2_1_to_v2_2(
     assert len(entries) == 1
     entry = entries[0]
     assert entry.version == 2
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
     assert not entry.options
     assert entry.title == "Claude"
     assert len(entry.subentries) == 2
@@ -817,7 +819,7 @@ async def test_migration_from_v2_1_to_v2_2(
             DeviceEntryDisabler.CONFIG_ENTRY,
             RegistryEntryDisabler.CONFIG_ENTRY,
             True,
-            3,
+            4,
             None,
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.DEVICE,
@@ -827,7 +829,7 @@ async def test_migration_from_v2_1_to_v2_2(
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.DEVICE,
             True,
-            3,
+            4,
             None,
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.DEVICE,
@@ -837,7 +839,7 @@ async def test_migration_from_v2_1_to_v2_2(
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.USER,
             True,
-            3,
+            4,
             None,
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.USER,
@@ -847,7 +849,7 @@ async def test_migration_from_v2_1_to_v2_2(
             None,
             None,
             True,
-            3,
+            4,
             None,
             None,
             None,
@@ -984,3 +986,69 @@ async def test_migrate_entry_to_v2_3(
     assert mock_config_entry.disabled_by == config_entry_disabled_by_after_migration
     assert conversation_device.disabled_by == device_disabled_by_after_migration
     assert conversation_entity.disabled_by == entity_disabled_by_after_migration
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_migrate_entry_to_v2_4(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration to version 2.4."""
+    # Create a v2.3 config entry
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "test-api-key"},
+        version=2,
+        minor_version=3,
+        subentries_data=[
+            {
+                "data": {
+                    "recommended": True,
+                    "llm_hass_api": ["assist"],
+                    "prompt": "You are a helpful assistant",
+                    "chat_model": "claude-haiku-4-5",
+                },
+                "subentry_id": "mock_id_1",
+                "subentry_type": "conversation",
+                "title": "Claude haiku default",
+                "unique_id": None,
+            },
+            {
+                "data": {
+                    "recommended": False,
+                    "llm_hass_api": ["assist"],
+                    "prompt": "You are a helpful assistant",
+                    "chat_model": "claude-haiku-4-5",
+                    "temperature": 0.5,
+                },
+                "subentry_id": "mock_id_2",
+                "subentry_type": "conversation",
+                "title": "Claude haiku non-default",
+                "unique_id": None,
+            },
+        ],
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    # Run migration
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check that minor version was updated
+    assert mock_config_entry.version == 2
+    assert mock_config_entry.minor_version == 4
+
+    # Verify data was not changed for the first subentry
+    assert mock_config_entry.subentries["mock_id_1"].data == {
+        "recommended": True,
+        "llm_hass_api": ["assist"],
+        "prompt": "You are a helpful assistant",
+        "chat_model": "claude-haiku-4-5",
+    }
+
+    # Verify that temperature was removed from the second subentry
+    assert mock_config_entry.subentries["mock_id_2"].data == {
+        "recommended": False,
+        "llm_hass_api": ["assist"],
+        "prompt": "You are a helpful assistant",
+        "chat_model": "claude-haiku-4-5",
+    }

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -13,6 +13,7 @@ import httpx
 from httpx import URL, Request, Response
 import pytest
 
+from homeassistant.components.anthropic.config_flow import AnthropicConfigFlow
 from homeassistant.components.anthropic.const import DOMAIN
 from homeassistant.config_entries import (
     ConfigEntryDisabler,
@@ -31,6 +32,8 @@ from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+
+MINOR_VERSION = AnthropicConfigFlow.MINOR_VERSION
 
 
 @pytest.mark.parametrize(
@@ -210,7 +213,7 @@ async def test_migration_from_v1_to_v2(
     await hass.async_block_till_done()
 
     assert mock_config_entry.version == 2
-    assert mock_config_entry.minor_version == 4
+    assert mock_config_entry.minor_version == MINOR_VERSION
     assert mock_config_entry.data == {"api_key": "1234"}
     assert mock_config_entry.options == {}
 
@@ -410,7 +413,9 @@ async def test_migration_from_v1_disabled(
     assert entry.disabled_by is merged_config_entry_disabled_by
     assert entry.version == 2
     assert (
-        entry.minor_version == 3 if merged_config_entry_disabled_by is not None else 4
+        entry.minor_version == 3
+        if merged_config_entry_disabled_by is not None
+        else MINOR_VERSION
     )
     assert not entry.options
     assert entry.title == "Claude conversation"
@@ -531,7 +536,7 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
 
     for idx, entry in enumerate(entries):
         assert entry.version == 2
-        assert entry.minor_version == 4
+        assert entry.minor_version == MINOR_VERSION
         assert not entry.options
         assert len(entry.subentries) == 1
         subentry = list(entry.subentries.values())[0]
@@ -622,7 +627,7 @@ async def test_migration_from_v1_to_v2_with_same_keys(
 
     entry = entries[0]
     assert entry.version == 2
-    assert entry.minor_version == 4
+    assert entry.minor_version == MINOR_VERSION
     assert not entry.options
     assert len(entry.subentries) == 2  # Two subentries from the two original entries
 
@@ -742,7 +747,7 @@ async def test_migration_from_v2_1_to_v2_2(
     assert len(entries) == 1
     entry = entries[0]
     assert entry.version == 2
-    assert entry.minor_version == 4
+    assert entry.minor_version == MINOR_VERSION
     assert not entry.options
     assert entry.title == "Claude"
     assert len(entry.subentries) == 2
@@ -819,7 +824,7 @@ async def test_migration_from_v2_1_to_v2_2(
             DeviceEntryDisabler.CONFIG_ENTRY,
             RegistryEntryDisabler.CONFIG_ENTRY,
             True,
-            4,
+            MINOR_VERSION,
             None,
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.DEVICE,
@@ -829,7 +834,7 @@ async def test_migration_from_v2_1_to_v2_2(
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.DEVICE,
             True,
-            4,
+            MINOR_VERSION,
             None,
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.DEVICE,
@@ -839,7 +844,7 @@ async def test_migration_from_v2_1_to_v2_2(
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.USER,
             True,
-            4,
+            MINOR_VERSION,
             None,
             DeviceEntryDisabler.USER,
             RegistryEntryDisabler.USER,
@@ -849,7 +854,7 @@ async def test_migration_from_v2_1_to_v2_2(
             None,
             None,
             True,
-            4,
+            MINOR_VERSION,
             None,
             None,
             None,
@@ -1035,7 +1040,7 @@ async def test_migrate_entry_to_v2_4(
 
     # Check that minor version was updated
     assert mock_config_entry.version == 2
-    assert mock_config_entry.minor_version == 4
+    assert mock_config_entry.minor_version == MINOR_VERSION
 
     # Verify data was not changed for the first subentry
     assert mock_config_entry.subentries["mock_id_1"].data == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the `Temperature` parameter from Anthropic integration.

Rationale:
1. This parameter only works when thinking is disabled. Thinking is now enabled by default
2. Newer models such as Claude Opus 4.7 don't support it even with thinking disabled
3. Setting Temperature to 0 for deterministic results was never guaranteed
4. Prompting often produces better results than changing the temperature.

I am not sure if this should be marked as a breaking change or not. Technically it's not breaking, but in certain cases users might want to update their prompt.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44842
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
