### PR TITLE
Add read-only climate entity to Waterfurnace

### DIFF
--- a/homeassistant/components/waterfurnace/__init__.py
+++ b/homeassistant/components/waterfurnace/__init__.py
@@ -26,7 +26,7 @@ from .coordinator import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/waterfurnace/climate.py
+++ b/homeassistant/components/waterfurnace/climate.py
@@ -1,0 +1,97 @@
+"""Support for WaterFurnace climate entity."""
+
+from __future__ import annotations
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import WaterFurnaceConfigEntry
+from .const import DOMAIN
+from .coordinator import WaterFurnaceCoordinator
+from .entity import WaterFurnaceEntity
+
+PARALLEL_UPDATES = 0
+
+# Maps ActiveSettings.mode string to HVACMode
+ACTIVE_MODE_TO_HVAC: dict[str, HVACMode] = {
+    "Off": HVACMode.OFF,
+    "Auto": HVACMode.AUTO,
+    "Cool": HVACMode.COOL,
+    "Heat": HVACMode.HEAT,
+    "E-Heat": HVACMode.HEAT,
+}
+
+# Maps WFReading.mode string to HVACAction
+FURNACE_MODE_TO_ACTION: dict[str, HVACAction] = {
+    "Standby": HVACAction.IDLE,
+    "Fan Only": HVACAction.FAN,
+    "Cooling 1": HVACAction.COOLING,
+    "Cooling 2": HVACAction.COOLING,
+    "Reheat": HVACAction.HEATING,
+    "Heating 1": HVACAction.HEATING,
+    "Heating 2": HVACAction.HEATING,
+    "E-Heat": HVACAction.HEATING,
+    "Aux Heat": HVACAction.HEATING,
+    "Lockout": HVACAction.OFF,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WaterFurnaceConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up WaterFurnace climate from a config entry."""
+    async_add_entities(
+        WaterFurnaceClimate(device_data.realtime)
+        for device_data in config_entry.runtime_data.values()
+    )
+
+
+class WaterFurnaceClimate(WaterFurnaceEntity, ClimateEntity):
+    """Read-only climate entity for WaterFurnace geothermal systems."""
+
+    _attr_name = None
+    _attr_supported_features = ClimateEntityFeature(0)
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+
+    def __init__(self, coordinator: WaterFurnaceCoordinator) -> None:
+        """Initialize the climate entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.unit}_climate"
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current room temperature."""
+        return self.coordinator.data.tstatroomtemp
+
+    @property
+    def current_humidity(self) -> float | None:
+        """Return the current humidity."""
+        return self.coordinator.data.tstatrelativehumidity
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return the current HVAC mode."""
+        return ACTIVE_MODE_TO_HVAC.get(self.coordinator.data.activesettings.mode)
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current HVAC action."""
+        return FURNACE_MODE_TO_ACTION.get(self.coordinator.data.mode)
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set HVAC mode — not supported (read-only)."""
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="set_hvac_mode_not_supported",
+        )

--- a/homeassistant/components/waterfurnace/entity.py
+++ b/homeassistant/components/waterfurnace/entity.py
@@ -1,0 +1,33 @@
+"""Base entity for WaterFurnace."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import WaterFurnaceCoordinator
+
+
+class WaterFurnaceEntity(CoordinatorEntity[WaterFurnaceCoordinator]):
+    """Base entity for WaterFurnace."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: WaterFurnaceCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+
+        device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.unit)},
+            manufacturer="WaterFurnace",
+            name="WaterFurnace System",
+        )
+
+        if coordinator.device_metadata:
+            if coordinator.device_metadata.description:
+                device_info["model"] = coordinator.device_metadata.description
+            if coordinator.device_metadata.awlabctypedesc:
+                device_info["name"] = coordinator.device_metadata.awlabctypedesc
+
+        self._attr_device_info = device_info

--- a/homeassistant/components/waterfurnace/sensor.py
+++ b/homeassistant/components/waterfurnace/sensor.py
@@ -15,12 +15,11 @@ from homeassistant.const import (
     UnitOfVolumeFlowRate,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DOMAIN, WaterFurnaceConfigEntry
+from . import WaterFurnaceConfigEntry
 from .coordinator import WaterFurnaceCoordinator
+from .entity import WaterFurnaceEntity
 
 SENSORS = [
     SensorEntityDescription(
@@ -162,12 +161,11 @@ async def async_setup_entry(
     )
 
 
-class WaterFurnaceSensor(CoordinatorEntity[WaterFurnaceCoordinator], SensorEntity):
+class WaterFurnaceSensor(WaterFurnaceEntity, SensorEntity):
     """Implementing the Waterfurnace sensor."""
 
     entity_description: SensorEntityDescription
     _attr_should_poll = False
-    _attr_has_entity_name = True
 
     def __init__(
         self, coordinator: WaterFurnaceCoordinator, description: SensorEntityDescription
@@ -175,24 +173,7 @@ class WaterFurnaceSensor(CoordinatorEntity[WaterFurnaceCoordinator], SensorEntit
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-
         self._attr_unique_id = f"{coordinator.unit}_{description.key}"
-
-        device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.unit)},
-            manufacturer="WaterFurnace",
-            name="WaterFurnace System",
-        )
-
-        if coordinator.device_metadata:
-            if coordinator.device_metadata.description:
-                # Eg. Series 7
-                device_info["model"] = coordinator.device_metadata.description
-            if coordinator.device_metadata.awlabctypedesc:
-                # Eg. Series 7, 5 Ton
-                device_info["name"] = coordinator.device_metadata.awlabctypedesc
-
-        self._attr_device_info = device_info
 
     @property
     def native_value(self):

--- a/homeassistant/components/waterfurnace/strings.json
+++ b/homeassistant/components/waterfurnace/strings.json
@@ -100,6 +100,11 @@
       }
     }
   },
+  "exceptions": {
+    "set_hvac_mode_not_supported": {
+      "message": "The WaterFurnace integration does not support setting the HVAC mode."
+    }
+  },
   "issues": {
     "deprecated_yaml_import_issue_cannot_connect": {
       "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your configuration, we could not connect to {integration_title}. Please check your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",

--- a/tests/components/waterfurnace/fixtures/device_data.json
+++ b/tests/components/waterfurnace/fixtures/device_data.json
@@ -12,5 +12,21 @@
   "auxpower": 0,
   "looppumppower": 50,
   "actualcompressorspeed": 1200,
-  "airflowcurrentspeed": 850
+  "airflowcurrentspeed": 850,
+  "tstatheatingsetpoint": 68,
+  "tstatcoolingsetpoint": 74,
+  "activesettings": {
+    "activemode": 3,
+    "heatingsp_read": 68,
+    "coolingsp_read": 74,
+    "fanmode_read": 0,
+    "temporaryoverride": 0,
+    "permanenthold": 0,
+    "vacationhold": 0,
+    "onpeakhold": 0,
+    "superboost": 0,
+    "tstatmode": 3,
+    "intertimeon_read": 0,
+    "intertimeoff_read": 0
+  }
 }

--- a/tests/components/waterfurnace/snapshots/test_climate.ambr
+++ b/tests/components/waterfurnace/snapshots/test_climate.ambr
@@ -1,0 +1,72 @@
+# serializer version: 1
+# name: test_climate_snapshot[climate.test_abc_type-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.AUTO: 'auto'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 7.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.test_abc_type',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'TEST_GWID_12345_climate',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_snapshot[climate.test_abc_type-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_humidity': 43,
+      'current_temperature': 21.2,
+      'friendly_name': 'Test ABC Type',
+      'hvac_action': <HVACAction.HEATING: 'heating'>,
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.AUTO: 'auto'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 7.0,
+      'supported_features': <ClimateEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.test_abc_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---

--- a/tests/components/waterfurnace/snapshots/test_sensor.ambr
+++ b/tests/components/waterfurnace/snapshots/test_sensor.ambr
@@ -278,7 +278,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '23.3333333333333',
   })
 # ---
 # name: test_sensors[sensor.test_abc_type_dehumidification_setpoint-entry]
@@ -549,7 +549,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '20.0',
   })
 # ---
 # name: test_sensors[sensor.test_abc_type_humidity-entry]

--- a/tests/components/waterfurnace/test_climate.py
+++ b/tests/components/waterfurnace/test_climate.py
@@ -1,0 +1,127 @@
+"""Test climate of WaterFurnace integration."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    SERVICE_SET_HVAC_MODE,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.components.waterfurnace.const import UPDATE_INTERVAL
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+ENTITY_ID = "climate.test_abc_type"
+
+
+@pytest.mark.usefixtures("mock_waterfurnace_client", "seed_statistics")
+async def test_climate_snapshot(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test climate entity against snapshot."""
+    with patch("homeassistant.components.waterfurnace.PLATFORMS", [Platform.CLIMATE]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
+async def test_set_hvac_mode_raises(
+    hass: HomeAssistant,
+) -> None:
+    """Test that setting HVAC mode raises ServiceValidationError."""
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: ENTITY_ID, "hvac_mode": HVACMode.HEAT},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
+@pytest.mark.parametrize(
+    ("active_mode_index", "expected_hvac_mode"),
+    [
+        (0, HVACMode.OFF),
+        (1, HVACMode.AUTO),
+        (2, HVACMode.COOL),
+        (3, HVACMode.HEAT),
+        (4, HVACMode.HEAT),
+    ],
+    ids=["Off", "Auto", "Cool", "Heat", "E-Heat"],
+)
+async def test_hvac_mode_mapping(
+    hass: HomeAssistant,
+    mock_waterfurnace_client: Mock,
+    active_mode_index: int,
+    expected_hvac_mode: HVACMode,
+) -> None:
+    """Test that ActiveSettings.mode maps to the correct HVACMode."""
+    mock_waterfurnace_client.read_with_retry.return_value.activesettings.activemode = (
+        active_mode_index
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == expected_hvac_mode.value
+
+
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
+@pytest.mark.parametrize(
+    ("mode_index", "expected_action"),
+    [
+        (0, HVACAction.IDLE),
+        (1, HVACAction.FAN),
+        (2, HVACAction.COOLING),
+        (3, HVACAction.COOLING),
+        (4, HVACAction.HEATING),
+        (5, HVACAction.HEATING),
+        (6, HVACAction.HEATING),
+        (7, HVACAction.HEATING),
+        (8, HVACAction.HEATING),
+        (9, HVACAction.OFF),
+    ],
+    ids=[
+        "Standby",
+        "Fan Only",
+        "Cooling 1",
+        "Cooling 2",
+        "Reheat",
+        "Heating 1",
+        "Heating 2",
+        "E-Heat",
+        "Aux Heat",
+        "Lockout",
+    ],
+)
+async def test_hvac_action_mapping(
+    hass: HomeAssistant,
+    mock_waterfurnace_client: Mock,
+    mode_index: int,
+    expected_action: HVACAction,
+) -> None:
+    """Test that WFReading.mode maps to the correct HVACAction."""
+    mock_waterfurnace_client.read_with_retry.return_value.modeofoperation = mode_index
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.attributes["hvac_action"] == expected_action

--- a/tests/components/waterfurnace/test_sensor.py
+++ b/tests/components/waterfurnace/test_sensor.py
@@ -1,7 +1,7 @@
 """Test sensor of WaterFurnace integration."""
 
 import asyncio
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -9,14 +9,14 @@ from syrupy.assertion import SnapshotAssertion
 from waterfurnace.waterfurnace import WFException
 
 from homeassistant.components.waterfurnace.const import UPDATE_INTERVAL
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
-@pytest.mark.usefixtures("seed_statistics", "init_integration")
+@pytest.mark.usefixtures("seed_statistics")
 async def test_sensors(
     hass: HomeAssistant,
     mock_waterfurnace_client: Mock,
@@ -25,6 +25,10 @@ async def test_sensors(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that we create the expected sensors."""
+    with patch("homeassistant.components.waterfurnace.PLATFORMS", [Platform.SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add read-only a climate entity for the waterfurnace integration showing current HVAC mode, HVAC action, room temperature, and humidity.

While we have access to the target temperature, adding it causes some weird UX issues because of the read-only nature of the implementation. Write access is currently missing from the underlying library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR introduces a read-only climate entity for the waterfurnace integration. This is read-only due to the lack of write support in the underlying library. Any write attempts raise a `ServiceValidationError`.

A shared entity, `WaterFurnaceEntity` was created to reduce duplication and existing tests were updated to accommodate the new fields used from the API and the new platform.

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44847

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
