### PR TITLE
Add detection_callback kwarg to bluetooth.async_get_scanner

### DIFF
--- a/homeassistant/components/bluetooth/api.py
+++ b/homeassistant/components/bluetooth/api.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, cast
 
 from bleak import BleakScanner
+from bleak.backends.scanner import AdvertisementDataCallback
 from habluetooth import (
     BaseHaScanner,
     BluetoothScannerDevice,
@@ -39,7 +40,10 @@ def _get_manager(hass: HomeAssistant) -> HomeAssistantBluetoothManager:
 
 
 @hass_callback
-def async_get_scanner(hass: HomeAssistant) -> BleakScanner:
+def async_get_scanner(
+    hass: HomeAssistant,
+    detection_callback: AdvertisementDataCallback | None = None,
+) -> BleakScanner:
     """Return a HaBleakScannerWrapper cast to BleakScanner.
 
     This is a wrapper around our BleakScanner singleton that allows
@@ -48,7 +52,9 @@ def async_get_scanner(hass: HomeAssistant) -> BleakScanner:
     The wrapper is cast to BleakScanner for type compatibility with
     libraries expecting a BleakScanner instance.
     """
-    return cast(BleakScanner, HaBleakScannerWrapper())
+    return cast(
+        BleakScanner, HaBleakScannerWrapper(detection_callback=detection_callback)
+    )
 
 
 @hass_callback

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -3122,6 +3122,31 @@ async def test_getting_the_scanner_returns_the_wrapped_instance(
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
+async def test_getting_the_scanner_with_detection_callback(
+    hass: HomeAssistant,
+) -> None:
+    """Test detection_callback is invoked for advertisements."""
+    detected: list[tuple[BLEDevice, AdvertisementData]] = []
+
+    def _detected(device: BLEDevice, advertisement_data: AdvertisementData) -> None:
+        detected.append((device, advertisement_data))
+
+    scanner = bluetooth.async_get_scanner(hass, detection_callback=_detected)
+    assert isinstance(scanner, HaBleakScannerWrapper)
+
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand",
+        manufacturer_data={89: b"\xd8.\xad\xcd\r\x85"},
+    )
+    inject_advertisement(hass, switchbot_device, switchbot_adv)
+    await hass.async_block_till_done()
+
+    assert len(detected) == 1
+    assert detected[0][0].address == switchbot_device.address
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_scanner_count_connectable(hass: HomeAssistant) -> None:
     """Test getting the connectable scanner count."""
     scanner = FakeScanner("any", "any")


### PR DESCRIPTION
## Proposed change

bleak removed register_detection_callback; the detection callback must now be passed via the BleakScanner constructor. HaBleakScannerWrapper already accepts detection_callback in its constructor, so plumb that through async_get_scanner so downstream libraries can wire up their callback at construction time.

The kwarg is optional and defaults to None, so existing callers are unaffected.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr