### PR TITLE
Use bleak_scanner_factory in homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -15,6 +15,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"],
-  "requirements": ["aiohomekit==3.2.20"],
+  "requirements": ["aiohomekit==4.0.0"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."]
 }

--- a/homeassistant/components/homekit_controller/utils.py
+++ b/homeassistant/components/homekit_controller/utils.py
@@ -1,6 +1,6 @@
 """Helper functions for the homekit_controller component."""
 
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import cast
 
 from aiohomekit import Controller
@@ -59,11 +59,9 @@ async def async_get_controller(hass: HomeAssistant) -> Controller:
     if existing := hass.data.get(CONTROLLER):
         return cast(Controller, existing)
 
-    bleak_scanner_instance = bluetooth.async_get_scanner(hass)
-
     controller = Controller(
         async_zeroconf_instance=async_zeroconf_instance,
-        bleak_scanner_instance=bleak_scanner_instance,
+        bleak_scanner_factory=partial(bluetooth.async_get_scanner, hass),
         char_cache=char_cache,
     )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -282,7 +282,7 @@ aiohasupervisor==0.4.3
 aiohomeconnect==0.36.0
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.2.20
+aiohomekit==4.0.0
 
 # homeassistant.components.mcp_server
 aiohttp_sse==2.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -270,7 +270,7 @@ aiohasupervisor==0.4.3
 aiohomeconnect==0.36.0
 
 # homeassistant.components.homekit_controller
-aiohomekit==3.2.20
+aiohomekit==4.0.0
 
 # homeassistant.components.mcp_server
 aiohttp_sse==2.2.0


### PR DESCRIPTION
## Proposed change

aiohomekit replaced bleak_scanner_instance with bleak_scanner_factory because bleak removed register_detection_callback; the detection callback must now be supplied at BleakScanner construction time. Pass a partial that forwards the callback to bluetooth.async_get_scanner so aiohomekit can build the wrapper at the right moment.

Requires aiohomekit https://github.com/Jc2k/aiohomekit/pull/549 to be released, and stacks on top of https://github.com/home-assistant/core/pull/168525.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr