### PR TITLE
Add Tuya Madimack Elite V3 fixture

### DIFF
--- a/tests/components/tuya/fixtures/znrb_8ln34bg8u4y6rdda.json
+++ b/tests/components/tuya/fixtures/znrb_8ln34bg8u4y6rdda.json
@@ -1,0 +1,419 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Madimack Elite V3 Pool Heat Pump",
+  "category": "znrb",
+  "product_id": "8ln34bg8u4y6rdda",
+  "product_name": "Madimack Elite V3 Pool Heat Pump",
+  "online": true,
+  "sub": false,
+  "time_zone": "+10:00",
+  "active_time": "2024-10-05T23:24:35+00:00",
+  "create_time": "2024-10-05T23:24:35+00:00",
+  "update_time": "2024-10-05T23:24:35+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["auto", "heating", "cold"]
+      }
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 104,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "temp_unit_convert": {
+      "type": "Enum",
+      "value": {
+        "range": ["f", "c"]
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": {},
+      "report_type": null
+    },
+    "mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["auto", "heating", "cold"]
+      },
+      "report_type": null
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {},
+      "report_type": null
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 104,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "temp_unit_convert": {
+      "type": "Enum",
+      "value": {
+        "range": ["f", "c"]
+      },
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 250,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "compressor_strength": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 0,
+        "max": 150,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "temp_top": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 104,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "temp_bottom": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 104,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "temp_coiler": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 250,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "temp_venting": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 250,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "temp_effluent": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 250,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "temp_around": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": -22,
+        "max": 250,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": false,
+    "mode": "heating",
+    "child_lock": false,
+    "temp_set": 31,
+    "temp_unit_convert": "c",
+    "temp_current": -22,
+    "compressor_strength": 0,
+    "temp_top": 40,
+    "temp_bottom": 18,
+    "temp_coiler": 22,
+    "temp_venting": 22,
+    "temp_effluent": 22,
+    "temp_around": 24
+  },
+  "set_up": true,
+  "support_local": true,
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": {
+          "switch": "$"
+        },
+        "valueDesc": {},
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "mode",
+      "config_item": {
+        "statusFormat": {
+          "mode": "$"
+        },
+        "valueDesc": {
+          "range": ["auto", "heating", "cold"]
+        },
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "child_lock",
+      "config_item": {
+        "statusFormat": {
+          "child_lock": "$"
+        },
+        "valueDesc": {},
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "temp_set",
+      "config_item": {
+        "statusFormat": {
+          "temp_set": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 104,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "6": {
+      "value_convert": "default",
+      "status_code": "temp_unit_convert",
+      "config_item": {
+        "statusFormat": {
+          "temp_unit_convert": "$"
+        },
+        "valueDesc": {
+          "range": ["f", "c"]
+        },
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "16": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": {
+          "temp_current": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 250,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "20": {
+      "value_convert": "default",
+      "status_code": "compressor_strength",
+      "config_item": {
+        "statusFormat": {
+          "compressor_strength": "$"
+        },
+        "valueDesc": {
+          "unit": "%",
+          "min": 0,
+          "max": 150,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "21": {
+      "value_convert": "default",
+      "status_code": "temp_top",
+      "config_item": {
+        "statusFormat": {
+          "temp_top": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 104,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "22": {
+      "value_convert": "default",
+      "status_code": "temp_bottom",
+      "config_item": {
+        "statusFormat": {
+          "temp_bottom": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 104,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "23": {
+      "value_convert": "default",
+      "status_code": "temp_coiler",
+      "config_item": {
+        "statusFormat": {
+          "temp_coiler": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 250,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "24": {
+      "value_convert": "default",
+      "status_code": "temp_venting",
+      "config_item": {
+        "statusFormat": {
+          "temp_venting": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 250,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "25": {
+      "value_convert": "default",
+      "status_code": "temp_effluent",
+      "config_item": {
+        "statusFormat": {
+          "temp_effluent": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 250,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    },
+    "26": {
+      "value_convert": "default",
+      "status_code": "temp_around",
+      "config_item": {
+        "statusFormat": {
+          "temp_around": "$"
+        },
+        "valueDesc": {
+          "unit": "",
+          "min": -22,
+          "max": 250,
+          "scale": 0,
+          "step": 1
+        },
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "8ln34bg8u4y6rdda"
+      }
+    }
+  }
+}

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -2076,6 +2076,37 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[addr6y4u8gb43nl8brnz]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'addr6y4u8gb43nl8brnz',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'Madimack Elite V3 Pool Heat Pump',
+    'model_id': '8ln34bg8u4y6rdda',
+    'name': 'Madimack Elite V3 Pool Heat Pump',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[ai9swgb6tyinbwbxjxq]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/tuya/snapshots/test_number.ambr
+++ b/tests/components/tuya/snapshots/test_number.ambr
@@ -1937,6 +1937,66 @@
     'state': '90.0',
   })
 # ---
+# name: test_platform_setup_and_discovery[number.madimack_elite_v3_pool_heat_pump_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 104.0,
+      'min': -22.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.madimack_elite_v3_pool_heat_pump_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_set',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[number.madimack_elite_v3_pool_heat_pump_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Temperature',
+      'max': 104.0,
+      'min': -22.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.madimack_elite_v3_pool_heat_pump_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '31.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[number.mirilla_puerta_volume-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -11348,60 +11348,6 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.inverter_pool_heat_pump-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_pool_heat_pump',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'outside_temperature',
-    'unique_id': 'tuya.zuqudhznfzttizpgbrnztemp_around',
-    'unit_of_measurement': '',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.inverter_pool_heat_pump-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Inverter Pool Heat Pump',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_pool_heat_pump',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '14.0',
-  })
-# ---
 # name: test_platform_setup_and_discovery[sensor.inverter_pool_heat_pump_coil_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -13831,60 +13777,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '16.0',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'outside_temperature',
-    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_around',
-    'unit_of_measurement': '',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Madimack Elite V3 Pool Heat Pump',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '24.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_coil_temperature-entry]

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -13779,6 +13779,330 @@
     'state': '16.0',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_coil_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_coil_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Coil temperature',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Coil temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'coil_temperature',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_coiler',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_coil_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Coil temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_coil_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '22.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_compressor_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_compressor_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Compressor strength',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Compressor strength',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'compressor_strength',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnzcompressor_strength',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_compressor_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Compressor strength',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_compressor_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_flow_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_flow_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Flow temperature',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Flow temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'flow_temperature',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_effluent',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_flow_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Flow temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_flow_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '22.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_heat_exchanger_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_heat_exchanger_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Heat exchanger temperature',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Heat exchanger temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'heat_exchanger_temperature',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_venting',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_heat_exchanger_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Heat exchanger temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_heat_exchanger_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '22.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_outside_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_outside_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Outside temperature',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Outside temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'outside_temperature',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_around',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_outside_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Outside temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_outside_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_current',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-22.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.medidor_de_energia_phase_a_current-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -11348,6 +11348,60 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.inverter_pool_heat_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_pool_heat_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'outside_temperature',
+    'unique_id': 'tuya.zuqudhznfzttizpgbrnztemp_around',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.inverter_pool_heat_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Inverter Pool Heat Pump',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_pool_heat_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.inverter_pool_heat_pump_coil_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -13777,6 +13831,60 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '16.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'outside_temperature',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnztemp_around',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.madimack_elite_v3_pool_heat_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.madimack_elite_v3_pool_heat_pump_coil_temperature-entry]

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -7407,6 +7407,107 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.madimack_elite_v3_pool_heat_pump_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.madimack_elite_v3_pool_heat_pump_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Child lock',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:account-lock',
+    'original_name': 'Child lock',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnzchild_lock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.madimack_elite_v3_pool_heat_pump_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Child lock',
+      'icon': 'mdi:account-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.madimack_elite_v3_pool_heat_pump_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.madimack_elite_v3_pool_heat_pump_switch-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.madimack_elite_v3_pool_heat_pump_switch',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Switch',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch',
+    'unique_id': 'tuya.addr6y4u8gb43nl8brnzswitch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.madimack_elite_v3_pool_heat_pump_switch-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Madimack Elite V3 Pool Heat Pump Switch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.madimack_elite_v3_pool_heat_pump_switch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.mesa_child_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
## Proposed change

Add a real Tuya fixture for a Madimack Elite V3 Pool Heat Pump (`znrb`) and update the corresponding existing entity snapshots.

This is the preliminary fixture-only PR requested during review. It intentionally does not change Tuya entity behavior; follow-up changes can use this fixture to add the remaining pool heat pump support.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Local verification:

- `pytest tests/components/tuya/test_init.py::test_device_registry tests/components/tuya/test_number.py::test_platform_setup_and_discovery tests/components/tuya/test_sensor.py::test_platform_setup_and_discovery tests/components/tuya/test_switch.py::test_platform_setup_and_discovery`
- `prettier --check tests/components/tuya/fixtures/znrb_8ln34bg8u4y6rdda.json`
- `git diff --check`

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
