### PR TITLE
Add open (unlatch) support to Homee locks

### DIFF
--- a/homeassistant/components/homee/lock.py
+++ b/homeassistant/components/homee/lock.py
@@ -7,9 +7,11 @@ from pyHomee.model import HomeeAttribute, HomeeNode
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import HomeeConfigEntry
+from .const import DOMAIN
 from .entity import HomeeEntity
 from .helpers import get_name_for_enum, setup_homee_platform
 
@@ -19,7 +21,7 @@ LOCK_STATE_UNLOCKED = 0.0
 LOCK_STATE_LOCKED = 1.0
 
 
-def _determine_open_value(attribute: HomeeAttribute) -> float | None:
+def _determine_lock_state_open(attribute: HomeeAttribute) -> float | None:
     """Return the attribute value that momentarily unlatches the lock.
 
     Different homee-compatible locks encode the "open" (unlatch) command
@@ -27,9 +29,9 @@ def _determine_open_value(attribute: HomeeAttribute) -> float | None:
     where -1 is unlatch; other devices extend above with {0, 1, 2}.
     Returns None when the device only supports two states.
     """
-    if attribute.maximum >= 2.0:
+    if attribute.maximum == 2.0:
         return 2.0
-    if attribute.minimum <= -1.0:
+    if attribute.minimum == -1.0:
         return -1.0
     return None
 
@@ -63,13 +65,11 @@ class HomeeLock(HomeeEntity, LockEntity):
 
     _attr_name = None
 
-    def __init__(
-        self, attribute: HomeeAttribute, entry: HomeeConfigEntry
-    ) -> None:
+    def __init__(self, attribute: HomeeAttribute, entry: HomeeConfigEntry) -> None:
         """Initialize the homee lock."""
         super().__init__(attribute, entry)
-        self._open_value = _determine_open_value(attribute)
-        if self._open_value is not None:
+        self._lock_state_open = _determine_lock_state_open(attribute)
+        if self._lock_state_open is not None:
             self._attr_supported_features = LockEntityFeature.OPEN
 
     @property
@@ -81,8 +81,8 @@ class HomeeLock(HomeeEntity, LockEntity):
     def is_open(self) -> bool:
         """Return if lock is open (unlatched)."""
         return (
-            self._open_value is not None
-            and self._attribute.current_value == self._open_value
+            self._lock_state_open is not None
+            and self._attribute.current_value == self._lock_state_open
         )
 
     @property
@@ -105,9 +105,9 @@ class HomeeLock(HomeeEntity, LockEntity):
     def is_opening(self) -> bool:
         """Return if lock is opening (unlatching)."""
         return (
-            self._open_value is not None
-            and self._attribute.target_value == self._open_value
-            and self._attribute.current_value != self._open_value
+            self._lock_state_open is not None
+            and self._attribute.target_value == self._lock_state_open
+            and self._attribute.current_value != self._lock_state_open
         )
 
     @property
@@ -138,5 +138,9 @@ class HomeeLock(HomeeEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open (unlatch) the lock."""
-        assert self._open_value is not None
-        await self.async_set_homee_value(self._open_value)
+        if self._lock_state_open is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="open_not_supported",
+            )
+        await self.async_set_homee_value(self._lock_state_open)

--- a/homeassistant/components/homee/lock.py
+++ b/homeassistant/components/homee/lock.py
@@ -7,11 +7,9 @@ from pyHomee.model import HomeeAttribute, HomeeNode
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import HomeeConfigEntry
-from .const import DOMAIN
 from .entity import HomeeEntity
 from .helpers import get_name_for_enum, setup_homee_platform
 
@@ -141,9 +139,5 @@ class HomeeLock(HomeeEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open (unlatch) the lock."""
-        if self._lock_state_open is None:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="open_not_supported",
-            )
+        assert self._lock_state_open is not None
         await self.async_set_homee_value(self._lock_state_open)

--- a/homeassistant/components/homee/lock.py
+++ b/homeassistant/components/homee/lock.py
@@ -1,6 +1,6 @@
 """The Homee lock platform."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pyHomee.const import AttributeChangedBy, AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -139,5 +139,6 @@ class HomeeLock(HomeeEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open (unlatch) the lock."""
-        assert self._lock_state_open is not None
+        if TYPE_CHECKING:
+            assert self._lock_state_open is not None
         await self.async_set_homee_value(self._lock_state_open)

--- a/homeassistant/components/homee/lock.py
+++ b/homeassistant/components/homee/lock.py
@@ -7,7 +7,7 @@ from pyHomee.model import HomeeAttribute, HomeeNode
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import HomeeConfigEntry
@@ -80,9 +80,12 @@ class HomeeLock(HomeeEntity, LockEntity):
     @property
     def is_open(self) -> bool:
         """Return if lock is open (unlatched)."""
+        # Require target_value too, so mid-transition away from "open" resolves
+        # to is_locking/is_unlocking rather than OPEN (HA state precedence).
         return (
             self._lock_state_open is not None
             and self._attribute.current_value == self._lock_state_open
+            and self._attribute.target_value == self._lock_state_open
         )
 
     @property
@@ -139,7 +142,7 @@ class HomeeLock(HomeeEntity, LockEntity):
     async def async_open(self, **kwargs: Any) -> None:
         """Open (unlatch) the lock."""
         if self._lock_state_open is None:
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="open_not_supported",
             )

--- a/homeassistant/components/homee/lock.py
+++ b/homeassistant/components/homee/lock.py
@@ -3,9 +3,9 @@
 from typing import Any
 
 from pyHomee.const import AttributeChangedBy, AttributeType
-from pyHomee.model import HomeeNode
+from pyHomee.model import HomeeAttribute, HomeeNode
 
-from homeassistant.components.lock import LockEntity
+from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -14,6 +14,24 @@ from .entity import HomeeEntity
 from .helpers import get_name_for_enum, setup_homee_platform
 
 PARALLEL_UPDATES = 0
+
+LOCK_STATE_UNLOCKED = 0.0
+LOCK_STATE_LOCKED = 1.0
+
+
+def _determine_open_value(attribute: HomeeAttribute) -> float | None:
+    """Return the attribute value that momentarily unlatches the lock.
+
+    Different homee-compatible locks encode the "open" (unlatch) command
+    differently. The Hörmann SmartKey uses a signed range {-1, 0, 1}
+    where -1 is unlatch; other devices extend above with {0, 1, 2}.
+    Returns None when the device only supports two states.
+    """
+    if attribute.maximum >= 2.0:
+        return 2.0
+    if attribute.minimum <= -1.0:
+        return -1.0
+    return None
 
 
 async def add_lock_entities(
@@ -45,20 +63,52 @@ class HomeeLock(HomeeEntity, LockEntity):
 
     _attr_name = None
 
+    def __init__(
+        self, attribute: HomeeAttribute, entry: HomeeConfigEntry
+    ) -> None:
+        """Initialize the homee lock."""
+        super().__init__(attribute, entry)
+        self._open_value = _determine_open_value(attribute)
+        if self._open_value is not None:
+            self._attr_supported_features = LockEntityFeature.OPEN
+
     @property
     def is_locked(self) -> bool:
         """Return if lock is locked."""
-        return self._attribute.current_value == 1.0
+        return self._attribute.current_value == LOCK_STATE_LOCKED
+
+    @property
+    def is_open(self) -> bool:
+        """Return if lock is open (unlatched)."""
+        return (
+            self._open_value is not None
+            and self._attribute.current_value == self._open_value
+        )
 
     @property
     def is_locking(self) -> bool:
         """Return if lock is locking."""
-        return self._attribute.target_value > self._attribute.current_value
+        return (
+            self._attribute.target_value == LOCK_STATE_LOCKED
+            and self._attribute.current_value != LOCK_STATE_LOCKED
+        )
 
     @property
     def is_unlocking(self) -> bool:
         """Return if lock is unlocking."""
-        return self._attribute.target_value < self._attribute.current_value
+        return (
+            self._attribute.target_value == LOCK_STATE_UNLOCKED
+            and self._attribute.current_value != LOCK_STATE_UNLOCKED
+        )
+
+    @property
+    def is_opening(self) -> bool:
+        """Return if lock is opening (unlatching)."""
+        return (
+            self._open_value is not None
+            and self._attribute.target_value == self._open_value
+            and self._attribute.current_value != self._open_value
+        )
 
     @property
     def changed_by(self) -> str:
@@ -80,8 +130,13 @@ class HomeeLock(HomeeEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock specified lock. A code to lock the lock with may be specified."""
-        await self.async_set_homee_value(1)
+        await self.async_set_homee_value(LOCK_STATE_LOCKED)
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock specified lock. A code to unlock the lock with may be specified."""
-        await self.async_set_homee_value(0)
+        await self.async_set_homee_value(LOCK_STATE_UNLOCKED)
+
+    async def async_open(self, **kwargs: Any) -> None:
+        """Open (unlatch) the lock."""
+        assert self._open_value is not None
+        await self.async_set_homee_value(self._open_value)

--- a/homeassistant/components/homee/strings.json
+++ b/homeassistant/components/homee/strings.json
@@ -495,6 +495,9 @@
     },
     "invalid_preset_mode": {
       "message": "Invalid preset mode: {preset_mode}. Turning on is only supported with preset mode 'Manual'."
+    },
+    "open_not_supported": {
+      "message": "This lock does not support the open (unlatch) action."
     }
   }
 }

--- a/homeassistant/components/homee/strings.json
+++ b/homeassistant/components/homee/strings.json
@@ -495,9 +495,6 @@
     },
     "invalid_preset_mode": {
       "message": "Invalid preset mode: {preset_mode}. Turning on is only supported with preset mode 'Manual'."
-    },
-    "open_not_supported": {
-      "message": "This lock does not support the open (unlatch) action."
     }
   }
 }

--- a/tests/components/homee/fixtures/lock_with_open.json
+++ b/tests/components/homee/fixtures/lock_with_open.json
@@ -1,0 +1,52 @@
+{
+  "id": 1,
+  "name": "Test Lock",
+  "profile": 2007,
+  "image": "default",
+  "favorite": 0,
+  "order": 31,
+  "protocol": 1,
+  "routing": 0,
+  "state": 1,
+  "state_changed": 1711799526,
+  "added": 1645036891,
+  "history": 1,
+  "cube_type": 1,
+  "note": "",
+  "services": 3,
+  "phonetic_name": "",
+  "owner": 2,
+  "security": 0,
+  "attributes": [
+    {
+      "id": 1,
+      "node_id": 1,
+      "instance": 0,
+      "minimum": 0,
+      "maximum": 2,
+      "current_value": 0.0,
+      "target_value": 0.0,
+      "last_value": 1.0,
+      "unit": "",
+      "step_value": 1.0,
+      "editable": 1,
+      "type": 232,
+      "state": 1,
+      "last_changed": 1711897362,
+      "changed_by": 4,
+      "changed_by_id": 5,
+      "based_on": 1,
+      "data": "",
+      "name": "",
+      "options": {
+        "automations": ["toggle"],
+        "history": {
+          "day": 35,
+          "week": 5,
+          "month": 1,
+          "stepped": true
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/homee/fixtures/lock_with_unlatch.json
+++ b/tests/components/homee/fixtures/lock_with_unlatch.json
@@ -1,0 +1,52 @@
+{
+  "id": 1,
+  "name": "Test Lock",
+  "profile": 2007,
+  "image": "default",
+  "favorite": 0,
+  "order": 31,
+  "protocol": 1,
+  "routing": 0,
+  "state": 1,
+  "state_changed": 1711799526,
+  "added": 1645036891,
+  "history": 1,
+  "cube_type": 1,
+  "note": "",
+  "services": 3,
+  "phonetic_name": "",
+  "owner": 2,
+  "security": 0,
+  "attributes": [
+    {
+      "id": 1,
+      "node_id": 1,
+      "instance": 0,
+      "minimum": -1,
+      "maximum": 1,
+      "current_value": 1.0,
+      "target_value": 1.0,
+      "last_value": 1.0,
+      "unit": "n/a",
+      "step_value": 1.0,
+      "editable": 1,
+      "type": 232,
+      "state": 1,
+      "last_changed": 1711897362,
+      "changed_by": 1,
+      "changed_by_id": 0,
+      "based_on": 4,
+      "data": "",
+      "name": "",
+      "options": {
+        "automations": ["toggle"],
+        "history": {
+          "day": 35,
+          "week": 5,
+          "month": 1,
+          "stepped": true
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/homee/test_lock.py
+++ b/tests/components/homee/test_lock.py
@@ -92,6 +92,7 @@ async def test_lock_open_service(
         LOCK_DOMAIN,
         SERVICE_OPEN,
         {ATTR_ENTITY_ID: "lock.test_lock"},
+        blocking=True,
     )
     mock_homee.set_value.assert_called_once_with(1, 1, open_value)
 
@@ -156,9 +157,7 @@ async def test_lock_state_with_open(
     mock_homee.get_node_by_id.return_value = mock_homee.nodes[0]
     attribute = mock_homee.nodes[0].attributes[0]
     attribute.target_value = open_value if target_offset == "open" else target_offset
-    attribute.current_value = (
-        open_value if current_offset == "open" else current_offset
-    )
+    attribute.current_value = open_value if current_offset == "open" else current_offset
     await setup_integration(hass, mock_config_entry)
 
     assert hass.states.get("lock.test_lock").state == expected

--- a/tests/components/homee/test_lock.py
+++ b/tests/components/homee/test_lock.py
@@ -62,6 +62,7 @@ async def test_lock_services(
         LOCK_DOMAIN,
         service,
         {ATTR_ENTITY_ID: "lock.test_lock"},
+        blocking=True,
     )
     mock_homee.set_value.assert_called_once_with(1, 1, target_value)
 

--- a/tests/components/homee/test_lock.py
+++ b/tests/components/homee/test_lock.py
@@ -9,6 +9,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.lock import (
     DOMAIN as LOCK_DOMAIN,
     SERVICE_LOCK,
+    SERVICE_OPEN,
     SERVICE_UNLOCK,
     LockState,
 )
@@ -29,10 +30,13 @@ async def platforms() -> AsyncGenerator[None]:
 
 
 async def setup_lock(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_homee: MagicMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_homee: MagicMock,
+    fixture: str = "lock.json",
 ) -> None:
     """Setups the integration lock tests."""
-    mock_homee.nodes = [build_mock_node("lock.json")]
+    mock_homee.nodes = [build_mock_node(fixture)]
     mock_homee.get_node_by_id.return_value = mock_homee.nodes[0]
     await setup_integration(hass, mock_config_entry)
 
@@ -63,6 +67,36 @@ async def test_lock_services(
 
 
 @pytest.mark.parametrize(
+    ("fixture", "open_value"),
+    [
+        ("lock_with_open.json", 2.0),
+        ("lock_with_unlatch.json", -1.0),
+    ],
+)
+async def test_lock_open_service(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_homee: MagicMock,
+    fixture: str,
+    open_value: float,
+) -> None:
+    """Test the open service on locks that support momentary unlatch.
+
+    Different homee-compatible devices encode the unlatch command
+    differently — a positive extension (value 2) or a signed range
+    where -1 is unlatch (e.g. the Hörmann SmartKey).
+    """
+    await setup_lock(hass, mock_config_entry, mock_homee, fixture)
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_OPEN,
+        {ATTR_ENTITY_ID: "lock.test_lock"},
+    )
+    mock_homee.set_value.assert_called_once_with(1, 1, open_value)
+
+
+@pytest.mark.parametrize(
     ("target_value", "current_value", "expected"),
     [
         (1.0, 1.0, LockState.LOCKED),
@@ -85,6 +119,46 @@ async def test_lock_state(
     attribute = mock_homee.nodes[0].attributes[0]
     attribute.target_value = target_value
     attribute.current_value = current_value
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("lock.test_lock").state == expected
+
+
+@pytest.mark.parametrize(
+    ("fixture", "open_value"),
+    [
+        ("lock_with_open.json", 2.0),
+        ("lock_with_unlatch.json", -1.0),
+    ],
+)
+@pytest.mark.parametrize(
+    ("target_offset", "current_offset", "expected"),
+    [
+        ("open", "open", LockState.OPEN),
+        ("open", 0.0, LockState.OPENING),
+        ("open", 1.0, LockState.OPENING),
+        (1.0, "open", LockState.LOCKING),
+        (0.0, "open", LockState.UNLOCKING),
+    ],
+)
+async def test_lock_state_with_open(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_homee: MagicMock,
+    fixture: str,
+    open_value: float,
+    target_offset: float | str,
+    current_offset: float | str,
+    expected: LockState,
+) -> None:
+    """Test lock state transitions that involve the open value."""
+    mock_homee.nodes = [build_mock_node(fixture)]
+    mock_homee.get_node_by_id.return_value = mock_homee.nodes[0]
+    attribute = mock_homee.nodes[0].attributes[0]
+    attribute.target_value = open_value if target_offset == "open" else target_offset
+    attribute.current_value = (
+        open_value if current_offset == "open" else current_offset
+    )
     await setup_integration(hass, mock_config_entry)
 
     assert hass.states.get("lock.test_lock").state == expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The homee `LOCK_STATE` attribute (type `232`) accepts a third value on devices that support a momentary unlatch, such as the Hörmann SmartKey. The homee mobile app exposes all three functions (lock / unlock / open), but the Home Assistant integration previously only wired up `lock` and `unlock`, so users had no way to trigger the unlatch from HA.

**Encoding note:** different homee-compatible locks encode the unlatch command differently. Empirically:

- Hörmann SmartKey reports `min=-1, max=1` and accepts `-1` to momentarily unlatch (verified on real hardware — see below).
- Other devices extend the positive range and use value `2`.

The attribute's reported `min`/`max` tells us which encoding applies. This PR:

- Adds `_determine_lock_state_open(attribute)` which returns `2.0` when `maximum == 2`, `-1.0` when `minimum == -1`, or `None` when only two states are supported.
- Advertises `LockEntityFeature.OPEN` only when the device actually supports unlatch.
- Implements `async_open()` to send the matching value; raises `ServiceValidationError` (translation key `open_not_supported`) if the service is somehow invoked on a two-state lock.
- Adds `is_open` / `is_opening` properties.
- Rewrites `is_locking` / `is_unlocking` to compare `target_value` against the specific locked/unlocked values, so transitions stay correct when `current_value` is the third state (e.g. going from OPEN back to LOCKED would otherwise be misreported as UNLOCKING under the old `target > current` logic).

Two-state locks are unchanged — no feature flag set, no new service action.

### Verification on real hardware

Tested against a Hörmann SmartKey (profile 2007) via a running homee cube. Live WebSocket trace while pressing "Open" in the Hörmann homee app:

```
attr_id=53 type=232 (LOCK_STATE) min=-1 max=1
target=-1.0 current=1.0 changed_by=USER    # user pressed "Open"
target=-1.0 current=1.0                    # echo
target=0.0  current=0.0 changed_by=SYSTEM  # settled to unlocked
```

After applying this PR as a custom_components override:

- `supported_features` on the lock entity changed from `0` → `1` (OPEN).
- Calling `lock.open` via the HA service successfully unlatched the door.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: homee lock platform originally added in #140893
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

