### PR TITLE
Allow multiple sites for same TP-Link Omada controller

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from tplink_omada_client import OmadaSite
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import (
@@ -22,6 +24,8 @@ from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
 from .services import async_setup_services
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -99,3 +103,27 @@ def _remove_old_devices(
             device_registry.async_update_device(
                 registered_device.id, remove_config_entry_id=entry.entry_id
             )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:
+    """Migrate old config entry to a new format."""
+
+    if entry.version == 1:
+        # Migrate unique_id from controller_id to controller_id_site_id
+        # to allow multiple sites per controller to be set up independently.
+        _LOGGER.debug(
+            "Migrating tplink_omada config entry from version %s.%s",
+            entry.version,
+            entry.minor_version,
+        )
+
+        controller_id = entry.unique_id
+        site_id = entry.data[CONF_SITE]
+        new_unique_id = f"{controller_id}_{site_id}"
+        hass.config_entries.async_update_entry(
+            entry,
+            unique_id=new_unique_id,
+            version=2,
+        )
+
+    return True

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -115,12 +115,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> b
             entry.minor_version,
         )
 
-        controller_id = entry.unique_id
-        site_id = entry.data[CONF_SITE]
-        new_unique_id = f"{controller_id}_{site_id}"
         hass.config_entries.async_update_entry(
             entry,
-            unique_id=new_unique_id,
+            unique_id=f"{entry.unique_id}_{entry.data[CONF_SITE]}",
             version=2,
         )
 

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -1,5 +1,7 @@
 """The TP-Link Omada integration."""
 
+import logging
+
 from tplink_omada_client import OmadaSite
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import (
@@ -20,6 +22,8 @@ from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
 from .services import async_setup_services
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -97,3 +101,27 @@ def _remove_old_devices(
             device_registry.async_update_device(
                 registered_device.id, remove_config_entry_id=entry.entry_id
             )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:
+    """Migrate old config entry to a new format."""
+
+    if entry.version == 1:
+        # Migrate unique_id from controller_id to controller_id_site_id
+        # to allow multiple sites per controller to be set up independently.
+        _LOGGER.debug(
+            "Migrating tplink_omada config entry from version %s.%s",
+            entry.version,
+            entry.minor_version,
+        )
+
+        controller_id = entry.unique_id
+        site_id = entry.data[CONF_SITE]
+        new_unique_id = f"{controller_id}_{site_id}"
+        hass.config_entries.async_update_entry(
+            entry,
+            unique_id=new_unique_id,
+            version=2,
+        )
+
+    return True

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -94,13 +94,14 @@ async def _validate_input(hass: HomeAssistant, data: dict[str, Any]) -> HubInfo:
 class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for TP-Link Omada."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Create the config flow for a new integration."""
         self._omada_opts: dict[str, Any] = {}
         self._sites: list[OmadaSite] = []
         self._controller_name = ""
+        self._controller_id = ""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -117,12 +118,10 @@ class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
             )
 
-        await self.async_set_unique_id(info.controller_id)
-        self._abort_if_unique_id_configured()
-
         self._omada_opts.update(user_input)
         self._sites = info.sites
         self._controller_name = info.name
+        self._controller_id = info.controller_id
         if len(self._sites) > 1:
             return await self.async_step_site()
         return await self.async_step_site({CONF_SITE: self._sites[0].id})
@@ -149,6 +148,9 @@ class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
             return self.async_show_form(step_id="site", data_schema=schema)
+
+        await self.async_set_unique_id(f"{self._controller_id}_{user_input[CONF_SITE]}")
+        self._abort_if_unique_id_configured()
 
         self._omada_opts.update(user_input)
         site_name = next(
@@ -178,7 +180,9 @@ class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
 
             if info is not None:
                 # Check the controller ID is the same as before
-                await self.async_set_unique_id(info.controller_id)
+                reauth_entry = self._get_reauth_entry()
+                site_id = reauth_entry.data[CONF_SITE]
+                await self.async_set_unique_id(f"{info.controller_id}_{site_id}")
                 self._abort_if_unique_id_mismatch(reason="device_mismatch")
 
                 # Auth successful - update the config entry with the new credentials

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -93,13 +93,14 @@ async def _validate_input(hass: HomeAssistant, data: dict[str, Any]) -> HubInfo:
 class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for TP-Link Omada."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Create the config flow for a new integration."""
         self._omada_opts: dict[str, Any] = {}
         self._sites: list[OmadaSite] = []
         self._controller_name = ""
+        self._controller_id = ""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -116,12 +117,10 @@ class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
             )
 
-        await self.async_set_unique_id(info.controller_id)
-        self._abort_if_unique_id_configured()
-
         self._omada_opts.update(user_input)
         self._sites = info.sites
         self._controller_name = info.name
+        self._controller_id = info.controller_id
         if len(self._sites) > 1:
             return await self.async_step_site()
         return await self.async_step_site({CONF_SITE: self._sites[0].id})
@@ -148,6 +147,9 @@ class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
             return self.async_show_form(step_id="site", data_schema=schema)
+
+        await self.async_set_unique_id(f"{self._controller_id}_{user_input[CONF_SITE]}")
+        self._abort_if_unique_id_configured()
 
         self._omada_opts.update(user_input)
         site_name = next(
@@ -177,7 +179,9 @@ class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
 
             if info is not None:
                 # Check the controller ID is the same as before
-                await self.async_set_unique_id(info.controller_id)
+                reauth_entry = self._get_reauth_entry()
+                site_id = reauth_entry.data[CONF_SITE]
+                await self.async_set_unique_id(f"{info.controller_id}_{site_id}")
                 self._abort_if_unique_id_mismatch(reason="device_mismatch")
 
                 # Auth successful - update the config entry with the new credentials

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -180,8 +180,9 @@ class TpLinkOmadaConfigFlow(ConfigFlow, domain=DOMAIN):
             if info is not None:
                 # Check the controller ID is the same as before
                 reauth_entry = self._get_reauth_entry()
-                site_id = reauth_entry.data[CONF_SITE]
-                await self.async_set_unique_id(f"{info.controller_id}_{site_id}")
+                await self.async_set_unique_id(
+                    f"{info.controller_id}_{reauth_entry.data[CONF_SITE]}"
+                )
                 self._abort_if_unique_id_mismatch(reason="device_mismatch")
 
                 # Auth successful - update the config entry with the new credentials

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -45,7 +45,8 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_VERIFY_SSL: False,
             CONF_SITE: "Default",
         },
-        unique_id="12345",
+        unique_id="12345_Default",
+        version=2,
     )
 
 

--- a/tests/components/tplink_omada/snapshots/test_diagnostics.ambr
+++ b/tests/components/tplink_omada/snapshots/test_diagnostics.ambr
@@ -22,8 +22,8 @@
       'subentries': list([
       ]),
       'title': 'Test Omada Controller',
-      'unique_id': '12345',
-      'version': 1,
+      'unique_id': '12345_Default',
+      'version': 2,
     }),
     'runtime': dict({
       'clients': dict({

--- a/tests/components/tplink_omada/test_config_flow.py
+++ b/tests/components/tplink_omada/test_config_flow.py
@@ -56,7 +56,7 @@ async def test_form_single_site(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "OC200 (Display Name)"
     assert result["data"] == MOCK_ENTRY_DATA
-    assert result["result"].unique_id == "12345"
+    assert result["result"].unique_id == "12345_SiteId"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -102,6 +102,7 @@ async def test_form_multiple_sites(
         "username": "test-username",
         "password": "test-password",
     }
+    assert result["result"].unique_id == "12345_second"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -176,6 +177,108 @@ async def test_form_no_sites(hass: HomeAssistant, mock_omada_client: MagicMock) 
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_form_single_site_already_configured(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test that setting up the same controller and site twice is rejected."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_ENTRY_DATA,
+        unique_id="12345_SiteId",
+        version=2,
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        MOCK_USER_DATA,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_form_multiple_sites_second_site_allowed(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_setup_entry: MagicMock,
+) -> None:
+    """Test that a second site from the same controller can be set up."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_USER_DATA, "site": "first"},
+        unique_id="12345_first",
+        version=2,
+    )
+    existing_entry.add_to_hass(hass)
+
+    mock_omada_client.get_sites.return_value = [
+        OmadaSite("Site 1", "first"),
+        OmadaSite("Site 2", "second"),
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        MOCK_USER_DATA,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "site"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"site": "second"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == "12345_second"
+
+
+async def test_form_multiple_sites_duplicate_site_aborts(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test that selecting an already-configured site aborts the flow."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_USER_DATA, "site": "first"},
+        unique_id="12345_first",
+        version=2,
+    )
+    existing_entry.add_to_hass(hass)
+
+    mock_omada_client.get_sites.return_value = [
+        OmadaSite("Site 1", "first"),
+        OmadaSite("Site 2", "second"),
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        MOCK_USER_DATA,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "site"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"site": "first"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -70,7 +70,8 @@ async def test_missing_devices_removed_at_startup(
         title="Test Omada Controller",
         domain=DOMAIN,
         data=dict(MOCK_ENTRY_DATA),
-        unique_id="12345",
+        unique_id="12345_SiteId",
+        version=2,
     )
     mock_config_entry.add_to_hass(hass)
 
@@ -88,3 +89,25 @@ async def test_missing_devices_removed_at_startup(
     await hass.async_block_till_done()
 
     assert device_registry.async_get(device_entry.id) is None
+
+
+async def test_migrate_entry_v1_to_v2(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test migration of a version 1 config entry to version 2."""
+    entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data=dict(MOCK_ENTRY_DATA),
+        unique_id="12345",
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 2
+    assert entry.unique_id == "12345_SiteId"
+    assert entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #166233, by changing the unique ID for the config entry to be based on both the controller ID and the site ID. Both IDs are long strings of hex digits.
Added a migration function to upgrade existing unique IDs. The config entry already has the site ID baked into it, so no back-end calls are required to do the upgrade of the unique ID.
Added test coverage to verify upgrade path and unique ID checks during initial setup flow.

Documentation updates not needed, as this is already a documented, non-working feature.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166233 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
