### PR TITLE
Add instance version check to Mastodon

### DIFF
--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from awesomeversion import AwesomeVersion
 from mastodon.Mastodon import (
     Account,
     Instance,
@@ -19,12 +20,16 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 
-from .const import CONF_BASE_URL, DOMAIN, LOGGER
+from .const import CONF_BASE_URL, DOMAIN, LOGGER, MIN_REQUIRED_MASTODON_VERSION
 from .coordinator import MastodonConfigEntry, MastodonCoordinator, MastodonData
 from .services import async_setup_services
 from .utils import construct_mastodon_username, create_mastodon_client
@@ -56,6 +61,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: MastodonConfigEntry) -> 
         ) from error
     except MastodonError as ex:
         raise ConfigEntryNotReady("Failed to connect") from ex
+
+    version = AwesomeVersion(instance.version)
+    if version.valid and version < MIN_REQUIRED_MASTODON_VERSION:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="version_error",
+            translation_placeholders={
+                "mastodon_version": instance.version,
+                "min_version": MIN_REQUIRED_MASTODON_VERSION,
+            },
+        )
 
     assert entry.unique_id
 

--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -137,6 +137,7 @@ def setup_mastodon(
     try:
         instance = client.instance_v2()
     except MastodonNotFoundError:
+        # For instances prior to 4, can be removed in 2026.11
         instance = client.instance_v1()
 
     account = client.account_verify_credentials()

--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MastodonConfigEntry) -> 
             translation_key="version_error",
             translation_placeholders={
                 "mastodon_version": instance.version,
-                "min_version": MIN_REQUIRED_MASTODON_VERSION,
+                "min_version": str(MIN_REQUIRED_MASTODON_VERSION),
             },
         )
 

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from awesomeversion import AwesomeVersion
 from mastodon.Mastodon import (
     Account,
     Instance,
@@ -25,7 +26,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.util import slugify
 
-from .const import CONF_BASE_URL, DOMAIN, LOGGER
+from .const import CONF_BASE_URL, DOMAIN, LOGGER, MIN_REQUIRED_MASTODON_VERSION
 from .utils import construct_mastodon_username, create_mastodon_client
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
@@ -119,6 +120,10 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
         except Exception:  # noqa: BLE001
             LOGGER.exception("Unexpected error")
             return None, None, {"base": "unknown"}
+        else:
+            version = AwesomeVersion(instance.version)
+            if version.valid and version < MIN_REQUIRED_MASTODON_VERSION:
+                return instance, account, {"base": "mastodon_version"}
         return instance, account, {}
 
     def show_user_form(

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -110,6 +110,7 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 instance = client.instance_v2()
             except MastodonNotFoundError:
+                # For instances prior to 4, can be removed in 2026.11
                 instance = client.instance_v1()
             account = client.account_verify_credentials()
 

--- a/homeassistant/components/mastodon/const.py
+++ b/homeassistant/components/mastodon/const.py
@@ -3,9 +3,12 @@
 import logging
 from typing import Final
 
+from awesomeversion import AwesomeVersion
+
 LOGGER = logging.getLogger(__name__)
 
 DOMAIN: Final = "mastodon"
+MIN_REQUIRED_MASTODON_VERSION = AwesomeVersion("4.2.0")
 
 CONF_BASE_URL: Final = "base_url"
 DATA_HASS_CONFIG = "mastodon_hass_config"

--- a/homeassistant/components/mastodon/const.py
+++ b/homeassistant/components/mastodon/const.py
@@ -8,7 +8,7 @@ from awesomeversion import AwesomeVersion
 LOGGER = logging.getLogger(__name__)
 
 DOMAIN: Final = "mastodon"
-MIN_REQUIRED_MASTODON_VERSION = AwesomeVersion("4.2.0")
+MIN_REQUIRED_MASTODON_VERSION: Final = AwesomeVersion("4.2.0")
 
 CONF_BASE_URL: Final = "base_url"
 DATA_HASS_CONFIG = "mastodon_hass_config"

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -8,6 +8,7 @@
       "wrong_account": "You have to use the same account that was used to configure the integration."
     },
     "error": {
+      "mastodon_version": "Minimum required Mastodon instance version is 4.2.0",
       "network_error": "The Mastodon instance was not found.",
       "unauthorized_error": "The credentials are incorrect.",
       "unknown": "Unknown error occurred when connecting to the Mastodon instance."
@@ -130,6 +131,9 @@
     },
     "unable_to_upload_image": {
       "message": "Unable to upload image {media_path}."
+    },
+    "version_error": {
+      "message": "Your instance is running verison {mastodon_version} of Mastodon. Minimum required version is {min_version}."
     }
   },
   "selector": {

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -133,7 +133,7 @@
       "message": "Unable to upload image {media_path}."
     },
     "version_error": {
-      "message": "Your instance is running verison {mastodon_version} of Mastodon. Minimum required version is {min_version}."
+      "message": "Your instance is running version {mastodon_version} of Mastodon. Minimum required version is {min_version}."
     }
   },
   "selector": {

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -8,7 +8,7 @@
       "wrong_account": "You have to use the same account that was used to configure the integration."
     },
     "error": {
-      "mastodon_version": "Minimum required Mastodon instance version is 4.2.0",
+      "mastodon_version": "Mastodon instance version 4.2.0 or later is required.",
       "network_error": "The Mastodon instance was not found.",
       "unauthorized_error": "The credentials are incorrect.",
       "unknown": "Unknown error occurred when connecting to the Mastodon instance."
@@ -133,7 +133,7 @@
       "message": "Unable to upload image {media_path}."
     },
     "version_error": {
-      "message": "Your instance is running version {mastodon_version} of Mastodon. Minimum required version is {min_version}."
+      "message": "Your instance is running version {mastodon_version} of Mastodon. Mastodon instance version {min_version} or later is required."
     }
   },
   "selector": {

--- a/tests/components/mastodon/test_config_flow.py
+++ b/tests/components/mastodon/test_config_flow.py
@@ -176,6 +176,54 @@ async def test_flow_errors(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(
+    ("version"),
+    [("v1.0.0-RC2"), ("v0.1.0"), ("v1.9.0"), ("4.1.0"), ("4.1.0-nightly.2026-04-17")],
+)
+async def test_flow_version_error(
+    hass: HomeAssistant,
+    mock_mastodon_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    version: str,
+) -> None:
+    """Test flow version error."""
+    mock_mastodon_client.instance_v1.return_value.version = version
+    mock_mastodon_client.instance_v2.return_value.version = version
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_BASE_URL: "https://mastodon.social",
+            CONF_CLIENT_ID: "client_id",
+            CONF_CLIENT_SECRET: "client_secret",
+            CONF_ACCESS_TOKEN: "access_token",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "mastodon_version"}
+
+    mock_mastodon_client.instance_v1.return_value.version = "4.4.0-nightly.2025-02-07"
+    mock_mastodon_client.instance_v2.return_value.version = "4.4.0-nightly.2025-02-07"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_BASE_URL: "https://mastodon.social",
+            CONF_CLIENT_ID: "client_id",
+            CONF_CLIENT_SECRET: "client_secret",
+            CONF_ACCESS_TOKEN: "access_token",
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
 async def test_duplicate(
     hass: HomeAssistant,
     mock_mastodon_client: AsyncMock,
@@ -294,6 +342,48 @@ async def test_reauth_flow_exceptions(
         result["flow_id"],
         {CONF_ACCESS_TOKEN: "token"},
     )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+
+@pytest.mark.parametrize(
+    ("version"),
+    [
+        ("v1.0.0-RC2"),
+        ("v0.1.0"),
+        ("v1.9.0"),
+        ("4.1.0"),
+        ("4.1.0-nightly.2026-04-17"),
+    ],
+)
+async def test_reauth_version_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_mastodon_client: AsyncMock,
+    version: str,
+) -> None:
+    """Test reauth version error."""
+    mock_mastodon_client.instance_v1.return_value.version = version
+    mock_mastodon_client.instance_v2.return_value.version = version
+
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ACCESS_TOKEN: "token"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "mastodon_version"}
+
+    mock_mastodon_client.instance_v1.return_value.version = "4.4.0-nightly.2025-02-07"
+    mock_mastodon_client.instance_v2.return_value.version = "4.4.0-nightly.2025-02-07"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ACCESS_TOKEN: "token"},
+    )
+
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -85,6 +85,27 @@ async def test_setup_integration_fallback_to_instance_v1(
     mock_mastodon_client.instance_v1.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("version"),
+    [("v1.0.0-RC2"), ("v0.1.0"), ("v1.9.0"), ("4.1.0"), ("4.1.0-nightly.2026-04-17")],
+)
+async def test_setup_failed_too_old(
+    hass: HomeAssistant,
+    mock_mastodon_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    version: str,
+) -> None:
+    """Test setup of Mastodon entry with too old version of Mastodon."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_mastodon_client.instance_v1.return_value.version = version
+    mock_mastodon_client.instance_v2.return_value.version = version
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
 async def test_migrate(
     hass: HomeAssistant,
     mock_mastodon_client: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Mastodon version 4.1 has security issues and instances running this version are being defederated by other instances, we are unable to test against this or earlier version.
The new minimum supported Mastodon version is 4.2 (current latest is 4.5)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding version checking will allow us to gradually remove support for older versions and allow use of new features introduced in the API.

The instance_v1 that we fallback to is for instances prior to 4, once this version check has gone in we can remove that old fallback in 6 months.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
