### PR TITLE
Improve nobo_hub config entry setup

### DIFF
--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -7,9 +7,10 @@ from pynobo import nobo
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_AUTO_DISCOVERED, CONF_SERIAL
+from .const import CONF_AUTO_DISCOVERED, CONF_SERIAL, DOMAIN
 
 PLATFORMS = [Platform.CLIMATE, Platform.SELECT, Platform.SENSOR]
 
@@ -20,16 +21,51 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
     """Set up Nobø Ecohub from a config entry."""
 
     serial = entry.data[CONF_SERIAL]
-    discover = entry.data[CONF_AUTO_DISCOVERED]
-    ip_address = None if discover else entry.data[CONF_IP_ADDRESS]
-    hub = nobo(
-        serial=serial,
-        ip=ip_address,
-        discover=discover,
-        synchronous=False,
-        timezone=dt_util.get_default_time_zone(),
-    )
-    await hub.connect()
+    stored_ip = entry.data[CONF_IP_ADDRESS]
+    auto_discovered = entry.data[CONF_AUTO_DISCOVERED]
+
+    async def _connect(ip: str) -> nobo:
+        hub = nobo(
+            serial=serial,
+            ip=ip,
+            discover=False,
+            synchronous=False,
+            timezone=dt_util.get_default_time_zone(),
+        )
+        await hub.connect()
+        return hub
+
+    try:
+        hub = await _connect(stored_ip)
+    except Exception as err:
+        if not auto_discovered:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect_manual",
+                translation_placeholders={"serial": serial, "ip": stored_ip},
+            ) from err
+        # Stored IP may be stale for an auto-discovered entry - try UDP
+        # rediscovery to pick up a new DHCP lease.
+        discovered = await nobo.async_discover_hubs(serial=serial)
+        if not discovered:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="hub_not_found",
+                translation_placeholders={"serial": serial},
+            ) from err
+        new_ip, _ = next(iter(discovered))
+        try:
+            hub = await _connect(new_ip)
+        except Exception as err2:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect_rediscovered",
+                translation_placeholders={"ip": new_ip},
+            ) from err2
+        if new_ip != stored_ip:
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, CONF_IP_ADDRESS: new_ip}
+            )
 
     async def _async_close(event):
         """Close the Nobø Ecohub socket connection when HA stops."""

--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -56,12 +56,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
         new_ip, _ = next(iter(discovered))
         try:
             hub = await _connect(new_ip)
-        except OSError as err2:
+        except OSError as rediscover_err:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect_rediscovered",
                 translation_placeholders={"ip": new_ip},
-            ) from err2
+            ) from rediscover_err
         if new_ip != stored_ip:
             hass.config_entries.async_update_entry(
                 entry, data={**entry.data, CONF_IP_ADDRESS: new_ip}

--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
 
     try:
         hub = await _connect(stored_ip)
-    except Exception as err:
+    except OSError as err:
         if not auto_discovered:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
         new_ip, _ = next(iter(discovered))
         try:
             hub = await _connect(new_ip)
-        except Exception as err2:
+        except OSError as err2:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect_rediscovered",

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -47,6 +47,17 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect_manual": {
+      "message": "Unable to connect to Nobø Ecohub with serial {serial} at {ip}. If the hub has moved to a new IP address, remove and re-add the integration."
+    },
+    "cannot_connect_rediscovered": {
+      "message": "Unable to connect to Nobø Ecohub at rediscovered IP {ip}; setup will retry."
+    },
+    "hub_not_found": {
+      "message": "Nobø Ecohub with serial {serial} not found on the network. The hub may be offline or on a different subnet; setup will retry."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -52,10 +52,10 @@
       "message": "Unable to connect to Nobø Ecohub with serial {serial} at {ip}. If the hub has moved to a new IP address, remove and re-add the integration."
     },
     "cannot_connect_rediscovered": {
-      "message": "Unable to connect to Nobø Ecohub at rediscovered IP {ip}; setup will retry."
+      "message": "Unable to connect to Nobø Ecohub at rediscovered IP {ip}; will retry."
     },
     "hub_not_found": {
-      "message": "Nobø Ecohub with serial {serial} not found on the network. The hub may be offline or on a different subnet; setup will retry."
+      "message": "Nobø Ecohub with serial {serial} not found on the network. The hub may be offline or on a different subnet; will retry."
     }
   },
   "options": {

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -1,0 +1,161 @@
+"""Tests for the Nobø Ecohub integration setup."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.nobo_hub import async_setup_entry
+from homeassistant.components.nobo_hub.const import (
+    CONF_AUTO_DISCOVERED,
+    CONF_SERIAL,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from tests.common import MockConfigEntry
+
+SERIAL = "102000013098"
+STORED_IP = "192.168.1.122"
+
+
+def _make_entry(
+    hass: HomeAssistant,
+    *,
+    auto_discovered: bool,
+    ip_address: str = STORED_IP,
+) -> MockConfigEntry:
+    """Create a mock config entry for Nobø Ecohub."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My Eco Hub",
+        unique_id=SERIAL,
+        data={
+            CONF_SERIAL: SERIAL,
+            CONF_IP_ADDRESS: ip_address,
+            CONF_AUTO_DISCOVERED: auto_discovered,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _make_hub_mock(connect_exc: BaseException | None = None) -> MagicMock:
+    """Create a mock pynobo.nobo instance."""
+    hub = MagicMock()
+    hub.connect = AsyncMock(side_effect=connect_exc)
+    hub.start = AsyncMock()
+    hub.stop = AsyncMock()
+    hub.register_callback = MagicMock()
+    hub.deregister_callback = MagicMock()
+    hub.hub_serial = SERIAL
+    hub.hub_info = {
+        "name": "My Eco Hub",
+        "serial": SERIAL,
+        "software_version": "115",
+        "hardware_version": "hw",
+    }
+    hub.zones = {}
+    hub.components = {}
+    hub.overrides = {}
+    hub.week_profiles = {}
+    return hub
+
+
+async def test_setup_manual_entry_uses_stored_ip(hass: HomeAssistant) -> None:
+    """Manual entry connects using the stored IP without rediscovery."""
+    entry = _make_entry(hass, auto_discovered=False)
+    hub = _make_hub_mock()
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.return_value = hub
+        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert mock_cls.call_args.kwargs["ip"] == STORED_IP
+    assert mock_cls.call_args.kwargs["discover"] is False
+    mock_cls.async_discover_hubs.assert_not_called()
+
+
+async def test_setup_autodiscovered_entry_uses_stored_ip(hass: HomeAssistant) -> None:
+    """Auto-discovered entry with a working stored IP does not rediscover."""
+    entry = _make_entry(hass, auto_discovered=True)
+    hub = _make_hub_mock()
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.return_value = hub
+        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    mock_cls.async_discover_hubs.assert_not_called()
+
+
+async def test_setup_manual_entry_connection_fails(hass: HomeAssistant) -> None:
+    """Manual entry raises ConfigEntryNotReady when the stored IP is unreachable."""
+    entry = _make_entry(hass, auto_discovered=False)
+    hub = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.return_value = hub
+        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        with pytest.raises(ConfigEntryNotReady) as exc_info:
+            await async_setup_entry(hass, entry)
+
+    assert exc_info.value.translation_key == "cannot_connect_manual"
+    assert exc_info.value.translation_placeholders == {
+        "serial": SERIAL,
+        "ip": STORED_IP,
+    }
+    mock_cls.async_discover_hubs.assert_not_called()
+
+
+async def test_setup_autodiscovered_rediscovery_updates_ip(hass: HomeAssistant) -> None:
+    """Auto-discovered entry recovers via rediscovery and persists the new IP."""
+    entry = _make_entry(hass, auto_discovered=True)
+    new_ip = "192.168.1.55"
+    hub_fail = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    hub_ok = _make_hub_mock()
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.side_effect = [hub_fail, hub_ok]
+        mock_cls.async_discover_hubs = AsyncMock(return_value={(new_ip, SERIAL)})
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.data[CONF_IP_ADDRESS] == new_ip
+    assert mock_cls.call_count == 2
+    assert mock_cls.call_args_list[0].kwargs["ip"] == STORED_IP
+    assert mock_cls.call_args_list[1].kwargs["ip"] == new_ip
+
+
+async def test_setup_autodiscovered_rediscovery_empty(hass: HomeAssistant) -> None:
+    """Auto-discovered entry raises hub_not_found when rediscovery finds nothing."""
+    entry = _make_entry(hass, auto_discovered=True)
+    hub_fail = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.return_value = hub_fail
+        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        with pytest.raises(ConfigEntryNotReady) as exc_info:
+            await async_setup_entry(hass, entry)
+
+    assert exc_info.value.translation_key == "hub_not_found"
+    assert exc_info.value.translation_placeholders == {"serial": SERIAL}
+
+
+async def test_setup_autodiscovered_rediscovered_ip_fails(hass: HomeAssistant) -> None:
+    """Auto-discovered entry raises cannot_connect_rediscovered when the new IP also fails."""
+    entry = _make_entry(hass, auto_discovered=True)
+    new_ip = "192.168.1.55"
+    hub_fail_first = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    hub_fail_second = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.side_effect = [hub_fail_first, hub_fail_second]
+        mock_cls.async_discover_hubs = AsyncMock(return_value={(new_ip, SERIAL)})
+        with pytest.raises(ConfigEntryNotReady) as exc_info:
+            await async_setup_entry(hass, entry)
+
+    assert exc_info.value.translation_key == "cannot_connect_rediscovered"
+    assert exc_info.value.translation_placeholders == {"ip": new_ip}

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -19,6 +19,7 @@ from tests.common import MockConfigEntry
 
 SERIAL = "102000013098"
 STORED_IP = "192.168.1.122"
+NEW_IP = "192.168.1.55"
 
 
 def _make_entry(
@@ -94,10 +95,17 @@ async def test_setup_autodiscovered_entry_uses_stored_ip(hass: HomeAssistant) ->
     mock_cls.async_discover_hubs.assert_not_called()
 
 
-async def test_setup_manual_entry_connection_fails(hass: HomeAssistant) -> None:
-    """Manual entry raises ConfigEntryNotReady when the stored IP is unreachable."""
+@pytest.mark.parametrize(
+    "connect_exc",
+    [OSError("Unreachable"), TimeoutError("Handshake timed out")],
+)
+async def test_setup_manual_entry_connection_fails(
+    hass: HomeAssistant,
+    connect_exc: BaseException,
+) -> None:
+    """Manual entry raises ConfigEntryNotReady on socket errors or timeouts."""
     entry = _make_entry(hass, auto_discovered=False)
-    hub = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    hub = _make_hub_mock(connect_exc=connect_exc)
     with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
         mock_cls.return_value = hub
         mock_cls.async_discover_hubs = AsyncMock(return_value=set())
@@ -112,63 +120,55 @@ async def test_setup_manual_entry_connection_fails(hass: HomeAssistant) -> None:
     mock_cls.async_discover_hubs.assert_not_called()
 
 
-async def test_setup_manual_entry_connection_times_out(hass: HomeAssistant) -> None:
-    """Manual entry raises ConfigEntryNotReady when connect() times out."""
-    entry = _make_entry(hass, auto_discovered=False)
-    hub = _make_hub_mock(connect_exc=TimeoutError("Handshake timed out"))
-    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
-        mock_cls.return_value = hub
-        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
-        with pytest.raises(ConfigEntryNotReady) as exc_info:
-            await async_setup_entry(hass, entry)
-
-    assert exc_info.value.translation_key == "cannot_connect_manual"
-
-
 async def test_setup_autodiscovered_rediscovery_updates_ip(hass: HomeAssistant) -> None:
     """Auto-discovered entry recovers via rediscovery and persists the new IP."""
     entry = _make_entry(hass, auto_discovered=True)
-    new_ip = "192.168.1.55"
     hub_fail = _make_hub_mock(connect_exc=OSError("Unreachable"))
     hub_ok = _make_hub_mock()
     with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
         mock_cls.side_effect = [hub_fail, hub_ok]
-        mock_cls.async_discover_hubs = AsyncMock(return_value={(new_ip, SERIAL)})
+        mock_cls.async_discover_hubs = AsyncMock(return_value={(NEW_IP, SERIAL)})
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.data[CONF_IP_ADDRESS] == new_ip
+    assert entry.data[CONF_IP_ADDRESS] == NEW_IP
     assert mock_cls.call_count == 2
     assert mock_cls.call_args_list[0].kwargs["ip"] == STORED_IP
-    assert mock_cls.call_args_list[1].kwargs["ip"] == new_ip
+    assert mock_cls.call_args_list[1].kwargs["ip"] == NEW_IP
 
 
-async def test_setup_autodiscovered_rediscovery_empty(hass: HomeAssistant) -> None:
-    """Auto-discovered entry raises hub_not_found when rediscovery finds nothing."""
+@pytest.mark.parametrize(
+    (
+        "discovered_hubs",
+        "rediscovered_connect_fails",
+        "expected_key",
+        "expected_placeholders",
+    ),
+    [
+        (set(), False, "hub_not_found", {"serial": SERIAL}),
+        ({(NEW_IP, SERIAL)}, True, "cannot_connect_rediscovered", {"ip": NEW_IP}),
+    ],
+    ids=["rediscovery_empty", "rediscovered_ip_fails"],
+)
+async def test_setup_autodiscovered_rediscovery_failure(
+    hass: HomeAssistant,
+    discovered_hubs: set[tuple[str, str]],
+    rediscovered_connect_fails: bool,
+    expected_key: str,
+    expected_placeholders: dict[str, str],
+) -> None:
+    """Auto-discovered entry raises the right error when rediscovery can't recover."""
     entry = _make_entry(hass, auto_discovered=True)
-    hub_fail = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    hub_first = _make_hub_mock(connect_exc=OSError("Unreachable"))
+    hub_second = _make_hub_mock(
+        connect_exc=OSError("Unreachable") if rediscovered_connect_fails else None
+    )
     with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
-        mock_cls.return_value = hub_fail
-        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        mock_cls.side_effect = [hub_first, hub_second]
+        mock_cls.async_discover_hubs = AsyncMock(return_value=discovered_hubs)
         with pytest.raises(ConfigEntryNotReady) as exc_info:
             await async_setup_entry(hass, entry)
 
-    assert exc_info.value.translation_key == "hub_not_found"
-    assert exc_info.value.translation_placeholders == {"serial": SERIAL}
-
-
-async def test_setup_autodiscovered_rediscovered_ip_fails(hass: HomeAssistant) -> None:
-    """Auto-discovered entry raises cannot_connect_rediscovered when the new IP also fails."""
-    entry = _make_entry(hass, auto_discovered=True)
-    new_ip = "192.168.1.55"
-    hub_fail_first = _make_hub_mock(connect_exc=OSError("Unreachable"))
-    hub_fail_second = _make_hub_mock(connect_exc=OSError("Unreachable"))
-    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
-        mock_cls.side_effect = [hub_fail_first, hub_fail_second]
-        mock_cls.async_discover_hubs = AsyncMock(return_value={(new_ip, SERIAL)})
-        with pytest.raises(ConfigEntryNotReady) as exc_info:
-            await async_setup_entry(hass, entry)
-
-    assert exc_info.value.translation_key == "cannot_connect_rediscovered"
-    assert exc_info.value.translation_placeholders == {"ip": new_ip}
+    assert exc_info.value.translation_key == expected_key
+    assert exc_info.value.translation_placeholders == expected_placeholders

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -112,6 +112,19 @@ async def test_setup_manual_entry_connection_fails(hass: HomeAssistant) -> None:
     mock_cls.async_discover_hubs.assert_not_called()
 
 
+async def test_setup_manual_entry_connection_times_out(hass: HomeAssistant) -> None:
+    """Manual entry raises ConfigEntryNotReady when connect() times out."""
+    entry = _make_entry(hass, auto_discovered=False)
+    hub = _make_hub_mock(connect_exc=TimeoutError("Handshake timed out"))
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.return_value = hub
+        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        with pytest.raises(ConfigEntryNotReady) as exc_info:
+            await async_setup_entry(hass, entry)
+
+    assert exc_info.value.translation_key == "cannot_connect_manual"
+
+
 async def test_setup_autodiscovered_rediscovery_updates_ip(hass: HomeAssistant) -> None:
     """Auto-discovered entry recovers via rediscovery and persists the new IP."""
     entry = _make_entry(hass, auto_discovered=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Context: This is the first of 3 PRs to bring the `nobo_hub` to the bronze level on the quality scale.

Harden `async_setup_entry` for the Nobø Ecohub integration. The previous setup path always handed auto-discovered entries back to `pynobo.nobo`'s UDP discovery, even when the config flow had already validated the hub at a specific IP. Since the hub only broadcasts every ~15 seconds, setup could land inside the broadcast gap and fail with a bare `Exception("Failed to discover any Nobø Ecohubs")` — reproducible on nearly every "remove and re-add" cycle.

This PR:
- Uses the stored IP address to connect directly, skipping the UDP discovery round-trip on every setup and making startup faster and more reliable.
- For entries added via auto-discovery, falls back to `nobo.async_discover_hubs()` if the stored IP is unreachable, and persists the rediscovered IP back to the config entry. This keeps the self-healing behaviour for users who rely on DHCP instead of a static reservation.
- Wraps both connection attempts in `ConfigEntryNotReady` with translated error messages (`cannot_connect_manual`, `hub_not_found`, `cannot_connect_rediscovered`) so failures show up cleanly in the UI and HA's retry logic kicks in instead of leaving the entry in permanent error state.

Tested against a real Nobø Ecohub: stable-IP startup, stale-IP rediscovery + persistence, and wrong-IP manual entry all behave as expected. Unit tests cover both success paths and all three failure paths.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
