### PR TITLE
Revert "Bump habluetooth to 6.0.0"

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -21,6 +21,6 @@
     "bluetooth-auto-recovery==1.5.3",
     "bluetooth-data-tools==1.28.4",
     "dbus-fast==4.0.4",
-    "habluetooth==6.0.0"
+    "habluetooth==5.11.1"
   ]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -35,7 +35,7 @@ file-read-backwards==2.0.0
 fnv-hash-fast==2.0.2
 go2rtc-client==0.4.0
 ha-ffmpeg==3.2.2
-habluetooth==6.0.0
+habluetooth==5.11.1
 hass-nabucasa==2.2.0
 hassil==3.5.0
 home-assistant-bluetooth==2.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1188,7 +1188,7 @@ ha-silabs-firmware-client==0.3.0
 habiticalib==0.4.7
 
 # homeassistant.components.bluetooth
-habluetooth==6.0.0
+habluetooth==5.11.1
 
 # homeassistant.components.hanna
 hanna-cloud==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1061,7 +1061,7 @@ ha-silabs-firmware-client==0.3.0
 habiticalib==0.4.7
 
 # homeassistant.components.bluetooth
-habluetooth==6.0.0
+habluetooth==5.11.1
 
 # homeassistant.components.hanna
 hanna-cloud==0.0.7

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -121,6 +121,9 @@ async def test_setup_and_stop_passive(
         async def stop(self, *args, **kwargs):
             """Stop the scanner."""
 
+        def register_detection_callback(self, *args, **kwargs):
+            """Register a callback."""
+
     with patch(
         "habluetooth.scanner.OriginalBleakScanner",
         MockPassiveBleakScanner,
@@ -167,6 +170,9 @@ async def test_setup_and_stop_old_bluez(
 
         async def stop(self, *args, **kwargs):
             """Stop the scanner."""
+
+        def register_detection_callback(self, *args, **kwargs):
+            """Register a callback."""
 
     with patch(
         "habluetooth.scanner.OriginalBleakScanner",
@@ -2565,9 +2571,9 @@ async def test_wrapped_instance_with_filter(
 
         assert _get_manager() is not None
         scanner = HaBleakScannerWrapper(
-            detection_callback=_device_detected,
-            filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]},
+            filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]}
         )
+        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
         await hass.async_block_till_done()
@@ -2577,18 +2583,25 @@ async def test_wrapped_instance_with_filter(
         assert discovered == [switchbot_device]
         assert len(detected) == 1
 
+        scanner.register_detection_callback(_device_detected)
+        # We should get a reply from the history when we register again
+        assert len(detected) == 2
+        scanner.register_detection_callback(_device_detected)
+        # We should get a reply from the history when we register again
+        assert len(detected) == 3
+
         with patch_discovered_devices([]):
             discovered = await scanner.discover(timeout=0)
             assert len(discovered) == 0
             assert discovered == []
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
-        assert len(detected) == 2
+        assert len(detected) == 4
 
         # The filter we created in the wrapped scanner with should be respected
         # and we should not get another callback
         inject_advertisement(hass, empty_device, empty_adv)
-        assert len(detected) == 2
+        assert len(detected) == 4
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -2630,10 +2643,10 @@ async def test_wrapped_instance_with_service_uuids(
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
-        _scanner = HaBleakScannerWrapper(
-            detection_callback=_device_detected,
-            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        scanner = HaBleakScannerWrapper(
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
+        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
@@ -2690,10 +2703,10 @@ async def test_wrapped_instance_with_service_uuids_with_coro_callback(
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
-        _scanner = HaBleakScannerWrapper(
-            detection_callback=_device_detected,
-            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        scanner = HaBleakScannerWrapper(
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
+        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
@@ -2744,10 +2757,10 @@ async def test_wrapped_instance_with_broken_callbacks(
         )
 
         assert _get_manager() is not None
-        _scanner = HaBleakScannerWrapper(
-            detection_callback=_device_detected,
-            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        scanner = HaBleakScannerWrapper(
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
+        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         await hass.async_block_till_done()
@@ -2794,10 +2807,11 @@ async def test_wrapped_instance_changes_uuids(
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
-        _scanner = HaBleakScannerWrapper(
-            detection_callback=_device_detected,
-            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        scanner = HaBleakScannerWrapper()
+        scanner.set_scanning_filter(
+            service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
+        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)
@@ -2849,10 +2863,11 @@ async def test_wrapped_instance_changes_filters(
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
-        _scanner = HaBleakScannerWrapper(
-            detection_callback=_device_detected,
-            filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]},
+        scanner = HaBleakScannerWrapper()
+        scanner.set_scanning_filter(
+            filters={"UUIDs": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]}
         )
+        scanner.register_detection_callback(_device_detected)
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
         inject_advertisement(hass, switchbot_device, switchbot_adv_2)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

TLDR: https://github.com/Bluetooth-Devices/habluetooth/pull/396 caused too much breakage and its likely I can't get it all fixed in time before beta.  Note that `bleak` already removed `register_detection_callback` but we still have libs relying on it since it still worked with `habluetooth` until the bump even though it no longer worked with bare `bleak`.

Reverts #167340; out of time to resolve the remaining issue before beta as I'm going to be traveling for the next week, already have more on my plate than I can finish in time, see https://github.com/Jc2k/aiohomekit/pull/549#issuecomment-4276282120 for context.

If I find the time to get `aiohomekit` working with 6.x, and finish testing the other packages that were still using the callback bleak removed, I'll bump it again before beta, however with my current schedule, I don't want to leave it in a broken state in case I can't get to it in time which seems likely at this point.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
