### PR TITLE
Handle rate limit error separately in Duco fan platform

### DIFF
--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from duco.exceptions import DucoError
+import logging
+
+from duco.exceptions import DucoError, DucoRateLimitError
 from duco.models import Node, NodeType, VentilationState
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
@@ -14,6 +16,8 @@ from homeassistant.util.percentage import percentage_to_ordered_list_item
 from .const import DOMAIN
 from .coordinator import DucoConfigEntry, DucoCoordinator
 from .entity import DucoEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
@@ -118,6 +122,12 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
             await self.coordinator.client.async_set_ventilation_state(
                 self._node_id, state
             )
+        except DucoRateLimitError as err:
+            _LOGGER.warning("Duco write rate limit exceeded for node %s", self._node_id)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="rate_limit_exceeded",
+            ) from err
         except DucoError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -76,6 +76,9 @@
     },
     "failed_to_set_state": {
       "message": "Failed to set ventilation state: {error}"
+    },
+    "rate_limit_exceeded": {
+      "message": "The Duco device has reached its daily write limit. Try again tomorrow."
     }
   }
 }

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -88,37 +88,23 @@ async def test_fan_set_state(
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    "exception",
-    [DucoConnectionError("Connection refused"), DucoError("Unexpected error")],
+    ("exception", "match"),
+    [
+        (DucoConnectionError("Connection refused"), "Failed to set ventilation state"),
+        (DucoError("Unexpected error"), "Failed to set ventilation state"),
+        (DucoRateLimitError(), "daily write limit"),
+    ],
 )
 async def test_fan_set_state_error(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,
     exception: Exception,
+    match: str,
 ) -> None:
     """Test that a HomeAssistantError is raised on API failure."""
     mock_duco_client.async_set_ventilation_state = AsyncMock(side_effect=exception)
 
-    with pytest.raises(HomeAssistantError, match="Failed to set ventilation state"):
-        await hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_SET_PERCENTAGE,
-            {ATTR_ENTITY_ID: _FAN_ENTITY, ATTR_PERCENTAGE: 100},
-            blocking=True,
-        )
-
-
-@pytest.mark.usefixtures("init_integration")
-async def test_fan_set_state_rate_limit_error(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-) -> None:
-    """Test that a HomeAssistantError is raised when the rate limit is exceeded."""
-    mock_duco_client.async_set_ventilation_state = AsyncMock(
-        side_effect=DucoRateLimitError()
-    )
-
-    with pytest.raises(HomeAssistantError, match="daily write limit"):
+    with pytest.raises(HomeAssistantError, match=match):
         await hass.services.async_call(
             FAN_DOMAIN,
             SERVICE_SET_PERCENTAGE,

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, patch
 
-from duco.exceptions import DucoConnectionError, DucoError
+from duco.exceptions import DucoConnectionError, DucoError, DucoRateLimitError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -105,6 +106,50 @@ async def test_fan_set_state_error(
             {ATTR_ENTITY_ID: _FAN_ENTITY, ATTR_PERCENTAGE: 100},
             blocking=True,
         )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_set_state_rate_limit_error(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test that a HomeAssistantError is raised when the rate limit is exceeded."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock(
+        side_effect=DucoRateLimitError()
+    )
+
+    with pytest.raises(HomeAssistantError, match="daily write limit"):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: _FAN_ENTITY, ATTR_PERCENTAGE: 100},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_set_state_rate_limit_logs_warning(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a warning is logged when the write rate limit is exceeded."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock(
+        side_effect=DucoRateLimitError()
+    )
+
+    with (
+        pytest.raises(HomeAssistantError),
+        caplog.at_level(logging.WARNING, logger="homeassistant.components.duco.fan"),
+    ):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: _FAN_ENTITY, ATTR_PERCENTAGE: 100},
+            blocking=True,
+        )
+
+    assert "write rate limit exceeded" in caplog.text
 
 
 @pytest.mark.usefixtures("init_integration")


### PR DESCRIPTION
> [!NOTE]
> This implementation was discussed in the [Home Assistant Discord](https://discord.com/channels/330944238910963714/1494075716453662824), where it was confirmed that `DucoRateLimitError` should be handled explicitly rather than falling through to the generic error path.

## Proposed change

Currently a `DucoRateLimitError` (HTTP 429) is treated as a generic `DucoError` in the fan platform, causing entities to go unavailable until the next poll. This change handles the rate limit case explicitly.

Changes:
- Catch `DucoRateLimitError` before the generic `DucoError` in `_async_set_state`
- Log a warning when the daily write limit is exceeded
- Raise `HomeAssistantError` with a translated `rate_limit_exceeded` message
- Add `rate_limit_exceeded` key to `strings.json` (was already present in `en.json` but missing from `strings.json`)
- Add tests for both the error and warning log behavior

`HomeAssistantError` is used (not `ServiceValidationError`) because a rate limit is a device limitation, not a user input error — the same action would succeed the next day.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect_pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest