### PR TITLE
unifi: implement action-exceptions quality scale rule

### DIFF
--- a/homeassistant/components/unifi/button.py
+++ b/homeassistant/components/unifi/button.py
@@ -31,9 +31,11 @@ from homeassistant.components.button import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import UnifiConfigEntry
+from .const import DOMAIN
 from .entity import (
     UnifiEntity,
     UnifiEntityDescription,
@@ -151,7 +153,13 @@ class UnifiButtonEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self.entity_description.control_fn(self.api, self._obj_id)
+        try:
+            await self.entity_description.control_fn(self.api, self._obj_id)
+        except aiounifi.AiounifiException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="action_request_failed",
+            ) from err
 
     @callback
     def async_update_state(self, event: ItemEvent, obj_id: str) -> None:

--- a/homeassistant/components/unifi/light.py
+++ b/homeassistant/components/unifi/light.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from aiounifi import AiounifiException
 from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.devices import Devices
 from aiounifi.models.api import ApiItem
@@ -21,10 +22,12 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.color import rgb_hex_to_rgb_list
 
 from . import UnifiConfigEntry
+from .const import DOMAIN
 from .entity import (
     UnifiEntity,
     UnifiEntityDescription,
@@ -171,13 +174,27 @@ class UnifiLightEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on light."""
-        await self.entity_description.control_fn(self.hub, self._obj_id, True, **kwargs)
+        try:
+            await self.entity_description.control_fn(
+                self.hub, self._obj_id, True, **kwargs
+            )
+        except AiounifiException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="action_request_failed",
+            ) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off light."""
-        await self.entity_description.control_fn(
-            self.hub, self._obj_id, False, **kwargs
-        )
+        try:
+            await self.entity_description.control_fn(
+                self.hub, self._obj_id, False, **kwargs
+            )
+        except AiounifiException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="action_request_failed",
+            ) from err
 
     @callback
     def async_update_state(self, event: ItemEvent, obj_id: str) -> None:

--- a/homeassistant/components/unifi/quality_scale.yaml
+++ b/homeassistant/components/unifi/quality_scale.yaml
@@ -33,7 +33,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters: todo
   docs-installation-parameters: todo

--- a/homeassistant/components/unifi/services.py
+++ b/homeassistant/components/unifi/services.py
@@ -3,11 +3,13 @@
 from collections.abc import Mapping
 from typing import Any
 
+import aiounifi
 from aiounifi.models.client import ClientReconnectRequest, ClientRemoveRequest
 import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
@@ -55,7 +57,10 @@ async def async_reconnect_client(hass: HomeAssistant, data: Mapping[str, Any]) -
     device_entry = device_registry.async_get(data[ATTR_DEVICE_ID])
 
     if device_entry is None:
-        return
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="reconnect_client_device_not_found",
+        )
 
     mac = ""
     for connection in device_entry.connections:
@@ -64,7 +69,10 @@ async def async_reconnect_client(hass: HomeAssistant, data: Mapping[str, Any]) -
             break
 
     if mac == "":
-        return
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="reconnect_client_no_mac",
+        )
 
     for config_entry in hass.config_entries.async_loaded_entries(DOMAIN):
         if (
@@ -74,7 +82,13 @@ async def async_reconnect_client(hass: HomeAssistant, data: Mapping[str, Any]) -
         ):
             continue
 
-        await hub.api.request(ClientReconnectRequest.create(mac))
+        try:
+            await hub.api.request(ClientReconnectRequest.create(mac))
+        except aiounifi.AiounifiException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="reconnect_client_request_failed",
+            ) from err
 
 
 async def async_remove_clients(hass: HomeAssistant, data: Mapping[str, Any]) -> None:
@@ -104,4 +118,10 @@ async def async_remove_clients(hass: HomeAssistant, data: Mapping[str, Any]) -> 
             clients_to_remove.append(client.mac)
 
         if clients_to_remove:
-            await hub.api.request(ClientRemoveRequest.create(clients_to_remove))
+            try:
+                await hub.api.request(ClientRemoveRequest.create(clients_to_remove))
+            except aiounifi.AiounifiException as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="remove_clients_request_failed",
+                ) from err

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -65,6 +65,9 @@
     }
   },
   "exceptions": {
+    "action_request_failed": {
+      "message": "Failed to send action request to UniFi Network"
+    },
     "reconnect_client_device_not_found": {
       "message": "Unable to reconnect client: device not found"
     },

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -64,6 +64,20 @@
       }
     }
   },
+  "exceptions": {
+    "reconnect_client_device_not_found": {
+      "message": "Unable to reconnect client: device not found"
+    },
+    "reconnect_client_no_mac": {
+      "message": "Unable to reconnect client: device does not have a network MAC address"
+    },
+    "reconnect_client_request_failed": {
+      "message": "Failed to send reconnect request to UniFi Network"
+    },
+    "remove_clients_request_failed": {
+      "message": "Failed to remove clients from UniFi Network"
+    }
+  },
   "options": {
     "abort": {
       "integration_not_setup": "UniFi integration is not set up"

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -50,6 +50,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -441,7 +442,13 @@ class UnifiSwitchEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
-        await self.entity_description.control_fn(self.hub, self._obj_id, True)
+        try:
+            await self.entity_description.control_fn(self.hub, self._obj_id, True)
+        except aiounifi.AiounifiException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="action_request_failed",
+            ) from err
         if coordinator := self.hub.entity_loader.get_data_update_coordinator(
             self.entity_description.api_handler_fn(self.api)
         ):
@@ -449,7 +456,13 @@ class UnifiSwitchEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
-        await self.entity_description.control_fn(self.hub, self._obj_id, False)
+        try:
+            await self.entity_description.control_fn(self.hub, self._obj_id, False)
+        except aiounifi.AiounifiException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="action_request_failed",
+            ) from err
         if coordinator := self.hub.entity_loader.get_data_update_coordinator(
             self.entity_description.api_handler_fn(self.api)
         ):

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -19,9 +19,11 @@ from homeassistant.components.update import (
     UpdateEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import UnifiConfigEntry
+from .const import DOMAIN
 from .entity import (
     UnifiEntity,
     UnifiEntityDescription,
@@ -95,7 +97,13 @@ class UnifiDeviceUpdateEntity[_HandlerT: Devices, _DataT: Device](
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self.entity_description.control_fn(self.api, self._obj_id)
+        try:
+            await self.entity_description.control_fn(self.api, self._obj_id)
+        except aiounifi.AiounifiException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="action_request_failed",
+            ) from err
 
     @callback
     def async_update_state(self, event: ItemEvent, obj_id: str) -> None:

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -5,12 +5,13 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
+import aiounifi
 from aiounifi.models.message import MessageKey
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
-from homeassistant.components.unifi.const import CONF_SITE_ID
+from homeassistant.components.unifi.const import CONF_SITE_ID, DOMAIN
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
     CONF_HOST,
@@ -19,6 +20,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.util import dt as dt_util
@@ -338,3 +340,27 @@ async def test_power_cycle_availability(
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("device_payload", [DEVICE_RESTART])
+async def test_button_request_failed(
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+) -> None:
+    """Verify HomeAssistantError is raised when API request fails."""
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            "press",
+            {"entity_id": "button.switch_restart"},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "action_request_failed"

--- a/tests/components/unifi/test_light.py
+++ b/tests/components/unifi/test_light.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 from unittest.mock import patch
 
+import aiounifi
 from aiounifi.models.message import MessageKey
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -14,7 +15,7 @@ from homeassistant.components.light import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.components.unifi.const import CONF_SITE_ID
+from homeassistant.components.unifi.const import CONF_SITE_ID, DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,
@@ -24,6 +25,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import (
@@ -426,3 +428,51 @@ async def test_light_rgb_vs_onoff_modes(
     assert onoff_light.attributes.get("color_mode") == "onoff"
     assert onoff_light.attributes.get("brightness") is None
     assert onoff_light.attributes.get("rgb_color") is None
+
+
+@pytest.mark.parametrize("device_payload", [[DEVICE_WITH_LED]])
+async def test_light_turn_on_request_failed(
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+) -> None:
+    """Verify HomeAssistantError is raised when turn on API request fails."""
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "light.device_with_led_led"},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "action_request_failed"
+
+
+@pytest.mark.parametrize("device_payload", [[DEVICE_WITH_LED]])
+async def test_light_turn_off_request_failed(
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+) -> None:
+    """Verify HomeAssistantError is raised when turn off API request fails."""
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "light.device_with_led_led"},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "action_request_failed"

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import PropertyMock, patch
 
+import aiounifi
 import pytest
 
 from homeassistant.components.unifi.const import CONF_SITE_ID, DOMAIN
@@ -12,6 +13,7 @@ from homeassistant.components.unifi.services import (
 )
 from homeassistant.const import ATTR_DEVICE_ID, CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
@@ -53,15 +55,16 @@ async def test_reconnect_client(
 async def test_reconnect_non_existant_device(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Verify no call is made if device does not exist."""
+    """Verify ServiceValidationError is raised if device does not exist."""
     aioclient_mock.clear_requests()
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_RECONNECT_CLIENT,
-        service_data={ATTR_DEVICE_ID: "device_entry.id"},
-        blocking=True,
-    )
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RECONNECT_CLIENT,
+            service_data={ATTR_DEVICE_ID: "device_entry.id"},
+            blocking=True,
+        )
     assert aioclient_mock.call_count == 0
 
 
@@ -71,7 +74,7 @@ async def test_reconnect_device_without_mac(
     aioclient_mock: AiohttpClientMocker,
     config_entry_setup: MockConfigEntry,
 ) -> None:
-    """Verify no call is made if device does not have a known mac."""
+    """Verify ServiceValidationError is raised if device does not have a known mac."""
     aioclient_mock.clear_requests()
 
     device_entry = device_registry.async_get_or_create(
@@ -79,12 +82,13 @@ async def test_reconnect_device_without_mac(
         connections={("other connection", "not mac")},
     )
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_RECONNECT_CLIENT,
-        service_data={ATTR_DEVICE_ID: device_entry.id},
-        blocking=True,
-    )
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RECONNECT_CLIENT,
+            service_data={ATTR_DEVICE_ID: device_entry.id},
+            blocking=True,
+        )
     assert aioclient_mock.call_count == 0
 
 
@@ -298,14 +302,61 @@ async def test_services_handle_unloaded_config_entry(
     await hass.services.async_call(DOMAIN, SERVICE_REMOVE_CLIENTS, blocking=True)
     assert aioclient_mock.call_count == 0
 
+
+@pytest.mark.parametrize(
+    "client_payload", [[{"is_wired": False, "mac": "00:00:00:00:00:01"}]]
+)
+async def test_reconnect_client_request_failed(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry_setup: MockConfigEntry,
+    client_payload: list[dict[str, Any]],
+) -> None:
+    """Verify HomeAssistantError is raised when API request fails."""
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry_setup.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, clients_all_payload[0]["mac"])},
+        connections={(dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"])},
     )
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_RECONNECT_CLIENT,
-        service_data={ATTR_DEVICE_ID: device_entry.id},
-        blocking=True,
-    )
-    assert aioclient_mock.call_count == 0
+
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RECONNECT_CLIENT,
+            service_data={ATTR_DEVICE_ID: device_entry.id},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "clients_all_payload",
+    [
+        [
+            {
+                "first_seen": 100,
+                "last_seen": 500,
+                "mac": "00:00:00:00:00:01",
+            }
+        ]
+    ],
+)
+async def test_remove_clients_request_failed(
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+) -> None:
+    """Verify HomeAssistantError is raised when API request fails."""
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_REMOVE_CLIENTS, blocking=True)

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -52,19 +52,21 @@ async def test_reconnect_client(
 
 
 @pytest.mark.usefixtures("config_entry_setup")
-async def test_reconnect_non_existant_device(
+async def test_reconnect_non_existent_device(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Verify ServiceValidationError is raised if device does not exist."""
     aioclient_mock.clear_requests()
 
-    with pytest.raises(ServiceValidationError):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_RECONNECT_CLIENT,
             service_data={ATTR_DEVICE_ID: "device_entry.id"},
             blocking=True,
         )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "reconnect_client_device_not_found"
     assert aioclient_mock.call_count == 0
 
 
@@ -82,13 +84,15 @@ async def test_reconnect_device_without_mac(
         connections={("other connection", "not mac")},
     )
 
-    with pytest.raises(ServiceValidationError):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_RECONNECT_CLIENT,
             service_data={ATTR_DEVICE_ID: device_entry.id},
             blocking=True,
         )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "reconnect_client_no_mac"
     assert aioclient_mock.call_count == 0
 
 
@@ -324,7 +328,7 @@ async def test_reconnect_client_request_failed(
             "request",
             side_effect=aiounifi.AiounifiException,
         ),
-        pytest.raises(HomeAssistantError),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
             DOMAIN,
@@ -332,6 +336,8 @@ async def test_reconnect_client_request_failed(
             service_data={ATTR_DEVICE_ID: device_entry.id},
             blocking=True,
         )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "reconnect_client_request_failed"
 
 
 @pytest.mark.parametrize(
@@ -357,6 +363,8 @@ async def test_remove_clients_request_failed(
             "request",
             side_effect=aiounifi.AiounifiException,
         ),
-        pytest.raises(HomeAssistantError),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(DOMAIN, SERVICE_REMOVE_CLIENTS, blocking=True)
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "remove_clients_request_failed"

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -355,6 +355,7 @@ async def test_reconnect_client_request_failed(
 async def test_remove_clients_request_failed(
     hass: HomeAssistant,
     config_entry_setup: MockConfigEntry,
+    clients_all_payload: list[dict[str, Any]],
 ) -> None:
     """Verify HomeAssistantError is raised when API request fails."""
     with (

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
+import aiounifi
 from aiounifi.models.message import MessageKey
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -32,6 +33,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.util import dt as dt_util
@@ -1923,3 +1925,57 @@ async def test_port_control_switches(
     mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
     assert hass.states.get("switch.mock_name_port_1").state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    "config_entry_options", [{CONF_BLOCK_CLIENT: [BLOCKED["mac"]]}]
+)
+@pytest.mark.parametrize("client_payload", [[BLOCKED]])
+async def test_switch_turn_on_request_failed(
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+) -> None:
+    """Verify HomeAssistantError is raised when turn on API request fails."""
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.block_client_1"},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "action_request_failed"
+
+
+@pytest.mark.parametrize(
+    "config_entry_options", [{CONF_BLOCK_CLIENT: [BLOCKED["mac"]]}]
+)
+@pytest.mark.parametrize("client_payload", [[BLOCKED]])
+async def test_switch_turn_off_request_failed(
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+) -> None:
+    """Verify HomeAssistantError is raised when turn off API request fails."""
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.block_client_1"},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "action_request_failed"

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -3,12 +3,13 @@
 from copy import deepcopy
 from unittest.mock import patch
 
+import aiounifi
 from aiounifi.models.message import MessageKey
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from yarl import URL
 
-from homeassistant.components.unifi.const import CONF_SITE_ID
+from homeassistant.components.unifi.const import CONF_SITE_ID, DOMAIN
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -25,6 +26,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import (
@@ -174,3 +176,27 @@ async def test_hub_state_change(
     # Controller available
     await mock_websocket_state.reconnect()
     assert hass.states.get("update.device_1").state == STATE_ON
+
+
+@pytest.mark.parametrize("device_payload", [[DEVICE_1]])
+async def test_install_request_failed(
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+) -> None:
+    """Verify HomeAssistantError is raised when install API request fails."""
+    with (
+        patch.object(
+            config_entry_setup.runtime_data.api,
+            "request",
+            side_effect=aiounifi.AiounifiException,
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.device_1"},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "action_request_failed"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Implement the `action-exceptions` quality scale rule (Silver tier) for the UniFi integration.

Service actions now raise proper exceptions instead of silently returning:

- `ServiceValidationError` (with translation key) for user-input errors:
  - Device not found in device registry
  - Device has no network MAC address
- `HomeAssistantError` (with translation key) for API/communication failures:
  - Failed reconnect request to UniFi Network
  - Failed remove-clients request to UniFi Network

Exception messages are provided via `strings.json` for i18n support.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
