### PR TITLE
Migrate ZWave ME to use `runtime_data`

### DIFF
--- a/homeassistant/components/zwave_me/__init__.py
+++ b/homeassistant/components/zwave_me/__init__.py
@@ -1,101 +1,33 @@
 """The Z-Wave-Me WS integration."""
 
-from zwave_me_ws import ZWaveMe, ZWaveMeData
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TOKEN, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.dispatcher import dispatcher_send
 
-from .const import DOMAIN, PLATFORMS, ZWaveMePlatform
-
-ZWAVE_ME_PLATFORMS = [platform.value for platform in ZWaveMePlatform]
+from .const import PLATFORMS
+from .controller import ZWaveMeConfigEntry, ZWaveMeController
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ZWaveMeConfigEntry) -> bool:
     """Set up Z-Wave-Me from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-    controller = hass.data[DOMAIN][entry.entry_id] = ZWaveMeController(hass, entry)
+    controller = ZWaveMeController(hass, entry)
     if await controller.async_establish_connection():
         await async_setup_platforms(hass, entry, controller)
         registry = dr.async_get(hass)
         controller.remove_stale_devices(registry)
+        entry.runtime_data = controller
         return True
     raise ConfigEntryNotReady
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ZWaveMeConfigEntry) -> bool:
     """Unload a config entry."""
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        controller = hass.data[DOMAIN].pop(entry.entry_id)
-        await controller.zwave_api.close_ws()
+        await entry.runtime_data.zwave_api.close_ws()
     return unload_ok
-
-
-class ZWaveMeController:
-    """Main ZWave-Me API class."""
-
-    def __init__(self, hass: HomeAssistant, config: ConfigEntry) -> None:
-        """Create the API instance."""
-        self.device_ids: set = set()
-        self._hass = hass
-        self.config = config
-        self.zwave_api = ZWaveMe(
-            on_device_create=self.on_device_create,
-            on_device_update=self.on_device_update,
-            on_device_remove=self.on_device_unavailable,
-            on_device_destroy=self.on_device_destroy,
-            on_new_device=self.add_device,
-            token=self.config.data[CONF_TOKEN],
-            url=self.config.data[CONF_URL],
-            platforms=ZWAVE_ME_PLATFORMS,
-        )
-        self.platforms_inited = False
-
-    async def async_establish_connection(self):
-        """Get connection status."""
-        return await self.zwave_api.get_connection()
-
-    def add_device(self, device: ZWaveMeData) -> None:
-        """Send signal to create device."""
-        if device.id in self.device_ids:
-            dispatcher_send(self._hass, f"ZWAVE_ME_INFO_{device.id}", device)
-        else:
-            dispatcher_send(
-                self._hass, f"ZWAVE_ME_NEW_{device.deviceType.upper()}", device
-            )
-            self.device_ids.add(device.id)
-
-    def on_device_create(self, devices: list[ZWaveMeData]) -> None:
-        """Create multiple devices."""
-        for device in devices:
-            if device.deviceType in ZWAVE_ME_PLATFORMS and self.platforms_inited:
-                self.add_device(device)
-
-    def on_device_update(self, new_info: ZWaveMeData) -> None:
-        """Send signal to update device."""
-        dispatcher_send(self._hass, f"ZWAVE_ME_INFO_{new_info.id}", new_info)
-
-    def on_device_unavailable(self, device_id: str) -> None:
-        """Send signal to set device unavailable."""
-        dispatcher_send(self._hass, f"ZWAVE_ME_UNAVAILABLE_{device_id}")
-
-    def on_device_destroy(self, device_id: str) -> None:
-        """Send signal to destroy device."""
-        dispatcher_send(self._hass, f"ZWAVE_ME_DESTROY_{device_id}")
-
-    def remove_stale_devices(self, registry: dr.DeviceRegistry):
-        """Remove old-format devices in the registry."""
-        for device_id in self.device_ids:
-            device = registry.async_get_device(
-                identifiers={(DOMAIN, f"{self.config.unique_id}-{device_id}")}
-            )
-            if device is not None:
-                registry.async_remove_device(device.id)
 
 
 async def async_setup_platforms(

--- a/homeassistant/components/zwave_me/__init__.py
+++ b/homeassistant/components/zwave_me/__init__.py
@@ -12,13 +12,15 @@ from .controller import ZWaveMeConfigEntry, ZWaveMeController
 async def async_setup_entry(hass: HomeAssistant, entry: ZWaveMeConfigEntry) -> bool:
     """Set up Z-Wave-Me from a config entry."""
     controller = ZWaveMeController(hass, entry)
-    if await controller.async_establish_connection():
-        entry.runtime_data = controller
-        await async_setup_platforms(hass, entry, controller)
-        registry = dr.async_get(hass)
-        controller.remove_stale_devices(registry)
-        return True
-    raise ConfigEntryNotReady
+
+    if not await controller.async_establish_connection():
+        raise ConfigEntryNotReady
+
+    entry.runtime_data = controller
+    await async_setup_platforms(hass, entry, controller)
+    registry = dr.async_get(hass)
+    controller.remove_stale_devices(registry)
+    return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ZWaveMeConfigEntry) -> bool:

--- a/homeassistant/components/zwave_me/__init__.py
+++ b/homeassistant/components/zwave_me/__init__.py
@@ -13,10 +13,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZWaveMeConfigEntry) -> b
     """Set up Z-Wave-Me from a config entry."""
     controller = ZWaveMeController(hass, entry)
     if await controller.async_establish_connection():
+        entry.runtime_data = controller
         await async_setup_platforms(hass, entry, controller)
         registry = dr.async_get(hass)
         controller.remove_stale_devices(registry)
-        entry.runtime_data = controller
         return True
     raise ConfigEntryNotReady
 

--- a/homeassistant/components/zwave_me/binary_sensor.py
+++ b/homeassistant/components/zwave_me/binary_sensor.py
@@ -38,15 +38,15 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
-        controller = config_entry.runtime_data
-        description = BINARY_SENSORS_MAP.get(
-            new_device.probeType, BINARY_SENSORS_MAP["generic"]
-        )
-        sensor = ZWaveMeBinarySensor(controller, new_device, description)
-
         async_add_entities(
             [
-                sensor,
+                ZWaveMeBinarySensor(
+                    config_entry.runtime_data,
+                    new_device,
+                    BINARY_SENSORS_MAP.get(
+                        new_device.probeType, BINARY_SENSORS_MAP["generic"]
+                    ),
+                )
             ]
         )
 

--- a/homeassistant/components/zwave_me/binary_sensor.py
+++ b/homeassistant/components/zwave_me/binary_sensor.py
@@ -9,13 +9,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeController
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry, ZWaveMeController
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 BINARY_SENSORS_MAP: dict[str, BinarySensorEntityDescription] = {
@@ -32,14 +31,14 @@ DEVICE_NAME = ZWaveMePlatform.BINARY_SENSOR
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the binary sensor platform."""
 
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
-        controller: ZWaveMeController = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         description = BINARY_SENSORS_MAP.get(
             new_device.probeType, BINARY_SENSORS_MAP["generic"]
         )

--- a/homeassistant/components/zwave_me/binary_sensor.py
+++ b/homeassistant/components/zwave_me/binary_sensor.py
@@ -13,8 +13,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry, ZWaveMeController
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry, ZWaveMeController
 from .entity import ZWaveMeEntity
 
 BINARY_SENSORS_MAP: dict[str, BinarySensorEntityDescription] = {

--- a/homeassistant/components/zwave_me/button.py
+++ b/homeassistant/components/zwave_me/button.py
@@ -5,8 +5,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.BUTTON

--- a/homeassistant/components/zwave_me/button.py
+++ b/homeassistant/components/zwave_me/button.py
@@ -21,14 +21,7 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device):
-        controller = config_entry.runtime_data
-        button = ZWaveMeButton(controller, new_device)
-
-        async_add_entities(
-            [
-                button,
-            ]
-        )
+        async_add_entities([ZWaveMeButton(config_entry.runtime_data, new_device)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_me/button.py
+++ b/homeassistant/components/zwave_me/button.py
@@ -1,12 +1,12 @@
 """Representation of a toggleButton."""
 
 from homeassistant.components.button import ButtonEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.BUTTON
@@ -14,14 +14,14 @@ DEVICE_NAME = ZWaveMePlatform.BUTTON
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the number platform."""
 
     @callback
     def add_new_device(new_device):
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         button = ZWaveMeButton(controller, new_device)
 
         async_add_entities(

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -35,14 +35,7 @@ async def async_setup_entry(
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
         """Add a new device."""
-        controller = config_entry.runtime_data
-        climate = ZWaveMeClimate(controller, new_device)
-
-        async_add_entities(
-            [
-                climate,
-            ]
-        )
+        async_add_entities([ZWaveMeClimate(config_entry.runtime_data, new_device)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -11,13 +11,13 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 TEMPERATURE_DEFAULT_STEP = 0.5
@@ -27,7 +27,7 @@ DEVICE_NAME = ZWaveMePlatform.CLIMATE
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the climate platform."""
@@ -35,7 +35,7 @@ async def async_setup_entry(
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
         """Add a new device."""
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         climate = ZWaveMeClimate(controller, new_device)
 
         async_add_entities(

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -16,8 +16,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry
 from .entity import ZWaveMeEntity
 
 TEMPERATURE_DEFAULT_STEP = 0.5

--- a/homeassistant/components/zwave_me/controller.py
+++ b/homeassistant/components/zwave_me/controller.py
@@ -20,7 +20,7 @@ class ZWaveMeController:
 
     def __init__(self, hass: HomeAssistant, config: ZWaveMeConfigEntry) -> None:
         """Create the API instance."""
-        self.device_ids: set = set()
+        self.device_ids: set[str] = set()
         self._hass = hass
         self.config = config
         self.zwave_api = ZWaveMe(

--- a/homeassistant/components/zwave_me/controller.py
+++ b/homeassistant/components/zwave_me/controller.py
@@ -35,7 +35,7 @@ class ZWaveMeController:
         )
         self.platforms_inited = False
 
-    async def async_establish_connection(self):
+    async def async_establish_connection(self) -> bool:
         """Get connection status."""
         return await self.zwave_api.get_connection()
 

--- a/homeassistant/components/zwave_me/controller.py
+++ b/homeassistant/components/zwave_me/controller.py
@@ -1,0 +1,77 @@
+"""The Z-Wave-Me WS controller."""
+
+from zwave_me_ws import ZWaveMe, ZWaveMeData
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import dispatcher_send
+
+from .const import DOMAIN, ZWaveMePlatform
+
+type ZWaveMeConfigEntry = ConfigEntry[ZWaveMeController]
+
+ZWAVE_ME_PLATFORMS = [platform.value for platform in ZWaveMePlatform]
+
+
+class ZWaveMeController:
+    """Main ZWave-Me API class."""
+
+    def __init__(self, hass: HomeAssistant, config: ZWaveMeConfigEntry) -> None:
+        """Create the API instance."""
+        self.device_ids: set = set()
+        self._hass = hass
+        self.config = config
+        self.zwave_api = ZWaveMe(
+            on_device_create=self.on_device_create,
+            on_device_update=self.on_device_update,
+            on_device_remove=self.on_device_unavailable,
+            on_device_destroy=self.on_device_destroy,
+            on_new_device=self.add_device,
+            token=self.config.data[CONF_TOKEN],
+            url=self.config.data[CONF_URL],
+            platforms=ZWAVE_ME_PLATFORMS,
+        )
+        self.platforms_inited = False
+
+    async def async_establish_connection(self):
+        """Get connection status."""
+        return await self.zwave_api.get_connection()
+
+    def add_device(self, device: ZWaveMeData) -> None:
+        """Send signal to create device."""
+        if device.id in self.device_ids:
+            dispatcher_send(self._hass, f"ZWAVE_ME_INFO_{device.id}", device)
+        else:
+            dispatcher_send(
+                self._hass, f"ZWAVE_ME_NEW_{device.deviceType.upper()}", device
+            )
+            self.device_ids.add(device.id)
+
+    def on_device_create(self, devices: list[ZWaveMeData]) -> None:
+        """Create multiple devices."""
+        for device in devices:
+            if device.deviceType in ZWAVE_ME_PLATFORMS and self.platforms_inited:
+                self.add_device(device)
+
+    def on_device_update(self, new_info: ZWaveMeData) -> None:
+        """Send signal to update device."""
+        dispatcher_send(self._hass, f"ZWAVE_ME_INFO_{new_info.id}", new_info)
+
+    def on_device_unavailable(self, device_id: str) -> None:
+        """Send signal to set device unavailable."""
+        dispatcher_send(self._hass, f"ZWAVE_ME_UNAVAILABLE_{device_id}")
+
+    def on_device_destroy(self, device_id: str) -> None:
+        """Send signal to destroy device."""
+        dispatcher_send(self._hass, f"ZWAVE_ME_DESTROY_{device_id}")
+
+    def remove_stale_devices(self, registry: dr.DeviceRegistry):
+        """Remove old-format devices in the registry."""
+        for device_id in self.device_ids:
+            device = registry.async_get_device(
+                identifiers={(DOMAIN, f"{self.config.unique_id}-{device_id}")}
+            )
+            if device is not None:
+                registry.async_remove_device(device.id)

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -13,8 +13,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.COVER

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -9,12 +9,12 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.COVER
@@ -22,14 +22,14 @@ DEVICE_NAME = ZWaveMePlatform.COVER
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the cover platform."""
 
     @callback
     def add_new_device(new_device):
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         cover = ZWaveMeCover(controller, new_device)
 
         async_add_entities(

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -29,14 +29,7 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device):
-        controller = config_entry.runtime_data
-        cover = ZWaveMeCover(controller, new_device)
-
-        async_add_entities(
-            [
-                cover,
-            ]
-        )
+        async_add_entities([ZWaveMeCover(config_entry.runtime_data, new_device)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_me/entity.py
+++ b/homeassistant/components/zwave_me/entity.py
@@ -8,12 +8,13 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
+from .controller import ZWaveMeController
 
 
 class ZWaveMeEntity(Entity):
     """Representation of a ZWaveMe device."""
 
-    def __init__(self, controller, device):
+    def __init__(self, controller: ZWaveMeController, device: ZWaveMeData) -> None:
         """Initialize the device."""
         self.controller = controller
         self.device = device

--- a/homeassistant/components/zwave_me/fan.py
+++ b/homeassistant/components/zwave_me/fan.py
@@ -9,8 +9,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry
 from .const import DOMAIN, ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.FAN

--- a/homeassistant/components/zwave_me/fan.py
+++ b/homeassistant/components/zwave_me/fan.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from .const import ZWaveMePlatform
 from .controller import ZWaveMeConfigEntry
 from .entity import ZWaveMeEntity
 
@@ -25,7 +25,7 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device):
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         fan = ZWaveMeFan(controller, new_device)
 
         async_add_entities(

--- a/homeassistant/components/zwave_me/fan.py
+++ b/homeassistant/components/zwave_me/fan.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import ZWaveMeConfigEntry
 from .const import DOMAIN, ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
@@ -18,7 +18,7 @@ DEVICE_NAME = ZWaveMePlatform.FAN
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the fan platform."""

--- a/homeassistant/components/zwave_me/fan.py
+++ b/homeassistant/components/zwave_me/fan.py
@@ -25,14 +25,7 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device):
-        controller = config_entry.runtime_data
-        fan = ZWaveMeFan(controller, new_device)
-
-        async_add_entities(
-            [
-                fan,
-            ]
-        )
+        async_add_entities([ZWaveMeFan(config_entry.runtime_data, new_device)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_me/light.py
+++ b/homeassistant/components/zwave_me/light.py
@@ -33,14 +33,7 @@ async def async_setup_entry(
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
         """Add a new device."""
-        controller = config_entry.runtime_data
-        rgb = ZWaveMeRGB(controller, new_device)
-
-        async_add_entities(
-            [
-                rgb,
-            ]
-        )
+        async_add_entities([ZWaveMeRGB(config_entry.runtime_data, new_device)])
 
     async_dispatcher_connect(
         hass, f"ZWAVE_ME_NEW_{ZWaveMePlatform.RGB_LIGHT.upper()}", add_new_device

--- a/homeassistant/components/zwave_me/light.py
+++ b/homeassistant/components/zwave_me/light.py
@@ -18,8 +18,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry, ZWaveMeController
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry, ZWaveMeController
 from .entity import ZWaveMeEntity
 
 

--- a/homeassistant/components/zwave_me/light.py
+++ b/homeassistant/components/zwave_me/light.py
@@ -14,19 +14,18 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeController
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry, ZWaveMeController
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the rgb platform."""
@@ -34,7 +33,7 @@ async def async_setup_entry(
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
         """Add a new device."""
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         rgb = ZWaveMeRGB(controller, new_device)
 
         async_add_entities(

--- a/homeassistant/components/zwave_me/lock.py
+++ b/homeassistant/components/zwave_me/lock.py
@@ -11,8 +11,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.LOCK

--- a/homeassistant/components/zwave_me/lock.py
+++ b/homeassistant/components/zwave_me/lock.py
@@ -7,12 +7,12 @@ from typing import Any
 from zwave_me_ws import ZWaveMeData
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.LOCK
@@ -20,7 +20,7 @@ DEVICE_NAME = ZWaveMePlatform.LOCK
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the lock platform."""
@@ -28,7 +28,7 @@ async def async_setup_entry(
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
         """Add a new device."""
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         lock = ZWaveMeLock(controller, new_device)
 
         async_add_entities(

--- a/homeassistant/components/zwave_me/lock.py
+++ b/homeassistant/components/zwave_me/lock.py
@@ -28,14 +28,7 @@ async def async_setup_entry(
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
         """Add a new device."""
-        controller = config_entry.runtime_data
-        lock = ZWaveMeLock(controller, new_device)
-
-        async_add_entities(
-            [
-                lock,
-            ]
-        )
+        async_add_entities([ZWaveMeLock(config_entry.runtime_data, new_device)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_me/number.py
+++ b/homeassistant/components/zwave_me/number.py
@@ -21,14 +21,7 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device):
-        controller = config_entry.runtime_data
-        switch = ZWaveMeNumber(controller, new_device)
-
-        async_add_entities(
-            [
-                switch,
-            ]
-        )
+        async_add_entities([ZWaveMeNumber(config_entry.runtime_data, new_device)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_me/number.py
+++ b/homeassistant/components/zwave_me/number.py
@@ -5,8 +5,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.NUMBER

--- a/homeassistant/components/zwave_me/number.py
+++ b/homeassistant/components/zwave_me/number.py
@@ -1,12 +1,12 @@
 """Representation of a switchMultilevel."""
 
 from homeassistant.components.number import NumberEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.NUMBER
@@ -14,14 +14,14 @@ DEVICE_NAME = ZWaveMePlatform.NUMBER
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the number platform."""
 
     @callback
     def add_new_device(new_device):
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         switch = ZWaveMeNumber(controller, new_device)
 
         async_add_entities(

--- a/homeassistant/components/zwave_me/sensor.py
+++ b/homeassistant/components/zwave_me/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
@@ -28,8 +27,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeController
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry, ZWaveMeController
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 
@@ -117,14 +116,14 @@ DEVICE_NAME = ZWaveMePlatform.SENSOR
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
 
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
-        controller: ZWaveMeController = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         description = SENSORS_MAP.get(new_device.probeType, SENSORS_MAP["generic"])
         sensor = ZWaveMeSensor(controller, new_device, description)
 

--- a/homeassistant/components/zwave_me/sensor.py
+++ b/homeassistant/components/zwave_me/sensor.py
@@ -27,8 +27,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry, ZWaveMeController
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry, ZWaveMeController
 from .entity import ZWaveMeEntity
 
 

--- a/homeassistant/components/zwave_me/sensor.py
+++ b/homeassistant/components/zwave_me/sensor.py
@@ -123,13 +123,13 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device: ZWaveMeData) -> None:
-        controller = config_entry.runtime_data
-        description = SENSORS_MAP.get(new_device.probeType, SENSORS_MAP["generic"])
-        sensor = ZWaveMeSensor(controller, new_device, description)
-
         async_add_entities(
             [
-                sensor,
+                ZWaveMeSensor(
+                    config_entry.runtime_data,
+                    new_device,
+                    SENSORS_MAP.get(new_device.probeType, SENSORS_MAP["generic"]),
+                )
             ]
         )
 

--- a/homeassistant/components/zwave_me/siren.py
+++ b/homeassistant/components/zwave_me/siren.py
@@ -9,8 +9,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry, ZWaveMeController
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry, ZWaveMeController
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.SIREN

--- a/homeassistant/components/zwave_me/siren.py
+++ b/homeassistant/components/zwave_me/siren.py
@@ -25,14 +25,7 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device):
-        controller = config_entry.runtime_data
-        siren = ZWaveMeSiren(controller, new_device)
-
-        async_add_entities(
-            [
-                siren,
-            ]
-        )
+        async_add_entities([ZWaveMeSiren(config_entry.runtime_data, new_device)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_me/siren.py
+++ b/homeassistant/components/zwave_me/siren.py
@@ -2,13 +2,15 @@
 
 from typing import Any
 
+from zwave_me_ws import ZWaveMeData
+
 from homeassistant.components.siren import SirenEntity, SirenEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry, ZWaveMeController
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 DEVICE_NAME = ZWaveMePlatform.SIREN
@@ -16,14 +18,14 @@ DEVICE_NAME = ZWaveMePlatform.SIREN
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the siren platform."""
 
     @callback
     def add_new_device(new_device):
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         siren = ZWaveMeSiren(controller, new_device)
 
         async_add_entities(
@@ -42,7 +44,7 @@ async def async_setup_entry(
 class ZWaveMeSiren(ZWaveMeEntity, SirenEntity):
     """Representation of a ZWaveMe siren."""
 
-    def __init__(self, controller, device):
+    def __init__(self, controller: ZWaveMeController, device: ZWaveMeData) -> None:
         """Initialize the device."""
         super().__init__(controller, device)
         self._attr_supported_features = (

--- a/homeassistant/components/zwave_me/switch.py
+++ b/homeassistant/components/zwave_me/switch.py
@@ -3,17 +3,19 @@
 import logging
 from typing import Any
 
+from zwave_me_ws import ZWaveMeData
+
 from homeassistant.components.switch import (
     SwitchDeviceClass,
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, ZWaveMePlatform
+from . import ZWaveMeConfigEntry, ZWaveMeController
+from .const import ZWaveMePlatform
 from .entity import ZWaveMeEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,14 +31,14 @@ SWITCH_MAP: dict[str, SwitchEntityDescription] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: ZWaveMeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the switch platform."""
 
     @callback
     def add_new_device(new_device):
-        controller = hass.data[DOMAIN][config_entry.entry_id]
+        controller = config_entry.runtime_data
         switch = ZWaveMeSwitch(controller, new_device, SWITCH_MAP["generic"])
 
         async_add_entities(
@@ -55,7 +57,12 @@ async def async_setup_entry(
 class ZWaveMeSwitch(ZWaveMeEntity, SwitchEntity):
     """Representation of a ZWaveMe binary switch."""
 
-    def __init__(self, controller, device, description):
+    def __init__(
+        self,
+        controller: ZWaveMeController,
+        device: ZWaveMeData,
+        description: SwitchEntityDescription,
+    ) -> None:
         """Initialize the device."""
         super().__init__(controller, device)
         self.entity_description = description

--- a/homeassistant/components/zwave_me/switch.py
+++ b/homeassistant/components/zwave_me/switch.py
@@ -38,12 +38,11 @@ async def async_setup_entry(
 
     @callback
     def add_new_device(new_device):
-        controller = config_entry.runtime_data
-        switch = ZWaveMeSwitch(controller, new_device, SWITCH_MAP["generic"])
-
         async_add_entities(
             [
-                switch,
+                ZWaveMeSwitch(
+                    config_entry.runtime_data, new_device, SWITCH_MAP["generic"]
+                )
             ]
         )
 

--- a/homeassistant/components/zwave_me/switch.py
+++ b/homeassistant/components/zwave_me/switch.py
@@ -14,8 +14,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import ZWaveMeConfigEntry, ZWaveMeController
 from .const import ZWaveMePlatform
+from .controller import ZWaveMeConfigEntry, ZWaveMeController
 from .entity import ZWaveMeEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/zwave_me/test_remove_stale_devices.py
+++ b/tests/components/zwave_me/test_remove_stale_devices.py
@@ -6,7 +6,7 @@ import uuid
 import pytest
 from zwave_me_ws import ZWaveMeData
 
-from homeassistant.components.zwave_me import ZWaveMePlatform
+from homeassistant.components.zwave_me.const import ZWaveMePlatform
 from homeassistant.const import CONF_TOKEN, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -53,7 +53,7 @@ async def test_remove_stale_devices(
     )
     with (
         patch(
-            "homeassistant.components.zwave_me.ZWaveMe.get_connection",
+            "homeassistant.components.zwave_me.controller.ZWaveMe.get_connection",
             mock_connection,
         ),
         patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make use of `runtime_data` instead of legacy `hass.data[DOMAIN]` pattern. To avoid circle imports, the controller class has been moved into an own module. Further some missing type annotations to the base entity class has been added. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
