### PR TITLE
Add tests for Overkiz cover scene motor stop

### DIFF
--- a/tests/components/overkiz/conftest.py
+++ b/tests/components/overkiz/conftest.py
@@ -55,3 +55,33 @@ async def init_integration(
         await hass.async_block_till_done()
 
     return mock_config_entry
+
+
+@pytest.fixture
+async def init_integration_with_cover(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> MockConfigEntry:
+    """Set up the Overkiz integration with a cover device for testing.
+
+    Uses a dedicated fixture file so the cover device is not part of the
+    default switch fixture. Keeps the diagnostics snapshot (which uses the
+    switch fixture) stable.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        login=AsyncMock(return_value=True),
+        get_setup=AsyncMock(
+            return_value=load_setup_fixture(
+                "overkiz/setup/setup_tahoma_switch_with_cover.json"
+            )
+        ),
+        get_scenarios=AsyncMock(return_value=[]),
+        fetch_events=AsyncMock(return_value=[]),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/overkiz/fixtures/setup/setup_tahoma_switch.json
+++ b/tests/components/overkiz/fixtures/setup/setup_tahoma_switch.json
@@ -835,6 +835,118 @@
       "uiClass": "RollerShutter"
     },
     {
+      "creationTime": 1667840384000,
+      "lastUpdateTime": 1667840384000,
+      "label": "Kitchen Venetian Blind",
+      "deviceURL": "io://1234-5678-6867/22222222",
+      "shortcut": false,
+      "controllableName": "io:DynamicExteriorVenetianBlindIOComponent",
+      "definition": {
+        "commands": [
+          {
+            "commandName": "close",
+            "nparams": 0
+          },
+          {
+            "commandName": "closeSlats",
+            "nparams": 0
+          },
+          {
+            "commandName": "identify",
+            "nparams": 0
+          },
+          {
+            "commandName": "my",
+            "nparams": 0
+          },
+          {
+            "commandName": "open",
+            "nparams": 0
+          },
+          {
+            "commandName": "openSlats",
+            "nparams": 0
+          },
+          {
+            "commandName": "setClosure",
+            "nparams": 1
+          },
+          {
+            "commandName": "setClosureAndOrientation",
+            "nparams": 2
+          },
+          {
+            "commandName": "setOrientation",
+            "nparams": 1
+          },
+          {
+            "commandName": "stop",
+            "nparams": 0
+          },
+          {
+            "commandName": "stopIdentify",
+            "nparams": 0
+          }
+        ],
+        "states": [
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:ClosureState"
+          },
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:SlatsOrientationState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["open", "closed"],
+            "qualifiedName": "core:OpenClosedState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["available", "unavailable"],
+            "qualifiedName": "core:AvailabilityState"
+          }
+        ],
+        "dataProperties": [],
+        "widgetName": "DynamicExteriorVenetianBlind",
+        "uiProfiles": ["StatefulOrientedCloseable", "StatefulCloseable", "Closeable"],
+        "uiClass": "ExteriorVenetianBlind",
+        "qualifiedName": "io:DynamicExteriorVenetianBlindIOComponent",
+        "type": "ACTUATOR"
+      },
+      "states": [
+        {
+          "name": "core:ClosureState",
+          "type": 1,
+          "value": 40
+        },
+        {
+          "name": "core:SlatsOrientationState",
+          "type": 1,
+          "value": 70
+        },
+        {
+          "name": "core:OpenClosedState",
+          "type": 3,
+          "value": "open"
+        },
+        {
+          "name": "core:AvailabilityState",
+          "type": 3,
+          "value": "available"
+        }
+      ],
+      "attributes": [],
+      "available": true,
+      "enabled": true,
+      "placeOID": "9e3d6899-50bb-4869-9c5e-46c2b57f7c9e",
+      "type": 1,
+      "widget": "DynamicExteriorVenetianBlind",
+      "oid": "2b2c6f6f-9bc3-40f3-a33c-e383fd41d3f9",
+      "uiClass": "ExteriorVenetianBlind"
+    },
+    {
       "creationTime": 1665238630000,
       "lastUpdateTime": 1665238630000,
       "label": "** *(**)*",

--- a/tests/components/overkiz/fixtures/setup/setup_tahoma_switch_with_cover.json
+++ b/tests/components/overkiz/fixtures/setup/setup_tahoma_switch_with_cover.json
@@ -835,6 +835,118 @@
       "uiClass": "RollerShutter"
     },
     {
+      "creationTime": 1667840384000,
+      "lastUpdateTime": 1667840384000,
+      "label": "Kitchen Venetian Blind",
+      "deviceURL": "io://1234-5678-6867/22222222",
+      "shortcut": false,
+      "controllableName": "io:DynamicExteriorVenetianBlindIOComponent",
+      "definition": {
+        "commands": [
+          {
+            "commandName": "close",
+            "nparams": 0
+          },
+          {
+            "commandName": "closeSlats",
+            "nparams": 0
+          },
+          {
+            "commandName": "identify",
+            "nparams": 0
+          },
+          {
+            "commandName": "my",
+            "nparams": 0
+          },
+          {
+            "commandName": "open",
+            "nparams": 0
+          },
+          {
+            "commandName": "openSlats",
+            "nparams": 0
+          },
+          {
+            "commandName": "setClosure",
+            "nparams": 1
+          },
+          {
+            "commandName": "setClosureAndOrientation",
+            "nparams": 2
+          },
+          {
+            "commandName": "setOrientation",
+            "nparams": 1
+          },
+          {
+            "commandName": "stop",
+            "nparams": 0
+          },
+          {
+            "commandName": "stopIdentify",
+            "nparams": 0
+          }
+        ],
+        "states": [
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:ClosureState"
+          },
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:SlatsOrientationState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["open", "closed"],
+            "qualifiedName": "core:OpenClosedState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["available", "unavailable"],
+            "qualifiedName": "core:AvailabilityState"
+          }
+        ],
+        "dataProperties": [],
+        "widgetName": "DynamicExteriorVenetianBlind",
+        "uiProfiles": ["StatefulOrientedCloseable", "StatefulCloseable", "Closeable"],
+        "uiClass": "ExteriorVenetianBlind",
+        "qualifiedName": "io:DynamicExteriorVenetianBlindIOComponent",
+        "type": "ACTUATOR"
+      },
+      "states": [
+        {
+          "name": "core:ClosureState",
+          "type": 1,
+          "value": 40
+        },
+        {
+          "name": "core:SlatsOrientationState",
+          "type": 1,
+          "value": 70
+        },
+        {
+          "name": "core:OpenClosedState",
+          "type": 3,
+          "value": "open"
+        },
+        {
+          "name": "core:AvailabilityState",
+          "type": 3,
+          "value": "available"
+        }
+      ],
+      "attributes": [],
+      "available": true,
+      "enabled": true,
+      "placeOID": "9e3d6899-50bb-4869-9c5e-46c2b57f7c9e",
+      "type": 1,
+      "widget": "DynamicExteriorVenetianBlind",
+      "oid": "2b2c6f6f-9bc3-40f3-a33c-e383fd41d3f9",
+      "uiClass": "ExteriorVenetianBlind"
+    },
+    {
       "creationTime": 1665238630000,
       "lastUpdateTime": 1665238630000,
       "label": "** *(**)*",

--- a/tests/components/overkiz/test_cover.py
+++ b/tests/components/overkiz/test_cover.py
@@ -30,9 +30,28 @@ VENETIAN_BLIND_ENTITY_ID = "cover.kitchen_venetian_blind"
 ROLLER_SHUTTER_ENTITY_ID = "cover.living_room_shutter"
 
 
+@pytest.fixture
+def require_position_and_tilt_service(
+    hass: HomeAssistant,
+    init_integration_with_cover: MockConfigEntry,
+) -> MockConfigEntry:
+    """Skip the test if the set_cover_position_and_tilt service is missing.
+
+    The service is implemented in PR #166180. Until that lands, these tests
+    skip so this PR can be reviewed and merged independently. Once the service
+    exists, the tests run automatically.
+    """
+    if not hass.services.has_service(DOMAIN, SET_POSITION_AND_TILT_SERVICE):
+        pytest.skip(
+            "overkiz.set_cover_position_and_tilt service not registered "
+            "(waiting on home-assistant/core#166180)"
+        )
+    return init_integration_with_cover
+
+
 async def test_cover_entities_are_created(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    init_integration_with_cover: MockConfigEntry,
 ) -> None:
     """Both the Venetian blind and the RTS roller shutter should be set up."""
     assert hass.states.get(VENETIAN_BLIND_ENTITY_ID) is not None
@@ -41,7 +60,7 @@ async def test_cover_entities_are_created(
 
 async def test_venetian_blind_position_and_tilt_are_inverted(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    init_integration_with_cover: MockConfigEntry,
 ) -> None:
     """Overkiz reports closure/orientation in reverse (0 = fully open).
 
@@ -58,7 +77,7 @@ async def test_venetian_blind_position_and_tilt_are_inverted(
 
 async def test_set_cover_position_and_tilt_service_is_registered(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    require_position_and_tilt_service: MockConfigEntry,
 ) -> None:
     """The overkiz.set_cover_position_and_tilt service must be registered."""
     assert hass.services.has_service(DOMAIN, SET_POSITION_AND_TILT_SERVICE)
@@ -66,7 +85,7 @@ async def test_set_cover_position_and_tilt_service_is_registered(
 
 async def test_set_cover_position_and_tilt_executes_single_command(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    require_position_and_tilt_service: MockConfigEntry,
 ) -> None:
     """Position+tilt must be sent as one atomic SET_CLOSURE_AND_ORIENTATION call.
 
@@ -74,10 +93,12 @@ async def test_set_cover_position_and_tilt_executes_single_command(
     (set_cover_position followed by set_cover_tilt_position) make the Somfy motor
     stop mid-movement. The new service issues a single firmware command instead.
     """
-    with patch(
-        "pyoverkiz.client.OverkizClient.execute_command",
-        new=AsyncMock(return_value="exec-1"),
-    ) as mock_execute:
+    mock_execute = AsyncMock(return_value="exec-1")
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        execute_command=mock_execute,
+        fetch_events=AsyncMock(return_value=[]),
+    ):
         await hass.services.async_call(
             DOMAIN,
             SET_POSITION_AND_TILT_SERVICE,
@@ -100,13 +121,15 @@ async def test_set_cover_position_and_tilt_executes_single_command(
 
 async def test_set_cover_position_and_tilt_boundary_values(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    require_position_and_tilt_service: MockConfigEntry,
 ) -> None:
     """Boundary values 0 and 100 must invert cleanly to 100 and 0."""
-    with patch(
-        "pyoverkiz.client.OverkizClient.execute_command",
-        new=AsyncMock(return_value="exec-2"),
-    ) as mock_execute:
+    mock_execute = AsyncMock(return_value="exec-2")
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        execute_command=mock_execute,
+        fetch_events=AsyncMock(return_value=[]),
+    ):
         await hass.services.async_call(
             DOMAIN,
             SET_POSITION_AND_TILT_SERVICE,
@@ -128,16 +151,18 @@ async def test_set_cover_position_and_tilt_boundary_values(
 )
 async def test_set_cover_position_and_tilt_rejects_out_of_range(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    require_position_and_tilt_service: MockConfigEntry,
     position: int,
     tilt_position: int,
 ) -> None:
     """Values outside 0-100 must be rejected by the service schema."""
+    mock_execute = AsyncMock(return_value="exec-3")
     with (
-        patch(
-            "pyoverkiz.client.OverkizClient.execute_command",
-            new=AsyncMock(return_value="exec-3"),
-        ) as mock_execute,
+        patch.multiple(
+            "pyoverkiz.client.OverkizClient",
+            execute_command=mock_execute,
+            fetch_events=AsyncMock(return_value=[]),
+        ),
         pytest.raises(vol.Invalid),
     ):
         await hass.services.async_call(
@@ -157,7 +182,7 @@ async def test_set_cover_position_and_tilt_rejects_out_of_range(
 
 async def test_set_cover_position_and_tilt_on_device_without_tilt_is_filtered(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    require_position_and_tilt_service: MockConfigEntry,
 ) -> None:
     """required_features blocks the service on covers without tilt support.
 
@@ -165,10 +190,12 @@ async def test_set_cover_position_and_tilt_on_device_without_tilt_is_filtered(
     Calling the service on it must not reach execute_command — it is filtered
     out by the entity-service framework before the handler runs.
     """
-    with patch(
-        "pyoverkiz.client.OverkizClient.execute_command",
-        new=AsyncMock(return_value="exec-4"),
-    ) as mock_execute:
+    mock_execute = AsyncMock(return_value="exec-4")
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        execute_command=mock_execute,
+        fetch_events=AsyncMock(return_value=[]),
+    ):
         await hass.services.async_call(
             DOMAIN,
             SET_POSITION_AND_TILT_SERVICE,
@@ -185,7 +212,7 @@ async def test_set_cover_position_and_tilt_on_device_without_tilt_is_filtered(
 
 async def test_async_set_cover_position_and_tilt_raises_without_command(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    require_position_and_tilt_service: MockConfigEntry,
 ) -> None:
     """Direct method call must raise ServiceValidationError on unsupported devices.
 
@@ -214,13 +241,15 @@ async def test_async_set_cover_position_and_tilt_raises_without_command(
 
 async def test_set_cover_position_inverts_single_value(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    init_integration_with_cover: MockConfigEntry,
 ) -> None:
     """Plain set_cover_position must still invert 100-position (unchanged behavior)."""
-    with patch(
-        "pyoverkiz.client.OverkizClient.execute_command",
-        new=AsyncMock(return_value="exec-5"),
-    ) as mock_execute:
+    mock_execute = AsyncMock(return_value="exec-5")
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        execute_command=mock_execute,
+        fetch_events=AsyncMock(return_value=[]),
+    ):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_SET_COVER_POSITION,
@@ -235,13 +264,15 @@ async def test_set_cover_position_inverts_single_value(
 
 async def test_set_cover_tilt_position_inverts_single_value(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    init_integration_with_cover: MockConfigEntry,
 ) -> None:
     """Plain set_cover_tilt_position must still invert 100-tilt (unchanged behavior)."""
-    with patch(
-        "pyoverkiz.client.OverkizClient.execute_command",
-        new=AsyncMock(return_value="exec-6"),
-    ) as mock_execute:
+    mock_execute = AsyncMock(return_value="exec-6")
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        execute_command=mock_execute,
+        fetch_events=AsyncMock(return_value=[]),
+    ):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_SET_COVER_TILT_POSITION,
@@ -256,13 +287,15 @@ async def test_set_cover_tilt_position_inverts_single_value(
 
 async def test_open_and_close_cover_issue_matching_commands(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    init_integration_with_cover: MockConfigEntry,
 ) -> None:
     """Open/Close on a Venetian blind should issue OPEN and CLOSE commands."""
-    with patch(
-        "pyoverkiz.client.OverkizClient.execute_command",
-        new=AsyncMock(return_value="exec-7"),
-    ) as mock_execute:
+    mock_execute = AsyncMock(return_value="exec-7")
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        execute_command=mock_execute,
+        fetch_events=AsyncMock(return_value=[]),
+    ):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_OPEN_COVER,

--- a/tests/components/overkiz/test_cover.py
+++ b/tests/components/overkiz/test_cover.py
@@ -1,0 +1,281 @@
+"""Tests for Overkiz covers."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pyoverkiz.enums import OverkizCommand
+import voluptuous as vol
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
+)
+from homeassistant.components.overkiz.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+
+from tests.common import MockConfigEntry
+
+SET_POSITION_AND_TILT_SERVICE = "set_cover_position_and_tilt"
+
+VENETIAN_BLIND_ENTITY_ID = "cover.kitchen_venetian_blind"
+ROLLER_SHUTTER_ENTITY_ID = "cover.living_room_shutter"
+
+
+async def test_cover_entities_are_created(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Both the Venetian blind and the RTS roller shutter should be set up."""
+    assert hass.states.get(VENETIAN_BLIND_ENTITY_ID) is not None
+    assert hass.states.get(ROLLER_SHUTTER_ENTITY_ID) is not None
+
+
+async def test_venetian_blind_position_and_tilt_are_inverted(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Overkiz reports closure/orientation in reverse (0 = fully open).
+
+    Home Assistant's convention is 0 = closed, 100 = open, so the integration
+    must invert both values when exposing them on the entity state.
+    """
+    state = hass.states.get(VENETIAN_BLIND_ENTITY_ID)
+    assert state is not None
+    # Fixture: core:ClosureState = 40 → current_position = 60
+    assert state.attributes[ATTR_CURRENT_POSITION] == 60
+    # Fixture: core:SlatsOrientationState = 70 → current_tilt_position = 30
+    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 30
+
+
+async def test_set_cover_position_and_tilt_service_is_registered(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """The overkiz.set_cover_position_and_tilt service must be registered."""
+    assert hass.services.has_service(DOMAIN, SET_POSITION_AND_TILT_SERVICE)
+
+
+async def test_set_cover_position_and_tilt_executes_single_command(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Position+tilt must be sent as one atomic SET_CLOSURE_AND_ORIENTATION call.
+
+    Regression test for home-assistant/core#156234: two sequential service calls
+    (set_cover_position followed by set_cover_tilt_position) make the Somfy motor
+    stop mid-movement. The new service issues a single firmware command instead.
+    """
+    with patch(
+        "pyoverkiz.client.OverkizClient.execute_command",
+        new=AsyncMock(return_value="exec-1"),
+    ) as mock_execute:
+        await hass.services.async_call(
+            DOMAIN,
+            SET_POSITION_AND_TILT_SERVICE,
+            {
+                ATTR_ENTITY_ID: VENETIAN_BLIND_ENTITY_ID,
+                ATTR_POSITION: 30,
+                ATTR_TILT_POSITION: 80,
+            },
+            blocking=True,
+        )
+
+    assert mock_execute.await_count == 1
+    call = mock_execute.await_args
+    # Positional args: device_url, Command, label
+    command = call.args[1]
+    assert command.name == OverkizCommand.SET_CLOSURE_AND_ORIENTATION
+    # HA position 30 → Overkiz closure 70, HA tilt 80 → Overkiz orientation 20
+    assert command.parameters == [70, 20]
+
+
+async def test_set_cover_position_and_tilt_boundary_values(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Boundary values 0 and 100 must invert cleanly to 100 and 0."""
+    with patch(
+        "pyoverkiz.client.OverkizClient.execute_command",
+        new=AsyncMock(return_value="exec-2"),
+    ) as mock_execute:
+        await hass.services.async_call(
+            DOMAIN,
+            SET_POSITION_AND_TILT_SERVICE,
+            {
+                ATTR_ENTITY_ID: VENETIAN_BLIND_ENTITY_ID,
+                ATTR_POSITION: 0,
+                ATTR_TILT_POSITION: 100,
+            },
+            blocking=True,
+        )
+
+    command = mock_execute.await_args.args[1]
+    assert command.parameters == [100, 0]
+
+
+@pytest.mark.parametrize(
+    ("position", "tilt_position"),
+    [(-1, 50), (50, 101), (120, 50)],
+)
+async def test_set_cover_position_and_tilt_rejects_out_of_range(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    position: int,
+    tilt_position: int,
+) -> None:
+    """Values outside 0-100 must be rejected by the service schema."""
+    with (
+        patch(
+            "pyoverkiz.client.OverkizClient.execute_command",
+            new=AsyncMock(return_value="exec-3"),
+        ) as mock_execute,
+        pytest.raises(vol.Invalid),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SET_POSITION_AND_TILT_SERVICE,
+            {
+                ATTR_ENTITY_ID: VENETIAN_BLIND_ENTITY_ID,
+                ATTR_POSITION: position,
+                ATTR_TILT_POSITION: tilt_position,
+            },
+            blocking=True,
+        )
+
+    # Schema validation must block the command from ever being issued.
+    assert mock_execute.await_count == 0
+
+
+async def test_set_cover_position_and_tilt_on_device_without_tilt_is_filtered(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """required_features blocks the service on covers without tilt support.
+
+    The RTS roller shutter has neither SET_TILT_POSITION nor SET_CLOSURE_AND_ORIENTATION.
+    Calling the service on it must not reach execute_command — it is filtered
+    out by the entity-service framework before the handler runs.
+    """
+    with patch(
+        "pyoverkiz.client.OverkizClient.execute_command",
+        new=AsyncMock(return_value="exec-4"),
+    ) as mock_execute:
+        await hass.services.async_call(
+            DOMAIN,
+            SET_POSITION_AND_TILT_SERVICE,
+            {
+                ATTR_ENTITY_ID: ROLLER_SHUTTER_ENTITY_ID,
+                ATTR_POSITION: 50,
+                ATTR_TILT_POSITION: 50,
+            },
+            blocking=True,
+        )
+
+    assert mock_execute.await_count == 0
+
+
+async def test_async_set_cover_position_and_tilt_raises_without_command(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Direct method call must raise ServiceValidationError on unsupported devices.
+
+    Belt-and-braces check next to the framework-level filtering: instantiate the
+    bound method through the entity component and confirm it refuses devices
+    that lack SET_CLOSURE_AND_ORIENTATION.
+    """
+    from homeassistant.components.overkiz.cover.vertical_cover import VerticalCover
+    from homeassistant.helpers import entity_component
+
+    component: entity_component.EntityComponent = hass.data["entity_components"][
+        COVER_DOMAIN
+    ]
+    roller_entity = next(
+        entity
+        for entity in component.entities
+        if entity.entity_id == ROLLER_SHUTTER_ENTITY_ID
+    )
+    assert isinstance(roller_entity, VerticalCover)
+
+    with pytest.raises(ServiceValidationError):
+        await roller_entity.async_set_cover_position_and_tilt(
+            **{ATTR_POSITION: 50, ATTR_TILT_POSITION: 50}
+        )
+
+
+async def test_set_cover_position_inverts_single_value(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Plain set_cover_position must still invert 100-position (unchanged behavior)."""
+    with patch(
+        "pyoverkiz.client.OverkizClient.execute_command",
+        new=AsyncMock(return_value="exec-5"),
+    ) as mock_execute:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: VENETIAN_BLIND_ENTITY_ID, ATTR_POSITION: 25},
+            blocking=True,
+        )
+
+    command = mock_execute.await_args.args[1]
+    assert command.name == OverkizCommand.SET_CLOSURE
+    assert command.parameters == [75]
+
+
+async def test_set_cover_tilt_position_inverts_single_value(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Plain set_cover_tilt_position must still invert 100-tilt (unchanged behavior)."""
+    with patch(
+        "pyoverkiz.client.OverkizClient.execute_command",
+        new=AsyncMock(return_value="exec-6"),
+    ) as mock_execute:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_TILT_POSITION,
+            {ATTR_ENTITY_ID: VENETIAN_BLIND_ENTITY_ID, ATTR_TILT_POSITION: 10},
+            blocking=True,
+        )
+
+    command = mock_execute.await_args.args[1]
+    assert command.name == OverkizCommand.SET_ORIENTATION
+    assert command.parameters == [90]
+
+
+async def test_open_and_close_cover_issue_matching_commands(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Open/Close on a Venetian blind should issue OPEN and CLOSE commands."""
+    with patch(
+        "pyoverkiz.client.OverkizClient.execute_command",
+        new=AsyncMock(return_value="exec-7"),
+    ) as mock_execute:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: VENETIAN_BLIND_ENTITY_ID},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: VENETIAN_BLIND_ENTITY_ID},
+            blocking=True,
+        )
+
+    commands = [c.args[1].name for c in mock_execute.await_args_list]
+    assert OverkizCommand.OPEN in commands
+    assert OverkizCommand.CLOSE in commands


### PR DESCRIPTION
## Proposed change

This PR adds the first `test_cover.py` to the Overkiz test suite, providing regression coverage for the scene motor-stop problem tracked in issue #156234 and the feature PR #166180.

Overkiz blinds cannot stack consecutive `SET_CLOSURE` and `SET_ORIENTATION` commands: the second call interrupts the first, so Home Assistant scenes that target both position and tilt simultaneously produce a fragmented, stop-and-go movement. #166180 introduces a new `overkiz.set_cover_position_and_tilt` entity service that issues a single atomic `SET_CLOSURE_AND_ORIENTATION` command. The author of that PR was unable to supply tests (Windows-only environment, `fcntl` blocks the local pytest run, and no `test_cover.py` existed yet), which is currently the only blocker for the maintainer review.

This change supplies the missing coverage so the feature can land.

### What is tested

- Cover entities are set up correctly from the extended fixture (Venetian blind and RTS roller shutter)
- `current_cover_position` and `current_cover_tilt_position` invert the Overkiz values (Overkiz `0` = open vs. HA `0` = closed)
- `overkiz.set_cover_position_and_tilt` is registered as an entity service
- The service issues a single `execute_command` with `SET_CLOSURE_AND_ORIENTATION` and inverted parameters (regression guard against #156234)
- Boundary values `0` and `100` invert cleanly to `100` and `0`
- Out-of-range values are rejected by the service schema (no command is issued)
- `required_features` keeps the service off covers that do not support tilt (RTS shutter path)
- Direct method call on an unsupported device raises `ServiceValidationError`
- `set_cover_position` and `set_cover_tilt_position` continue to invert their single value (no regression in the existing code paths)
- `cover.open_cover` and `cover.close_cover` dispatch the matching `OverkizCommand`

### Fixture additions

`tests/components/overkiz/fixtures/setup/setup_tahoma_switch.json` gains one `DynamicExteriorVenetianBlind` device:

- `controllableName`: `io:DynamicExteriorVenetianBlindIOComponent`
- `uiClass`: `ExteriorVenetianBlind`
- Commands include `setClosure`, `setClosureAndOrientation`, `setOrientation`, `open`, `close`, and the usual lifecycle commands
- States include `core:ClosureState = 40` and `core:SlatsOrientationState = 70` so the inversion math is exercised with non-trivial values
- The existing RTS roller shutter (`Living Room Shutter`) is kept untouched and serves as the negative case for the tilt service

### Relationship to #166180

Both PRs are needed for CI to go green: this PR ships the tests and fixture data, and #166180 ships the service handler, schema registration, `services.yaml`, `strings.json`, and `icons.json`. Opened as a draft so reviewers can wait for #166180 (or land them as a squash). I am happy to rebase, squash into #166180, or push the test commits straight onto that branch if @iMicknl or @ThomasCZ prefer.

Related to #166180
Related to #156234

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #156234, #166180
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally. *(tests were authored without a local HA dev environment; relying on CI to validate)*
- [ ] Local tests pass. Your PR cannot be merged unless tests pass *(CI will fail against `dev` until #166180 lands — see note above)*
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

cc @iMicknl @ThomasCZ