### PR TITLE
Use runtime_data in tami4 integration

### DIFF
--- a/homeassistant/components/tami4/__init__.py
+++ b/homeassistant/components/tami4/__init__.py
@@ -4,18 +4,17 @@ from __future__ import annotations
 
 from Tami4EdgeAPI import Tami4EdgeAPI, exceptions
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
-from .const import API, CONF_REFRESH_TOKEN, COORDINATOR, DOMAIN
-from .coordinator import Tami4EdgeCoordinator
+from .const import CONF_REFRESH_TOKEN
+from .coordinator import Tami4ConfigEntry, Tami4Data, Tami4EdgeCoordinator
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: Tami4ConfigEntry) -> bool:
     """Set up tami4 from a config entry."""
     refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
 
@@ -29,19 +28,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = Tami4EdgeCoordinator(hass, entry, api)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        API: api,
-        COORDINATOR: coordinator,
-    }
+    entry.runtime_data = Tami4Data(api=api, coordinator=coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: Tami4ConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/tami4/__init__.py
+++ b/homeassistant/components/tami4/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
 from .const import CONF_REFRESH_TOKEN
-from .coordinator import Tami4ConfigEntry, Tami4Data, Tami4EdgeCoordinator
+from .coordinator import Tami4ConfigEntry, Tami4EdgeCoordinator
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR]
 
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: Tami4ConfigEntry) -> boo
     coordinator = Tami4EdgeCoordinator(hass, entry, api)
     await coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = Tami4Data(api=api, coordinator=coordinator)
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/tami4/button.py
+++ b/homeassistant/components/tami4/button.py
@@ -8,12 +8,11 @@ from Tami4EdgeAPI import Tami4EdgeAPI
 from Tami4EdgeAPI.drink import Drink
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import API, DOMAIN
+from .coordinator import Tami4ConfigEntry
 from .entity import Tami4EdgeBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,12 +41,12 @@ BOIL_WATER_BUTTON = Tami4EdgeButtonEntityDescription(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: Tami4ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Tami4Edge."""
 
-    api: Tami4EdgeAPI = hass.data[DOMAIN][entry.entry_id][API]
+    api = entry.runtime_data.api
     buttons: list[Tami4EdgeBaseEntity] = [Tami4EdgeButton(api, BOIL_WATER_BUTTON)]
 
     device = await hass.async_add_executor_job(api.get_device)

--- a/homeassistant/components/tami4/const.py
+++ b/homeassistant/components/tami4/const.py
@@ -3,5 +3,3 @@
 DOMAIN = "tami4"
 CONF_PHONE = "phone"
 CONF_REFRESH_TOKEN = "refresh_token"
-API = "api"
-COORDINATOR = "coordinator"

--- a/homeassistant/components/tami4/coordinator.py
+++ b/homeassistant/components/tami4/coordinator.py
@@ -13,6 +13,16 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 _LOGGER = logging.getLogger(__name__)
 
+type Tami4ConfigEntry = ConfigEntry[Tami4Data]
+
+
+@dataclass
+class Tami4Data:
+    """Runtime data for Tami4Edge."""
+
+    api: Tami4EdgeAPI
+    coordinator: Tami4EdgeCoordinator
+
 
 @dataclass
 class FlattenedWaterQuality:
@@ -37,10 +47,10 @@ class FlattenedWaterQuality:
 class Tami4EdgeCoordinator(DataUpdateCoordinator[FlattenedWaterQuality]):
     """Tami4Edge water quality coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: Tami4ConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, api: Tami4EdgeAPI
+        self, hass: HomeAssistant, config_entry: Tami4ConfigEntry, api: Tami4EdgeAPI
     ) -> None:
         """Initialize the water quality coordinator."""
         super().__init__(

--- a/homeassistant/components/tami4/coordinator.py
+++ b/homeassistant/components/tami4/coordinator.py
@@ -13,15 +13,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 _LOGGER = logging.getLogger(__name__)
 
-type Tami4ConfigEntry = ConfigEntry[Tami4Data]
-
-
-@dataclass
-class Tami4Data:
-    """Runtime data for Tami4Edge."""
-
-    api: Tami4EdgeAPI
-    coordinator: Tami4EdgeCoordinator
+type Tami4ConfigEntry = ConfigEntry[Tami4EdgeCoordinator]
 
 
 @dataclass
@@ -60,12 +52,12 @@ class Tami4EdgeCoordinator(DataUpdateCoordinator[FlattenedWaterQuality]):
             name="Tami4Edge water quality coordinator",
             update_interval=timedelta(minutes=60),
         )
-        self._api = api
+        self.api = api
 
     async def _async_update_data(self) -> FlattenedWaterQuality:
         """Fetch data from the API endpoint."""
         try:
-            device = await self.hass.async_add_executor_job(self._api.get_device)
+            device = await self.hass.async_add_executor_job(self.api.get_device)
 
             return FlattenedWaterQuality(device.water_quality)
         except exceptions.APIRequestFailedException as ex:

--- a/homeassistant/components/tami4/sensor.py
+++ b/homeassistant/components/tami4/sensor.py
@@ -10,14 +10,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import API, COORDINATOR, DOMAIN
-from .coordinator import Tami4EdgeCoordinator
+from .coordinator import Tami4ConfigEntry, Tami4EdgeCoordinator
 from .entity import Tami4EdgeBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,13 +51,12 @@ ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: Tami4ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Tami4Edge."""
-    data = hass.data[DOMAIN][entry.entry_id]
-    api: Tami4EdgeAPI = data[API]
-    coordinator: Tami4EdgeCoordinator = data[COORDINATOR]
+    api = entry.runtime_data.api
+    coordinator = entry.runtime_data.coordinator
 
     async_add_entities(
         Tami4EdgeSensorEntity(

--- a/homeassistant/components/tami4/sensor.py
+++ b/homeassistant/components/tami4/sensor.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from Tami4EdgeAPI import Tami4EdgeAPI
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,

--- a/homeassistant/components/tami4/sensor.py
+++ b/homeassistant/components/tami4/sensor.py
@@ -55,13 +55,12 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Tami4Edge."""
-    api = entry.runtime_data.api
-    coordinator = entry.runtime_data.coordinator
+    coordinator = entry.runtime_data
 
     async_add_entities(
         Tami4EdgeSensorEntity(
             coordinator=coordinator,
-            api=api,
+            api=coordinator.api,
             entity_description=entity_description,
         )
         for entity_description in ENTITY_DESCRIPTIONS

--- a/homeassistant/components/tami4/sensor.py
+++ b/homeassistant/components/tami4/sensor.py
@@ -60,7 +60,6 @@ async def async_setup_entry(
     async_add_entities(
         Tami4EdgeSensorEntity(
             coordinator=coordinator,
-            api=coordinator.api,
             entity_description=entity_description,
         )
         for entity_description in ENTITY_DESCRIPTIONS
@@ -77,11 +76,10 @@ class Tami4EdgeSensorEntity(
     def __init__(
         self,
         coordinator: Tami4EdgeCoordinator,
-        api: Tami4EdgeAPI,
         entity_description: SensorEntityDescription,
     ) -> None:
         """Initialize the Tami4Edge sensor entity."""
-        Tami4EdgeBaseEntity.__init__(self, api, entity_description)
+        Tami4EdgeBaseEntity.__init__(self, coordinator.api, entity_description)
         CoordinatorEntity.__init__(self, coordinator)
         self._update_attr()
 


### PR DESCRIPTION
## Proposed change

Migrate the `tami4` integration to use `runtime_data` instead of storing data in `hass.data[DOMAIN]`.

- Add `Tami4ConfigEntry` type alias ~and `Tami4Data` dataclass in `coordinator.py`~
- Store ~`Tami4Data` (containing `api` and `coordinator`)~ coordinator in `entry.runtime_data`
- Update `button.py` and `sensor.py` to access data via `entry.runtime_data`
- Simplify `async_unload_entry` (no longer needs to clean up `hass.data`)
- Remove unused `API` and `COORDINATOR` constants from `const.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr