### PR TITLE
Always load all platforms in sfr_box

### DIFF
--- a/homeassistant/components/sfr_box/__init__.py
+++ b/homeassistant/components/sfr_box/__init__.py
@@ -94,6 +94,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
     """Unload a config entry."""
-    if entry.data.get(CONF_USERNAME) and entry.data.get(CONF_PASSWORD):
-        return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/sfr_box/__init__.py
+++ b/homeassistant/components/sfr_box/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
 
 from sfrbox_api.bridge import SFRBox
 from sfrbox_api.exceptions import SFRBoxAuthenticationError, SFRBoxError
@@ -14,14 +13,13 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, PLATFORMS, PLATFORMS_WITH_AUTH
+from .const import DOMAIN, PLATFORMS
 from .coordinator import SFRConfigEntry, SFRDataUpdateCoordinator, SFRRuntimeData
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
     """Set up SFR box as config entry."""
     box = SFRBox(ip=entry.data[CONF_HOST], client=async_get_clientsession(hass))
-    platforms = PLATFORMS
     has_auth = False
     if (username := entry.data.get(CONF_USERNAME)) and (
         password := entry.data.get(CONF_PASSWORD)
@@ -39,11 +37,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
                 translation_key="unknown_error",
                 translation_placeholders={"error": str(err)},
             ) from err
-        platforms = PLATFORMS_WITH_AUTH
         has_auth = True
 
     data = SFRRuntimeData(
         box=box,
+        has_authentication=has_auth,
         dsl=SFRDataUpdateCoordinator(
             hass, entry, box, "dsl", lambda b: b.dsl_get_info()
         ),
@@ -65,8 +63,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
     # Preload system information
     await data.system.async_config_entry_first_refresh()
     system_info = data.system.data
-    if TYPE_CHECKING:
-        assert system_info is not None
 
     # Preload other coordinators (based on net infrastructure)
     tasks = [data.wan.async_config_entry_first_refresh()]
@@ -91,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
     )
 
     entry.runtime_data = data
-    await hass.config_entries.async_forward_entry_setups(entry, platforms)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
@@ -99,7 +95,5 @@ async def async_setup_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: SFRConfigEntry) -> bool:
     """Unload a config entry."""
     if entry.data.get(CONF_USERNAME) and entry.data.get(CONF_PASSWORD):
-        return await hass.config_entries.async_unload_platforms(
-            entry, PLATFORMS_WITH_AUTH
-        )
+        return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/sfr_box/binary_sensor.py
+++ b/homeassistant/components/sfr_box/binary_sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from sfrbox_api.models import DslInfo, FtthInfo, VoipInfo, WanInfo
 
@@ -88,8 +87,6 @@ async def async_setup_entry(
     """Set up the sensors."""
     data = entry.runtime_data
     system_info = data.system.data
-    if TYPE_CHECKING:
-        assert system_info is not None
 
     entities: list[SFRBoxBinarySensor] = [
         SFRBoxBinarySensor(data.wan, description, system_info)

--- a/homeassistant/components/sfr_box/button.py
+++ b/homeassistant/components/sfr_box/button.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Concatenate
+from typing import Any, Concatenate
 
 from sfrbox_api.bridge import SFRBox
 from sfrbox_api.exceptions import SFRBoxError
@@ -78,9 +78,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up the buttons."""
     data = entry.runtime_data
+    if not data.has_authentication:
+        # All buttons currently require authentication
+        return
+
     system_info = data.system.data
-    if TYPE_CHECKING:
-        assert system_info is not None
 
     entities = [
         SFRBoxButton(data.box, description, system_info) for description in BUTTON_TYPES

--- a/homeassistant/components/sfr_box/const.py
+++ b/homeassistant/components/sfr_box/const.py
@@ -7,5 +7,4 @@ DEFAULT_USERNAME = "admin"
 
 DOMAIN = "sfr_box"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
-PLATFORMS_WITH_AUTH = [*PLATFORMS, Platform.BUTTON]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]

--- a/homeassistant/components/sfr_box/coordinator.py
+++ b/homeassistant/components/sfr_box/coordinator.py
@@ -29,6 +29,7 @@ class SFRRuntimeData:
     """Runtime data for SFR Box."""
 
     box: SFRBox
+    has_authentication: bool
     dsl: SFRDataUpdateCoordinator[DslInfo]
     ftth: SFRDataUpdateCoordinator[FtthInfo]
     system: SFRDataUpdateCoordinator[SystemInfo]

--- a/homeassistant/components/sfr_box/sensor.py
+++ b/homeassistant/components/sfr_box/sensor.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from sfrbox_api.models import DslInfo, SystemInfo, VoipInfo, WanInfo
 
@@ -236,8 +235,6 @@ async def async_setup_entry(
     """Set up the sensors."""
     data = entry.runtime_data
     system_info = data.system.data
-    if TYPE_CHECKING:
-        assert system_info is not None
 
     entities: list[SFRBoxSensor] = [
         SFRBoxSensor(data.system, description, system_info)

--- a/tests/components/sfr_box/snapshots/test_button.ambr
+++ b/tests/components/sfr_box/snapshots/test_button.ambr
@@ -50,7 +50,3 @@
     'state': 'unknown',
   })
 # ---
-# name: test_buttons_no_auth
-  list([
-  ])
-# ---

--- a/tests/components/sfr_box/snapshots/test_button.ambr
+++ b/tests/components/sfr_box/snapshots/test_button.ambr
@@ -50,3 +50,7 @@
     'state': 'unknown',
   })
 # ---
+# name: test_buttons_no_auth
+  list([
+  ])
+# ---

--- a/tests/components/sfr_box/test_binary_sensor.py
+++ b/tests/components/sfr_box/test_binary_sensor.py
@@ -24,10 +24,6 @@ def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with (
         patch("homeassistant.components.sfr_box.PLATFORMS", [Platform.BINARY_SENSOR]),
-        patch(
-            "homeassistant.components.sfr_box.PLATFORMS_WITH_AUTH",
-            [Platform.BINARY_SENSOR],
-        ),
         patch("homeassistant.components.sfr_box.coordinator.SFRBox.authenticate"),
     ):
         yield

--- a/tests/components/sfr_box/test_button.py
+++ b/tests/components/sfr_box/test_button.py
@@ -23,11 +23,9 @@ pytestmark = pytest.mark.usefixtures(
 
 @pytest.fixture(autouse=True)
 def override_platforms() -> Generator[None]:
-    """Override PLATFORMS_WITH_AUTH."""
+    """Override PLATFORMS."""
     with (
-        patch(
-            "homeassistant.components.sfr_box.PLATFORMS_WITH_AUTH", [Platform.BUTTON]
-        ),
+        patch("homeassistant.components.sfr_box.PLATFORMS", [Platform.BUTTON]),
         patch("homeassistant.components.sfr_box.coordinator.SFRBox.authenticate"),
     ):
         yield

--- a/tests/components/sfr_box/test_button.py
+++ b/tests/components/sfr_box/test_button.py
@@ -57,7 +57,7 @@ async def test_buttons_no_auth(
     await hass.async_block_till_done()
 
     # Ensure auth-only entities are not registered
-    assert sorted(entity_registry.entities) == snapshot
+    assert len(entity_registry.entities) == 0
 
 
 async def test_reboot(hass: HomeAssistant, config_entry_with_auth: ConfigEntry) -> None:

--- a/tests/components/sfr_box/test_button.py
+++ b/tests/components/sfr_box/test_button.py
@@ -46,6 +46,20 @@ async def test_buttons(
     )
 
 
+async def test_buttons_no_auth(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test for SFR Box buttons."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Ensure auth-only entities are not registered
+    assert sorted(entity_registry.entities) == snapshot
+
+
 async def test_reboot(hass: HomeAssistant, config_entry_with_auth: ConfigEntry) -> None:
     """Test for SFR Box reboot button."""
     await hass.config_entries.async_setup(config_entry_with_auth.entry_id)

--- a/tests/components/sfr_box/test_sensor.py
+++ b/tests/components/sfr_box/test_sensor.py
@@ -23,9 +23,6 @@ def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with (
         patch("homeassistant.components.sfr_box.PLATFORMS", [Platform.SENSOR]),
-        patch(
-            "homeassistant.components.sfr_box.PLATFORMS_WITH_AUTH", [Platform.SENSOR]
-        ),
         patch("homeassistant.components.sfr_box.coordinator.SFRBox.authenticate"),
     ):
         yield


### PR DESCRIPTION
## Proposed change

- Simplify platform setup/unload by always using `PLATFORMS` (button platform now guards itself via `has_authentication`)
- Update platform files (`binary_sensor.py`, `button.py`, `sensor.py`) to remove unnecessary `TYPE_CHECKING` assertions
- Remove unused `PLATFORMS_WITH_AUTH` from `const.py`
- Update test fixtures to match simplified platform constants

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr