### PR TITLE
Fix nobo_hub via_device warning

### DIFF
--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -5,12 +5,25 @@ from __future__ import annotations
 from pynobo import nobo
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_IP_ADDRESS, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import (
+    ATTR_NAME,
+    CONF_IP_ADDRESS,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_AUTO_DISCOVERED, CONF_SERIAL, DOMAIN
+from .const import (
+    ATTR_HARDWARE_VERSION,
+    ATTR_SOFTWARE_VERSION,
+    CONF_AUTO_DISCOVERED,
+    CONF_SERIAL,
+    DOMAIN,
+    NOBO_MANUFACTURER,
+)
 
 PLATFORMS = [Platform.CLIMATE, Platform.SELECT, Platform.SENSOR]
 
@@ -75,6 +88,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_close)
     )
     entry.runtime_data = hub
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, hub.hub_serial)},
+        serial_number=hub.hub_serial,
+        name=hub.hub_info[ATTR_NAME],
+        manufacturer=NOBO_MANUFACTURER,
+        model="Nobø Ecohub",
+        sw_version=hub.hub_info[ATTR_SOFTWARE_VERSION],
+        hw_version=hub.hub_info[ATTR_HARDWARE_VERSION],
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -205,12 +205,11 @@ async def test_setup_registers_hub_device_before_forwarding_platforms(
     hub = _make_hub_mock()
     forward_called_with_device = {}
 
-    async def _capture_forward(_entry, _platforms):
+    async def _capture_forward(_entry, _platforms) -> None:
         device_registry = dr.async_get(hass)
         forward_called_with_device["device"] = device_registry.async_get_device(
             identifiers={(DOMAIN, SERIAL)}
         )
-        return True
 
     with (
         patch("homeassistant.components.nobo_hub.nobo") as mock_cls,
@@ -225,4 +224,4 @@ async def test_setup_registers_hub_device_before_forwarding_platforms(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert forward_called_with_device["device"] is not None
+    assert forward_called_with_device.get("device") is not None

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -172,3 +173,56 @@ async def test_setup_autodiscovered_rediscovery_failure(
 
     assert exc_info.value.translation_key == expected_key
     assert exc_info.value.translation_placeholders == expected_placeholders
+
+
+async def test_setup_registers_hub_device(hass: HomeAssistant) -> None:
+    """The hub device is registered with the expected metadata."""
+    entry = _make_entry(hass, auto_discovered=False)
+    hub = _make_hub_mock()
+    with patch("homeassistant.components.nobo_hub.nobo") as mock_cls:
+        mock_cls.return_value = hub
+        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    assert device is not None
+    assert device.config_entries == {entry.entry_id}
+    assert device.name == "My Eco Hub"
+    assert device.manufacturer == "Glen Dimplex Nordic AS"
+    assert device.model == "Nobø Ecohub"
+    assert device.serial_number == SERIAL
+    assert device.sw_version == "115"
+    assert device.hw_version == "hw"
+
+
+async def test_setup_registers_hub_device_before_forwarding_platforms(
+    hass: HomeAssistant,
+) -> None:
+    """The hub device exists by the time platforms are forwarded."""
+    entry = _make_entry(hass, auto_discovered=False)
+    hub = _make_hub_mock()
+    forward_called_with_device = {}
+
+    async def _capture_forward(_entry, _platforms):
+        device_registry = dr.async_get(hass)
+        forward_called_with_device["device"] = device_registry.async_get_device(
+            identifiers={(DOMAIN, SERIAL)}
+        )
+        return True
+
+    with (
+        patch("homeassistant.components.nobo_hub.nobo") as mock_cls,
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            side_effect=_capture_forward,
+        ),
+    ):
+        mock_cls.return_value = hub
+        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert forward_called_with_device["device"] is not None

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -175,7 +175,10 @@ async def test_setup_autodiscovered_rediscovery_failure(
     assert exc_info.value.translation_placeholders == expected_placeholders
 
 
-async def test_setup_registers_hub_device(hass: HomeAssistant) -> None:
+async def test_setup_registers_hub_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
     """The hub device is registered with the expected metadata."""
     entry = _make_entry(hass, auto_discovered=False)
     hub = _make_hub_mock()
@@ -185,7 +188,6 @@ async def test_setup_registers_hub_device(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
     assert device is not None
     assert device.config_entries == {entry.entry_id}
@@ -195,33 +197,3 @@ async def test_setup_registers_hub_device(hass: HomeAssistant) -> None:
     assert device.serial_number == SERIAL
     assert device.sw_version == "115"
     assert device.hw_version == "hw"
-
-
-async def test_setup_registers_hub_device_before_forwarding_platforms(
-    hass: HomeAssistant,
-) -> None:
-    """The hub device exists by the time platforms are forwarded."""
-    entry = _make_entry(hass, auto_discovered=False)
-    hub = _make_hub_mock()
-    forward_called_with_device = {}
-
-    async def _capture_forward(_entry, _platforms) -> None:
-        device_registry = dr.async_get(hass)
-        forward_called_with_device["device"] = device_registry.async_get_device(
-            identifiers={(DOMAIN, SERIAL)}
-        )
-
-    with (
-        patch("homeassistant.components.nobo_hub.nobo") as mock_cls,
-        patch.object(
-            hass.config_entries,
-            "async_forward_entry_setups",
-            side_effect=_capture_forward,
-        ),
-    ):
-        mock_cls.return_value = hub
-        mock_cls.async_discover_hubs = AsyncMock(return_value=set())
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert forward_called_with_device.get("device") is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Context: This is the second of 3 PRs to bring the `nobo_hub` integration to the bronze level on the quality scale.

### Register Nobø Ecohub device early in setup

Nobø Hub entities set `via_device=(DOMAIN, hub.hub_serial)`, but the parent hub device was being created lazily by `NoboGlobalSelector`'s `DeviceInfo`. When the climate platform loaded before select, zone entities referenced a device that did not yet exist:
```
Detected that integration 'nobo_hub' calls device_registry.async_get_or_create referencing a non existing via_device ('nobo_hub', '<serial>'). This will stop working in Home Assistant 2025.12.0                           
```                                                                                                                                                                                                                                                                                                                  
This PR registers the hub device explicitly in `async_setup_entry` before forwarding to platforms.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
