### PR TITLE
User camera unique id in go2rtc if available

### DIFF
--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -67,7 +67,7 @@ from .const import (
     RECOMMENDED_VERSION,
 )
 from .server import Server
-from .util import get_go2rtc_unix_socket_path
+from .util import get_camera_identifier, get_go2rtc_unix_socket_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -308,7 +308,7 @@ class WebRTCProvider(CameraWebRTCProvider):
             return
 
         self._sessions[session_id] = ws_client = Go2RtcWsClient(
-            self._session, self._url, source=camera.entity_id
+            self._session, self._url, source=get_camera_identifier(camera)
         )
 
         @callback
@@ -354,7 +354,7 @@ class WebRTCProvider(CameraWebRTCProvider):
         """Get an image from the camera."""
         await self._update_stream_source(camera)
         return await self._rest_client.get_jpeg_snapshot(
-            camera.entity_id, width, height
+            get_camera_identifier(camera), width, height
         )
 
     async def _update_stream_source(self, camera: Camera) -> None:
@@ -399,18 +399,19 @@ class WebRTCProvider(CameraWebRTCProvider):
                     stream_source += "#rotate=90"
 
         streams = await self._rest_client.streams.list()
+        identifier = get_camera_identifier(camera)
 
-        if (stream := streams.get(camera.entity_id)) is None or not any(
+        if (stream := streams.get(identifier)) is None or not any(
             stream_source == producer.url for producer in stream.producers
         ):
             await self._rest_client.streams.add(
-                camera.entity_id,
+                identifier,
                 [
                     stream_source,
                     # We are setting any ffmpeg rtsp related logs to debug
                     # Connection problems to the camera will be logged by the first stream
                     # Therefore setting it to debug will not hide any important logs
-                    f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+                    f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
                 ],
             )
 

--- a/homeassistant/components/go2rtc/util.py
+++ b/homeassistant/components/go2rtc/util.py
@@ -1,14 +1,15 @@
 """Go2rtc utility functions."""
 
 from pathlib import Path
-import re
+import string
+from urllib.parse import quote
 
 from homeassistant.components.camera import Camera
 
 _HA_MANAGED_UNIX_SOCKET_FILE = "go2rtc.sock"
 # Go2rtc is not validating the camera identifier, but some characters (e.g. : or #)
 # have special meaning in URLs and could cause issues.
-_SANITIZE_IDENTIFIER = re.compile(r"[^a-zA-Z0-9._-]")
+_SAFE_CHARS = string.ascii_letters + string.digits + "._-"
 
 
 def get_go2rtc_unix_socket_path(path: str | Path) -> str:
@@ -21,4 +22,4 @@ def get_go2rtc_unix_socket_path(path: str | Path) -> str:
 def get_camera_identifier(camera: Camera) -> str:
     """Get the Go2rtc camera identifier."""
     attr = camera.unique_id or camera.entity_id
-    return _SANITIZE_IDENTIFIER.sub(lambda m: f"%{ord(m.group()):02X}", attr)
+    return quote(attr, safe=_SAFE_CHARS)

--- a/homeassistant/components/go2rtc/util.py
+++ b/homeassistant/components/go2rtc/util.py
@@ -1,8 +1,14 @@
 """Go2rtc utility functions."""
 
 from pathlib import Path
+import re
+
+from homeassistant.components.camera import Camera
 
 _HA_MANAGED_UNIX_SOCKET_FILE = "go2rtc.sock"
+# Go2rtc is not validating the camera identifier, but some characters (e.g. : or #)
+# have special meaning in URLs and could cause issues.
+_SANITIZE_IDENTIFIER = re.compile(r"[^a-zA-Z0-9._-]")
 
 
 def get_go2rtc_unix_socket_path(path: str | Path) -> str:
@@ -10,3 +16,9 @@ def get_go2rtc_unix_socket_path(path: str | Path) -> str:
     if not isinstance(path, Path):
         path = Path(path)
     return str(path / _HA_MANAGED_UNIX_SOCKET_FILE)
+
+
+def get_camera_identifier(camera: Camera) -> str:
+    """Get the Go2rtc camera identifier."""
+    attr = camera.unique_id or camera.entity_id
+    return _SANITIZE_IDENTIFIER.sub(lambda m: f"%{ord(m.group()):02X}", attr)

--- a/homeassistant/components/go2rtc/util.py
+++ b/homeassistant/components/go2rtc/util.py
@@ -21,5 +21,7 @@ def get_go2rtc_unix_socket_path(path: str | Path) -> str:
 
 def get_camera_identifier(camera: Camera) -> str:
     """Get the Go2rtc camera identifier."""
-    attr = camera.unique_id or camera.entity_id
+    attr = camera.entity_id
+    if camera.unique_id is not None:
+        attr = f"{camera.platform.platform_name}_{camera.unique_id}"
     return quote(attr, safe=_SAFE_CHARS)

--- a/tests/components/go2rtc/__init__.py
+++ b/tests/components/go2rtc/__init__.py
@@ -9,10 +9,11 @@ class MockCamera(Camera):
     _attr_name = "Test"
     _attr_supported_features: CameraEntityFeature = CameraEntityFeature.STREAM
 
-    def __init__(self) -> None:
+    def __init__(self, unique_id: str | None) -> None:
         """Initialize the mock entity."""
         super().__init__()
         self._stream_source: str | None = "rtsp://stream"
+        self._attr_unique_id = unique_id
 
     def set_stream_source(self, stream_source: str | None) -> None:
         """Set the stream source."""

--- a/tests/components/go2rtc/conftest.py
+++ b/tests/components/go2rtc/conftest.py
@@ -186,9 +186,16 @@ def integration_config_entry(hass: HomeAssistant) -> ConfigEntry:
 
 
 @pytest.fixture
+def camera_unique_id() -> str | None:
+    """Camera unique ID."""
+    return "test_camera_unique_id"
+
+
+@pytest.fixture
 async def init_test_integration(
     hass: HomeAssistant,
     integration_config_entry: ConfigEntry,
+    camera_unique_id: str | None,
 ) -> MockCamera:
     """Initialize components."""
 
@@ -218,7 +225,7 @@ async def init_test_integration(
             async_unload_entry=async_unload_entry_init,
         ),
     )
-    test_camera = MockCamera()
+    test_camera = MockCamera(camera_unique_id)
     setup_test_component_platform(
         hass, CAMERA_DOMAIN, [test_camera], from_config_entry=True
     )

--- a/tests/components/go2rtc/conftest.py
+++ b/tests/components/go2rtc/conftest.py
@@ -188,7 +188,7 @@ def integration_config_entry(hass: HomeAssistant) -> ConfigEntry:
 @pytest.fixture
 def camera_unique_id() -> str | None:
     """Camera unique ID."""
-    return "test_camera_unique_id"
+    return "camera_unique_id"
 
 
 @pytest.fixture

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -201,6 +201,7 @@ async def _test_setup_and_signaling(
         "test_camera_unique_id",
         None,
     ],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     ("config", "ui_enabled", "expected_username", "expected_password"),
@@ -299,6 +300,7 @@ async def test_setup_go_binary(
         "test_camera_unique_id",
         None,
     ],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     ("go2rtc_binary", "is_docker_env"),

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -88,10 +88,9 @@ async def _test_setup_and_signaling(
     config: ConfigType,
     after_setup_fn: Callable[[], None],
     camera: MockCamera,
-    camera_unique_id: str | None,
 ) -> None:
     """Test the go2rtc config entry."""
-    identifier = camera_unique_id or camera.entity_id
+    identifier = get_camera_identifier(camera)
     assert camera.camera_capabilities.frontend_stream_types == {StreamType.HLS}
 
     assert await async_setup_component(hass, DOMAIN, config)
@@ -256,7 +255,6 @@ async def test_setup_go_binary(
     ui_enabled: bool,
     expected_username: str,
     expected_password: str,
-    camera_unique_id: str | None,
 ) -> None:
     """Test the go2rtc config entry with binary."""
     assert (len(hass.config_entries.async_entries(DOMAIN)) == 1) == has_go2rtc_entry
@@ -288,7 +286,6 @@ async def test_setup_go_binary(
             config,
             after_setup,
             init_test_integration,
-            camera_unique_id,
         )
 
     await hass.async_stop()
@@ -321,7 +318,6 @@ async def test_setup(
     mock_get_binary: Mock,
     mock_is_docker_env: Mock,
     has_go2rtc_entry: bool,
-    camera_unique_id: str | None,
 ) -> None:
     """Test the go2rtc config entry without binary."""
     assert (len(hass.config_entries.async_entries(DOMAIN)) == 1) == has_go2rtc_entry
@@ -339,7 +335,6 @@ async def test_setup(
         config,
         after_setup,
         init_test_integration,
-        camera_unique_id,
     )
 
     mock_get_binary.assert_not_called()

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -42,7 +42,10 @@ from homeassistant.components.go2rtc.const import (
     DOMAIN,
     RECOMMENDED_VERSION,
 )
-from homeassistant.components.go2rtc.util import get_go2rtc_unix_socket_path
+from homeassistant.components.go2rtc.util import (
+    get_camera_identifier,
+    get_go2rtc_unix_socket_path,
+)
 from homeassistant.components.stream import Orientation
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
@@ -85,9 +88,10 @@ async def _test_setup_and_signaling(
     config: ConfigType,
     after_setup_fn: Callable[[], None],
     camera: MockCamera,
+    camera_unique_id: str | None,
 ) -> None:
     """Test the go2rtc config entry."""
-    entity_id = camera.entity_id
+    identifier = camera_unique_id or camera.entity_id
     assert camera.camera_capabilities.frontend_stream_types == {StreamType.HLS}
 
     assert await async_setup_component(hass, DOMAIN, config)
@@ -124,17 +128,17 @@ async def _test_setup_and_signaling(
     await test("sesion_1")
 
     rest_client.streams.add.assert_called_once_with(
-        entity_id,
+        identifier,
         [
             "rtsp://stream",
-            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+            f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
         ],
     )
 
     # Stream exists but the source is different
     rest_client.streams.add.reset_mock()
     rest_client.streams.list.return_value = {
-        entity_id: Stream([Producer("rtsp://different")])
+        identifier: Stream([Producer("rtsp://different")])
     }
 
     receive_message_callback.reset_mock()
@@ -142,17 +146,17 @@ async def _test_setup_and_signaling(
     await test("session_2")
 
     rest_client.streams.add.assert_called_once_with(
-        entity_id,
+        identifier,
         [
             "rtsp://stream",
-            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+            f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
         ],
     )
 
     # If the stream is already added, the stream should not be added again.
     rest_client.streams.add.reset_mock()
     rest_client.streams.list.return_value = {
-        entity_id: Stream([Producer("rtsp://stream")])
+        identifier: Stream([Producer("rtsp://stream")])
     }
 
     receive_message_callback.reset_mock()
@@ -191,6 +195,13 @@ async def _test_setup_and_signaling(
     "mock_get_binary",
     "mock_is_docker_env",
     "mock_go2rtc_entry",
+)
+@pytest.mark.parametrize(
+    "camera_unique_id",
+    [
+        "test_camera_unique_id",
+        None,
+    ],
 )
 @pytest.mark.parametrize(
     ("config", "ui_enabled", "expected_username", "expected_password"),
@@ -245,6 +256,7 @@ async def test_setup_go_binary(
     ui_enabled: bool,
     expected_username: str,
     expected_password: str,
+    camera_unique_id: str | None,
 ) -> None:
     """Test the go2rtc config entry with binary."""
     assert (len(hass.config_entries.async_entries(DOMAIN)) == 1) == has_go2rtc_entry
@@ -276,6 +288,7 @@ async def test_setup_go_binary(
             config,
             after_setup,
             init_test_integration,
+            camera_unique_id,
         )
 
     await hass.async_stop()
@@ -283,6 +296,13 @@ async def test_setup_go_binary(
 
 
 @pytest.mark.usefixtures("mock_go2rtc_entry")
+@pytest.mark.parametrize(
+    "camera_unique_id",
+    [
+        "test_camera_unique_id",
+        None,
+    ],
+)
 @pytest.mark.parametrize(
     ("go2rtc_binary", "is_docker_env"),
     [
@@ -301,6 +321,7 @@ async def test_setup(
     mock_get_binary: Mock,
     mock_is_docker_env: Mock,
     has_go2rtc_entry: bool,
+    camera_unique_id: str | None,
 ) -> None:
     """Test the go2rtc config entry without binary."""
     assert (len(hass.config_entries.async_entries(DOMAIN)) == 1) == has_go2rtc_entry
@@ -318,6 +339,7 @@ async def test_setup(
         config,
         after_setup,
         init_test_integration,
+        camera_unique_id,
     )
 
     mock_get_binary.assert_not_called()
@@ -816,11 +838,12 @@ async def test_generic_workaround(
         image = await async_get_image(hass, camera.entity_id)
         assert image.content == image_bytes
 
+    identifier = get_camera_identifier(camera)
     rest_client.streams.add.assert_called_once_with(
-        camera.entity_id,
+        identifier,
         [
             "ffmpeg:https://my_stream_url.m3u8",
-            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+            f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
         ],
     )
 
@@ -849,11 +872,12 @@ async def _test_camera_orientation(
     await camera_fn(hass, camera)
 
     # Verify the stream was configured correctly
+    identifier = get_camera_identifier(camera)
     rest_client.streams.add.assert_called_once_with(
-        camera.entity_id,
+        identifier,
         [
             expected_stream_source,
-            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+            f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
         ],
     )
 

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -835,14 +835,14 @@ async def test_generic_workaround(
         image = await async_get_image(hass, camera.entity_id)
         assert image.content == image_bytes
 
-    identifier = get_camera_identifier(camera)
-    rest_client.streams.add.assert_called_once_with(
-        identifier,
-        [
-            "ffmpeg:https://my_stream_url.m3u8",
-            f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
-        ],
-    )
+        identifier = get_camera_identifier(camera)
+        rest_client.streams.add.assert_called_once_with(
+            identifier,
+            [
+                "ffmpeg:https://my_stream_url.m3u8",
+                f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
+            ],
+        )
 
 
 async def _test_camera_orientation(

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -198,7 +198,7 @@ async def _test_setup_and_signaling(
 @pytest.mark.parametrize(
     "camera_unique_id",
     [
-        "test_camera_unique_id",
+        "camera_unique_id",
         None,
     ],
     indirect=True,
@@ -297,7 +297,7 @@ async def test_setup_go_binary(
 @pytest.mark.parametrize(
     "camera_unique_id",
     [
-        "test_camera_unique_id",
+        "camera_unique_id",
         None,
     ],
     indirect=True,

--- a/tests/components/go2rtc/test_util.py
+++ b/tests/components/go2rtc/test_util.py
@@ -29,6 +29,8 @@ from homeassistant.components.go2rtc.util import get_camera_identifier
         ("cam@1", "camera.test", "cam%401"),
         ("cam_1", "camera.test", "cam_1"),
         ("cam%231", "camera.test", "cam%25231"),
+        # Non-ASCII: UTF-8 byte-wise encoding (€ = E2 82 AC)
+        ("cam€1", "camera.test", "cam%E2%82%AC1"),
     ],
 )
 def test_get_camera_identifier(

--- a/tests/components/go2rtc/test_util.py
+++ b/tests/components/go2rtc/test_util.py
@@ -1,0 +1,41 @@
+"""Go2rtc utility function tests."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from homeassistant.components.camera import Camera
+from homeassistant.components.go2rtc.util import get_camera_identifier
+
+
+@pytest.mark.parametrize(
+    ("unique_id", "entity_id", "expected"),
+    [
+        # Prefer unique_id over entity_id
+        ("unique123", "camera.test", "unique123"),
+        # Fall back to entity_id when unique_id is None
+        (None, "camera.test", "camera.test"),
+        # Safe characters pass through
+        ("abc-def_ghi.123", "camera.test", "abc-def_ghi.123"),
+        # Special characters are percent-encoded
+        ("cam#1", "camera.test", "cam%231"),
+        ("cam:1", "camera.test", "cam%3A1"),
+        ("cam/1", "camera.test", "cam%2F1"),
+        ("cam?1", "camera.test", "cam%3F1"),
+        ("cam&1", "camera.test", "cam%261"),
+        ("cam=1", "camera.test", "cam%3D1"),
+        ("cam%1", "camera.test", "cam%251"),
+        ("cam 1", "camera.test", "cam%201"),
+        ("cam@1", "camera.test", "cam%401"),
+        ("cam_1", "camera.test", "cam_1"),
+        ("cam%231", "camera.test", "cam%25231"),
+    ],
+)
+def test_get_camera_identifier(
+    unique_id: str | None, entity_id: str, expected: str
+) -> None:
+    """Test get_camera_identifier sanitizes and prefers unique_id."""
+    camera = Mock(spec=Camera)
+    camera.unique_id = unique_id
+    camera.entity_id = entity_id
+    assert get_camera_identifier(camera) == expected

--- a/tests/components/go2rtc/test_util.py
+++ b/tests/components/go2rtc/test_util.py
@@ -12,32 +12,33 @@ from homeassistant.components.go2rtc.util import get_camera_identifier
     ("unique_id", "entity_id", "expected"),
     [
         # Prefer unique_id over entity_id
-        ("unique123", "camera.test", "unique123"),
+        ("unique123", "camera.test", "test_unique123"),
         # Fall back to entity_id when unique_id is None
         (None, "camera.test", "camera.test"),
         # Safe characters pass through
-        ("abc-def_ghi.123", "camera.test", "abc-def_ghi.123"),
+        ("abc-def_ghi.123", "camera.test", "test_abc-def_ghi.123"),
         # Special characters are percent-encoded
-        ("cam#1", "camera.test", "cam%231"),
-        ("cam:1", "camera.test", "cam%3A1"),
-        ("cam/1", "camera.test", "cam%2F1"),
-        ("cam?1", "camera.test", "cam%3F1"),
-        ("cam&1", "camera.test", "cam%261"),
-        ("cam=1", "camera.test", "cam%3D1"),
-        ("cam%1", "camera.test", "cam%251"),
-        ("cam 1", "camera.test", "cam%201"),
-        ("cam@1", "camera.test", "cam%401"),
-        ("cam_1", "camera.test", "cam_1"),
-        ("cam%231", "camera.test", "cam%25231"),
+        ("cam#1", "camera.test", "test_cam%231"),
+        ("cam:1", "camera.test", "test_cam%3A1"),
+        ("cam/1", "camera.test", "test_cam%2F1"),
+        ("cam?1", "camera.test", "test_cam%3F1"),
+        ("cam&1", "camera.test", "test_cam%261"),
+        ("cam=1", "camera.test", "test_cam%3D1"),
+        ("cam%1", "camera.test", "test_cam%251"),
+        ("cam 1", "camera.test", "test_cam%201"),
+        ("cam@1", "camera.test", "test_cam%401"),
+        ("cam_1", "camera.test", "test_cam_1"),
+        ("cam%231", "camera.test", "test_cam%25231"),
         # Non-ASCII: UTF-8 byte-wise encoding (€ = E2 82 AC)
-        ("cam€1", "camera.test", "cam%E2%82%AC1"),
+        ("cam€1", "camera.test", "test_cam%E2%82%AC1"),
     ],
 )
 def test_get_camera_identifier(
     unique_id: str | None, entity_id: str, expected: str
 ) -> None:
     """Test get_camera_identifier sanitizes and prefers unique_id."""
-    camera = Mock(spec=Camera)
+    camera = Mock(spec_set=Camera)
+    camera.platform.platform_name = "test"
     camera.unique_id = unique_id
     camera.entity_id = entity_id
     assert get_camera_identifier(camera) == expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prefer unique id over entity id, so we don't need to update the config if the user manually changes the entity id.
No migration is needed as the managed go2rtc is creating a new config file on each boot.

Unfortunately go2rtc is not validating the identifier but if passed in stream source some characters have special meaning.
To avoid strange issues we allow just a simple character set. All chars not in this set will be replaced by their hex representatives to still make sure we have a unique string.

Downside of using the unique id is that it's harder for a user to identify the camera in the go2rtc UI. This is acceptable as users should only use the go2rtc UI when debugging, which should be less frequent.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
