### PR TITLE
Use runtime_data in vallox integration

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -16,7 +16,6 @@ from .const import DEFAULT_NAME, DOMAIN
 from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 from .services import async_setup_services
 
-
 CONFIG_SCHEMA = vol.Schema(
     vol.All(
         cv.deprecated(DOMAIN),

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DEFAULT_NAME, DOMAIN
 from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
+from .services import async_setup_services
 
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -7,15 +7,14 @@ import ipaddress
 from vallox_websocket_api import Vallox
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DEFAULT_NAME, DOMAIN
-from .coordinator import ValloxDataUpdateCoordinator
-from .services import async_setup_services
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
+
 
 CONFIG_SCHEMA = vol.Schema(
     vol.All(
@@ -48,10 +47,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ValloxConfigEntry) -> bool:
     """Set up the client and boot the platforms."""
     host = entry.data[CONF_HOST]
-    name = entry.data[CONF_NAME]
 
     client = Vallox(host)
 
@@ -59,20 +57,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        "client": client,
-        "coordinator": coordinator,
-        "name": name,
-    }
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ValloxConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/vallox/binary_sensor.py
+++ b/homeassistant/components/vallox/binary_sensor.py
@@ -8,13 +8,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import ValloxDataUpdateCoordinator
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 from .entity import ValloxEntity
 
 
@@ -61,14 +59,11 @@ BINARY_SENSOR_ENTITIES: tuple[ValloxBinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ValloxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensors."""
-
-    data = hass.data[DOMAIN][entry.entry_id]
-
     async_add_entities(
-        ValloxBinarySensorEntity(data["name"], data["coordinator"], description)
+        ValloxBinarySensorEntity(entry.data[CONF_NAME], entry.runtime_data, description)
         for description in BINARY_SENSOR_ENTITIES
     )

--- a/homeassistant/components/vallox/coordinator.py
+++ b/homeassistant/components/vallox/coordinator.py
@@ -15,16 +15,18 @@ from .const import STATE_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
+type ValloxConfigEntry = ConfigEntry[ValloxDataUpdateCoordinator]
+
 
 class ValloxDataUpdateCoordinator(DataUpdateCoordinator[MetricData]):
     """The DataUpdateCoordinator for Vallox."""
 
-    config_entry: ConfigEntry
+    config_entry: ValloxConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: ValloxConfigEntry,
         client: Vallox,
     ) -> None:
         """Initialize Vallox data coordinator."""

--- a/homeassistant/components/vallox/date.py
+++ b/homeassistant/components/vallox/date.py
@@ -7,13 +7,11 @@ from datetime import date
 from vallox_websocket_api import Vallox
 
 from homeassistant.components.date import DateEntity
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import ValloxDataUpdateCoordinator
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 from .entity import ValloxEntity
 
 
@@ -50,17 +48,16 @@ class ValloxFilterChangeDateEntity(ValloxEntity, DateEntity):
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ValloxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Vallox filter change date entity."""
-
-    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         [
             ValloxFilterChangeDateEntity(
-                data["name"], data["coordinator"], data["client"]
+                entry.data[CONF_NAME], coordinator, coordinator.client
             )
         ]
     )

--- a/homeassistant/components/vallox/date.py
+++ b/homeassistant/components/vallox/date.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from datetime import date
 
-from vallox_websocket_api import Vallox
-
 from homeassistant.components.date import DateEntity
 from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
@@ -25,13 +23,11 @@ class ValloxFilterChangeDateEntity(ValloxEntity, DateEntity):
         self,
         name: str,
         coordinator: ValloxDataUpdateCoordinator,
-        client: Vallox,
     ) -> None:
         """Initialize the Vallox date."""
         super().__init__(name, coordinator)
 
         self._attr_unique_id = f"{self._device_uuid}-filter_change_date"
-        self._client = client
 
     @property
     def native_value(self) -> date | None:
@@ -42,7 +38,7 @@ class ValloxFilterChangeDateEntity(ValloxEntity, DateEntity):
     async def async_set_value(self, value: date) -> None:
         """Change the date."""
 
-        await self._client.set_filter_change_date(value)
+        await self.coordinator.client.set_filter_change_date(value)
         await self.coordinator.async_request_refresh()
 
 
@@ -55,9 +51,5 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        [
-            ValloxFilterChangeDateEntity(
-                entry.data[CONF_NAME], coordinator, coordinator.client
-            )
-        ]
+        [ValloxFilterChangeDateEntity(entry.data[CONF_NAME], coordinator)]
     )

--- a/homeassistant/components/vallox/fan.py
+++ b/homeassistant/components/vallox/fan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, NamedTuple
 
-from vallox_websocket_api import Vallox, ValloxApiException, ValloxInvalidInputException
+from vallox_websocket_api import ValloxApiException, ValloxInvalidInputException
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.const import CONF_NAME
@@ -63,11 +63,7 @@ async def async_setup_entry(
     """Set up the fan device."""
     coordinator = entry.runtime_data
 
-    device = ValloxFanEntity(
-        entry.data[CONF_NAME],
-        coordinator.client,
-        coordinator,
-    )
+    device = ValloxFanEntity(entry.data[CONF_NAME], coordinator)
 
     async_add_entities([device])
 
@@ -86,13 +82,10 @@ class ValloxFanEntity(ValloxEntity, FanEntity):
     def __init__(
         self,
         name: str,
-        client: Vallox,
         coordinator: ValloxDataUpdateCoordinator,
     ) -> None:
         """Initialize the fan."""
         super().__init__(name, coordinator)
-
-        self._client = client
 
         self._attr_unique_id = str(self._device_uuid)
         self._attr_preset_modes = list(PRESET_MODE_TO_VALLOX_PROFILE)
@@ -185,7 +178,7 @@ class ValloxFanEntity(ValloxEntity, FanEntity):
 
     async def _async_set_power(self, mode: bool) -> bool:
         try:
-            await self._client.set_values(
+            await self.coordinator.client.set_values(
                 {METRIC_KEY_MODE: MODE_ON if mode else MODE_OFF}
             )
         except ValloxApiException as err:
@@ -203,7 +196,7 @@ class ValloxFanEntity(ValloxEntity, FanEntity):
 
         try:
             profile = PRESET_MODE_TO_VALLOX_PROFILE[preset_mode]
-            await self._client.set_profile(profile)
+            await self.coordinator.client.set_profile(profile)
 
         except ValloxApiException as err:
             raise HomeAssistantError(f"Failed to set profile: {preset_mode}") from err
@@ -224,7 +217,7 @@ class ValloxFanEntity(ValloxEntity, FanEntity):
         )
 
         try:
-            await self._client.set_fan_speed(vallox_profile, percentage)
+            await self.coordinator.client.set_fan_speed(vallox_profile, percentage)
         except ValloxInvalidInputException as err:
             # This can happen if current profile does not support setting the fan speed.
             raise ValueError(

--- a/homeassistant/components/vallox/fan.py
+++ b/homeassistant/components/vallox/fan.py
@@ -8,14 +8,13 @@ from typing import Any, NamedTuple
 from vallox_websocket_api import Vallox, ValloxApiException, ValloxInvalidInputException
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import (
-    DOMAIN,
     METRIC_KEY_MODE,
     METRIC_KEY_PROFILE_FAN_SPEED_AWAY,
     METRIC_KEY_PROFILE_FAN_SPEED_BOOST,
@@ -25,7 +24,7 @@ from .const import (
     PRESET_MODE_TO_VALLOX_PROFILE,
     VALLOX_PROFILE_TO_PRESET_MODE,
 )
-from .coordinator import ValloxDataUpdateCoordinator
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 from .entity import ValloxEntity
 
 
@@ -58,18 +57,16 @@ def _convert_to_int(value: StateType) -> int | None:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ValloxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the fan device."""
-    data = hass.data[DOMAIN][entry.entry_id]
-
-    client = data["client"]
+    coordinator = entry.runtime_data
 
     device = ValloxFanEntity(
-        data["name"],
-        client,
-        data["coordinator"],
+        entry.data[CONF_NAME],
+        coordinator.client,
+        coordinator,
     )
 
     async_add_entities([device])

--- a/homeassistant/components/vallox/number.py
+++ b/homeassistant/components/vallox/number.py
@@ -11,13 +11,11 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfTemperature
+from homeassistant.const import CONF_NAME, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import ValloxDataUpdateCoordinator
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 from .entity import ValloxEntity
 
 
@@ -103,15 +101,15 @@ NUMBER_ENTITIES: tuple[ValloxNumberEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ValloxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensors."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         ValloxNumberEntity(
-            data["name"], data["coordinator"], description, data["client"]
+            entry.data[CONF_NAME], coordinator, description, coordinator.client
         )
         for description in NUMBER_ENTITIES
     )

--- a/homeassistant/components/vallox/number.py
+++ b/homeassistant/components/vallox/number.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from vallox_websocket_api import Vallox
-
 from homeassistant.components.number import (
     NumberDeviceClass,
     NumberEntity,
@@ -30,7 +28,6 @@ class ValloxNumberEntity(ValloxEntity, NumberEntity):
         name: str,
         coordinator: ValloxDataUpdateCoordinator,
         description: ValloxNumberEntityDescription,
-        client: Vallox,
     ) -> None:
         """Initialize the Vallox number entity."""
         super().__init__(name, coordinator)
@@ -38,7 +35,6 @@ class ValloxNumberEntity(ValloxEntity, NumberEntity):
         self.entity_description = description
 
         self._attr_unique_id = f"{self._device_uuid}-{description.key}"
-        self._client = client
 
     @property
     def native_value(self) -> float | None:
@@ -52,7 +48,7 @@ class ValloxNumberEntity(ValloxEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        await self._client.set_values(
+        await self.coordinator.client.set_values(
             {self.entity_description.metric_key: float(value)}
         )
         await self.coordinator.async_request_refresh()
@@ -108,8 +104,6 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        ValloxNumberEntity(
-            entry.data[CONF_NAME], coordinator, description, coordinator.client
-        )
+        ValloxNumberEntity(entry.data[CONF_NAME], coordinator, description)
         for description in NUMBER_ENTITIES
     )

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -11,9 +11,9 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
+    CONF_NAME,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
     EntityCategory,
@@ -26,13 +26,12 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    DOMAIN,
     METRIC_KEY_MODE,
     MODE_ON,
     VALLOX_CELL_STATE_TO_STR,
     VALLOX_PROFILE_TO_PRESET_MODE,
 )
-from .coordinator import ValloxDataUpdateCoordinator
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 from .entity import ValloxEntity
 
 
@@ -279,12 +278,12 @@ SENSOR_ENTITIES: tuple[ValloxSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ValloxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensors."""
-    name = hass.data[DOMAIN][entry.entry_id]["name"]
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    name = entry.data[CONF_NAME]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         description.entity_type(name, coordinator, description)

--- a/homeassistant/components/vallox/services.py
+++ b/homeassistant/components/vallox/services.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from enum import StrEnum, auto
 import logging
 
-from vallox_websocket_api import Profile, Vallox, ValloxApiException
+from vallox_websocket_api import Profile, ValloxApiException
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 
 from .const import DOMAIN, I18N_KEY_TO_VALLOX_PROFILE
-from .coordinator import ValloxDataUpdateCoordinator
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,16 +47,15 @@ SERVICE_SCHEMA_SET_PROFILE = vol.Schema(
 )
 
 
-def _get_client(
+def _get_coordinator(
     hass: HomeAssistant,
-) -> tuple[Vallox, ValloxDataUpdateCoordinator]:
-    """Return (client, coordinator) for Vallox config entry."""
-    entries = hass.config_entries.async_loaded_entries(DOMAIN)
+) -> ValloxDataUpdateCoordinator:
+    """Return the coordinator for the Vallox config entry."""
+    entries: list[ValloxConfigEntry] = hass.config_entries.async_loaded_entries(DOMAIN)
     if len(entries) != 1:
         raise ValueError("Expected exactly one loaded Vallox config entry")
 
-    data = hass.data[DOMAIN][entries[0].entry_id]
-    return data["client"], data["coordinator"]
+    return entries[0].runtime_data
 
 
 async def _async_set_profile_fan_speed(call: ServiceCall, profile: Profile) -> None:
@@ -64,9 +63,9 @@ async def _async_set_profile_fan_speed(call: ServiceCall, profile: Profile) -> N
     fan_speed: int = call.data[ATTR_PROFILE_FAN_SPEED]
     _LOGGER.debug("Setting %s fan speed to: %d%%", profile.name, fan_speed)
 
-    client, coordinator = _get_client(call.hass)
+    coordinator = _get_coordinator(call.hass)
     try:
-        await client.set_fan_speed(profile, fan_speed)
+        await coordinator.client.set_fan_speed(profile, fan_speed)
     except ValloxApiException as err:
         _LOGGER.error("Error setting fan speed for %s profile: %s", profile.name, err)
     else:
@@ -94,9 +93,11 @@ async def _async_set_profile(call: ServiceCall) -> None:
     duration: int | None = call.data.get(ATTR_DURATION)
     _LOGGER.debug("Activating profile %s for %s min", profile_key, duration)
 
-    client, coordinator = _get_client(call.hass)
+    coordinator = _get_coordinator(call.hass)
     try:
-        await client.set_profile(I18N_KEY_TO_VALLOX_PROFILE[profile_key], duration)
+        await coordinator.client.set_profile(
+            I18N_KEY_TO_VALLOX_PROFILE[profile_key], duration
+        )
     except ValloxApiException as err:
         _LOGGER.error(
             "Error setting profile %s for duration %s: %s",

--- a/homeassistant/components/vallox/switch.py
+++ b/homeassistant/components/vallox/switch.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from vallox_websocket_api import Vallox
-
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
@@ -27,7 +25,6 @@ class ValloxSwitchEntity(ValloxEntity, SwitchEntity):
         name: str,
         coordinator: ValloxDataUpdateCoordinator,
         description: ValloxSwitchEntityDescription,
-        client: Vallox,
     ) -> None:
         """Initialize the Vallox switch."""
         super().__init__(name, coordinator)
@@ -35,7 +32,6 @@ class ValloxSwitchEntity(ValloxEntity, SwitchEntity):
         self.entity_description = description
 
         self._attr_unique_id = f"{self._device_uuid}-{description.key}"
-        self._client = client
 
     @property
     def is_on(self) -> bool | None:
@@ -57,7 +53,7 @@ class ValloxSwitchEntity(ValloxEntity, SwitchEntity):
     async def _set_value(self, value: bool) -> None:
         """Update the current value."""
         metric_key = self.entity_description.metric_key
-        await self._client.set_values({metric_key: 1 if value else 0})
+        await self.coordinator.client.set_values({metric_key: 1 if value else 0})
         await self.coordinator.async_request_refresh()
 
 
@@ -86,8 +82,6 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        ValloxSwitchEntity(
-            entry.data[CONF_NAME], coordinator, description, coordinator.client
-        )
+        ValloxSwitchEntity(entry.data[CONF_NAME], coordinator, description)
         for description in SWITCH_ENTITIES
     )

--- a/homeassistant/components/vallox/switch.py
+++ b/homeassistant/components/vallox/switch.py
@@ -8,13 +8,11 @@ from typing import Any
 from vallox_websocket_api import Vallox
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import ValloxDataUpdateCoordinator
+from .coordinator import ValloxConfigEntry, ValloxDataUpdateCoordinator
 from .entity import ValloxEntity
 
 
@@ -81,16 +79,15 @@ SWITCH_ENTITIES: tuple[ValloxSwitchEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ValloxConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the switches."""
-
-    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         ValloxSwitchEntity(
-            data["name"], data["coordinator"], description, data["client"]
+            entry.data[CONF_NAME], coordinator, description, coordinator.client
         )
         for description in SWITCH_ENTITIES
     )


### PR DESCRIPTION
## Proposed change

Migrate the `vallox` integration to use `entry.runtime_data` instead of `hass.data[DOMAIN]`.

- Add a `ValloxConfigEntry` type alias in `coordinator.py` (`ConfigEntry[ValloxDataUpdateCoordinator]`).
- Store the coordinator directly in `entry.runtime_data` instead of a dict containing `client`, `coordinator` and `name`.
- Simplify `async_unload_entry` accordingly.
- Update all six platforms (`binary_sensor`, `date`, `fan`, `number`, `sensor`, `switch`) to consume `entry.runtime_data`. Platforms now read `name` from `entry.data[CONF_NAME]` and `client` from `coordinator.client` instead of the old dict.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr