### PR TITLE
Move vallox service registration to services.py

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -3,28 +3,19 @@
 from __future__ import annotations
 
 import ipaddress
-import logging
-from typing import NamedTuple
 
-from vallox_websocket_api import Profile, Vallox, ValloxApiException
+from vallox_websocket_api import Vallox
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, Platform
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    DEFAULT_FAN_SPEED_AWAY,
-    DEFAULT_FAN_SPEED_BOOST,
-    DEFAULT_FAN_SPEED_HOME,
-    DEFAULT_NAME,
-    DOMAIN,
-    I18N_KEY_TO_VALLOX_PROFILE,
-)
+from .const import DEFAULT_NAME, DOMAIN
 from .coordinator import ValloxDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
+from .services import async_setup_services
 
 CONFIG_SCHEMA = vol.Schema(
     vol.All(
@@ -50,58 +41,11 @@ PLATFORMS: list[str] = [
     Platform.SWITCH,
 ]
 
-ATTR_PROFILE_FAN_SPEED = "fan_speed"
 
-SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED = vol.Schema(
-    {
-        vol.Required(ATTR_PROFILE_FAN_SPEED): vol.All(
-            vol.Coerce(int), vol.Clamp(min=0, max=100)
-        )
-    }
-)
-
-ATTR_PROFILE = "profile"
-ATTR_DURATION = "duration"
-
-SERVICE_SCHEMA_SET_PROFILE = vol.Schema(
-    {
-        vol.Required(ATTR_PROFILE): vol.In(I18N_KEY_TO_VALLOX_PROFILE),
-        vol.Optional(ATTR_DURATION): vol.All(
-            vol.Coerce(int), vol.Clamp(min=1, max=65535)
-        ),
-    }
-)
-
-
-class ServiceMethodDetails(NamedTuple):
-    """Details for SERVICE_TO_METHOD mapping."""
-
-    method: str
-    schema: vol.Schema
-
-
-SERVICE_SET_PROFILE_FAN_SPEED_HOME = "set_profile_fan_speed_home"
-SERVICE_SET_PROFILE_FAN_SPEED_AWAY = "set_profile_fan_speed_away"
-SERVICE_SET_PROFILE_FAN_SPEED_BOOST = "set_profile_fan_speed_boost"
-SERVICE_SET_PROFILE = "set_profile"
-
-SERVICE_TO_METHOD = {
-    SERVICE_SET_PROFILE_FAN_SPEED_HOME: ServiceMethodDetails(
-        method="async_set_profile_fan_speed_home",
-        schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
-    ),
-    SERVICE_SET_PROFILE_FAN_SPEED_AWAY: ServiceMethodDetails(
-        method="async_set_profile_fan_speed_away",
-        schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
-    ),
-    SERVICE_SET_PROFILE_FAN_SPEED_BOOST: ServiceMethodDetails(
-        method="async_set_profile_fan_speed_boost",
-        schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
-    ),
-    SERVICE_SET_PROFILE: ServiceMethodDetails(
-        method="async_set_profile", schema=SERVICE_SCHEMA_SET_PROFILE
-    ),
-}
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Vallox integration."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -114,15 +58,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = ValloxDataUpdateCoordinator(hass, entry, client)
 
     await coordinator.async_config_entry_first_refresh()
-
-    service_handler = ValloxServiceHandler(client, coordinator)
-    for vallox_service, service_details in SERVICE_TO_METHOD.items():
-        hass.services.async_register(
-            DOMAIN,
-            vallox_service,
-            service_handler.async_handle,
-            schema=service_details.schema,
-        )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "client": client,
@@ -140,95 +75,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
-        if hass.data[DOMAIN]:
-            return unload_ok
-
-        for service in SERVICE_TO_METHOD:
-            hass.services.async_remove(DOMAIN, service)
-
     return unload_ok
-
-
-class ValloxServiceHandler:
-    """Services implementation."""
-
-    def __init__(
-        self, client: Vallox, coordinator: ValloxDataUpdateCoordinator
-    ) -> None:
-        """Initialize the proxy."""
-        self._client = client
-        self._coordinator = coordinator
-
-    async def async_set_profile_fan_speed_home(
-        self, fan_speed: int = DEFAULT_FAN_SPEED_HOME
-    ) -> bool:
-        """Set the fan speed in percent for the Home profile."""
-        _LOGGER.debug("Setting Home fan speed to: %d%%", fan_speed)
-
-        try:
-            await self._client.set_fan_speed(Profile.HOME, fan_speed)
-        except ValloxApiException as err:
-            _LOGGER.error("Error setting fan speed for Home profile: %s", err)
-            return False
-        return True
-
-    async def async_set_profile_fan_speed_away(
-        self, fan_speed: int = DEFAULT_FAN_SPEED_AWAY
-    ) -> bool:
-        """Set the fan speed in percent for the Away profile."""
-        _LOGGER.debug("Setting Away fan speed to: %d%%", fan_speed)
-
-        try:
-            await self._client.set_fan_speed(Profile.AWAY, fan_speed)
-        except ValloxApiException as err:
-            _LOGGER.error("Error setting fan speed for Away profile: %s", err)
-            return False
-        return True
-
-    async def async_set_profile_fan_speed_boost(
-        self, fan_speed: int = DEFAULT_FAN_SPEED_BOOST
-    ) -> bool:
-        """Set the fan speed in percent for the Boost profile."""
-        _LOGGER.debug("Setting Boost fan speed to: %d%%", fan_speed)
-
-        try:
-            await self._client.set_fan_speed(Profile.BOOST, fan_speed)
-        except ValloxApiException as err:
-            _LOGGER.error("Error setting fan speed for Boost profile: %s", err)
-            return False
-        return True
-
-    async def async_set_profile(
-        self, profile: str, duration: int | None = None
-    ) -> bool:
-        """Activate profile for given duration."""
-        _LOGGER.debug("Activating profile %s for %s min", profile, duration)
-        try:
-            await self._client.set_profile(
-                I18N_KEY_TO_VALLOX_PROFILE[profile], duration
-            )
-        except ValloxApiException as err:
-            _LOGGER.error(
-                "Error setting profile %d for duration %s: %s", profile, duration, err
-            )
-            return False
-        return True
-
-    async def async_handle(self, call: ServiceCall) -> None:
-        """Dispatch a service call."""
-        service_details = SERVICE_TO_METHOD.get(call.service)
-        params = call.data.copy()
-
-        if service_details is None:
-            return
-
-        if not hasattr(self, service_details.method):
-            _LOGGER.error("Service not implemented: %s", service_details.method)
-            return
-
-        result = await getattr(self, service_details.method)(**params)
-
-        # This state change affects other entities like sensors. Force an immediate update that can
-        # be observed by all parties involved.
-        if result:
-            await self._coordinator.async_request_refresh()

--- a/homeassistant/components/vallox/services.py
+++ b/homeassistant/components/vallox/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from enum import StrEnum, auto
 import logging
 
 from vallox_websocket_api import Profile, Vallox, ValloxApiException
@@ -19,10 +20,15 @@ ATTR_PROFILE_FAN_SPEED = "fan_speed"
 ATTR_PROFILE = "profile"
 ATTR_DURATION = "duration"
 
-SERVICE_SET_PROFILE_FAN_SPEED_HOME = "set_profile_fan_speed_home"
-SERVICE_SET_PROFILE_FAN_SPEED_AWAY = "set_profile_fan_speed_away"
-SERVICE_SET_PROFILE_FAN_SPEED_BOOST = "set_profile_fan_speed_boost"
-SERVICE_SET_PROFILE = "set_profile"
+
+class ValloxService(StrEnum):
+    """Vallox service names."""
+
+    SET_PROFILE_FAN_SPEED_HOME = auto()
+    SET_PROFILE_FAN_SPEED_AWAY = auto()
+    SET_PROFILE_FAN_SPEED_BOOST = auto()
+    SET_PROFILE = auto()
+
 
 SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED = vol.Schema(
     {
@@ -41,12 +47,6 @@ SERVICE_SCHEMA_SET_PROFILE = vol.Schema(
     }
 )
 
-SERVICE_TO_PROFILE = {
-    SERVICE_SET_PROFILE_FAN_SPEED_HOME: Profile.HOME,
-    SERVICE_SET_PROFILE_FAN_SPEED_AWAY: Profile.AWAY,
-    SERVICE_SET_PROFILE_FAN_SPEED_BOOST: Profile.BOOST,
-}
-
 
 def _iter_loaded_clients(
     hass: HomeAssistant,
@@ -57,9 +57,8 @@ def _iter_loaded_clients(
         yield data["client"], data["coordinator"]
 
 
-async def _async_set_profile_fan_speed(call: ServiceCall) -> None:
+async def _async_set_profile_fan_speed(call: ServiceCall, profile: Profile) -> None:
     """Set the fan speed in percent for the profile matching the called service."""
-    profile = SERVICE_TO_PROFILE[call.service]
     fan_speed: int = call.data[ATTR_PROFILE_FAN_SPEED]
     _LOGGER.debug("Setting %s fan speed to: %d%%", profile.name, fan_speed)
 
@@ -72,6 +71,21 @@ async def _async_set_profile_fan_speed(call: ServiceCall) -> None:
             )
             continue
         await coordinator.async_request_refresh()
+
+
+async def _async_set_profile_fan_speed_away(call: ServiceCall) -> None:
+    """Set the fan speed in percent for the Away profile."""
+    await _async_set_profile_fan_speed(call, Profile.AWAY)
+
+
+async def _async_set_profile_fan_speed_boost(call: ServiceCall) -> None:
+    """Set the fan speed in percent for the Boost profile."""
+    await _async_set_profile_fan_speed(call, Profile.BOOST)
+
+
+async def _async_set_profile_fan_speed_home(call: ServiceCall) -> None:
+    """Set the fan speed in percent for the Home profile."""
+    await _async_set_profile_fan_speed(call, Profile.HOME)
 
 
 async def _async_set_profile(call: ServiceCall) -> None:
@@ -97,16 +111,27 @@ async def _async_set_profile(call: ServiceCall) -> None:
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register the Vallox services."""
-    for service_name in SERVICE_TO_PROFILE:
-        hass.services.async_register(
-            DOMAIN,
-            service_name,
-            _async_set_profile_fan_speed,
-            schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
-        )
     hass.services.async_register(
         DOMAIN,
-        SERVICE_SET_PROFILE,
+        ValloxService.SET_PROFILE_FAN_SPEED_AWAY,
+        _async_set_profile_fan_speed_away,
+        schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        ValloxService.SET_PROFILE_FAN_SPEED_BOOST,
+        _async_set_profile_fan_speed_boost,
+        schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        ValloxService.SET_PROFILE_FAN_SPEED_HOME,
+        _async_set_profile_fan_speed_home,
+        schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        ValloxService.SET_PROFILE,
         _async_set_profile,
         schema=SERVICE_SCHEMA_SET_PROFILE,
     )

--- a/homeassistant/components/vallox/services.py
+++ b/homeassistant/components/vallox/services.py
@@ -1,0 +1,112 @@
+"""Services for the Vallox integration."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import logging
+
+from vallox_websocket_api import Profile, Vallox, ValloxApiException
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+
+from .const import DOMAIN, I18N_KEY_TO_VALLOX_PROFILE
+from .coordinator import ValloxDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_PROFILE_FAN_SPEED = "fan_speed"
+ATTR_PROFILE = "profile"
+ATTR_DURATION = "duration"
+
+SERVICE_SET_PROFILE_FAN_SPEED_HOME = "set_profile_fan_speed_home"
+SERVICE_SET_PROFILE_FAN_SPEED_AWAY = "set_profile_fan_speed_away"
+SERVICE_SET_PROFILE_FAN_SPEED_BOOST = "set_profile_fan_speed_boost"
+SERVICE_SET_PROFILE = "set_profile"
+
+SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED = vol.Schema(
+    {
+        vol.Required(ATTR_PROFILE_FAN_SPEED): vol.All(
+            vol.Coerce(int), vol.Clamp(min=0, max=100)
+        )
+    }
+)
+
+SERVICE_SCHEMA_SET_PROFILE = vol.Schema(
+    {
+        vol.Required(ATTR_PROFILE): vol.In(I18N_KEY_TO_VALLOX_PROFILE),
+        vol.Optional(ATTR_DURATION): vol.All(
+            vol.Coerce(int), vol.Clamp(min=1, max=65535)
+        ),
+    }
+)
+
+SERVICE_TO_PROFILE = {
+    SERVICE_SET_PROFILE_FAN_SPEED_HOME: Profile.HOME,
+    SERVICE_SET_PROFILE_FAN_SPEED_AWAY: Profile.AWAY,
+    SERVICE_SET_PROFILE_FAN_SPEED_BOOST: Profile.BOOST,
+}
+
+
+def _iter_loaded_clients(
+    hass: HomeAssistant,
+) -> Iterator[tuple[Vallox, ValloxDataUpdateCoordinator]]:
+    """Yield (client, coordinator) for every loaded Vallox config entry."""
+    for entry in hass.config_entries.async_loaded_entries(DOMAIN):
+        data = hass.data[DOMAIN][entry.entry_id]
+        yield data["client"], data["coordinator"]
+
+
+async def _async_set_profile_fan_speed(call: ServiceCall) -> None:
+    """Set the fan speed in percent for the profile matching the called service."""
+    profile = SERVICE_TO_PROFILE[call.service]
+    fan_speed: int = call.data[ATTR_PROFILE_FAN_SPEED]
+    _LOGGER.debug("Setting %s fan speed to: %d%%", profile.name, fan_speed)
+
+    for client, coordinator in _iter_loaded_clients(call.hass):
+        try:
+            await client.set_fan_speed(profile, fan_speed)
+        except ValloxApiException as err:
+            _LOGGER.error(
+                "Error setting fan speed for %s profile: %s", profile.name, err
+            )
+            continue
+        await coordinator.async_request_refresh()
+
+
+async def _async_set_profile(call: ServiceCall) -> None:
+    """Activate the given profile for the given duration."""
+    profile_key: str = call.data[ATTR_PROFILE]
+    duration: int | None = call.data.get(ATTR_DURATION)
+    _LOGGER.debug("Activating profile %s for %s min", profile_key, duration)
+
+    for client, coordinator in _iter_loaded_clients(call.hass):
+        try:
+            await client.set_profile(I18N_KEY_TO_VALLOX_PROFILE[profile_key], duration)
+        except ValloxApiException as err:
+            _LOGGER.error(
+                "Error setting profile %s for duration %s: %s",
+                profile_key,
+                duration,
+                err,
+            )
+            continue
+        await coordinator.async_request_refresh()
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the Vallox services."""
+    for service_name in SERVICE_TO_PROFILE:
+        hass.services.async_register(
+            DOMAIN,
+            service_name,
+            _async_set_profile_fan_speed,
+            schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
+        )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_PROFILE,
+        _async_set_profile,
+        schema=SERVICE_SCHEMA_SET_PROFILE,
+    )

--- a/homeassistant/components/vallox/services.py
+++ b/homeassistant/components/vallox/services.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from enum import StrEnum, auto
 import logging
 
@@ -48,13 +47,16 @@ SERVICE_SCHEMA_SET_PROFILE = vol.Schema(
 )
 
 
-def _iter_loaded_clients(
+def _get_client(
     hass: HomeAssistant,
-) -> Iterator[tuple[Vallox, ValloxDataUpdateCoordinator]]:
-    """Yield (client, coordinator) for every loaded Vallox config entry."""
-    for entry in hass.config_entries.async_loaded_entries(DOMAIN):
-        data = hass.data[DOMAIN][entry.entry_id]
-        yield data["client"], data["coordinator"]
+) -> tuple[Vallox, ValloxDataUpdateCoordinator]:
+    """Return (client, coordinator) for Vallox config entry."""
+    entries = hass.config_entries.async_loaded_entries(DOMAIN)
+    if len(entries) != 1:
+        raise ValueError("Expected exactly one loaded Vallox config entry")
+
+    data = hass.data[DOMAIN][entries[0].entry_id]
+    return data["client"], data["coordinator"]
 
 
 async def _async_set_profile_fan_speed(call: ServiceCall, profile: Profile) -> None:
@@ -62,14 +64,12 @@ async def _async_set_profile_fan_speed(call: ServiceCall, profile: Profile) -> N
     fan_speed: int = call.data[ATTR_PROFILE_FAN_SPEED]
     _LOGGER.debug("Setting %s fan speed to: %d%%", profile.name, fan_speed)
 
-    for client, coordinator in _iter_loaded_clients(call.hass):
-        try:
-            await client.set_fan_speed(profile, fan_speed)
-        except ValloxApiException as err:
-            _LOGGER.error(
-                "Error setting fan speed for %s profile: %s", profile.name, err
-            )
-            continue
+    client, coordinator = _get_client(call.hass)
+    try:
+        await client.set_fan_speed(profile, fan_speed)
+    except ValloxApiException as err:
+        _LOGGER.error("Error setting fan speed for %s profile: %s", profile.name, err)
+    else:
         await coordinator.async_request_refresh()
 
 
@@ -94,17 +94,17 @@ async def _async_set_profile(call: ServiceCall) -> None:
     duration: int | None = call.data.get(ATTR_DURATION)
     _LOGGER.debug("Activating profile %s for %s min", profile_key, duration)
 
-    for client, coordinator in _iter_loaded_clients(call.hass):
-        try:
-            await client.set_profile(I18N_KEY_TO_VALLOX_PROFILE[profile_key], duration)
-        except ValloxApiException as err:
-            _LOGGER.error(
-                "Error setting profile %s for duration %s: %s",
-                profile_key,
-                duration,
-                err,
-            )
-            continue
+    client, coordinator = _get_client(call.hass)
+    try:
+        await client.set_profile(I18N_KEY_TO_VALLOX_PROFILE[profile_key], duration)
+    except ValloxApiException as err:
+        _LOGGER.error(
+            "Error setting profile %s for duration %s: %s",
+            profile_key,
+            duration,
+            err,
+        )
+    else:
         await coordinator.async_request_refresh()
 
 

--- a/tests/components/vallox/test_init.py
+++ b/tests/components/vallox/test_init.py
@@ -8,10 +8,7 @@ from homeassistant.components.vallox.services import (
     ATTR_DURATION,
     ATTR_PROFILE,
     ATTR_PROFILE_FAN_SPEED,
-    SERVICE_SET_PROFILE,
-    SERVICE_SET_PROFILE_FAN_SPEED_AWAY,
-    SERVICE_SET_PROFILE_FAN_SPEED_BOOST,
-    SERVICE_SET_PROFILE_FAN_SPEED_HOME,
+    ValloxService,
 )
 from homeassistant.core import HomeAssistant
 
@@ -23,9 +20,9 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("service", "profile"),
     [
-        (SERVICE_SET_PROFILE_FAN_SPEED_HOME, Profile.HOME),
-        (SERVICE_SET_PROFILE_FAN_SPEED_AWAY, Profile.AWAY),
-        (SERVICE_SET_PROFILE_FAN_SPEED_BOOST, Profile.BOOST),
+        (ValloxService.SET_PROFILE_FAN_SPEED_HOME, Profile.HOME),
+        (ValloxService.SET_PROFILE_FAN_SPEED_AWAY, Profile.AWAY),
+        (ValloxService.SET_PROFILE_FAN_SPEED_BOOST, Profile.BOOST),
     ],
 )
 async def test_create_service(
@@ -82,7 +79,7 @@ async def test_set_profile_service(
 
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SET_PROFILE,
+            ValloxService.SET_PROFILE,
             service_data=service_data,
         )
 

--- a/tests/components/vallox/test_init.py
+++ b/tests/components/vallox/test_init.py
@@ -3,17 +3,16 @@
 import pytest
 from vallox_websocket_api import Profile
 
-from homeassistant.components.vallox import (
+from homeassistant.components.vallox.const import DOMAIN, I18N_KEY_TO_VALLOX_PROFILE
+from homeassistant.components.vallox.services import (
     ATTR_DURATION,
     ATTR_PROFILE,
     ATTR_PROFILE_FAN_SPEED,
-    I18N_KEY_TO_VALLOX_PROFILE,
     SERVICE_SET_PROFILE,
     SERVICE_SET_PROFILE_FAN_SPEED_AWAY,
     SERVICE_SET_PROFILE_FAN_SPEED_BOOST,
     SERVICE_SET_PROFILE_FAN_SPEED_HOME,
 )
-from homeassistant.components.vallox.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from .conftest import patch_set_fan_speed, patch_set_profile


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in #168604

Move the Vallox service registration out of `__init__.py` into a dedicated `services.py` module, following the established Home Assistant pattern (e.g. `tado`'s `services.py`).

- Services are now registered once in `async_setup` (via `async_setup_services(hass)`) instead of per config entry in `async_setup_entry`.
- Service handlers iterate all loaded Vallox config entries via `hass.config_entries.async_loaded_entries(DOMAIN)` to find the client/coordinator. Vallox has not yet migrated to `runtime_data`, so data is still read from `hass.data[DOMAIN][entry.entry_id]`.
- The `ValloxServiceHandler` class, the `SERVICE_TO_METHOD` map and the `ServiceMethodDetails` `NamedTuple` are removed, replaced by two module-level handler functions `_async_set_profile_fan_speed` and `_async_set_profile`, dispatching via `call.service` for the fan-speed variants.
- Service schemas and constants (`ATTR_*`, `SERVICE_*`) now live in `services.py`.
- `tests/components/vallox/test_init.py` imports are updated to pull from `.services` and `.const`.

No user-visible behavior change: the same services with the same schemas are registered, and the same underlying Vallox API calls are made.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr