### PR TITLE
Use runtime_data in volumio integration

### DIFF
--- a/homeassistant/components/volumio/__init__.py
+++ b/homeassistant/components/volumio/__init__.py
@@ -1,5 +1,8 @@
 """The Volumio integration."""
 
+from dataclasses import dataclass
+from typing import Any
+
 from pyvolumio import CannotConnectError, Volumio
 
 from homeassistant.config_entries import ConfigEntry
@@ -8,12 +11,21 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DATA_INFO, DATA_VOLUMIO, DOMAIN
-
 PLATFORMS = [Platform.MEDIA_PLAYER]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+@dataclass
+class VolumioData:
+    """Volumio data class."""
+
+    volumio: Volumio
+    info: dict[str, Any]
+
+
+type VolumioConfigEntry = ConfigEntry[VolumioData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: VolumioConfigEntry) -> bool:
     """Set up Volumio from a config entry."""
 
     volumio = Volumio(
@@ -24,20 +36,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except CannotConnectError as error:
         raise ConfigEntryNotReady from error
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        DATA_VOLUMIO: volumio,
-        DATA_INFO: info,
-    }
+    entry.runtime_data = VolumioData(volumio=volumio, info=info)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: VolumioConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/volumio/const.py
+++ b/homeassistant/components/volumio/const.py
@@ -1,6 +1,3 @@
 """Constants for the Volumio integration."""
 
 DOMAIN = "volumio"
-
-DATA_INFO = "info"
-DATA_VOLUMIO = "volumio"

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -17,29 +17,29 @@ from homeassistant.components.media_player import (
     MediaType,
     RepeatMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import Throttle
 
+from . import VolumioConfigEntry
 from .browse_media import browse_node, browse_top_level
-from .const import DATA_INFO, DATA_VOLUMIO, DOMAIN
+from .const import DOMAIN
 
 PLAYLIST_UPDATE_INTERVAL = timedelta(seconds=15)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: VolumioConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Volumio media player platform."""
 
-    data = hass.data[DOMAIN][config_entry.entry_id]
-    volumio = data[DATA_VOLUMIO]
-    info = data[DATA_INFO]
+    data = config_entry.runtime_data
+    volumio = data.volumio
+    info = data.info
     uid = config_entry.data[CONF_ID]
     name = config_entry.data[CONF_NAME]
 


### PR DESCRIPTION
## Proposed change

Migrate the `volumio` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`.

- Introduce a new `VolumioData` dataclass and a `VolumioConfigEntry` typed alias in `__init__.py`.
- Remove the now-unused `DATA_INFO` and `DATA_VOLUMIO` constants from `const.py`.
- Update `media_player.py` to read the runtime data from `entry.runtime_data` and use the new typed config entry.
- Simplify `async_unload_entry` since there is no longer any state to clean up from `hass.data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr