### PR TITLE
Revert "Update PyTurboJPEG to 2.2.0"

### DIFF
--- a/homeassistant/components/camera/manifest.json
+++ b/homeassistant/components/camera/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/camera",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["PyTurboJPEG==2.2.0"]
+  "requirements": ["PyTurboJPEG==1.8.3"]
 }

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["PyTurboJPEG==2.2.0", "av==16.0.1", "numpy==2.3.2"]
+  "requirements": ["PyTurboJPEG==1.8.3", "av==16.0.1", "numpy==2.3.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -59,7 +59,7 @@ PyNaCl==1.6.2
 pyOpenSSL==26.0.0
 pyspeex-noise==1.0.2
 python-slugify==8.0.4
-PyTurboJPEG==2.2.0
+PyTurboJPEG==1.8.3
 PyYAML==6.0.3
 requests==2.33.1
 securetar==2026.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pymicro-vad==1.0.1
 pyOpenSSL==26.0.0
 pyspeex-noise==1.0.2
 python-slugify==8.0.4
-PyTurboJPEG==2.2.0
+PyTurboJPEG==1.8.3
 PyYAML==6.0.3
 requests==2.33.1
 securetar==2026.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -96,7 +96,7 @@ PyTransportNSW==0.1.1
 
 # homeassistant.components.camera
 # homeassistant.components.stream
-PyTurboJPEG==2.2.0
+PyTurboJPEG==1.8.3
 
 # homeassistant.components.vicare
 PyViCare==2.59.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -93,7 +93,7 @@ PyTransportNSW==0.1.1
 
 # homeassistant.components.camera
 # homeassistant.components.stream
-PyTurboJPEG==2.2.0
+PyTurboJPEG==1.8.3
 
 # homeassistant.components.vicare
 PyViCare==2.59.0

--- a/tests/components/camera/test_img_util.py
+++ b/tests/components/camera/test_img_util.py
@@ -1,5 +1,6 @@
 """Test img_util module."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -19,10 +20,6 @@ EMPTY_16_12_JPEG = b"empty_16_12"
 
 def _clear_turbojpeg_singleton():
     TurboJPEGSingleton.__instance = None
-
-
-def _reset_turbojpeg_singleton():
-    TurboJPEGSingleton.__instance = TurboJPEG()
 
 
 def test_turbojpeg_singleton() -> None:
@@ -82,7 +79,9 @@ def test_scale_jpeg_camera_image() -> None:
     assert jpeg_bytes == EMPTY_16_12_JPEG
 
 
-def test_turbojpeg_load_failure() -> None:
+def test_turbojpeg_load_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Handle libjpegturbo not being installed."""
     _clear_turbojpeg_singleton()
     with patch(
@@ -90,10 +89,24 @@ def test_turbojpeg_load_failure() -> None:
     ):
         TurboJPEGSingleton()
         assert TurboJPEGSingleton.instance() is False
+        assert caplog.record_tuples == [
+            (
+                "homeassistant.components.camera.img_util",
+                logging.ERROR,
+                "Error loading libturbojpeg; Camera snapshot performance will be sub-optimal",
+            )
+        ]
 
+
+def test_turbojpeg_load_success(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Handle libjpegturbo being installed."""
     _clear_turbojpeg_singleton()
     TurboJPEGSingleton()
-    assert TurboJPEGSingleton.instance() is not None
+    # Verify TurboJPEG was loaded successfully
+    assert isinstance(TurboJPEGSingleton.instance(), TurboJPEG)
+    assert caplog.record_tuples == []
 
 
 SCALE_TEST_EXPECTED = [


### PR DESCRIPTION
Reverts home-assistant/core#168354 as CI is using ubuntu and Ubuntu is still using version 2. Also the dev container is still using version 2.

Improve tests so we verify that TurboJPEG is loaded successfully