### PR TITLE
Use runtime_data in wyoming integration

### DIFF
--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -14,7 +13,7 @@ from homeassistant.helpers.typing import ConfigType
 from .const import ATTR_SPEAKER, DOMAIN
 from .data import WyomingService
 from .devices import SatelliteDevice
-from .models import DomainDataItem
+from .models import DomainDataItem, WyomingConfigEntry
 from .websocket_api import async_register_websocket_api
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,7 +41,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: WyomingConfigEntry) -> bool:
     """Load Wyoming."""
     service = await WyomingService.create(entry.data["host"], entry.data["port"])
 
@@ -50,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady("Unable to connect")
 
     item = DomainDataItem(service=service)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = item
+    entry.runtime_data = item
 
     await hass.config_entries.async_forward_entry_setups(entry, service.platforms)
     entry.async_on_unload(entry.add_update_listener(update_listener))
@@ -79,21 +78,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
+async def update_listener(hass: HomeAssistant, entry: WyomingConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WyomingConfigEntry) -> bool:
     """Unload Wyoming."""
-    item: DomainDataItem = hass.data[DOMAIN][entry.entry_id]
+    item = entry.runtime_data
 
     platforms = list(item.service.platforms)
     if item.device is not None:
         platforms += SATELLITE_PLATFORMS
 
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
-    if unload_ok:
-        del hass.data[DOMAIN][entry.entry_id]
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, platforms)

--- a/homeassistant/components/wyoming/assist_satellite.py
+++ b/homeassistant/components/wyoming/assist_satellite.py
@@ -34,16 +34,15 @@ from homeassistant.components.assist_satellite import (
     AssistSatelliteEntityDescription,
     AssistSatelliteEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.ulid import ulid_now
 
-from .const import DOMAIN, SAMPLE_CHANNELS, SAMPLE_WIDTH
+from .const import SAMPLE_CHANNELS, SAMPLE_WIDTH
 from .data import WyomingService
 from .devices import SatelliteDevice
 from .entity import WyomingSatelliteEntity
-from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,11 +67,11 @@ _STAGES: dict[PipelineStage, assist_pipeline.PipelineStage] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Wyoming Assist satellite entity."""
-    domain_data: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    domain_data = config_entry.runtime_data
     assert domain_data.device is not None
 
     async_add_entities(
@@ -97,7 +96,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
         hass: HomeAssistant,
         service: WyomingService,
         device: SatelliteDevice,
-        config_entry: ConfigEntry,
+        config_entry: WyomingConfigEntry,
     ) -> None:
         """Initialize an Assist satellite."""
         WyomingSatelliteEntity.__init__(self, device)

--- a/homeassistant/components/wyoming/binary_sensor.py
+++ b/homeassistant/components/wyoming/binary_sensor.py
@@ -2,30 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .entity import WyomingSatelliteEntity
-
-if TYPE_CHECKING:
-    from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up binary sensor entities."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
 
     # Setup is only forwarded for satellites
     assert item.device is not None

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -10,7 +10,6 @@ from wyoming.info import HandleProgram, IntentProgram
 from wyoming.intent import Intent, NotRecognized
 
 from homeassistant.components import conversation
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import MATCH_ALL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
@@ -20,18 +19,18 @@ from homeassistant.util import ulid as ulid_util
 from .const import DOMAIN
 from .data import WyomingService
 from .error import WyomingError
-from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Wyoming conversation."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
     async_add_entities(
         [
             WyomingConversationEntity(config_entry, item.service),
@@ -48,7 +47,7 @@ class WyomingConversationEntity(
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: WyomingConfigEntry,
         service: WyomingService,
     ) -> None:
         """Set up provider."""

--- a/homeassistant/components/wyoming/models.py
+++ b/homeassistant/components/wyoming/models.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from homeassistant.config_entries import ConfigEntry
+
 from .data import WyomingService
 from .devices import SatelliteDevice
 
@@ -12,3 +14,6 @@ class DomainDataItem:
 
     service: WyomingService
     device: SatelliteDevice | None = None
+
+
+type WyomingConfigEntry = ConfigEntry[DomainDataItem]

--- a/homeassistant/components/wyoming/number.py
+++ b/homeassistant/components/wyoming/number.py
@@ -2,19 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 from homeassistant.components.number import NumberEntityDescription, RestoreNumber
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .entity import WyomingSatelliteEntity
-
-if TYPE_CHECKING:
-    from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _MAX_AUTO_GAIN: Final = 31
 _MIN_VOLUME_MULTIPLIER: Final = 0.1
@@ -23,11 +19,11 @@ _MAX_VOLUME_MULTIPLIER: Final = 10.0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Wyoming number entities."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
 
     # Setup is only forwarded for satellites
     assert item.device is not None

--- a/homeassistant/components/wyoming/select.py
+++ b/homeassistant/components/wyoming/select.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 from homeassistant.components.assist_pipeline import (
     AssistPipelineSelect,
@@ -10,7 +10,6 @@ from homeassistant.components.assist_pipeline import (
     VadSensitivitySelect,
 )
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import restore_state
@@ -19,9 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .const import DOMAIN
 from .devices import SatelliteDevice
 from .entity import WyomingSatelliteEntity
-
-if TYPE_CHECKING:
-    from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _NOISE_SUPPRESSION_LEVEL: Final = {
     "off": 0,
@@ -35,11 +32,11 @@ _DEFAULT_NOISE_SUPPRESSION_LEVEL: Final = "off"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Wyoming select entities."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
 
     # Setup is only forwarded for satellites
     assert item.device is not None

--- a/homeassistant/components/wyoming/stt.py
+++ b/homeassistant/components/wyoming/stt.py
@@ -8,25 +8,24 @@ from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.client import AsyncTcpClient
 
 from homeassistant.components import stt
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, SAMPLE_CHANNELS, SAMPLE_RATE, SAMPLE_WIDTH
+from .const import SAMPLE_CHANNELS, SAMPLE_RATE, SAMPLE_WIDTH
 from .data import WyomingService
 from .error import WyomingError
-from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Wyoming speech-to-text."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
     async_add_entities(
         [
             WyomingSttProvider(config_entry, item.service),
@@ -39,7 +38,7 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: WyomingConfigEntry,
         service: WyomingService,
     ) -> None:
         """Set up provider."""

--- a/homeassistant/components/wyoming/switch.py
+++ b/homeassistant/components/wyoming/switch.py
@@ -2,29 +2,25 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import restore_state
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .entity import WyomingSatelliteEntity
-
-if TYPE_CHECKING:
-    from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up VoIP switch entities."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
 
     # Setup is only forwarded for satellites
     assert item.device is not None

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -18,25 +18,24 @@ from wyoming.tts import (
 )
 
 from homeassistant.components import tts
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import ATTR_SPEAKER, DOMAIN
+from .const import ATTR_SPEAKER
 from .data import WyomingService
 from .error import WyomingError
-from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Wyoming speech-to-text."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
     async_add_entities(
         [
             WyomingTtsProvider(config_entry, item.service),
@@ -52,7 +51,7 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: WyomingConfigEntry,
         service: WyomingService,
     ) -> None:
         """Set up provider."""

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -9,25 +9,23 @@ from wyoming.client import AsyncTcpClient
 from wyoming.wake import Detect, Detection
 
 from homeassistant.components import wake_word
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .data import WyomingService, load_wyoming_info
 from .error import WyomingError
-from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WyomingConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Wyoming wake-word-detection."""
-    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    item = config_entry.runtime_data
     async_add_entities(
         [
             WyomingWakeWordProvider(hass, config_entry, item.service),
@@ -41,7 +39,7 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: WyomingConfigEntry,
         service: WyomingService,
     ) -> None:
         """Set up provider."""

--- a/homeassistant/components/wyoming/websocket_api.py
+++ b/homeassistant/components/wyoming/websocket_api.py
@@ -9,7 +9,7 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
-from .models import DomainDataItem
+from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,14 +29,14 @@ def websocket_info(
     msg: dict[str, Any],
 ) -> None:
     """List service information for Wyoming all config entries."""
-    entry_items: dict[str, DomainDataItem] = hass.data.get(DOMAIN, {})
+    entries: list[WyomingConfigEntry] = hass.config_entries.async_loaded_entries(DOMAIN)
 
     connection.send_result(
         msg["id"],
         {
             "info": {
-                entry_id: item.service.info.to_dict()
-                for entry_id, item in entry_items.items()
+                entry.entry_id: entry.runtime_data.service.info.to_dict()
+                for entry in entries
             }
         },
     )

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -22,7 +22,6 @@ from wyoming.info import (
     WakeProgram,
 )
 
-from homeassistant.components.wyoming import DOMAIN
 from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.core import HomeAssistant
 
@@ -236,4 +235,6 @@ async def reload_satellite(
         # _run_mock: satellite task does not actually run
         await hass.config_entries.async_reload(config_entry_id)
 
-    return hass.data[DOMAIN][config_entry_id].device
+    entry = hass.config_entries.async_get_entry(config_entry_id)
+    assert entry is not None
+    return entry.runtime_data.device

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components import stt
-from homeassistant.components.wyoming import DOMAIN
 from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -254,4 +253,4 @@ async def satellite_device(
     hass: HomeAssistant, init_satellite, satellite_config_entry: ConfigEntry
 ) -> SatelliteDevice:
     """Get a satellite device fixture."""
-    return hass.data[DOMAIN][satellite_config_entry.entry_id].device
+    return satellite_config_entry.runtime_data.device

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -25,7 +25,7 @@ from wyoming.tts import Synthesize
 from wyoming.vad import VoiceStarted, VoiceStopped
 from wyoming.wake import Detect, Detection
 
-from homeassistant.components import assist_pipeline, assist_satellite, intent, wyoming
+from homeassistant.components import assist_pipeline, assist_satellite, intent
 from homeassistant.components.wyoming.assist_satellite import WyomingAssistSatellite
 from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.const import STATE_ON
@@ -266,7 +266,7 @@ async def test_satellite_pipeline(hass: HomeAssistant) -> None:
         patch("homeassistant.components.wyoming.assist_satellite._PING_SEND_DELAY", 0),
     ):
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
         assert device is not None
 
         async with asyncio.timeout(1):
@@ -643,7 +643,7 @@ async def test_satellite_disconnect_during_pipeline(hass: HomeAssistant) -> None
         ),
     ):
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
 
         async with asyncio.timeout(1):
             await on_restart_event.wait()
@@ -1153,7 +1153,7 @@ async def test_pipeline_changed(hass: HomeAssistant) -> None:
         ),
     ):
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
 
         async with asyncio.timeout(1):
             await mock_client.connect_event.wait()
@@ -1225,7 +1225,7 @@ async def test_audio_settings_changed(hass: HomeAssistant) -> None:
         ),
     ):
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
 
         async with asyncio.timeout(1):
             await mock_client.connect_event.wait()
@@ -1440,7 +1440,7 @@ async def test_timers(hass: HomeAssistant) -> None:
         ) as mock_client,
     ):
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
 
         async with asyncio.timeout(1):
             await mock_client.connect_event.wait()
@@ -1641,7 +1641,7 @@ async def test_announce(
         temp_wav_file.seek(0)
 
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
         assert device is not None
 
         satellite_entry = next(
@@ -1746,7 +1746,7 @@ async def test_tts_timeout(
         ),
     ):
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
         assert device is not None
 
         satellite_entry = next(
@@ -1844,7 +1844,7 @@ async def test_satellite_tts_streaming(hass: HomeAssistant) -> None:
         patch("homeassistant.components.wyoming.assist_satellite._PING_SEND_DELAY", 0),
     ):
         entry = await setup_config_entry(hass)
-        device: SatelliteDevice = hass.data[wyoming.DOMAIN][entry.entry_id].device
+        device: SatelliteDevice = entry.runtime_data.device
         assert device is not None
 
         async with asyncio.timeout(1):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `wyoming` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`.

- Added a `WyomingConfigEntry` typed alias (wrapping `DomainDataItem`) in `models.py`.
- `__init__.py` now stores the `DomainDataItem` on `entry.runtime_data` and drops the `hass.data` bookkeeping in `async_unload_entry`.
- All platform files (`assist_satellite.py`, `binary_sensor.py`, `conversation.py`, `number.py`, `select.py`, `stt.py`, `switch.py`, `tts.py`, `wake_word.py`) and `websocket_api.py` were updated to read from `entry.runtime_data`.
- The `wyoming/info` websocket command now iterates loaded config entries via `hass.config_entries.async_loaded_entries`.
- Tests in `tests/components/wyoming/` were updated to use `entry.runtime_data` instead of the old `hass.data[DOMAIN]` lookup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr