### PR TITLE
Use runtime_data in weatherflow integration

### DIFF
--- a/homeassistant/components/weatherflow/__init__.py
+++ b/homeassistant/components/weatherflow/__init__.py
@@ -21,8 +21,10 @@ PLATFORMS = [
     Platform.SENSOR,
 ]
 
+type WeatherFlowConfigEntry = ConfigEntry[WeatherFlowListener]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+async def async_setup_entry(hass: HomeAssistant, entry: WeatherFlowConfigEntry) -> bool:
     """Set up WeatherFlow from a config entry."""
 
     client = WeatherFlowListener()
@@ -56,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except ListenerError as ex:
         raise ConfigEntryNotReady from ex
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+    entry.runtime_data = client
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def _async_handle_ha_shutdown(event: Event) -> None:
@@ -70,21 +72,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: WeatherFlowConfigEntry
+) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        client: WeatherFlowListener = hass.data[DOMAIN].pop(entry.entry_id, None)
-        if client:
-            await client.stop_listening()
+        await entry.runtime_data.stop_listening()
 
     return unload_ok
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+    hass: HomeAssistant,
+    config_entry: WeatherFlowConfigEntry,
+    device_entry: DeviceEntry,
 ) -> bool:
     """Remove a config entry from a device."""
-    client: WeatherFlowListener = hass.data[DOMAIN][config_entry.entry_id]
+    client = config_entry.runtime_data
     return not any(
         identifier
         for identifier in device_entry.identifiers

--- a/homeassistant/components/weatherflow/event.py
+++ b/homeassistant/components/weatherflow/event.py
@@ -7,12 +7,12 @@ from dataclasses import dataclass
 from pyweatherflowudp.device import EVENT_RAIN_START, EVENT_STRIKE, WeatherFlowDevice
 
 from homeassistant.components.event import EventEntity, EventEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import WeatherFlowConfigEntry
 from .const import DOMAIN, LOGGER, format_dispatch_call
 
 
@@ -42,7 +42,7 @@ EVENT_DESCRIPTIONS: list[WeatherFlowEventEntityDescription] = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WeatherFlowConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WeatherFlow event entities using config entry."""

--- a/homeassistant/components/weatherflow/sensor.py
+++ b/homeassistant/components/weatherflow/sensor.py
@@ -22,7 +22,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DEGREE,
     LIGHT_LUX,
@@ -46,6 +45,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
+from . import WeatherFlowConfigEntry
 from .const import DOMAIN, LOGGER, format_dispatch_call
 
 
@@ -295,7 +295,7 @@ SENSORS: tuple[WeatherFlowSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WeatherFlowConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WeatherFlow sensors using config entry."""


### PR DESCRIPTION
## Proposed change

Migrate the `weatherflow` integration to use `ConfigEntry.runtime_data` instead of storing the `WeatherFlowListener` client in `hass.data[DOMAIN][entry.entry_id]`.

- Add a typed `WeatherFlowConfigEntry = ConfigEntry[WeatherFlowListener]` alias in `__init__.py`.
- Update `async_setup_entry`, `async_unload_entry`, and `async_remove_config_entry_device` to use the typed config entry and `entry.runtime_data`.
- Update the `event` and `sensor` platforms to accept the typed `WeatherFlowConfigEntry` ~and retrieve the client from `config_entry.runtime_data`.~

This is a pure refactor; there is no functional change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr