### PR TITLE
Use runtime_data in wolflink integration

### DIFF
--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -12,22 +12,15 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 
-from .const import (
-    COORDINATOR,
-    DEVICE_GATEWAY,
-    DEVICE_ID,
-    DEVICE_NAME,
-    DOMAIN,
-    PARAMETERS,
-)
-from .coordinator import WolfLinkCoordinator, fetch_parameters
+from .const import DEVICE_GATEWAY, DEVICE_ID, DEVICE_NAME, DOMAIN
+from .coordinator import WolflinkConfigEntry, WolfLinkCoordinator, fetch_parameters
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: WolflinkConfigEntry) -> bool:
     """Set up Wolf SmartSet Service from a config entry."""
 
     username = entry.data[CONF_USERNAME]
@@ -56,24 +49,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {}
-    hass.data[DOMAIN][entry.entry_id][PARAMETERS] = parameters
-    hass.data[DOMAIN][entry.entry_id][COORDINATOR] = coordinator
-    hass.data[DOMAIN][entry.entry_id][DEVICE_ID] = device_id
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WolflinkConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/wolflink/const.py
+++ b/homeassistant/components/wolflink/const.py
@@ -2,8 +2,6 @@
 
 DOMAIN = "wolflink"
 
-COORDINATOR = "coordinator"
-PARAMETERS = "parameters"
 DEVICE_ID = "device_id"
 DEVICE_GATEWAY = "device_gateway"
 DEVICE_NAME = "device_name"

--- a/homeassistant/components/wolflink/coordinator.py
+++ b/homeassistant/components/wolflink/coordinator.py
@@ -16,16 +16,18 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+type WolflinkConfigEntry = ConfigEntry[WolfLinkCoordinator]
+
 
 class WolfLinkCoordinator(DataUpdateCoordinator[dict[int, tuple[int, str]]]):
     """Class to manage fetching Wolf SmartSet data."""
 
-    config_entry: ConfigEntry
+    config_entry: WolflinkConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: ConfigEntry,
+        entry: WolflinkConfigEntry,
         wolf_client: WolfClient,
         parameters: list[Parameter],
         gateway_id: int,
@@ -40,30 +42,30 @@ class WolfLinkCoordinator(DataUpdateCoordinator[dict[int, tuple[int, str]]]):
             update_interval=timedelta(seconds=60),
         )
         self._wolf_client = wolf_client
-        self._parameters = parameters
+        self.parameters = parameters
         self._gateway_id = gateway_id
-        self._device_id = device_id
+        self.device_id = device_id
         self._refetch_parameters = False
 
     async def _async_update_data(self) -> dict[int, tuple[int, str]]:
         """Update all stored entities for Wolf SmartSet."""
         try:
             if not await self._wolf_client.fetch_system_state_list(
-                self._device_id, self._gateway_id
+                self.device_id, self._gateway_id
             ):
                 self._refetch_parameters = True
                 raise UpdateFailed(
                     "Could not fetch values from server because device is offline."
                 )
             if self._refetch_parameters:
-                self._parameters = await fetch_parameters(
-                    self._wolf_client, self._gateway_id, self._device_id
+                self.parameters = await fetch_parameters(
+                    self._wolf_client, self._gateway_id, self.device_id
                 )
                 self._refetch_parameters = False
             values = {
                 v.value_id: v.value
                 for v in await self._wolf_client.fetch_value(
-                    self._gateway_id, self._device_id, self._parameters
+                    self._gateway_id, self.device_id, self.parameters
                 )
             }
             return {
@@ -71,7 +73,7 @@ class WolfLinkCoordinator(DataUpdateCoordinator[dict[int, tuple[int, str]]]):
                     parameter.value_id,
                     values[parameter.value_id],
                 )
-                for parameter in self._parameters
+                for parameter in self.parameters
                 if parameter.value_id in values
             }
         except RequestError as exception:

--- a/homeassistant/components/wolflink/sensor.py
+++ b/homeassistant/components/wolflink/sensor.py
@@ -26,7 +26,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
@@ -43,8 +42,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import COORDINATOR, DEVICE_ID, DOMAIN, MANUFACTURER, PARAMETERS, STATES
-from .coordinator import WolfLinkCoordinator
+from .const import DOMAIN, MANUFACTURER, STATES
+from .coordinator import WolflinkConfigEntry, WolfLinkCoordinator
 
 
 def get_listitem_resolve_state(wolf_object, state):
@@ -133,17 +132,15 @@ SENSOR_DESCRIPTIONS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WolflinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up all entries for Wolf Platform."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
-    parameters = hass.data[DOMAIN][config_entry.entry_id][PARAMETERS]
-    device_id = hass.data[DOMAIN][config_entry.entry_id][DEVICE_ID]
+    coordinator = config_entry.runtime_data
 
     entities: list[WolfLinkSensor] = [
-        WolfLinkSensor(coordinator, parameter, device_id, description)
-        for parameter in parameters
+        WolfLinkSensor(coordinator, parameter, coordinator.device_id, description)
+        for parameter in coordinator.parameters
         for description in SENSOR_DESCRIPTIONS
         if description.supported_fn(parameter)
     ]


### PR DESCRIPTION
## Proposed change

Migrate the `wolflink` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`.

- Add a `WolflinkConfigEntry` typed alias in `coordinator.py`.
- Store the coordinator on `entry.runtime_data` in `async_setup_entry`.
- Expose `parameters` and `device_id` as public attributes on the coordinator so the sensor platform can read them from the coordinator rather than from `hass.data`.
- Update `__init__.py` and `sensor.py` to use `entry.runtime_data` and the new typed config entry alias.
- Remove the now-unused `COORDINATOR` and `PARAMETERS` constants from `const.py`.
- Simplify `async_unload_entry` since there is no longer any state to clean up from `hass.data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr