### PR TITLE
Remove hassio-main panel registration

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -25,17 +25,15 @@ from aiohasupervisor.models import (
     SupervisorOptions,
     YellowOptions,
 )
-import voluptuous as vol
 
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.auth.models import RefreshToken
-from homeassistant.components import frontend, panel_custom
+from homeassistant.components import frontend
 from homeassistant.components.homeassistant import async_set_stop_handler
 from homeassistant.components.http import (
     CONF_SERVER_HOST,
     CONF_SERVER_PORT,
     CONF_SSL_CERTIFICATE,
-    StaticPathConfig,
 )
 from homeassistant.config_entries import SOURCE_SYSTEM, ConfigEntry
 from homeassistant.const import (
@@ -156,12 +154,7 @@ _LOGGER = logging.getLogger(__name__)
 # wait for the import of the platforms
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH, Platform.UPDATE]
 
-CONF_FRONTEND_REPO = "development_repo"
-
-CONFIG_SCHEMA = vol.Schema(
-    {vol.Optional(DOMAIN): vol.Schema({vol.Optional(CONF_FRONTEND_REPO): cv.isdir})},
-    extra=vol.ALLOW_EXTRA,
-)
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
 DEPRECATION_URL = (
@@ -198,7 +191,7 @@ def hostname_from_addon_slug(addon_slug: str) -> str:
     return addon_slug.replace("_", "-")
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa: C901
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Hass.io component."""
     # Check local setup
     for env in ("SUPERVISOR", "SUPERVISOR_TOKEN"):
@@ -250,29 +243,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         refresh_token = await hass.auth.async_create_refresh_token(user)
         config_store.update(hassio_user=user.id)
 
-    # This overrides the normal API call that would be forwarded
-    development_repo = config.get(DOMAIN, {}).get(CONF_FRONTEND_REPO)
-    if development_repo is not None:
-        await hass.http.async_register_static_paths(
-            [
-                StaticPathConfig(
-                    "/api/hassio/app",
-                    os.path.join(development_repo, "hassio/build"),
-                    False,
-                )
-            ]
-        )
-
     hass.http.register_view(HassIOView(host, websession))
-
-    await panel_custom.async_register_panel(
-        hass,
-        frontend_url_path="hassio",
-        webcomponent_name="hassio-main",
-        js_url="/api/hassio/app/entrypoint.js",
-        embed_iframe=True,
-        require_admin=True,
-    )
 
     async def update_hass_api(http_config: dict[str, Any], refresh_token: RefreshToken):
         """Update Home Assistant API data on Hass.io."""

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -14,7 +14,6 @@ from aiohttp import web
 from aiohttp.client import ClientTimeout
 from aiohttp.hdrs import (
     AUTHORIZATION,
-    CACHE_CONTROL,
     CONTENT_ENCODING,
     CONTENT_LENGTH,
     CONTENT_TYPE,
@@ -81,17 +80,10 @@ PATHS_ADMIN = re.compile(
     r")$"
 )
 
-# Unauthenticated requests come in for Supervisor panel + add-on images
+# Unauthenticated requests come in for add-on images
 PATHS_NO_AUTH = re.compile(
     r"^(?:"
-    r"|app/.*"
     r"|(store/)?addons/[^/]+/(logo|icon)"
-    r")$"
-)
-
-NO_STORE = re.compile(
-    r"^(?:"
-    r"|app/entrypoint.js"
     r")$"
 )
 
@@ -218,7 +210,7 @@ class HassIOView(HomeAssistantView):
 
             # Stream response
             response = web.StreamResponse(
-                status=client.status, headers=_response_header(client, path)
+                status=client.status, headers=_response_header(client)
             )
             response.content_type = client.content_type
 
@@ -243,16 +235,13 @@ class HassIOView(HomeAssistantView):
     post = _handle
 
 
-def _response_header(response: aiohttp.ClientResponse, path: str) -> dict[str, str]:
+def _response_header(response: aiohttp.ClientResponse) -> dict[str, str]:
     """Create response header."""
-    headers = {
+    return {
         name: value
         for name, value in response.headers.items()
         if name not in RESPONSE_HEADERS_FILTER
     }
-    if NO_STORE.match(path):
-        headers[CACHE_CONTROL] = "no-store, max-age=0"
-    return headers
 
 
 def _get_timeout(path: str) -> ClientTimeout:

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -56,12 +56,12 @@ async def test_forward_request_onboarded_user_get(
     assert aioclient_mock.mock_calls[0][3] == {"X-Hass-Source": "core.http"}
 
 
-@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "RANDOM"])
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
 async def test_forward_request_onboarded_user_unallowed_methods(
     hassio_user_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_user_client.post("/api/hassio/addons/bl_b392/icon")
+    resp = await hassio_user_client.request(method, "/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
@@ -124,12 +124,12 @@ async def test_forward_request_onboarded_noauth_get(
     assert aioclient_mock.mock_calls[0][3] == {"X-Hass-Source": "core.http"}
 
 
-@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "RANDOM"])
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
 async def test_forward_request_onboarded_noauth_unallowed_methods(
     hassio_noauth_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_noauth_client.post("/api/hassio/addons/bl_b392/icon")
+    resp = await hassio_noauth_client.request(method, "/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
@@ -235,12 +235,12 @@ async def test_forward_request_not_onboarded_post(
     }
 
 
-@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "RANDOM"])
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
 async def test_forward_request_not_onboarded_unallowed_methods(
     hassio_noauth_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_noauth_client.post("/api/hassio/addons/bl_b392/icon")
+    resp = await hassio_noauth_client.request(method, "/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
@@ -351,12 +351,12 @@ async def test_forward_request_admin_post(
     }
 
 
-@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "RANDOM"])
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
 async def test_forward_request_admin_unallowed_methods(
     hassio_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_client.post("/api/hassio/addons/bl_b392/icon")
+    resp = await hassio_client.request(method, "/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -33,7 +33,6 @@ def hassio_user_client(
 @pytest.mark.parametrize(
     "path",
     [
-        "app/entrypoint.js",
         "addons/bl_b392/logo",
         "addons/bl_b392/icon",
     ],
@@ -62,7 +61,7 @@ async def test_forward_request_onboarded_user_unallowed_methods(
     hassio_user_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_user_client.post("/api/hassio/app/entrypoint.js")
+    resp = await hassio_user_client.post("/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
@@ -75,10 +74,7 @@ async def test_forward_request_onboarded_user_unallowed_methods(
     ("bad_path", "expected_status"),
     [
         # Caught by bullshit filter
-        ("app/%252E./entrypoint.js", HTTPStatus.BAD_REQUEST),
-        # The .. is processed, making it an unauthenticated path
-        ("app/../entrypoint.js", HTTPStatus.UNAUTHORIZED),
-        ("app/%2E%2E/entrypoint.js", HTTPStatus.UNAUTHORIZED),
+        ("addons/bl_b392/%252E./icon", HTTPStatus.BAD_REQUEST),
         # Unauthenticated path
         ("supervisor/info", HTTPStatus.UNAUTHORIZED),
         ("supervisor/logs", HTTPStatus.UNAUTHORIZED),
@@ -105,7 +101,6 @@ async def test_forward_request_onboarded_user_unallowed_paths(
 @pytest.mark.parametrize(
     "path",
     [
-        "app/entrypoint.js",
         "addons/bl_b392/logo",
         "addons/bl_b392/icon",
     ],
@@ -134,7 +129,7 @@ async def test_forward_request_onboarded_noauth_unallowed_methods(
     hassio_noauth_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_noauth_client.post("/api/hassio/app/entrypoint.js")
+    resp = await hassio_noauth_client.post("/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
@@ -147,10 +142,7 @@ async def test_forward_request_onboarded_noauth_unallowed_methods(
     ("bad_path", "expected_status"),
     [
         # Caught by bullshit filter
-        ("app/%252E./entrypoint.js", HTTPStatus.BAD_REQUEST),
-        # The .. is processed, making it an unauthenticated path
-        ("app/../entrypoint.js", HTTPStatus.UNAUTHORIZED),
-        ("app/%2E%2E/entrypoint.js", HTTPStatus.UNAUTHORIZED),
+        ("addons/bl_b392/%252E./icon", HTTPStatus.BAD_REQUEST),
         # Unauthenticated path
         ("supervisor/info", HTTPStatus.UNAUTHORIZED),
         ("supervisor/logs", HTTPStatus.UNAUTHORIZED),
@@ -177,7 +169,6 @@ async def test_forward_request_onboarded_noauth_unallowed_paths(
 @pytest.mark.parametrize(
     ("path", "authenticated"),
     [
-        ("app/entrypoint.js", False),
         ("addons/bl_b392/logo", False),
         ("addons/bl_b392/icon", False),
         ("backups/1234abcd/info", True),
@@ -249,7 +240,7 @@ async def test_forward_request_not_onboarded_unallowed_methods(
     hassio_noauth_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_noauth_client.post("/api/hassio/app/entrypoint.js")
+    resp = await hassio_noauth_client.post("/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
@@ -262,10 +253,7 @@ async def test_forward_request_not_onboarded_unallowed_methods(
     ("bad_path", "expected_status"),
     [
         # Caught by bullshit filter
-        ("app/%252E./entrypoint.js", HTTPStatus.BAD_REQUEST),
-        # The .. is processed, making it an unauthenticated path
-        ("app/../entrypoint.js", HTTPStatus.UNAUTHORIZED),
-        ("app/%2E%2E/entrypoint.js", HTTPStatus.UNAUTHORIZED),
+        ("addons/bl_b392/%252E./icon", HTTPStatus.BAD_REQUEST),
         # Unauthenticated path
         ("supervisor/info", HTTPStatus.UNAUTHORIZED),
         ("supervisor/logs", HTTPStatus.UNAUTHORIZED),
@@ -293,7 +281,6 @@ async def test_forward_request_not_onboarded_unallowed_paths(
 @pytest.mark.parametrize(
     ("path", "authenticated"),
     [
-        ("app/entrypoint.js", False),
         ("addons/bl_b392/logo", False),
         ("addons/bl_b392/icon", False),
         ("backups/1234abcd/info", True),
@@ -369,7 +356,7 @@ async def test_forward_request_admin_unallowed_methods(
     hassio_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
 ) -> None:
     """Test fetching normal path."""
-    resp = await hassio_client.post("/api/hassio/app/entrypoint.js")
+    resp = await hassio_client.post("/api/hassio/addons/bl_b392/icon")
 
     # Check we got right response
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
@@ -382,10 +369,7 @@ async def test_forward_request_admin_unallowed_methods(
     ("bad_path", "expected_status"),
     [
         # Caught by bullshit filter
-        ("app/%252E./entrypoint.js", HTTPStatus.BAD_REQUEST),
-        # The .. is processed, making it an unauthenticated path
-        ("app/../entrypoint.js", HTTPStatus.UNAUTHORIZED),
-        ("app/%2E%2E/entrypoint.js", HTTPStatus.UNAUTHORIZED),
+        ("addons/bl_b392/%252E./icon", HTTPStatus.BAD_REQUEST),
         # Unauthenticated path
         ("supervisor/info", HTTPStatus.UNAUTHORIZED),
     ],
@@ -409,9 +393,9 @@ async def test_bad_gateway_when_cannot_find_supervisor(
     hassio_client: TestClient, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we get a bad gateway error if we can't find supervisor."""
-    aioclient_mock.get("http://127.0.0.1/app/entrypoint.js", exc=TimeoutError)
+    aioclient_mock.get("http://127.0.0.1/addons/bl_b392/icon", exc=TimeoutError)
 
-    resp = await hassio_client.get("/api/hassio/app/entrypoint.js")
+    resp = await hassio_client.get("/api/hassio/addons/bl_b392/icon")
     assert resp.status == HTTPStatus.BAD_GATEWAY
 
 
@@ -478,30 +462,10 @@ async def test_simple_get_no_stream(
     hassio_client: TestClient, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Verify that a simple GET request is not a stream."""
-    aioclient_mock.get("http://127.0.0.1/app/entrypoint.js")
-    resp = await hassio_client.get("/api/hassio/app/entrypoint.js")
+    aioclient_mock.get("http://127.0.0.1/addons/bl_b392/icon")
+    resp = await hassio_client.get("/api/hassio/addons/bl_b392/icon")
     assert resp.status == HTTPStatus.OK
     assert aioclient_mock.mock_calls[-1][2] is None
-
-
-async def test_entrypoint_cache_control(
-    hassio_client: TestClient, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that we return cache control for requests to the entrypoint only."""
-    aioclient_mock.get("http://127.0.0.1/app/entrypoint.js")
-    aioclient_mock.get("http://127.0.0.1/app/entrypoint.fdhkusd8y43r.js")
-
-    resp1 = await hassio_client.get("/api/hassio/app/entrypoint.js")
-    resp2 = await hassio_client.get("/api/hassio/app/entrypoint.fdhkusd8y43r.js")
-
-    # Check we got right response
-    assert resp1.status == HTTPStatus.OK
-    assert resp2.status == HTTPStatus.OK
-
-    assert len(aioclient_mock.mock_calls) == 2
-    assert resp1.headers["Cache-Control"] == "no-store, max-age=0"
-
-    assert "Cache-Control" not in resp2.headers
 
 
 async def test_no_follow_logs_compress(
@@ -533,16 +497,16 @@ async def test_no_event_stream_compress(
 ) -> None:
     """Test that we do not compress SSE (Server-Sent Events) streams."""
     aioclient_mock.get(
-        "http://127.0.0.1/app/events",
+        "http://127.0.0.1/backups/1234abcd/info",
         headers={"Content-Type": "text/event-stream"},
     )
     aioclient_mock.get(
-        "http://127.0.0.1/app/data",
+        "http://127.0.0.1/addons/bl_b392/changelog",
         headers={"Content-Type": "application/json"},
     )
 
-    resp1 = await hassio_client.get("/api/hassio/app/events")
-    resp2 = await hassio_client.get("/api/hassio/app/data")
+    resp1 = await hassio_client.get("/api/hassio/backups/1234abcd/info")
+    resp2 = await hassio_client.get("/api/hassio/addons/bl_b392/changelog")
 
     # Check we got right response
     assert resp1.status == HTTPStatus.OK

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -160,35 +160,6 @@ async def test_setup_api_ping(
     assert is_hassio(hass)
 
 
-async def test_setup_api_panel(hass: HomeAssistant) -> None:
-    """Test setup with API ping."""
-    assert await async_setup_component(hass, "frontend", {})
-    with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {})
-        assert result
-
-    panels = hass.data[frontend.DATA_PANELS]
-
-    assert panels.get("hassio").to_response() == {
-        "component_name": "custom",
-        "icon": None,
-        "title": None,
-        "default_visible": True,
-        "config": {
-            "_panel_custom": {
-                "embed_iframe": True,
-                "js_url": "/api/hassio/app/entrypoint.js",
-                "name": "hassio-main",
-                "trust_external": False,
-            }
-        },
-        "url_path": "hassio",
-        "require_admin": True,
-        "show_in_sidebar": True,
-        "config_panel_domain": None,
-    }
-
-
 async def test_setup_app_panel(hass: HomeAssistant) -> None:
     """Test app panel is registered."""
     with patch.dict(os.environ, MOCK_ENVIRON):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Supervisor-served hassio-main web component was removed from the frontend in home-assistant/frontend#28245 (replacing it with the new apps panel, the frontend change got merged in Core with #162214). Drop the now-dead Core pieces that only existed to register and proxy that panel:

- `panel_custom.async_register_panel(..., "hassio-main", ...)` call and the `CONF_FRONTEND_REPO`/development_repo static-path override used to serve a local dev build of the panel bundle.
- `|app/.*` entry in `PATHS_NO_AUTH` and the `NO_STORE` regex in `hassio/http.py`, which only existed to forward the panel's `entrypoint.js` (and its cache-control header) unauthenticated.

The `/api/hassio/` proxy itself and all other paths (addon icons/logos, logs, changelog, documentation, backups, ...) are untouched.

**Note:** this also removes the development_repo YAML option under hassio: It only served the Supervisor panel's local dev build. Existing configs with it set will log an error via cv.empty_config_schema and the option is ignored. The option is not documented in the hassio integration docs, so no updates needed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/28245

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
