### PR TITLE
Fix MotionMount zeroconf overwriting manually configured static IP

### DIFF
--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -107,9 +107,17 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
             # so we can avoid probing the device if its already
             # configured or ignored
             await self.async_set_unique_id(unique_id)
-            self._abort_if_unique_id_configured(
-                updates={CONF_HOST: host, CONF_PORT: port}
+            existing_entry = self._async_current_entries()
+            existing_host = next(
+                (e.data.get(CONF_HOST, "") for e in existing_entry if e.unique_id == unique_id),
+                "",
             )
+            if not existing_host or existing_host.endswith(".local"):
+                host_updates = {CONF_HOST: host, CONF_PORT: port}
+            else:
+                host_updates = {CONF_PORT: port}
+                self.connection_data[CONF_HOST] = existing_host
+            self._abort_if_unique_id_configured(updates=host_updates)
         else:
             # Avoid probing devices that already have an entry
             self._async_abort_entries_match({CONF_HOST: host})
@@ -131,9 +139,17 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if unique_id:
             await self.async_set_unique_id(unique_id)
-            self._abort_if_unique_id_configured(
-                updates={CONF_HOST: host, CONF_PORT: port}
+            existing_entry = self._async_current_entries()
+            existing_host = next(
+                (e.data.get(CONF_HOST, "") for e in existing_entry if e.unique_id == unique_id),
+                "",
             )
+            host_updates = (
+                {CONF_HOST: host, CONF_PORT: port}
+                if not existing_host or existing_host.endswith(".local")
+                else {CONF_PORT: port}
+            )
+            self._abort_if_unique_id_configured(updates=host_updates)
         else:
             await self._async_handle_discovery_without_unique_id()
 

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -109,7 +109,11 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(unique_id)
             existing_entry = self._async_current_entries()
             existing_host = next(
-                (e.data.get(CONF_HOST, "") for e in existing_entry if e.unique_id == unique_id),
+                (
+                    e.data.get(CONF_HOST, "")
+                    for e in existing_entry
+                    if e.unique_id == unique_id
+                ),
                 "",
             )
             if not existing_host or existing_host.endswith(".local"):
@@ -141,7 +145,11 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(unique_id)
             existing_entry = self._async_current_entries()
             existing_host = next(
-                (e.data.get(CONF_HOST, "") for e in existing_entry if e.unique_id == unique_id),
+                (
+                    e.data.get(CONF_HOST, "")
+                    for e in existing_entry
+                    if e.unique_id == unique_id
+                ),
                 "",
             )
             host_updates = (

--- a/tests/components/motionmount/test_config_flow.py
+++ b/tests/components/motionmount/test_config_flow.py
@@ -389,6 +389,34 @@ async def test_zeroconf_device_exists_abort(
     assert result["reason"] == "already_configured"
 
 
+async def test_zeroconf_does_not_overwrite_static_ip(
+    hass: HomeAssistant,
+    mock_motionmount: MagicMock,
+) -> None:
+    """Test zeroconf discovery does not overwrite a manually configured static IP."""
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=ZEROCONF_MAC,
+        data={
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+        },
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_TVM_SERVICE_INFO_V2)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == HOST
+    assert mock_config_entry.data[CONF_HOST] != ZEROCONF_HOSTNAME
+
+
 async def test_zeroconf_authentication_needed(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a MotionMount is configured with a static IP address, zeroconf discovery
after a restart overwrites the stored host with the mDNS hostname
(e.g., `MM3F9593.local`). If the network does not resolve `.local` addresses
(e.g., custom local domain like `.localdomain`), the integration fails to
connect after every restart.
This PR fixes the issue by checking if the existing config entry has a
non-mDNS host (not ending in `.local`). If so, the host is not updated
during zeroconf discovery, preserving the manually configured static IP.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168509
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ x] I understand the code I am submitting and can explain how it works.
- [ x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
