### PR TITLE
Use runtime_data in ws66i integration

### DIFF
--- a/homeassistant/components/ws66i/__init__.py
+++ b/homeassistant/components/ws66i/__init__.py
@@ -6,14 +6,13 @@ import logging
 
 from pyws66i import WS66i, get_ws66i
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONF_SOURCES, DOMAIN
+from .const import CONF_SOURCES
 from .coordinator import Ws66iDataUpdateCoordinator
-from .models import SourceRep, Ws66iData
+from .models import SourceRep, Ws66iConfigEntry, Ws66iData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +55,7 @@ def _find_zones(hass: HomeAssistant, ws66i: WS66i) -> list[int]:
     return zone_list
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: Ws66iConfigEntry) -> bool:
     """Set up Soundavo WS66i 6-Zone Amplifier from a config entry."""
     # Get the source names from the options flow
     options: dict[str, dict[str, str]]
@@ -86,8 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Fetch initial data, retry on failed poll
     await coordinator.async_config_entry_first_refresh()
 
-    # Create the Ws66iData data class save it to hass
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = Ws66iData(
+    entry.runtime_data = Ws66iData(
         host_ip=entry.data[CONF_IP_ADDRESS],
         device=ws66i,
         sources=source_rep,
@@ -109,12 +107,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: Ws66iConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        ws66i: WS66i = hass.data[DOMAIN][entry.entry_id].device
-        ws66i.close()
-        hass.data[DOMAIN].pop(entry.entry_id)
+        entry.runtime_data.device.close()
 
     return unload_ok

--- a/homeassistant/components/ws66i/media_player.py
+++ b/homeassistant/components/ws66i/media_player.py
@@ -7,7 +7,6 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -15,18 +14,18 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MAX_VOL
 from .coordinator import Ws66iDataUpdateCoordinator
-from .models import Ws66iData
+from .models import Ws66iConfigEntry, Ws66iData
 
 PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: Ws66iConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the WS66i 6-zone amplifier platform from a config entry."""
-    ws66i_data: Ws66iData = hass.data[DOMAIN][config_entry.entry_id]
+    ws66i_data = config_entry.runtime_data
 
     # Build and add the entities from the data class
     async_add_entities(

--- a/homeassistant/components/ws66i/models.py
+++ b/homeassistant/components/ws66i/models.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 from pyws66i import WS66i
 
+from homeassistant.config_entries import ConfigEntry
+
 from .coordinator import Ws66iDataUpdateCoordinator
 
 
@@ -27,3 +29,6 @@ class Ws66iData:
     sources: SourceRep
     coordinator: Ws66iDataUpdateCoordinator
     zones: list[int]
+
+
+type Ws66iConfigEntry = ConfigEntry[Ws66iData]

--- a/tests/components/ws66i/test_init.py
+++ b/tests/components/ws66i/test_init.py
@@ -71,7 +71,7 @@ async def test_unload_config_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert hass.data[DOMAIN][config_entry.entry_id]
+    assert config_entry.state is ConfigEntryState.LOADED
 
     with patch.object(MockWs66i, "close") as method_call:
         await hass.config_entries.async_unload(config_entry.entry_id)
@@ -79,4 +79,4 @@ async def test_unload_config_entry(hass: HomeAssistant) -> None:
 
         assert method_call.called
 
-    assert not hass.data[DOMAIN]
+    assert config_entry.state is ConfigEntryState.NOT_LOADED


### PR DESCRIPTION
## Proposed change

Migrate the `ws66i` integration to use `ConfigEntry.runtime_data` instead of storing data in `hass.data[DOMAIN][entry.entry_id]`.

- Added a `Ws66iConfigEntry` typed alias in `models.py` (alongside the existing `Ws66iData` dataclass).
- Updated `__init__.py` and `media_player.py` to use the typed config entry and `entry.runtime_data`.
- Updated the init test to check `ConfigEntryState` instead of `hass.data`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr