### PR TITLE
Frontier silicon: use correct command to restart stopped stream

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -142,6 +142,7 @@ class AFSAPIDevice(MediaPlayerEntity):
                     PlayState.STOPPED: MediaPlayerState.IDLE,
                 }.get(self.__play_state, MediaPlayerState.IDLE)
             else:
+                self.__play_state = None
                 self._attr_state = MediaPlayerState.OFF
         except FSConnectionError:
             if self._attr_available:

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -87,7 +87,6 @@ class AFSAPIDevice(MediaPlayerEntity):
 
         self.__modes_by_label: dict[str, str] | None = None
         self.__sound_modes_by_label: dict[str, str] | None = None
-        self.__play_state: PlayState | None = None
         self.__play_caps: PlayCaps = PlayCaps(0)
 
         self._supports_sound_mode: bool = True
@@ -132,7 +131,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         afsapi = self.fs_device
         try:
             if await afsapi.get_power():
-                self.__play_state = await afsapi.get_play_status()
+                status = await afsapi.get_play_status()
                 self._attr_state = {
                     PlayState.IDLE: MediaPlayerState.IDLE,
                     PlayState.BUFFERING: MediaPlayerState.BUFFERING,
@@ -140,9 +139,8 @@ class AFSAPIDevice(MediaPlayerEntity):
                     PlayState.PAUSED: MediaPlayerState.PAUSED,
                     PlayState.REBUFFERING: MediaPlayerState.BUFFERING,
                     PlayState.STOPPED: MediaPlayerState.IDLE,
-                }.get(self.__play_state, MediaPlayerState.IDLE)
+                }.get(status, MediaPlayerState.IDLE)
             else:
-                self.__play_state = None
                 self._attr_state = MediaPlayerState.OFF
         except FSConnectionError:
             if self._attr_available:
@@ -284,7 +282,7 @@ class AFSAPIDevice(MediaPlayerEntity):
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        if self.__play_state == PlayState.STOPPED:
+        if (await self.fs_device.get_play_state()) == PlayState.STOPPED:
             # The 'play' command only seems to work when the current stream is paused.
             # We need to send a 'stop' command instead to resume a stopped stream.
             await self.fs_device.stop()

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -87,6 +87,7 @@ class AFSAPIDevice(MediaPlayerEntity):
 
         self.__modes_by_label: dict[str, str] | None = None
         self.__sound_modes_by_label: dict[str, str] | None = None
+        self.__play_state: PlayState | None = None
         self.__play_caps: PlayCaps = PlayCaps(0)
 
         self._supports_sound_mode: bool = True
@@ -131,7 +132,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         afsapi = self.fs_device
         try:
             if await afsapi.get_power():
-                status = await afsapi.get_play_status()
+                self.__play_state = await afsapi.get_play_status()
                 self._attr_state = {
                     PlayState.IDLE: MediaPlayerState.IDLE,
                     PlayState.BUFFERING: MediaPlayerState.BUFFERING,
@@ -139,7 +140,7 @@ class AFSAPIDevice(MediaPlayerEntity):
                     PlayState.PAUSED: MediaPlayerState.PAUSED,
                     PlayState.REBUFFERING: MediaPlayerState.BUFFERING,
                     PlayState.STOPPED: MediaPlayerState.IDLE,
-                }.get(status, MediaPlayerState.IDLE)
+                }.get(self.__play_state, MediaPlayerState.IDLE)
             else:
                 self._attr_state = MediaPlayerState.OFF
         except FSConnectionError:
@@ -282,7 +283,12 @@ class AFSAPIDevice(MediaPlayerEntity):
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        await self.fs_device.play()
+        if self.__play_state == PlayState.STOPPED:
+            # The 'play' command only seems to work when the current stream is paused.
+            # We need to send a 'stop' command instead to resume a stopped stream.
+            await self.fs_device.stop()
+        else:
+            await self.fs_device.play()
 
     async def async_media_pause(self) -> None:
         """Send pause command."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Frontier silicon devices require us to send a 'stop' command to restart a stopped stream instead of sending a 'play' command.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164643
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
