### PR TITLE
Improve exception handling for frontier_silicon

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable, Coroutine
+from functools import wraps
 import logging
-from typing import Any
+from typing import Any, Concatenate
 
 from afsapi import (
     AFSAPI,
+    FSApiError,
     FSConnectionError,
     FSNotImplementedError,
+    OutOfRangeError,
     PlayCaps,
     PlayRepeatMode,
     PlayState,
 )
+from afsapi.exceptions import FSNodeBlockedError
 
 from homeassistant.components.media_player import (
     BrowseError,
@@ -24,6 +29,7 @@ from homeassistant.components.media_player import (
     RepeatMode,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -33,6 +39,33 @@ from .browse_media import browse_node, browse_top_level
 from .const import DOMAIN, MEDIA_CONTENT_ID_PRESET
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def fs_command_exception_wrap[
+    _AFSAPIDeviceT: "AFSAPIDevice",
+    **_P,
+    _R,
+](
+    func: Callable[Concatenate[_AFSAPIDeviceT, _P], Awaitable[_R]],
+) -> Callable[Concatenate[_AFSAPIDeviceT, _P], Coroutine[Any, Any, _R]]:
+    """Wrap command methods and map API exceptions to HA errors."""
+
+    @wraps(func)
+    async def _wrap(self: _AFSAPIDeviceT, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return await func(self, *args, **kwargs)
+        except FSConnectionError as err:
+            command = func.__name__.removeprefix("async_")
+            raise HomeAssistantError(
+                f"Failed to execute {command}: could not connect to device"
+            ) from err
+        except (OutOfRangeError, FSNodeBlockedError) as err:
+            raise ServiceValidationError(str(err)) from err
+        except FSApiError as err:
+            command = func.__name__.removeprefix("async_")
+            raise HomeAssistantError(f"Failed to execute {command}: {err}") from err
+
+    return _wrap
 
 
 async def async_setup_entry(
@@ -272,14 +305,17 @@ class AFSAPIDevice(MediaPlayerEntity):
 
     # Management actions
     # power control
+    @fs_command_exception_wrap
     async def async_turn_on(self) -> None:
         """Turn on the device."""
         await self.fs_device.set_power(True)
 
+    @fs_command_exception_wrap
     async def async_turn_off(self) -> None:
         """Turn off the device."""
         await self.fs_device.set_power(False)
 
+    @fs_command_exception_wrap
     async def async_media_play(self) -> None:
         """Send play command."""
         if (await self.fs_device.get_play_state()) == PlayState.STOPPED:
@@ -289,45 +325,54 @@ class AFSAPIDevice(MediaPlayerEntity):
         else:
             await self.fs_device.play()
 
+    @fs_command_exception_wrap
     async def async_media_pause(self) -> None:
         """Send pause command."""
         await self.fs_device.pause()
 
+    @fs_command_exception_wrap
     async def async_media_stop(self) -> None:
         """Send stop command."""
         await self.fs_device.stop()
 
+    @fs_command_exception_wrap
     async def async_media_previous_track(self) -> None:
         """Send previous track command (results in rewind)."""
         await self.fs_device.rewind()
 
+    @fs_command_exception_wrap
     async def async_media_next_track(self) -> None:
         """Send next track command (results in fast-forward)."""
         await self.fs_device.forward()
 
+    @fs_command_exception_wrap
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         await self.fs_device.set_mute(mute)
 
     # volume
+    @fs_command_exception_wrap
     async def async_volume_up(self) -> None:
         """Send volume up command."""
         volume = await self.fs_device.get_volume()
         volume = int(volume or 0) + 1
         await self.fs_device.set_volume(min(volume, self._max_volume or 1))
 
+    @fs_command_exception_wrap
     async def async_volume_down(self) -> None:
         """Send volume down command."""
         volume = await self.fs_device.get_volume()
         volume = int(volume or 0) - 1
         await self.fs_device.set_volume(max(volume, 0))
 
+    @fs_command_exception_wrap
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume command."""
         if self._max_volume:  # Can't do anything sensible if not set
             volume = int(volume * self._max_volume)
             await self.fs_device.set_volume(volume)
 
+    @fs_command_exception_wrap
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         await self.fs_device.set_power(True)
@@ -337,6 +382,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         ):
             await self.fs_device.set_mode(mode)
 
+    @fs_command_exception_wrap
     async def async_select_sound_mode(self, sound_mode: str) -> None:
         """Select EQ Preset."""
         if (
@@ -345,6 +391,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         ):
             await self.fs_device.set_eq_preset(mode)
 
+    @fs_command_exception_wrap
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set repeat mode."""
         await self.fs_device.play_repeat(
@@ -355,10 +402,12 @@ class AFSAPIDevice(MediaPlayerEntity):
             }.get(repeat, PlayRepeatMode.OFF)
         )
 
+    @fs_command_exception_wrap
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Set shuffle mode."""
         await self.fs_device.set_play_shuffle(shuffle)
 
+    @fs_command_exception_wrap
     async def async_media_seek(self, position: float) -> None:
         """Seek to a position in seconds."""
         await self.fs_device.set_play_position(int(position * 1000))
@@ -374,6 +423,7 @@ class AFSAPIDevice(MediaPlayerEntity):
 
         return await browse_node(self.fs_device, media_content_type, media_content_id)
 
+    @fs_command_exception_wrap
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -12,12 +12,10 @@ from afsapi import (
     FSApiError,
     FSConnectionError,
     FSNotImplementedError,
-    OutOfRangeError,
     PlayCaps,
     PlayRepeatMode,
     PlayState,
 )
-from afsapi.exceptions import FSNodeBlockedError
 
 from homeassistant.components.media_player import (
     BrowseError,
@@ -29,7 +27,7 @@ from homeassistant.components.media_player import (
     RepeatMode,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -57,13 +55,17 @@ def fs_command_exception_wrap[
         except FSConnectionError as err:
             command = func.__name__.removeprefix("async_")
             raise HomeAssistantError(
-                f"Failed to execute {command}: could not connect to device"
+                translation_domain=DOMAIN,
+                translation_key="connection_error",
+                translation_placeholders={"command": command},
             ) from err
-        except (OutOfRangeError, FSNodeBlockedError) as err:
-            raise ServiceValidationError(str(err)) from err
         except FSApiError as err:
             command = func.__name__.removeprefix("async_")
-            raise HomeAssistantError(f"Failed to execute {command}: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="api_error",
+                translation_placeholders={"command": command, "message": str(err)},
+            ) from err
 
     return _wrap
 

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -40,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def fs_command_exception_wrap[
-    _AFSAPIDeviceT: "AFSAPIDevice",
+    _AFSAPIDeviceT: AFSAPIDevice,
     **_P,
     _R,
 ](

--- a/homeassistant/components/frontier_silicon/strings.json
+++ b/homeassistant/components/frontier_silicon/strings.json
@@ -33,5 +33,13 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "api_error": {
+      "message": "Failed to execute {command}: {message}"
+    },
+    "connection_error": {
+      "message": "Failed to execute {command}: could not connect to device"
+    }
   }
 }

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -10,35 +10,34 @@ from homeassistant.components.frontier_silicon.media_player import AFSAPIDevice
 from homeassistant.exceptions import HomeAssistantError
 
 
-async def test_async_media_previous_track_maps_connection_error() -> None:
-    """Test previous track maps connection failures to Home Assistant errors."""
+@pytest.mark.parametrize(
+    ("error", "translation_key", "message"),
+    [
+        (FSConnectionError("Connection failed"), "connection_error", None),
+        (
+            FSNotImplementedError("Command is not implemented"),
+            "api_error",
+            "Command is not implemented",
+        ),
+    ],
+)
+async def test_async_media_previous_track_maps_errors(
+    error: Exception, translation_key: str, message: str | None
+) -> None:
+    """Test previous track maps API failures to Home Assistant errors."""
     fs_device = AsyncMock()
-    fs_device.rewind.side_effect = FSConnectionError("Connection failed")
+    fs_device.rewind.side_effect = error
     entity = AFSAPIDevice("unique_id", "name", fs_device)
 
     with pytest.raises(HomeAssistantError) as exc_info:
         await entity.async_media_previous_track()
 
     assert exc_info.value.translation_domain == DOMAIN
-    assert exc_info.value.translation_key == "connection_error"
-    assert exc_info.value.translation_placeholders == {
-        "command": "media_previous_track"
-    }
-
-
-async def test_async_media_previous_track_maps_other_api_errors() -> None:
-    """Test previous track maps non-range API errors to Home Assistant errors."""
-    fs_device = AsyncMock()
-    fs_device.rewind.side_effect = FSNotImplementedError("Command is not implemented")
-    entity = AFSAPIDevice("unique_id", "name", fs_device)
-
-    with pytest.raises(HomeAssistantError) as exc_info:
-        await entity.async_media_previous_track()
-
-    assert exc_info.value.translation_domain == DOMAIN
-    assert exc_info.value.translation_key == "api_error"
+    assert exc_info.value.translation_key == translation_key
     assert exc_info.value.translation_placeholders["command"] == "media_previous_track"
-    assert (
-        "Command is not implemented"
-        in exc_info.value.translation_placeholders["message"]
-    )
+    if message is not None:
+        assert message in exc_info.value.translation_placeholders["message"]
+    else:
+        assert exc_info.value.translation_placeholders == {
+            "command": "media_previous_track"
+        }

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock
 from afsapi import FSConnectionError, FSNotImplementedError
 import pytest
 
-from homeassistant.components.frontier_silicon.const import DOMAIN
 from homeassistant.components.frontier_silicon.media_player import AFSAPIDevice
 from homeassistant.exceptions import HomeAssistantError
 

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -32,7 +32,6 @@ async def test_async_media_previous_track_maps_errors(
     with pytest.raises(HomeAssistantError) as exc_info:
         await entity.async_media_previous_track()
 
-    assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == translation_key
     assert exc_info.value.translation_placeholders["command"] == "media_previous_track"
 

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -2,46 +2,12 @@
 
 from unittest.mock import AsyncMock
 
-from afsapi.exceptions import (
-    FSConnectionError,
-    FSNodeBlockedError,
-    FSNotImplementedError,
-    OutOfRangeError,
-)
+from afsapi.exceptions import FSConnectionError, FSNotImplementedError
 import pytest
 
+from homeassistant.components.frontier_silicon.const import DOMAIN
 from homeassistant.components.frontier_silicon.media_player import AFSAPIDevice
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-
-
-async def test_async_media_previous_track_maps_out_of_range_error() -> None:
-    """Test previous track maps API range errors to service validation errors."""
-    fs_device = AsyncMock()
-    fs_device.rewind.side_effect = OutOfRangeError(
-        "Command failed. Value is not in range for this command."
-    )
-    entity = AFSAPIDevice("unique_id", "name", fs_device)
-
-    with pytest.raises(
-        ServiceValidationError,
-        match="Command failed. Value is not in range for this command.",
-    ):
-        await entity.async_media_previous_track()
-
-
-async def test_async_media_previous_track_maps_node_blocked_error() -> None:
-    """Test previous track maps API node blocked errors to service validation errors."""
-    fs_device = AsyncMock()
-    fs_device.rewind.side_effect = FSNodeBlockedError(
-        "Command failed. Node is blocked."
-    )
-    entity = AFSAPIDevice("unique_id", "name", fs_device)
-
-    with pytest.raises(
-        ServiceValidationError,
-        match="Command failed. Node is blocked.",
-    ):
-        await entity.async_media_previous_track()
+from homeassistant.exceptions import HomeAssistantError
 
 
 async def test_async_media_previous_track_maps_connection_error() -> None:
@@ -50,11 +16,14 @@ async def test_async_media_previous_track_maps_connection_error() -> None:
     fs_device.rewind.side_effect = FSConnectionError("Connection failed")
     entity = AFSAPIDevice("unique_id", "name", fs_device)
 
-    with pytest.raises(
-        HomeAssistantError,
-        match="Failed to execute media_previous_track: could not connect to device",
-    ):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await entity.async_media_previous_track()
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "connection_error"
+    assert exc_info.value.translation_placeholders == {
+        "command": "media_previous_track"
+    }
 
 
 async def test_async_media_previous_track_maps_other_api_errors() -> None:
@@ -63,8 +32,13 @@ async def test_async_media_previous_track_maps_other_api_errors() -> None:
     fs_device.rewind.side_effect = FSNotImplementedError("Command is not implemented")
     entity = AFSAPIDevice("unique_id", "name", fs_device)
 
-    with pytest.raises(
-        HomeAssistantError,
-        match="Failed to execute media_previous_track: Command is not implemented",
-    ):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await entity.async_media_previous_track()
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "api_error"
+    assert exc_info.value.translation_placeholders["command"] == "media_previous_track"
+    assert (
+        "Command is not implemented"
+        in exc_info.value.translation_placeholders["message"]
+    )

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -35,9 +35,7 @@ async def test_async_media_previous_track_maps_errors(
     assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == translation_key
     assert exc_info.value.translation_placeholders["command"] == "media_previous_track"
-    if message is not None:
-        assert message in exc_info.value.translation_placeholders["message"]
-    else:
-        assert exc_info.value.translation_placeholders == {
-            "command": "media_previous_track"
-        }
+
+    assert (
+        message is None or message in exc_info.value.translation_placeholders["message"]
+    )

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from afsapi.exceptions import FSConnectionError, FSNotImplementedError
+from afsapi import FSConnectionError, FSNotImplementedError
 import pytest
 
 from homeassistant.components.frontier_silicon.const import DOMAIN

--- a/tests/components/frontier_silicon/test_media_player.py
+++ b/tests/components/frontier_silicon/test_media_player.py
@@ -1,0 +1,70 @@
+"""Test the Frontier Silicon media player entity."""
+
+from unittest.mock import AsyncMock
+
+from afsapi.exceptions import (
+    FSConnectionError,
+    FSNodeBlockedError,
+    FSNotImplementedError,
+    OutOfRangeError,
+)
+import pytest
+
+from homeassistant.components.frontier_silicon.media_player import AFSAPIDevice
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+
+async def test_async_media_previous_track_maps_out_of_range_error() -> None:
+    """Test previous track maps API range errors to service validation errors."""
+    fs_device = AsyncMock()
+    fs_device.rewind.side_effect = OutOfRangeError(
+        "Command failed. Value is not in range for this command."
+    )
+    entity = AFSAPIDevice("unique_id", "name", fs_device)
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Command failed. Value is not in range for this command.",
+    ):
+        await entity.async_media_previous_track()
+
+
+async def test_async_media_previous_track_maps_node_blocked_error() -> None:
+    """Test previous track maps API node blocked errors to service validation errors."""
+    fs_device = AsyncMock()
+    fs_device.rewind.side_effect = FSNodeBlockedError(
+        "Command failed. Node is blocked."
+    )
+    entity = AFSAPIDevice("unique_id", "name", fs_device)
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Command failed. Node is blocked.",
+    ):
+        await entity.async_media_previous_track()
+
+
+async def test_async_media_previous_track_maps_connection_error() -> None:
+    """Test previous track maps connection failures to Home Assistant errors."""
+    fs_device = AsyncMock()
+    fs_device.rewind.side_effect = FSConnectionError("Connection failed")
+    entity = AFSAPIDevice("unique_id", "name", fs_device)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Failed to execute media_previous_track: could not connect to device",
+    ):
+        await entity.async_media_previous_track()
+
+
+async def test_async_media_previous_track_maps_other_api_errors() -> None:
+    """Test previous track maps non-range API errors to Home Assistant errors."""
+    fs_device = AsyncMock()
+    fs_device.rewind.side_effect = FSNotImplementedError("Command is not implemented")
+    entity = AFSAPIDevice("unique_id", "name", fs_device)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Failed to execute media_previous_track: Command is not implemented",
+    ):
+        await entity.async_media_previous_track()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, exceptions generated by the integration are not caught. This PR adds a wrapper to the functions that can receive an FSApiError to properly handle them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
