### PR TITLE
Move Tuya listener classes to separate module

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -23,25 +23,13 @@ from .const import (
     PLATFORMS,
     TUYA_CLIENT_ID,
 )
-from .coordinator import DeviceListener, TokenListener, TuyaConfigEntry
+from .coordinator import TuyaConfigEntry, async_create_listener
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 # Suppress logs from the library, it logs unneeded on error
 logging.getLogger("tuya_sharing").setLevel(logging.CRITICAL)
-
-
-def _create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Manager:
-    """Create a Tuya Manager instance."""
-    return Manager(
-        TUYA_CLIENT_ID,
-        entry.data[CONF_USER_CODE],
-        entry.data[CONF_TERMINAL_ID],
-        entry.data[CONF_ENDPOINT],
-        entry.data[CONF_TOKEN_INFO],
-        token_listener,
-    )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -57,16 +45,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
         register_tuya_quirks, str(Path(hass.config.config_dir, "tuya_quirks"))
     )
 
-    token_listener = TokenListener(hass, entry)
-
-    # Move to executor as it makes blocking call to import_module
-    # with args ('.system', 'urllib3.contrib.resolver')
-    manager = await hass.async_add_executor_job(_create_manager, entry, token_listener)
-
-    listener = DeviceListener(hass, manager)
-    manager.add_device_listener(listener)
-
-    # Get all devices from Tuya
+    # Get initial devices from Tuya
+    listener = await async_create_listener(hass, entry)
+    manager = listener.manager
     try:
         await hass.async_add_executor_job(manager.update_device_cache)
     except Exception as exc:
@@ -76,9 +57,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
             msg = "Authentication failed. Please re-authenticate"
             raise ConfigEntryAuthFailed(msg) from exc
         raise
-
-    # Connection is successful, store the listener
-    entry.runtime_data = listener
 
     # Cleanup device registry
     await cleanup_device_registry(hass, manager, entry)
@@ -106,7 +84,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
             model_id=device.product_id,
         )
 
+    # Connection is successful, store the listener and set up platforms
+    entry.runtime_data = listener
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
     # If the device does not register any entities, the device does not need to subscribe
     # So the subscription is here
     await hass.async_add_executor_job(manager.refresh_mq)

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -4,21 +4,13 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, NamedTuple
 
 from tuya_device_handlers.devices import register_tuya_quirks
-from tuya_sharing import (
-    CustomerDevice,
-    Manager,
-    SharingDeviceListener,
-    SharingTokenListener,
-)
+from tuya_sharing import Manager
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv, device_registry as dr
-from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -30,24 +22,14 @@ from .const import (
     LOGGER,
     PLATFORMS,
     TUYA_CLIENT_ID,
-    TUYA_DISCOVERY_NEW,
-    TUYA_HA_SIGNAL_UPDATE_ENTITY,
 )
+from .coordinator import DeviceListener, TokenListener, TuyaConfigEntry
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 # Suppress logs from the library, it logs unneeded on error
 logging.getLogger("tuya_sharing").setLevel(logging.CRITICAL)
-
-type TuyaConfigEntry = ConfigEntry[HomeAssistantTuyaData]
-
-
-class HomeAssistantTuyaData(NamedTuple):
-    """Tuya data stored in the Home Assistant data object."""
-
-    manager: Manager
-    listener: SharingDeviceListener
 
 
 def _create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Manager:
@@ -95,8 +77,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
             raise ConfigEntryAuthFailed(msg) from exc
         raise
 
-    # Connection is successful, store the manager & listener
-    entry.runtime_data = HomeAssistantTuyaData(manager=manager, listener=listener)
+    # Connection is successful, store the listener
+    entry.runtime_data = listener
 
     # Cleanup device registry
     await cleanup_device_registry(hass, manager, entry)
@@ -150,10 +132,11 @@ async def cleanup_device_registry(
 async def async_unload_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool:
     """Unloading the Tuya platforms."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        tuya = entry.runtime_data
-        if tuya.manager.mq is not None:
-            tuya.manager.mq.stop()
-        tuya.manager.remove_device_listener(tuya.listener)
+        listener = entry.runtime_data
+        manager = listener.manager
+        if manager.mq is not None:
+            manager.mq.stop()
+        manager.remove_device_listener(listener)
     return unload_ok
 
 
@@ -170,103 +153,3 @@ async def async_remove_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> Non
         entry.data[CONF_TOKEN_INFO],
     )
     await hass.async_add_executor_job(manager.unload)
-
-
-class DeviceListener(SharingDeviceListener):
-    """Device Update Listener."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        manager: Manager,
-    ) -> None:
-        """Init DeviceListener."""
-        self.hass = hass
-        self.manager = manager
-
-    def update_device(
-        self,
-        device: CustomerDevice,
-        updated_status_properties: list[str] | None = None,
-        dp_timestamps: dict[str, int] | None = None,
-    ) -> None:
-        """Update device status with optional DP timestamps."""
-        LOGGER.debug(
-            "Received update for device %s (online: %s): %s"
-            " (updated properties: %s, dp_timestamps: %s)",
-            device.id,
-            device.online,
-            device.status,
-            updated_status_properties,
-            dp_timestamps,
-        )
-        dispatcher_send(
-            self.hass,
-            f"{TUYA_HA_SIGNAL_UPDATE_ENTITY}_{device.id}",
-            updated_status_properties,
-            dp_timestamps,
-        )
-
-    def add_device(self, device: CustomerDevice) -> None:
-        """Add device added listener."""
-        # Ensure the device isn't present stale
-        self.hass.add_job(self.async_remove_device, device.id)
-
-        LOGGER.debug(
-            "Add device %s (online: %s): %s (function: %s, status range: %s)",
-            device.id,
-            device.online,
-            device.status,
-            device.function,
-            device.status_range,
-        )
-
-        dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
-
-    def remove_device(self, device_id: str) -> None:
-        """Add device removed listener."""
-        self.hass.add_job(self.async_remove_device, device_id)
-
-    @callback
-    def async_remove_device(self, device_id: str) -> None:
-        """Remove device from Home Assistant."""
-        LOGGER.debug("Remove device: %s", device_id)
-        device_registry = dr.async_get(self.hass)
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
-        )
-        if device_entry is not None:
-            device_registry.async_remove_device(device_entry.id)
-
-
-class TokenListener(SharingTokenListener):
-    """Token listener for upstream token updates."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        entry: TuyaConfigEntry,
-    ) -> None:
-        """Init TokenListener."""
-        self.hass = hass
-        self.entry = entry
-
-    def update_token(self, token_info: dict[str, Any]) -> None:
-        """Update token info in config entry."""
-        data = {
-            **self.entry.data,
-            CONF_TOKEN_INFO: {
-                "t": token_info["t"],
-                "uid": token_info["uid"],
-                "expire_time": token_info["expire_time"],
-                "access_token": token_info["access_token"],
-                "refresh_token": token_info["refresh_token"],
-            },
-        }
-
-        @callback
-        def async_update_entry() -> None:
-            """Update config entry."""
-            self.hass.config_entries.async_update_entry(self.entry, data=data)
-
-        self.hass.add_job(async_update_entry)

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -9,7 +9,6 @@ from tuya_device_handlers.devices import register_tuya_quirks
 from tuya_sharing import Manager
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -23,7 +22,7 @@ from .const import (
     PLATFORMS,
     TUYA_CLIENT_ID,
 )
-from .coordinator import TuyaConfigEntry, async_create_listener
+from .coordinator import DeviceListener, TuyaConfigEntry
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -46,17 +45,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
     )
 
     # Get initial devices from Tuya
-    listener = await async_create_listener(hass, entry)
+    listener = DeviceListener(hass, entry)
+    await listener.async_initialise()
     manager = listener.manager
-    try:
-        await hass.async_add_executor_job(manager.update_device_cache)
-    except Exception as exc:
-        # While in general, we should avoid catching broad exceptions,
-        # we have no other way of detecting this case.
-        if "sign invalid" in str(exc):
-            msg = "Authentication failed. Please re-authenticate"
-            raise ConfigEntryAuthFailed(msg) from exc
-        raise
 
     # Cleanup device registry
     await cleanup_device_registry(hass, manager, entry)

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -9,6 +9,7 @@ from tuya_device_handlers.devices import register_tuya_quirks
 from tuya_sharing import Manager
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -22,7 +23,13 @@ from .const import (
     PLATFORMS,
     TUYA_CLIENT_ID,
 )
-from .coordinator import DeviceListener, TuyaConfigEntry
+from .coordinator import (
+    DeviceListener,
+    HomeAssistantTuyaData,
+    TokenListener,
+    TuyaConfigEntry,
+    create_manager,
+)
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -44,10 +51,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
         register_tuya_quirks, str(Path(hass.config.config_dir, "tuya_quirks"))
     )
 
-    # Get initial devices from Tuya
-    listener = DeviceListener(hass, entry)
-    await listener.async_initialise()
-    manager = listener.manager
+    token_listener = TokenListener(hass, entry)
+
+    # Move to executor as it makes blocking call to import_module
+    # with args ('.system', 'urllib3.contrib.resolver')
+    manager = await hass.async_add_executor_job(create_manager, entry, token_listener)
+
+    listener = DeviceListener(hass, manager)
+    manager.add_device_listener(listener)
+
+    # Get all devices from Tuya
+    try:
+        await hass.async_add_executor_job(manager.update_device_cache)
+    except Exception as exc:
+        # While in general, we should avoid catching broad exceptions,
+        # we have no other way of detecting this case.
+        if "sign invalid" in str(exc):
+            msg = "Authentication failed. Please re-authenticate"
+            raise ConfigEntryAuthFailed(msg) from exc
+        raise
+
+    # Connection is successful, store the manager & listener
+    entry.runtime_data = HomeAssistantTuyaData(manager=manager, listener=listener)
 
     # Cleanup device registry
     await cleanup_device_registry(hass, manager, entry)
@@ -75,10 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
             model_id=device.product_id,
         )
 
-    # Connection is successful, store the listener and set up platforms
-    entry.runtime_data = listener
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     # If the device does not register any entities, the device does not need to subscribe
     # So the subscription is here
     await hass.async_add_executor_job(manager.refresh_mq)
@@ -104,11 +126,10 @@ async def cleanup_device_registry(
 async def async_unload_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool:
     """Unloading the Tuya platforms."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        listener = entry.runtime_data
-        manager = listener.manager
-        if manager.mq is not None:
-            manager.mq.stop()
-        manager.remove_device_listener(listener)
+        tuya = entry.runtime_data
+        if tuya.manager.mq is not None:
+            tuya.manager.mq.stop()
+        tuya.manager.remove_device_listener(tuya.listener)
     return unload_ok
 
 

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -22,8 +22,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 ALARM: dict[DeviceCategory, AlarmControlPanelEntityDescription] = {

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -20,8 +20,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 

--- a/homeassistant/components/tuya/button.py
+++ b/homeassistant/components/tuya/button.py
@@ -14,8 +14,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 BUTTONS: dict[DeviceCategory, tuple[ButtonEntityDescription, ...]] = {

--- a/homeassistant/components/tuya/camera.py
+++ b/homeassistant/components/tuya/camera.py
@@ -20,8 +20,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 CAMERAS: dict[DeviceCategory, CameraEntityDescription] = {

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -32,8 +32,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 _TUYA_TO_HA_HVACMODE_MAPPINGS = {

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -11,6 +11,7 @@ from tuya_sharing import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
 
@@ -41,32 +42,46 @@ def _create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Ma
     )
 
 
-async def async_create_listener(
-    hass: HomeAssistant, entry: TuyaConfigEntry
-) -> DeviceListener:
-    """Create DeviceListener."""
-    token_listener = TokenListener(hass, entry)
-
-    # Move to executor as it makes blocking call to import_module
-    # with args ('.system', 'urllib3.contrib.resolver')
-    manager = await hass.async_add_executor_job(_create_manager, entry, token_listener)
-
-    listener = DeviceListener(hass, manager)
-    manager.add_device_listener(listener)
-
-    return listener
-
-
 class DeviceListener(SharingDeviceListener):
     """Device Update Listener."""
+
+    manager: Manager
 
     def __init__(
         self,
         hass: HomeAssistant,
-        manager: Manager,
+        entry: TuyaConfigEntry,
     ) -> None:
         """Init DeviceListener."""
         self.hass = hass
+        self.entry = entry
+
+    async def async_initialise(self) -> None:
+        """Create DeviceListener."""
+        hass = self.hass
+        entry = self.entry
+
+        token_listener = TokenListener(hass, entry)
+
+        # Move to executor as it makes blocking call to import_module
+        # with args ('.system', 'urllib3.contrib.resolver')
+        manager = await hass.async_add_executor_job(
+            _create_manager, entry, token_listener
+        )
+
+        listener = DeviceListener(hass, manager)
+        manager.add_device_listener(listener)
+
+        try:
+            await hass.async_add_executor_job(manager.update_device_cache)
+        except Exception as exc:
+            # While in general, we should avoid catching broad exceptions,
+            # we have no other way of detecting this case.
+            if "sign invalid" in str(exc):
+                msg = "Authentication failed. Please re-authenticate"
+                raise ConfigEntryAuthFailed(msg) from exc
+            raise
+
         self.manager = manager
 
     def update_device(

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -1,0 +1,127 @@
+"""Support for Tuya Smart devices."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tuya_sharing import (
+    CustomerDevice,
+    Manager,
+    SharingDeviceListener,
+    SharingTokenListener,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import dispatcher_send
+
+from .const import (
+    CONF_TOKEN_INFO,
+    DOMAIN,
+    LOGGER,
+    TUYA_DISCOVERY_NEW,
+    TUYA_HA_SIGNAL_UPDATE_ENTITY,
+)
+
+type TuyaConfigEntry = ConfigEntry[SharingDeviceListener]
+
+
+class DeviceListener(SharingDeviceListener):
+    """Device Update Listener."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        manager: Manager,
+    ) -> None:
+        """Init DeviceListener."""
+        self.hass = hass
+        self.manager = manager
+
+    def update_device(
+        self,
+        device: CustomerDevice,
+        updated_status_properties: list[str] | None = None,
+        dp_timestamps: dict[str, int] | None = None,
+    ) -> None:
+        """Update device status with optional DP timestamps."""
+        LOGGER.debug(
+            "Received update for device %s (online: %s): %s"
+            " (updated properties: %s, dp_timestamps: %s)",
+            device.id,
+            device.online,
+            device.status,
+            updated_status_properties,
+            dp_timestamps,
+        )
+        dispatcher_send(
+            self.hass,
+            f"{TUYA_HA_SIGNAL_UPDATE_ENTITY}_{device.id}",
+            updated_status_properties,
+            dp_timestamps,
+        )
+
+    def add_device(self, device: CustomerDevice) -> None:
+        """Add device added listener."""
+        # Ensure the device isn't present stale
+        self.hass.add_job(self.async_remove_device, device.id)
+
+        LOGGER.debug(
+            "Add device %s (online: %s): %s (function: %s, status range: %s)",
+            device.id,
+            device.online,
+            device.status,
+            device.function,
+            device.status_range,
+        )
+
+        dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
+
+    def remove_device(self, device_id: str) -> None:
+        """Add device removed listener."""
+        self.hass.add_job(self.async_remove_device, device_id)
+
+    @callback
+    def async_remove_device(self, device_id: str) -> None:
+        """Remove device from Home Assistant."""
+        LOGGER.debug("Remove device: %s", device_id)
+        device_registry = dr.async_get(self.hass)
+        device_entry = device_registry.async_get_device(
+            identifiers={(DOMAIN, device_id)}
+        )
+        if device_entry is not None:
+            device_registry.async_remove_device(device_entry.id)
+
+
+class TokenListener(SharingTokenListener):
+    """Token listener for upstream token updates."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: TuyaConfigEntry,
+    ) -> None:
+        """Init TokenListener."""
+        self.hass = hass
+        self.entry = entry
+
+    def update_token(self, token_info: dict[str, Any]) -> None:
+        """Update token info in config entry."""
+        data = {
+            **self.entry.data,
+            CONF_TOKEN_INFO: {
+                "t": token_info["t"],
+                "uid": token_info["uid"],
+                "expire_time": token_info["expire_time"],
+                "access_token": token_info["access_token"],
+                "refresh_token": token_info["refresh_token"],
+            },
+        }
+
+        @callback
+        def async_update_entry() -> None:
+            """Update config entry."""
+            self.hass.config_entries.async_update_entry(self.entry, data=data)
+
+        self.hass.add_job(async_update_entry)

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -1,7 +1,5 @@
 """Support for Tuya Smart devices."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from tuya_sharing import (

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -15,14 +15,46 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import (
+    CONF_ENDPOINT,
+    CONF_TERMINAL_ID,
     CONF_TOKEN_INFO,
+    CONF_USER_CODE,
     DOMAIN,
     LOGGER,
+    TUYA_CLIENT_ID,
     TUYA_DISCOVERY_NEW,
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
 )
 
 type TuyaConfigEntry = ConfigEntry[SharingDeviceListener]
+
+
+def _create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Manager:
+    """Create a Tuya Manager instance."""
+    return Manager(
+        TUYA_CLIENT_ID,
+        entry.data[CONF_USER_CODE],
+        entry.data[CONF_TERMINAL_ID],
+        entry.data[CONF_ENDPOINT],
+        entry.data[CONF_TOKEN_INFO],
+        token_listener,
+    )
+
+
+async def async_create_listener(
+    hass: HomeAssistant, entry: TuyaConfigEntry
+) -> DeviceListener:
+    """Create DeviceListener."""
+    token_listener = TokenListener(hass, entry)
+
+    # Move to executor as it makes blocking call to import_module
+    # with args ('.system', 'urllib3.contrib.resolver')
+    manager = await hass.async_add_executor_job(_create_manager, entry, token_listener)
+
+    listener = DeviceListener(hass, manager)
+    manager.add_device_listener(listener)
+
+    return listener
 
 
 class DeviceListener(SharingDeviceListener):

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -1,6 +1,6 @@
 """Support for Tuya Smart devices."""
 
-from typing import Any
+from typing import Any, NamedTuple
 
 from tuya_sharing import (
     CustomerDevice,
@@ -11,7 +11,6 @@ from tuya_sharing import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
 
@@ -27,10 +26,17 @@ from .const import (
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
 )
 
-type TuyaConfigEntry = ConfigEntry[DeviceListener]
+type TuyaConfigEntry = ConfigEntry[HomeAssistantTuyaData]
 
 
-def _create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Manager:
+class HomeAssistantTuyaData(NamedTuple):
+    """Tuya data stored in the Home Assistant data object."""
+
+    manager: Manager
+    listener: SharingDeviceListener
+
+
+def create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Manager:
     """Create a Tuya Manager instance."""
     return Manager(
         TUYA_CLIENT_ID,
@@ -45,43 +51,13 @@ def _create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Ma
 class DeviceListener(SharingDeviceListener):
     """Device Update Listener."""
 
-    manager: Manager
-
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: TuyaConfigEntry,
+        manager: Manager,
     ) -> None:
         """Init DeviceListener."""
         self.hass = hass
-        self.entry = entry
-
-    async def async_initialise(self) -> None:
-        """Create DeviceListener."""
-        hass = self.hass
-        entry = self.entry
-
-        token_listener = TokenListener(hass, entry)
-
-        # Move to executor as it makes blocking call to import_module
-        # with args ('.system', 'urllib3.contrib.resolver')
-        manager = await hass.async_add_executor_job(
-            _create_manager, entry, token_listener
-        )
-
-        listener = DeviceListener(hass, manager)
-        manager.add_device_listener(listener)
-
-        try:
-            await hass.async_add_executor_job(manager.update_device_cache)
-        except Exception as exc:
-            # While in general, we should avoid catching broad exceptions,
-            # we have no other way of detecting this case.
-            if "sign invalid" in str(exc):
-                msg = "Authentication failed. Please re-authenticate"
-                raise ConfigEntryAuthFailed(msg) from exc
-            raise
-
         self.manager = manager
 
     def update_device(
@@ -108,8 +84,8 @@ class DeviceListener(SharingDeviceListener):
         )
 
     def add_device(self, device: CustomerDevice) -> None:
-        """Handle device added event."""
-        # Ensure the (stale) device isn't present
+        """Add device added listener."""
+        # Ensure the device isn't present stale
         self.hass.add_job(self.async_remove_device, device.id)
 
         LOGGER.debug(
@@ -124,7 +100,7 @@ class DeviceListener(SharingDeviceListener):
         dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
 
     def remove_device(self, device_id: str) -> None:
-        """Handle device removal event."""
+        """Add device removed listener."""
         self.hass.add_job(self.async_remove_device, device_id)
 
     @callback

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -93,8 +93,8 @@ class DeviceListener(SharingDeviceListener):
         )
 
     def add_device(self, device: CustomerDevice) -> None:
-        """Add device added listener."""
-        # Ensure the device isn't present stale
+        """Handle device added event."""
+        # Ensure the (stale) device isn't present
         self.hass.add_job(self.async_remove_device, device.id)
 
         LOGGER.debug(
@@ -109,7 +109,7 @@ class DeviceListener(SharingDeviceListener):
         dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
 
     def remove_device(self, device_id: str) -> None:
-        """Add device removed listener."""
+        """Handle device removal event."""
         self.hass.add_job(self.async_remove_device, device_id)
 
     @callback

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -26,7 +26,7 @@ from .const import (
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
 )
 
-type TuyaConfigEntry = ConfigEntry[SharingDeviceListener]
+type TuyaConfigEntry = ConfigEntry[DeviceListener]
 
 
 def _create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Manager:

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -35,8 +35,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 

--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -12,8 +12,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from . import TuyaConfigEntry
 from .const import DOMAIN, DPCode
+from .coordinator import TuyaConfigEntry
 
 _REDACTED_DPCODES = {
     DPCode.ALARM_MESSAGE,

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -25,8 +25,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -22,8 +22,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 FANS: dict[DeviceCategory, FanEntityDescription] = {

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -21,8 +21,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 from .util import ActionDPCodeNotFoundError
 

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -28,8 +28,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode, WorkMode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -19,7 +19,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import (
     DEVICE_CLASS_UNITS,
     DOMAIN,
@@ -28,6 +27,7 @@ from .const import (
     DeviceCategory,
     DPCode,
 )
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 NUMBERS: dict[DeviceCategory, tuple[NumberEntityDescription, ...]] = {

--- a/homeassistant/components/tuya/scene.py
+++ b/homeassistant/components/tuya/scene.py
@@ -11,8 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import DOMAIN
+from .coordinator import TuyaConfigEntry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -14,8 +14,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 # All descriptions can be found here. Mostly the Enum data types in the

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -44,7 +44,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import TuyaConfigEntry
 from .const import (
     DEVICE_CLASS_UNITS,
     DOMAIN,
@@ -53,6 +52,7 @@ from .const import (
     DeviceCategory,
     DPCode,
 )
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 CURRENT_WRAPPER = (ElectricityCurrentRawWrapper, ElectricityCurrentJsonWrapper)

--- a/homeassistant/components/tuya/siren.py
+++ b/homeassistant/components/tuya/siren.py
@@ -20,8 +20,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 SIRENS: dict[DeviceCategory, tuple[SirenEntityDescription, ...]] = {

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -20,8 +20,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 # All descriptions can be found here. Mostly the Boolean data types in the

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -24,8 +24,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 _TUYA_TO_HA_ACTIVITY_MAPPINGS = {

--- a/homeassistant/components/tuya/valve.py
+++ b/homeassistant/components/tuya/valve.py
@@ -18,8 +18,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 VALVES: dict[DeviceCategory, tuple[ValveEntityDescription, ...]] = {

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -181,7 +181,9 @@ async def initialize_entry(
     mock_config_entry.add_to_hass(hass)
 
     # Initialize the component
-    with patch("homeassistant.components.tuya.Manager", return_value=mock_manager):
+    with patch(
+        "homeassistant.components.tuya.coordinator.Manager", return_value=mock_manager
+    ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -15,7 +15,8 @@ from tuya_sharing import (
     Manager,
 )
 
-from homeassistant.components.tuya import DOMAIN, DeviceListener
+from homeassistant.components.tuya.const import DOMAIN
+from homeassistant.components.tuya.coordinator import DeviceListener
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import json_dumps

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -60,7 +60,10 @@ async def mock_loaded_entry(
 
     # Initialize the component
     with (
-        patch("homeassistant.components.tuya.Manager", return_value=mock_manager),
+        patch(
+            "homeassistant.components.tuya.coordinator.Manager",
+            return_value=mock_manager,
+        ),
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -45,7 +45,9 @@ async def test_registry_cleanup(
 
     # Now remove the second device from the manager and re-initialize
     del main_manager.device_map[second_device.id]
-    with patch("homeassistant.components.tuya.Manager", return_value=main_manager):
+    with patch(
+        "homeassistant.components.tuya.coordinator.Manager", return_value=main_manager
+    ):
         await hass.config_entries.async_reload(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move classes and functions to coordinator.py:
- `DeviceListener` class
- `TokenListener` class
- `HomeAssistantTuyaData` class (runtime_data)
- `TuyaConfigEntry` type alias
- `create_manager` function

This is just moving code around, no functionnality changes in this PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
