### PR TITLE
Add reauthentication flow to Fumis integration

### DIFF
--- a/homeassistant/components/fumis/config_flow.py
+++ b/homeassistant/components/fumis/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from fumis import (
@@ -77,6 +78,54 @@ class FumisFlowHandler(ConfigFlow, domain=DOMAIN):
                     }
                 ),
                 user_input,
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication of a Fumis stove."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle re-authentication confirmation."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            reauth_entry = self._get_reauth_entry()
+            fumis = Fumis(
+                mac=reauth_entry.data[CONF_MAC],
+                password=user_input[CONF_PIN],
+                session=async_get_clientsession(self.hass),
+            )
+            try:
+                await fumis.update_info()
+            except FumisAuthenticationError:
+                errors[CONF_PIN] = "invalid_auth"
+            except FumisStoveOfflineError:
+                errors["base"] = "device_offline"
+            except FumisConnectionError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={CONF_PIN: user_input[CONF_PIN]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PIN): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
             ),
             errors=errors,
         )

--- a/homeassistant/components/fumis/coordinator.py
+++ b/homeassistant/components/fumis/coordinator.py
@@ -14,6 +14,7 @@ from fumis import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC, CONF_PIN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -47,7 +48,7 @@ class FumisDataUpdateCoordinator(DataUpdateCoordinator[FumisInfo]):
         try:
             return await self.client.update_info()
         except FumisAuthenticationError as err:
-            raise UpdateFailed(
+            raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="authentication_error",
             ) from err

--- a/homeassistant/components/fumis/quality_scale.yaml
+++ b/homeassistant/components/fumis/quality_scale.yaml
@@ -36,7 +36,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/fumis/strings.json
+++ b/homeassistant/components/fumis/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -10,6 +11,15 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "pin": "[%key:component::fumis::config::step::user::data::pin%]"
+        },
+        "data_description": {
+          "pin": "[%key:component::fumis::config::step::user::data_description::pin%]"
+        },
+        "description": "The PIN code for your stove has changed. Please enter the new PIN code to re-authenticate."
+      },
       "user": {
         "data": {
           "mac": "MAC address",

--- a/tests/components/fumis/test_climate.py
+++ b/tests/components/fumis/test_climate.py
@@ -160,7 +160,6 @@ async def test_climate_error_handling(
 @pytest.mark.parametrize(
     "side_effect",
     [
-        FumisAuthenticationError,
         FumisStoveOfflineError,
         FumisConnectionError,
         FumisError,

--- a/tests/components/fumis/test_config_flow.py
+++ b/tests/components/fumis/test_config_flow.py
@@ -141,3 +141,67 @@ async def test_user_flow_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_fumis")
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the reauth flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "5678"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_PIN] == "5678"
+    assert mock_config_entry.data[CONF_MAC] == "AABBCCDDEEFF"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (FumisAuthenticationError, {CONF_PIN: "invalid_auth"}),
+        (FumisStoveOfflineError, {"base": "device_offline"}),
+        (FumisConnectionError, {"base": "cannot_connect"}),
+        (Exception, {"base": "unknown"}),
+    ],
+)
+async def test_reauth_flow_errors(
+    hass: HomeAssistant,
+    mock_fumis: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
+    expected_error: dict[str, str],
+) -> None:
+    """Test the reauth flow with errors."""
+    mock_config_entry.add_to_hass(hass)
+    mock_fumis.update_info.side_effect = side_effect
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "5678"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == expected_error
+
+    mock_fumis.update_info.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "5678"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"

--- a/tests/components/fumis/test_init.py
+++ b/tests/components/fumis/test_init.py
@@ -10,7 +10,8 @@ from fumis import (
 )
 import pytest
 
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.fumis.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -37,7 +38,6 @@ async def test_load_unload_config_entry(
 @pytest.mark.parametrize(
     ("side_effect", "expected_log"),
     [
-        (FumisAuthenticationError, "Authentication with the Fumis online service"),
         (FumisConnectionError, "communicating with the Fumis online service"),
         (FumisStoveOfflineError, "not connected to the internet"),
         (FumisError, "communicating with the Fumis online service"),
@@ -60,3 +60,27 @@ async def test_config_entry_not_ready(
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     assert expected_log in caplog.text
+
+
+async def test_config_entry_authentication_failed(
+    hass: HomeAssistant,
+    mock_fumis: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the config entry authentication error triggers reauth."""
+    mock_fumis.update_info.side_effect = FumisAuthenticationError
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == mock_config_entry.entry_id


### PR DESCRIPTION
## Proposed change

Add a reauthentication flow to the Fumis integration so users can update their PIN code when it changes. The coordinator now raises `ConfigEntryAuthFailed` on authentication errors, which triggers the reauth flow automatically.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr