### PR TITLE
Add LG Netcast service to send remote control commands

### DIFF
--- a/homeassistant/components/lg_netcast/__init__.py
+++ b/homeassistant/components/lg_netcast/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
 
-PLATFORMS: Final[list[Platform]] = [Platform.MEDIA_PLAYER]
+PLATFORMS: Final[list[Platform]] = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 

--- a/homeassistant/components/lg_netcast/remote.py
+++ b/homeassistant/components/lg_netcast/remote.py
@@ -1,0 +1,83 @@
+"""Remote control support for LG Netcast TV."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from pylgnetcast import LG_COMMAND, LgNetCastClient, LgNetCastError
+from requests import RequestException
+
+from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import LgNetCastConfigEntry
+from .const import ATTR_MANUFACTURER, DOMAIN
+
+VALID_COMMANDS: frozenset[str] = frozenset(
+    k
+    for k in vars(LG_COMMAND)
+    if not k.startswith("_") and isinstance(getattr(LG_COMMAND, k), int)
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LgNetCastConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up LG Netcast Remote from a config entry."""
+    client = config_entry.runtime_data
+    unique_id = config_entry.unique_id
+    if TYPE_CHECKING:
+        assert unique_id is not None
+
+    async_add_entities([LgNetCastRemote(client, unique_id)])
+
+
+class LgNetCastRemote(RemoteEntity):
+    """Device that sends commands to an LG Netcast TV."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+
+    def __init__(self, client: LgNetCastClient, unique_id: str) -> None:
+        """Initialize the LG Netcast remote."""
+        self._client = client
+        self._attr_unique_id = unique_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            manufacturer=ATTR_MANUFACTURER,
+        )
+
+    def send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send commands to the TV."""
+        num_repeats = kwargs[ATTR_NUM_REPEATS]
+
+        commands: list[int] = []
+        for cmd in command:
+            if cmd not in VALID_COMMANDS:
+                raise ServiceValidationError(f"Unknown command: {cmd!r}")
+            commands.append(getattr(LG_COMMAND, cmd))
+        for _ in range(num_repeats):
+            try:
+                with self._client as client:
+                    for lg_command in commands:
+                        client.send_command(lg_command)
+            except LgNetCastError, RequestException:
+                self._attr_is_on = False
+                self.schedule_update_ha_state()
+                return
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn on is handled via a separate turn_on trigger."""
+        raise NotImplementedError(
+            "Turning on the TV is not supported by the LG Netcast remote entity"
+        )
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn off the TV."""
+        self.send_command(["POWER"], **{ATTR_NUM_REPEATS: 1})

--- a/tests/components/lg_netcast/test_remote.py
+++ b/tests/components/lg_netcast/test_remote.py
@@ -1,0 +1,59 @@
+"""Tests for LG Netcast remote platform."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+from pylgnetcast import LG_COMMAND
+import pytest
+
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+
+from . import MODEL_NAME, setup_lgnetcast
+
+REMOTE_ENTITY_ID = f"{REMOTE_DOMAIN}.{MODEL_NAME.lower()}"
+
+
+@pytest.fixture(autouse=True)
+def mock_lg_netcast() -> Generator[MagicMock]:
+    """Mock LG Netcast library."""
+    with patch(
+        "homeassistant.components.lg_netcast.LgNetCastClient"
+    ) as mock_client_class:
+        yield mock_client_class
+
+
+async def test_send_command(hass: HomeAssistant, mock_lg_netcast: MagicMock) -> None:
+    """Test remote.send_command calls the client with the correct command code."""
+    await setup_lgnetcast(hass)
+    context_client = mock_lg_netcast.return_value.__enter__.return_value
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: REMOTE_ENTITY_ID, ATTR_COMMAND: ["POWER"]},
+        blocking=True,
+    )
+
+    context_client.send_command.assert_called_once_with(LG_COMMAND.POWER)
+
+
+async def test_send_command_invalid(
+    hass: HomeAssistant, mock_lg_netcast: MagicMock
+) -> None:
+    """Test remote.send_command raises ServiceValidationError  for an unknown command name."""
+    await setup_lgnetcast(hass)
+
+    with pytest.raises(ServiceValidationError, match="Unknown command"):
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: REMOTE_ENTITY_ID, ATTR_COMMAND: ["NOT_A_REAL_COMMAND"]},
+            blocking=True,
+        )


### PR DESCRIPTION
…ing tests

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change adds to possibility to send dedicated commands via the LG Netcast integration to a compatible SmartTV. The main use case is to script menu item selections for which there is no dedicated command, e.g. for muting the video.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44870
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
