### PR TITLE
Fix/waqi unavailable on empty data

### DIFF
--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -166,6 +166,11 @@ class WaqiSensor(CoordinatorEntity[WAQIDataUpdateCoordinator], SensorEntity):
         )
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.native_value is not None
+
+    @property
     def native_value(self) -> StateType:
         """Return the state of the device."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/tests/components/waqi/fixtures/air_quality_sensor_aqi_unavailable.json
+++ b/tests/components/waqi/fixtures/air_quality_sensor_aqi_unavailable.json
@@ -1,0 +1,42 @@
+{
+  "aqi": "-",
+  "idx": 4584,
+  "attributions": [
+    {
+      "url": "http://www.luchtmeetnet.nl/",
+      "name": "RIVM - Rijksinstituut voor Volksgezondheid en Milieum, Landelijk Meetnet Luchtkwaliteit",
+      "logo": "Netherland-RIVM.png"
+    },
+    {
+      "url": "https://waqi.info/",
+      "name": "World Air Quality Index Project"
+    }
+  ],
+  "city": {
+    "geo": [52.105031, 5.124464],
+    "name": "de Jongweg, Utrecht",
+    "url": "https://aqicn.org/city/netherland/utrecht/de-jongweg",
+    "location": ""
+  },
+  "dominentpol": "p",
+  "iaqi": {
+    "h": {
+      "v": 80
+    },
+    "p": {
+      "v": 1008.8
+    },
+    "t": {
+      "v": 16
+    }
+  },
+  "time": {
+    "s": "2023-08-07 17:00:00",
+    "tz": "+02:00",
+    "v": 1691427600,
+    "iso": "2023-08-07T17:00:00+02:00"
+  },
+  "debug": {
+    "sync": "2023-08-08T01:29:52+09:00"
+  }
+}

--- a/tests/components/waqi/test_sensor.py
+++ b/tests/components/waqi/test_sensor.py
@@ -2,15 +2,22 @@
 
 from unittest.mock import AsyncMock
 
+from aiowaqi import WAQIAirQuality
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.waqi.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    snapshot_platform,
+)
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -25,3 +32,27 @@ async def test_sensor(
     await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_sensor_unavailable_when_aqi_missing(
+    hass: HomeAssistant,
+    mock_waqi: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors report unavailable when AQI data is missing."""
+    problematic = WAQIAirQuality.from_dict(
+        await async_load_json_object_fixture(
+            hass, "air_quality_sensor_aqi_unavailable.json", DOMAIN
+        )
+    )
+    mock_waqi.get_by_station_number.return_value = problematic
+
+    await setup_integration(hass, mock_config_entry)
+
+    aqi_state = hass.states.get("sensor.de_jongweg_utrecht_air_quality_index")
+    assert aqi_state is not None
+    assert aqi_state.state == STATE_UNAVAILABLE
+
+    dominant_state = hass.states.get("sensor.de_jongweg_utrecht_dominant_pollutant")
+    assert dominant_state is not None
+    assert dominant_state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

**Scope: UX improvement only.**

When the WAQI API returns a value that `aiowaqi` cannot coerce — for example `"aqi": "-"` for stations that have no current reading, or a `dominentpol` value that isn't in the `Pollutant` enum — `aiowaqi` correctly returns `None`. However, `WaqiSensor` did not override `available`, so `CoordinatorEntity.available` stayed `True` and the sensor state became `STATE_UNKNOWN`.

This PR overrides `WaqiSensor.available` to also return `False` when `native_value is None`, mapping these cases to `STATE_UNAVAILABLE`, which is the semantically correct state for "no data to show" and matches the convention used by other Home Assistant integrations.

```python
@property
def available(self) -> bool:
    """Return if entity is available."""
    return super().available and self.native_value is not None
```

The existing `available_fn` on optional sensor descriptors (humidity, pressure, etc.) is unchanged, so startup-time entity filtering is preserved.

This PR does **not** address why a given station's data might disappear in the first place — that is a WAQI service / station-level concern, not an integration bug.

A regression test (`test_sensor_unavailable_when_aqi_missing`) and a fixture (`air_quality_sensor_aqi_unavailable.json` with `"aqi": "-"` and a non-enum `dominentpol`) have been added to cover both cases.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #<ISSUE-NUMBER>
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr