### PR TITLE
Cancel and await idle_start future if the task was canceled after an IMAP connection was lost

### DIFF
--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -556,7 +556,9 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                     try:
                         await idle
                     except asyncio.CancelledError:
-                        if (current_task := asyncio.current_task()) and current_task.cancelling():
+                        if (
+                            current_task := asyncio.current_task()
+                        ) and current_task.cancelling():
                             raise
                     except AioImapException:
                         pass

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -554,11 +554,13 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                         "Canceling IDLE wait for %s",
                         self.config_entry.data[CONF_SERVER],
                     )
-                    with suppress(
-                        AioImapException, asyncio.CancelledError, TimeoutError
-                    ):
-                        async with asyncio.timeout(BACKOFF_TIME):
-                            await idle
+                    try:
+                        await idle
+                    except asyncio.CancelledError:
+                        if (current_task := asyncio.current_task()) and current_task.cancelling():
+                            raise
+                    except AioImapException:
+                        pass
 
     async def shutdown(self, *_: Any) -> None:
         """Close resources."""

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -555,7 +555,7 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                         self.config_entry.data[CONF_SERVER],
                     )
                     with suppress(AioImapException, TimeoutError):
-                        async with asyncio.timeout(10):
+                        async with asyncio.timeout(BACKOFF_TIME):
                             await idle
 
     async def shutdown(self, *_: Any) -> None:

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from contextlib import suppress
 from datetime import datetime, timedelta
 import email
 from email.header import decode_header, make_header

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from contextlib import suppress
 from datetime import datetime, timedelta
 import email
 from email.header import decode_header, make_header
@@ -494,6 +495,7 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
 
     async def _async_wait_push_loop(self) -> None:
         """Wait for data push from server."""
+        idle: asyncio.Future | None = None
         while True:
             try:
                 self.number_of_messages = await self._async_fetch_number_of_messages()
@@ -527,8 +529,9 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
             else:
                 self.auth_errors = 0
                 self.async_set_updated_data(self.number_of_messages)
+
             try:
-                idle: asyncio.Future = await self.imap_client.idle_start()
+                idle = await self.imap_client.idle_start()
                 await self.imap_client.wait_server_push()
                 self.imap_client.idle_done()
                 async with asyncio.timeout(10):
@@ -542,6 +545,18 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                 )
                 await self._cleanup()
                 await asyncio.sleep(BACKOFF_TIME)
+
+            finally:
+                # Ensure no pending IDLE future survives
+                if idle is not None and not idle.done():
+                    idle.cancel()
+                    _LOGGER.debug(
+                        "Canceling IDLE wait for %s",
+                        self.config_entry.data[CONF_SERVER],
+                    )
+                    with suppress(AioImapException, TimeoutError):
+                        async with asyncio.timeout(10):
+                            await idle
 
     async def shutdown(self, *_: Any) -> None:
         """Close resources."""

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -554,7 +554,9 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                         "Canceling IDLE wait for %s",
                         self.config_entry.data[CONF_SERVER],
                     )
-                    with suppress(AioImapException, TimeoutError):
+                    with suppress(
+                        AioImapException, asyncio.CancelledError, TimeoutError
+                    ):
                         async with asyncio.timeout(BACKOFF_TIME):
                             await idle
 

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -538,6 +538,7 @@ async def test_lost_connection_with_imap_push(
 ) -> None:
     """Test error handling when the connection is lost."""
     # Mock an error in waiting for a pushed update
+    mock_imap_protocol.idle_start.return_value = asyncio.Future()
     mock_imap_protocol.wait_server_push.side_effect = imap_wait_server_push_exception
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
     config_entry.add_to_hass(hass)
@@ -549,6 +550,9 @@ async def test_lost_connection_with_imap_push(
     # Our entity should keep its current state as this
     assert state is not None
     assert state.state == "0"
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert "Canceling IDLE wait for imap.server.com" in caplog.text
 
 
 @pytest.mark.parametrize("imap_has_capability", [True], ids=["push"])

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -553,8 +553,6 @@ async def test_lost_connection_with_imap_push(
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
     await hass.async_block_till_done()
-
-    await hass.async_block_till_done(wait_background_tasks=True)
     assert "Canceling IDLE wait for imap.server.com" in caplog.text
 
 

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -551,6 +551,9 @@ async def test_lost_connection_with_imap_push(
     assert state is not None
     assert state.state == "0"
 
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
     await hass.async_block_till_done(wait_background_tasks=True)
     assert "Canceling IDLE wait for imap.server.com" in caplog.text
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If an IMAP server is awaited for push messages and the connection is lost, the IDLE command fails.
The future that was awaited still needs to be canceled.

This fix may solve issue https://github.com/home-assistant/core/issues/122809

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/122809
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
