### PR TITLE
Preserve Fahrenheit precision in google_assistant temperature range

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1076,14 +1076,16 @@ class TemperatureControlTrait(_Trait):
                     float(attrs[water_heater.ATTR_MIN_TEMP]),
                     unit,
                     UnitOfTemperature.CELSIUS,
-                )
+                ),
+                1,
             )
             max_temp = round(
                 TemperatureConverter.convert(
                     float(attrs[water_heater.ATTR_MAX_TEMP]),
                     unit,
                     UnitOfTemperature.CELSIUS,
-                )
+                ),
+                1,
             )
             response["temperatureRange"] = {
                 "minThresholdCelsius": min_temp,
@@ -1236,14 +1238,16 @@ class TemperatureSettingTrait(_Trait):
                 float(attrs[climate.ATTR_MIN_TEMP]),
                 unit,
                 UnitOfTemperature.CELSIUS,
-            )
+            ),
+            1,
         )
         max_temp = round(
             TemperatureConverter.convert(
                 float(attrs[climate.ATTR_MAX_TEMP]),
                 unit,
                 UnitOfTemperature.CELSIUS,
-            )
+            ),
+            1,
         )
         response["thermostatTemperatureRange"] = {
             "minThresholdCelsius": min_temp,

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1325,7 +1325,7 @@ async def test_temperature_setting_climate_onoff(hass: HomeAssistant) -> None:
     assert trt.sync_attributes() == {
         "availableThermostatModes": ["off", "cool", "heat", "heatcool", "on"],
         "thermostatTemperatureRange": {
-            "minThresholdCelsius": 7,
+            "minThresholdCelsius": 7.2,
             "maxThresholdCelsius": 35,
         },
         "thermostatTemperatureUnit": "F",
@@ -1373,6 +1373,43 @@ async def test_temperature_setting_climate_no_modes(hass: HomeAssistant) -> None
     }
 
 
+async def test_temperature_setting_climate_range_fahrenheit_precision(
+    hass: HomeAssistant,
+) -> None:
+    """Test that Fahrenheit range bounds are reported to Google with decimal precision.
+
+    Regression test: when a climate entity advertises an integer Fahrenheit min/max
+    whose Celsius equivalent is non-integer (e.g. 62°F = 16.666…°C), rounding the
+    converted value to a whole degree Celsius causes Google Home to display a range
+    shifted by up to 1°F when it converts back for display. Reporting one decimal
+    place of Celsius precision keeps Google's displayed range aligned with
+    Home Assistant's.
+    """
+    hass.config.units = US_CUSTOMARY_SYSTEM
+
+    trt = trait.TemperatureSettingTrait(
+        hass,
+        State(
+            "climate.bla",
+            climate.HVACMode.COOL,
+            {
+                ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE,
+                climate.ATTR_HVAC_MODES: [climate.HVACMode.OFF, climate.HVACMode.COOL],
+                climate.ATTR_MIN_TEMP: 62,
+                climate.ATTR_MAX_TEMP: 86,
+            },
+        ),
+        BASIC_CONFIG,
+    )
+    attrs = trt.sync_attributes()
+    assert attrs["thermostatTemperatureRange"] == {
+        "minThresholdCelsius": 16.7,
+        "maxThresholdCelsius": 30,
+    }
+    # 16.7°C → 62.06°F (displays as 62°F, matching Home Assistant's min of 62°F);
+    # the pre-fix value of 17°C → 62.6°F would have displayed as 63°F.
+
+
 async def test_temperature_setting_climate_range(hass: HomeAssistant) -> None:
     """Test TemperatureSetting trait support for climate domain - range."""
     assert helpers.get_google_type(climate.DOMAIN, None) is not None
@@ -1409,7 +1446,7 @@ async def test_temperature_setting_climate_range(hass: HomeAssistant) -> None:
         "availableThermostatModes": ["off", "cool", "heat", "auto", "on"],
         "thermostatTemperatureRange": {
             "minThresholdCelsius": 10,
-            "maxThresholdCelsius": 27,
+            "maxThresholdCelsius": 26.7,
         },
         "thermostatTemperatureUnit": "F",
     }


### PR DESCRIPTION
<!-- PR title (keep under 70 chars): -->
<!--   Preserve Fahrenheit precision in google_assistant temperature range -->

## Proposed change

Google Home displays the setpoint range for a climate or water_heater entity
that advertises its range in Fahrenheit as shifted by up to 1 F. For example,
an AC that Home Assistant reports as 62 F to 86 F is displayed by Google Home
as 63 F to 86 F.

The cause is in `TemperatureSettingTrait.sync_attributes`
(and the symmetric `water_heater` branch of
`TemperatureControlTrait.sync_attributes`): the F-unit bounds are converted
to Celsius and then rounded to a whole degree before being handed to Google.

```python
min_temp = round(
    TemperatureConverter.convert(
        float(attrs[climate.ATTR_MIN_TEMP]), unit, UnitOfTemperature.CELSIUS,
    )
)
```

62 F is 16.666... C. `round(16.666...)` is 17. Google then converts 17 C
back to Fahrenheit for display, getting 62.6 F, which the Home app rounds to
63 F. Conversely 86 F is exactly 30 C, which is why the upper bound happens
to round-trip cleanly and the reported shift is always at the min in the
reported case (and similarly asymmetric at other F boundaries: 80 F becomes
81 F, 45 F stays 45 F by luck, etc.).

This PR carries one decimal place of Celsius precision instead. That matches
how every other temperature in the same trait is already reported
(`thermostatTemperatureAmbient`, `thermostatTemperatureSetpoint`,
`thermostatTemperatureSetpointHigh`/`Low`), and makes the range round-trip
through Google without shifting: 16.7 C is 62.06 F, displayed as 62 F.

Existing tests assumed the rounded-to-int behavior and are updated to the
now-reported one-decimal values. A dedicated regression test is added for the
62 to 86 F case.

The rounding was introduced in #94143 (June 2023, HA 2023.7), which also
explains why nobody reported a regression against the much older baseline,
the field simply was not sent to Google before that PR, so Google fell back
to a default range.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes a bug (no linked issue; verified no open report matches)
- This PR does not introduce a new integration
- This PR is not related to feature #

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- N/A (internal conversion only, no user-visible API change)

If the code communicates with devices, web services, or third-party tools:

- N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[perfect-pr]: https://developers.home-assistant.io/docs/en/development_submitting.html#perfect-pull-requests
