### PR TITLE
Add dynamic device discovery and stale device removal to Duco integration

### DIFF
--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -64,9 +64,11 @@ async def async_setup_entry(
     """Set up Duco fan entities."""
     coordinator = entry.runtime_data
 
-    # A Duco installation always has exactly one BOX node, present from the
-    # first poll. Unlike sensor modules (UCCO2, BSRH), additional fan nodes
-    # cannot be added after setup, so a static entity list is sufficient here.
+    # The Duco firmware always assigns node ID 1 to the BOX, and a Duco
+    # installation always has exactly one BOX node present from the first poll
+    # (confirmed by vendor). Unlike RF sensor modules (UCCO2, BSRH), the BOX
+    # node is never added or removed after initial setup, so a static entity
+    # list is sufficient here — no coordinator listener is needed.
     async_add_entities(
         DucoVentilationFanEntity(coordinator, node)
         for node in coordinator.data.nodes.values()

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -64,11 +64,7 @@ async def async_setup_entry(
     """Set up Duco fan entities."""
     coordinator = entry.runtime_data
 
-    # The Duco firmware always assigns node ID 1 to the BOX, and a Duco
-    # installation always has exactly one BOX node present from the first poll
-    # (confirmed by vendor). Unlike RF sensor modules (UCCO2, BSRH), the BOX
-    # node is never added or removed after initial setup, so a static entity
-    # list is sufficient here — no coordinator listener is needed.
+    # BOX is always node 1 and is never dynamically added or removed — no listener needed.
     async_add_entities(
         DucoVentilationFanEntity(coordinator, node)
         for node in coordinator.data.nodes.values()

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -64,7 +64,7 @@ async def async_setup_entry(
     """Set up Duco fan entities."""
     coordinator = entry.runtime_data
 
-    # BOX is always node 1 and is never dynamically added or removed — no listener needed.
+    # BOX is always node 1 and is never dynamically added or removed, so no listener needed.
     async_add_entities(
         DucoVentilationFanEntity(coordinator, node)
         for node in coordinator.data.nodes.values()

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -64,6 +64,9 @@ async def async_setup_entry(
     """Set up Duco fan entities."""
     coordinator = entry.runtime_data
 
+    # A Duco installation always has exactly one BOX node, present from the
+    # first poll. Unlike sensor modules (UCCO2, BSRH), additional fan nodes
+    # cannot be added after setup, so a static entity list is sufficient here.
     async_add_entities(
         DucoVentilationFanEntity(coordinator, node)
         for node in coordinator.data.nodes.values()

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -55,11 +55,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done
-  dynamic-devices:
-    status: todo
-    comment: >-
-      Users can pair new modules (CO2 sensors, humidity sensors, zone valves)
-      to their Duco box. Dynamic device support to be added in a follow-up PR.
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -75,9 +71,11 @@ rules:
       There are no credentials to expire and no versioned API to become
       incompatible with.
   stale-devices:
-    status: todo
+    status: exempt
     comment: >-
-      To be implemented together with dynamic device support in a follow-up PR.
+      The Duco firmware retains nodes permanently after pairing; there is no
+      API mechanism to determine whether a sensor is still physically present.
+      Removing devices from the registry would discard valid firmware state.
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -70,13 +70,7 @@ rules:
       handled by the coordinator (unavailable entities) and resolve automatically.
       There are no credentials to expire and no versioned API to become
       incompatible with.
-  stale-devices:
-    status: exempt
-    comment: >-
-      The Duco firmware retains nodes permanently after pairing; there is no
-      API mechanism to determine whether a sensor is still physically present.
-      Removing devices from the registry would discard valid firmware state.
-
+  stale-devices: done
   # Platinum
   async-dependency: done
   inject-websession: done

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -20,8 +20,10 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import DucoConfigEntry, DucoCoordinator
 from .entity import DucoEntity
 
@@ -108,12 +110,48 @@ async def async_setup_entry(
     entry: DucoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Duco sensor entities."""
+    """Set up Duco sensor entities.
+
+    The Duco API dynamically reflects the current node topology (confirmed by
+    vendor):
+    - New sensor modules (UCCO2, BSRH) appear in the API automatically after
+      pairing, without requiring a box restart.
+    - Deregistered RF/wired nodes are removed from the API by the firmware.
+    - Box sensors (BSRH) that are physically disconnected from the PCB are NOT
+      considered deregistered; they remain in the API indefinitely and are
+      never reported as stale.
+
+    Node IDs are stable as long as a node remains registered. Once a node is
+    deregistered its ID may be reused for a newly paired node.
+    """
     coordinator = entry.runtime_data
+
+    # Track the node IDs for which entities have already been created, so we
+    # can detect both newly added and stale (deregistered) nodes on every
+    # coordinator update.
     known_nodes: set[int] = set()
 
     @callback
     def _async_add_new_entities() -> None:
+        # Remove devices whose nodes have disappeared from the API.
+        # The firmware removes deregistered RF/wired nodes automatically.
+        # BSRH box sensors that are physically unplugged from the PCB are
+        # not deregistered by the firmware and will never appear here as stale.
+        stale_node_ids = known_nodes - coordinator.data.nodes.keys()
+        if stale_node_ids:
+            device_reg = dr.async_get(hass)
+            mac = entry.unique_id
+            for node_id in stale_node_ids:
+                device = device_reg.async_get_device(
+                    identifiers={(DOMAIN, f"{mac}_{node_id}")}
+                )
+                if device:
+                    device_reg.async_update_device(
+                        device.id,
+                        remove_config_entry_id=entry.entry_id,
+                    )
+            known_nodes.difference_update(stale_node_ids)
+
         new_entities: list[SensorEntity] = []
         for node in coordinator.data.nodes.values():
             if node.node_id in known_nodes:

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import DucoConfigEntry, DucoCoordinator
@@ -110,23 +110,30 @@ async def async_setup_entry(
 ) -> None:
     """Set up Duco sensor entities."""
     coordinator = entry.runtime_data
+    known_nodes: set[int] = set()
 
-    async_add_entities(
-        [
-            *[
+    @callback
+    def _async_add_new_entities() -> None:
+        new_entities: list[SensorEntity] = []
+        for node in coordinator.data.nodes.values():
+            if node.node_id in known_nodes:
+                continue
+            known_nodes.add(node.node_id)
+            new_entities.extend(
                 DucoSensorEntity(coordinator, node, description)
-                for node in coordinator.data.nodes.values()
                 for description in SENSOR_DESCRIPTIONS
                 if node.general.node_type in description.node_types
-            ],
-            *[
+            )
+            new_entities.extend(
                 DucoBoxSensorEntity(coordinator, node, description)
-                for node in coordinator.data.nodes.values()
                 for description in BOX_SENSOR_DESCRIPTIONS
                 if node.general.node_type == NodeType.BOX
-            ],
-        ]
-    )
+            )
+        if new_entities:
+            async_add_entities(new_entities)
+
+    entry.async_on_unload(coordinator.async_add_listener(_async_add_new_entities))
+    _async_add_new_entities()
 
 
 class DucoSensorEntity(DucoEntity, SensorEntity):

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -110,20 +110,7 @@ async def async_setup_entry(
     entry: DucoConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Duco sensor entities.
-
-    The Duco API dynamically reflects the current node topology (confirmed by
-    vendor):
-    - New sensor modules (UCCO2, BSRH) appear in the API automatically after
-      pairing, without requiring a box restart.
-    - Deregistered RF/wired nodes are removed from the API by the firmware.
-    - Box sensors (BSRH) that are physically disconnected from the PCB are NOT
-      considered deregistered; they remain in the API indefinitely and are
-      never reported as stale.
-
-    Node IDs are stable as long as a node remains registered. Once a node is
-    deregistered its ID may be reused for a newly paired node.
-    """
+    """Set up Duco sensor entities."""
     coordinator = entry.runtime_data
 
     # Track the node IDs for which entities have already been created, so we

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 from duco.exceptions import DucoConnectionError, DucoError
+from duco.models import Node, NodeGeneralInfo, NodeSensorInfo, NodeVentilationInfo
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -125,3 +126,49 @@ async def test_lan_info_duco_error_marks_unavailable(
     state = hass.states.get("sensor.living_signal_strength")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_new_node_added_dynamically(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a new node appearing in coordinator data creates entities automatically."""
+    assert hass.states.get("sensor.new_rh_sensor_humidity") is None
+
+    new_node = Node(
+        node_id=200,
+        general=NodeGeneralInfo(
+            node_type="BSRH",
+            sub_type=0,
+            network_type="RF",
+            parent=1,
+            asso=1,
+            name="New RH sensor",
+            identify=0,
+        ),
+        ventilation=NodeVentilationInfo(
+            state="AUTO",
+            time_state_remain=0,
+            time_state_end=0,
+            mode="-",
+            flow_lvl_tgt=None,
+        ),
+        sensor=NodeSensorInfo(
+            co2=None,
+            iaq_co2=None,
+            rh=55.0,
+            iaq_rh=70,
+        ),
+    )
+    mock_duco_client.async_get_nodes.return_value = [*mock_nodes, new_node]
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.new_rh_sensor_humidity")
+    assert state is not None
+    assert state.state == "55.0"

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -182,12 +182,7 @@ async def test_deregistered_node_removes_device(
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that a node disappearing from the API removes its device from the registry.
-
-    The Duco firmware removes deregistered RF/wired nodes from the API
-    automatically (confirmed by vendor). This test simulates an RF sensor
-    (UCCO2, node 2) being deregistered from the Duco box.
-    """
+    """Test that a node disappearing from the API removes its device from the registry."""
     device_registry = dr.async_get(hass)
 
     # Verify node 2 (UCCO2 RF sensor) device exists before deregistration.

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -10,10 +10,10 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.duco.const import SCAN_INTERVAL
+from homeassistant.components.duco.const import DOMAIN, SCAN_INTERVAL
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
@@ -172,3 +172,41 @@ async def test_new_node_added_dynamically(
     state = hass.states.get("sensor.new_rh_sensor_humidity")
     assert state is not None
     assert state.state == "55.0"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_deregistered_node_removes_device(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a node disappearing from the API removes its device from the registry.
+
+    The Duco firmware removes deregistered RF/wired nodes from the API
+    automatically (confirmed by vendor). This test simulates an RF sensor
+    (UCCO2, node 2) being deregistered from the Duco box.
+    """
+    device_registry = dr.async_get(hass)
+
+    # Verify node 2 (UCCO2 RF sensor) device exists before deregistration.
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_2")}
+    )
+    assert device is not None
+
+    # Simulate the firmware removing the deregistered node from the API response.
+    mock_duco_client.async_get_nodes.return_value = [
+        node for node in mock_nodes if node.node_id != 2
+    ]
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # The device should be removed from the device registry.
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_2")}
+    )
+    assert device is None


### PR DESCRIPTION
## Proposed change

Implements the `dynamic-devices` and `stale-devices` quality scale rules for the Duco integration.

**Dynamic device discovery** (`dynamic-devices`): sensor modules (UCCO2, BSRH) paired with the Duco box after the integration is already set up now appear in Home Assistant automatically on the next coordinator poll, no reload or restart required. The sensor platform registers a coordinator listener that compares incoming nodes against a `known_nodes` set and creates entities for any new node IDs.

The fan platform (BOX node) does not need this pattern. The firmware always assigns node ID 1 to the BOX, and every Duco installation has exactly one BOX node present from the first poll. A static entity list is sufficient there.

**Stale device removal** (`stale-devices`): when a node disappears from the API between two coordinator updates, its device is removed from the device registry via `async_update_device(..., remove_config_entry_id=entry.entry_id)`.

Both behaviors were confirmed directly by the vendor (DUCO):
- New nodes appear in the API automatically after pairing, without requiring a box restart.
- Deregistered RF/wired nodes are removed from the API by the firmware.
- A BSRH humidity sensor that is physically disconnected from the box PCB (rather than deregistered via software) is *not* treated as deregistered. Its node remains in the API indefinitely. Stale detection is therefore safe: a disappearing node ID is an unambiguous firmware signal, not a transient error.
- Node IDs are stable as long as a node remains registered. After deregistration an ID may be reused for a newly paired node.


> [!IMPORTANT]
> ## Design decisions
>
> ### Dynamic device discovery (`dynamic-devices`)
>
> The Duco API dynamically reflects the current node topology. New sensor modules (UCCO2, BSRH) appear in the API automatically after pairing, without requiring a box restart. This was confirmed directly by the vendor.
>
> The sensor platform implements this via a coordinator listener: `_async_add_new_entities` is called on every coordinator update and compares the current API nodes against a `known_nodes` set. New nodes are added without a reload.
>
> The fan platform (BOX node) does not need this pattern. The firmware always assigns node ID 1 to the BOX, and every Duco installation has exactly one BOX node present from the first poll. A static entity list is sufficient.
>
> ### Stale device removal (`stale-devices`)
>
> When a node disappears from the API between two coordinator updates, it is removed from the device registry via `async_update_device(..., remove_config_entry_id=entry.entry_id)`.
>
> **Important exception:** BSRH sensors that are physically disconnected from the PCB are *not* considered deregistered by the firmware. The vendor confirmed this explicitly: only nodes that are actively deregistered via software are removed from the API. A physically unplugged BSRH remains in the API indefinitely. Stale detection is therefore safe: a disappearing node ID is an unambiguous firmware signal, not a transient error.
>
> Node IDs are stable as long as a node remains registered. After deregistration an ID may be reused for a newly paired node.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44875
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect_pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest