### PR TITLE
Add sensor platform to Fumis integration

### DIFF
--- a/homeassistant/components/fumis/__init__.py
+++ b/homeassistant/components/fumis/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import FumisConfigEntry, FumisDataUpdateCoordinator
 
-PLATFORMS = [Platform.CLIMATE]
+PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: FumisConfigEntry) -> bool:

--- a/homeassistant/components/fumis/icons.json
+++ b/homeassistant/components/fumis/icons.json
@@ -1,0 +1,48 @@
+{
+  "entity": {
+    "sensor": {
+      "combustion_chamber_temperature": {
+        "default": "mdi:thermometer-high"
+      },
+      "detailed_stove_status": {
+        "default": "mdi:fireplace"
+      },
+      "fan_1_speed": {
+        "default": "mdi:fan"
+      },
+      "fan_2_speed": {
+        "default": "mdi:fan"
+      },
+      "fuel_quantity": {
+        "default": "mdi:gauge"
+      },
+      "fuel_used": {
+        "default": "mdi:counter"
+      },
+      "igniter_starts": {
+        "default": "mdi:counter"
+      },
+      "misfires": {
+        "default": "mdi:alert-outline"
+      },
+      "overheatings": {
+        "default": "mdi:thermometer-alert"
+      },
+      "power_output": {
+        "default": "mdi:fire"
+      },
+      "pressure": {
+        "default": "mdi:gauge"
+      },
+      "stove_status": {
+        "default": "mdi:fireplace"
+      },
+      "time_to_service": {
+        "default": "mdi:wrench-clock"
+      },
+      "wifi_signal_strength": {
+        "default": "mdi:wifi"
+      }
+    }
+  }
+}

--- a/homeassistant/components/fumis/sensor.py
+++ b/homeassistant/components/fumis/sensor.py
@@ -201,7 +201,10 @@ SENSORS: tuple[FumisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.controller.time_to_service is not None,
+        has_fn=lambda data: (
+            data.controller.time_to_service is not None
+            and data.controller.time_to_service >= 0
+        ),
         value_fn=lambda data: data.controller.time_to_service,
     ),
     FumisSensorEntityDescription(

--- a/homeassistant/components/fumis/sensor.py
+++ b/homeassistant/components/fumis/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
+    REVOLUTIONS_PER_MINUTE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfPower,
@@ -71,7 +72,7 @@ SENSORS: tuple[FumisSensorEntityDescription, ...] = (
     FumisSensorEntityDescription(
         key="fan_1_speed",
         translation_key="fan_1_speed",
-        native_unit_of_measurement="rpm",
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -81,7 +82,7 @@ SENSORS: tuple[FumisSensorEntityDescription, ...] = (
     FumisSensorEntityDescription(
         key="fan_2_speed",
         translation_key="fan_2_speed",
-        native_unit_of_measurement="rpm",
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,

--- a/homeassistant/components/fumis/sensor.py
+++ b/homeassistant/components/fumis/sensor.py
@@ -1,0 +1,268 @@
+"""Support for Fumis sensor entities."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from fumis import FumisInfo, StoveState, StoveStatus
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.dt import utcnow
+from homeassistant.util.variance import ignore_variance
+
+from .coordinator import FumisConfigEntry, FumisDataUpdateCoordinator
+from .entity import FumisEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class FumisSensorEntityDescription(SensorEntityDescription):
+    """Describes a Fumis sensor entity."""
+
+    has_fn: Callable[[FumisInfo], bool] = lambda _: True
+    value_fn: Callable[[FumisInfo], datetime | float | int | str | None]
+
+
+SENSORS: tuple[FumisSensorEntityDescription, ...] = (
+    FumisSensorEntityDescription(
+        key="combustion_chamber_temperature",
+        translation_key="combustion_chamber_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.controller.combustion_chamber_temperature is not None,
+        value_fn=lambda data: data.controller.combustion_chamber_temperature,
+    ),
+    FumisSensorEntityDescription(
+        key="detailed_stove_status",
+        translation_key="detailed_stove_status",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=[
+            status.name.lower()
+            for status in StoveStatus
+            if status != StoveStatus.UNKNOWN
+        ],
+        value_fn=lambda data: (
+            None
+            if data.controller.stove_status is StoveStatus.UNKNOWN
+            else data.controller.stove_status.name.lower()
+        ),
+    ),
+    FumisSensorEntityDescription(
+        key="fan_1_speed",
+        translation_key="fan_1_speed",
+        native_unit_of_measurement="rpm",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        has_fn=lambda data: data.controller.fan1_speed is not None,
+        value_fn=lambda data: data.controller.fan1_speed,
+    ),
+    FumisSensorEntityDescription(
+        key="fan_2_speed",
+        translation_key="fan_2_speed",
+        native_unit_of_measurement="rpm",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        has_fn=lambda data: data.controller.fan2_speed is not None,
+        value_fn=lambda data: data.controller.fan2_speed,
+    ),
+    FumisSensorEntityDescription(
+        key="fuel_quantity",
+        translation_key="fuel_quantity",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        has_fn=lambda data: (
+            len(data.controller.fuels) > 0
+            and data.controller.fuels[0].quantity_percentage is not None
+        ),
+        value_fn=lambda data: data.controller.fuels[0].quantity_percentage,
+    ),
+    FumisSensorEntityDescription(
+        key="fuel_used",
+        translation_key="fuel_used",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.controller.statistic.fuel_quantity_used,
+    ),
+    FumisSensorEntityDescription(
+        key="heating_time",
+        translation_key="heating_time",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
+        value_fn=lambda data: data.controller.statistic.heating_time.total_seconds(),
+    ),
+    FumisSensorEntityDescription(
+        key="igniter_starts",
+        translation_key="igniter_starts",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.controller.statistic.igniter_starts,
+    ),
+    FumisSensorEntityDescription(
+        key="misfires",
+        translation_key="misfires",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.controller.statistic.misfires,
+    ),
+    FumisSensorEntityDescription(
+        key="module_temperature",
+        translation_key="module_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        has_fn=lambda data: data.unit.temperature is not None,
+        value_fn=lambda data: data.unit.temperature,
+    ),
+    FumisSensorEntityDescription(
+        key="overheatings",
+        translation_key="overheatings",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.controller.statistic.overheatings,
+    ),
+    FumisSensorEntityDescription(
+        key="power_output",
+        translation_key="power_output",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+        value_fn=lambda data: data.controller.power.kw,
+    ),
+    FumisSensorEntityDescription(
+        key="pressure",
+        translation_key="pressure",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        has_fn=lambda data: data.controller.pressure is not None,
+        value_fn=lambda data: data.controller.pressure,
+    ),
+    FumisSensorEntityDescription(
+        key="stove_status",
+        translation_key="stove_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=[state.value for state in StoveState if state != StoveState.UNKNOWN],
+        value_fn=lambda data: (
+            None
+            if data.controller.state is StoveState.UNKNOWN
+            else data.controller.state.value
+        ),
+    ),
+    FumisSensorEntityDescription(
+        key="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda data: data.controller.main_temperature is not None,
+        value_fn=lambda data: (
+            data.controller.main_temperature.actual
+            if data.controller.main_temperature
+            else None
+        ),
+    ),
+    FumisSensorEntityDescription(
+        key="time_to_service",
+        translation_key="time_to_service",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.controller.time_to_service is not None,
+        value_fn=lambda data: data.controller.time_to_service,
+    ),
+    FumisSensorEntityDescription(
+        key="uptime",
+        translation_key="uptime",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=ignore_variance(
+            lambda data: (
+                utcnow().replace(microsecond=0) - data.controller.statistic.uptime
+            ),
+            timedelta(minutes=5),
+        ),
+    ),
+    FumisSensorEntityDescription(
+        key="wifi_rssi",
+        translation_key="wifi_rssi",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.unit.rssi,
+    ),
+    FumisSensorEntityDescription(
+        key="wifi_signal_strength",
+        translation_key="wifi_signal_strength",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.unit.signal_strength,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FumisConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Fumis sensor entities based on a config entry."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        FumisSensorEntity(coordinator=coordinator, description=description)
+        for description in SENSORS
+        if description.has_fn(coordinator.data)
+    )
+
+
+class FumisSensorEntity(FumisEntity, SensorEntity):
+    """Defines a Fumis sensor entity."""
+
+    entity_description: FumisSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: FumisDataUpdateCoordinator,
+        description: FumisSensorEntityDescription,
+    ) -> None:
+        """Initialize the Fumis sensor entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
+
+    @property
+    def native_value(self) -> datetime | float | int | str | None:
+        """Return the sensor value."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/fumis/sensor.py
+++ b/homeassistant/components/fumis/sensor.py
@@ -98,7 +98,11 @@ SENSORS: tuple[FumisSensorEntityDescription, ...] = (
             len(data.controller.fuels) > 0
             and data.controller.fuels[0].quantity_percentage is not None
         ),
-        value_fn=lambda data: data.controller.fuels[0].quantity_percentage,
+        value_fn=lambda data: (
+            data.controller.fuels[0].quantity_percentage
+            if data.controller.fuels
+            else None
+        ),
     ),
     FumisSensorEntityDescription(
         key="fuel_used",

--- a/homeassistant/components/fumis/strings.json
+++ b/homeassistant/components/fumis/strings.json
@@ -23,6 +23,88 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "combustion_chamber_temperature": {
+        "name": "Combustion chamber"
+      },
+      "detailed_stove_status": {
+        "name": "Detailed stove status",
+        "state": {
+          "cold_start": "Cold start",
+          "cold_start_off": "Off (cold start)",
+          "combustion": "Combustion",
+          "cooling": "Cooling",
+          "eco": "Eco",
+          "hybrid_init": "Hybrid init",
+          "hybrid_start": "Hybrid start",
+          "ignition": "Ignition",
+          "off": "[%key:common::state::off%]",
+          "pre_combustion": "Pre-combustion",
+          "pre_heating": "Pre-heating",
+          "wood_burning_off": "Off (wood burning)",
+          "wood_combustion": "Wood combustion",
+          "wood_start": "Wood start"
+        }
+      },
+      "fan_1_speed": {
+        "name": "Fan 1 speed"
+      },
+      "fan_2_speed": {
+        "name": "Fan 2 speed"
+      },
+      "fuel_quantity": {
+        "name": "Fuel level"
+      },
+      "fuel_used": {
+        "name": "Fuel consumed"
+      },
+      "heating_time": {
+        "name": "Burning time"
+      },
+      "igniter_starts": {
+        "name": "Igniter starts"
+      },
+      "misfires": {
+        "name": "Misfires"
+      },
+      "module_temperature": {
+        "name": "WiRCU module"
+      },
+      "overheatings": {
+        "name": "Overheatings"
+      },
+      "power_output": {
+        "name": "Power output"
+      },
+      "pressure": {
+        "name": "Combustion chamber pressure"
+      },
+      "stove_status": {
+        "name": "Stove status",
+        "state": {
+          "burning": "Burning",
+          "cooling": "Cooling",
+          "eco": "Eco",
+          "heating_up": "Heating up",
+          "ignition": "Ignition",
+          "off": "[%key:common::state::off%]"
+        }
+      },
+      "time_to_service": {
+        "name": "Time to service"
+      },
+      "uptime": {
+        "name": "Uptime"
+      },
+      "wifi_rssi": {
+        "name": "Wi-Fi RSSI"
+      },
+      "wifi_signal_strength": {
+        "name": "Wi-Fi signal strength"
+      }
+    }
+  },
   "exceptions": {
     "authentication_error": {
       "message": "Authentication with the Fumis online service failed. Check your MAC address and PIN code."

--- a/tests/components/fumis/conftest.py
+++ b/tests/components/fumis/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 from fumis import FumisInfo
@@ -13,6 +14,12 @@ from homeassistant.const import CONF_MAC, CONF_PIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
+
+
+@pytest.fixture
+def device_fixture() -> str:
+    """Return the device fixture to use."""
+    return "info"
 
 
 @pytest.fixture
@@ -37,7 +44,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_fumis() -> Generator[MagicMock]:
+def mock_fumis(device_fixture: str) -> Generator[MagicMock]:
     """Return a mocked Fumis client."""
     with (
         patch(
@@ -51,7 +58,7 @@ def mock_fumis() -> Generator[MagicMock]:
     ):
         fumis = fumis_mock.return_value
         fumis.update_info.return_value = FumisInfo.from_json(
-            load_fixture("info.json", DOMAIN)
+            load_fixture(f"{device_fixture}.json", DOMAIN)
         )
         yield fumis
 
@@ -61,9 +68,17 @@ async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_fumis: MagicMock,
+    request: pytest.FixtureRequest,
 ) -> MockConfigEntry:
     """Set up the Fumis integration for testing."""
     mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+
+    context = nullcontext()
+    if platform := getattr(request, "param", None):
+        context = patch("homeassistant.components.fumis.PLATFORMS", [platform])
+
+    with context:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
     return mock_config_entry

--- a/tests/components/fumis/fixtures/info_minimal.json
+++ b/tests/components/fumis/fixtures/info_minimal.json
@@ -1,0 +1,54 @@
+{
+  "apiVersion": "1.3",
+  "unit": {
+    "id": "AABBCCDDEEFF",
+    "type": 3,
+    "version": "2.5.0",
+    "command": null,
+    "rssi": "-60",
+    "ip": "192.168.1.2",
+    "timezone": null,
+    "temperature": null
+  },
+  "controller": {
+    "type": 2,
+    "version": "2.6.0",
+    "command": -1,
+    "status": 999,
+    "heatingSlope": -0.1,
+    "stoveLastAvailability": 1776413799,
+    "mobileLastAvailability": 1776412827,
+    "currentTime": 1776413805,
+    "error": 0,
+    "alert": 0,
+    "timerEnable": false,
+    "fuelType": 1,
+    "timeToService": -1,
+    "delayedStartAt": -1,
+    "delayedStopAt": -1,
+    "power": {
+      "setType": 0,
+      "actualType": 0,
+      "kw": 0,
+      "actualPower": 0,
+      "setPower": 0
+    },
+    "statistic": {
+      "igniterStarts": 0,
+      "uptime": 0,
+      "heatingTime": 0,
+      "serviceTime": 0,
+      "overheatings": 0,
+      "misfires": 0,
+      "fuelQuantityUsed": 0
+    },
+    "diagnostic": {
+      "parameters": [],
+      "variables": [],
+      "timers": []
+    },
+    "fans": [],
+    "fuels": [],
+    "temperatures": []
+  }
+}

--- a/tests/components/fumis/snapshots/test_sensor.ambr
+++ b/tests/components/fumis/snapshots/test_sensor.ambr
@@ -1,0 +1,1091 @@
+# serializer version: 1
+# name: test_sensors[sensor][sensor.clou_duo_burning_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_burning_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Burning time',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Burning time',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'heating_time',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_heating_time',
+    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_burning_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Clou Duo Burning time',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_burning_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.13333333333333',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_combustion_chamber-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_combustion_chamber',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Combustion chamber',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Combustion chamber',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'combustion_chamber_temperature',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_combustion_chamber_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_combustion_chamber-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Clou Duo Combustion chamber',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_combustion_chamber',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '206.0',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_combustion_chamber_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_combustion_chamber_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Combustion chamber pressure',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Combustion chamber pressure',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pressure',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_pressure',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_combustion_chamber_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Combustion chamber pressure',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_combustion_chamber_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '675',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_detailed_stove_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'off',
+        'cold_start_off',
+        'wood_burning_off',
+        'pre_heating',
+        'ignition',
+        'pre_combustion',
+        'combustion',
+        'eco',
+        'cooling',
+        'hybrid_init',
+        'hybrid_start',
+        'wood_start',
+        'cold_start',
+        'wood_combustion',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_detailed_stove_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Detailed stove status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Detailed stove status',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'detailed_stove_status',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_detailed_stove_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_detailed_stove_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Clou Duo Detailed stove status',
+      'options': list([
+        'off',
+        'cold_start_off',
+        'wood_burning_off',
+        'pre_heating',
+        'ignition',
+        'pre_combustion',
+        'combustion',
+        'eco',
+        'cooling',
+        'hybrid_init',
+        'hybrid_start',
+        'wood_start',
+        'cold_start',
+        'wood_combustion',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_detailed_stove_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'combustion',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fan_1_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_fan_1_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fan 1 speed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan 1 speed',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan_1_speed',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_fan_1_speed',
+    'unit_of_measurement': 'rpm',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fan_1_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Fan 1 speed',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'rpm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_fan_1_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '108',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fan_2_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_fan_2_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fan 2 speed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan 2 speed',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan_2_speed',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_fan_2_speed',
+    'unit_of_measurement': 'rpm',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fan_2_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Fan 2 speed',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'rpm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_fan_2_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fuel_consumed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_fuel_consumed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fuel consumed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fuel consumed',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fuel_used',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_fuel_used',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fuel_consumed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Fuel consumed',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_fuel_consumed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fuel_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.clou_duo_fuel_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fuel level',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fuel level',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fuel_quantity',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_fuel_quantity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_fuel_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Fuel level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_fuel_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '95.0',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_igniter_starts-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_igniter_starts',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Igniter starts',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Igniter starts',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'igniter_starts',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_igniter_starts',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_igniter_starts-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Igniter starts',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_igniter_starts',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_misfires-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_misfires',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Misfires',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Misfires',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'misfires',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_misfires',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_misfires-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Misfires',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_misfires',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_overheatings-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_overheatings',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Overheatings',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Overheatings',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'overheatings',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_overheatings',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_overheatings-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Overheatings',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_overheatings',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_power_output-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_power_output',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power output',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power output',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_output',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_output',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_power_output-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Clou Duo Power output',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_power_output',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4.6',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_stove_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'off',
+        'heating_up',
+        'ignition',
+        'burning',
+        'eco',
+        'cooling',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.clou_duo_stove_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Stove status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Stove status',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'stove_status',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_stove_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_stove_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Clou Duo Stove status',
+      'options': list([
+        'off',
+        'heating_up',
+        'ignition',
+        'burning',
+        'eco',
+        'cooling',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_stove_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'burning',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.clou_duo_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Clou Duo Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20.7',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_time_to_service-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_time_to_service',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to service',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Time to service',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_to_service',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_time_to_service',
+    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_time_to_service-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Clou Duo Time to service',
+      'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_time_to_service',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2159',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'uptime',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Clou Duo Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-04-19T11:54:00+00:00',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_wi_fi_rssi-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_wi_fi_rssi',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi RSSI',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Wi-Fi RSSI',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_rssi',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_wifi_rssi',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_wi_fi_rssi-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'signal_strength',
+      'friendly_name': 'Clou Duo Wi-Fi RSSI',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_wi_fi_rssi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-60',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_wi_fi_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_wi_fi_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi signal strength',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wi-Fi signal strength',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_signal_strength',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_wifi_signal_strength',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_wi_fi_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Wi-Fi signal strength',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_wi_fi_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_wircu_module-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.clou_duo_wircu_module',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'WiRCU module',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'WiRCU module',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'module_temperature',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_module_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor][sensor.clou_duo_wircu_module-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Clou Duo WiRCU module',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.clou_duo_wircu_module',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '27.0',
+  })
+# ---

--- a/tests/components/fumis/test_sensor.py
+++ b/tests/components/fumis/test_sensor.py
@@ -29,10 +29,11 @@ async def test_sensors(
 @pytest.mark.parametrize(
     "entity_id",
     [
+        "sensor.clou_duo_combustion_chamber_pressure",
         "sensor.clou_duo_fan_1_speed",
         "sensor.clou_duo_fan_2_speed",
+        "sensor.clou_duo_wircu_module",
         "sensor.clou_duo_wi_fi_rssi",
-        "sensor.clou_duo_combustion_chamber_pressure",
     ],
 )
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/fumis/test_sensor.py
+++ b/tests/components/fumis/test_sensor.py
@@ -79,8 +79,8 @@ async def test_sensors_conditional_creation(
     assert "sensor.pellet_stove_combustion_chamber" not in entity_ids
     assert "sensor.pellet_stove_fan_1_speed" not in entity_ids
     assert "sensor.pellet_stove_fan_2_speed" not in entity_ids
-    assert "sensor.pellet_stove_fuel_quantity" not in entity_ids
-    assert "sensor.pellet_stove_module_temperature" not in entity_ids
+    assert "sensor.pellet_stove_fuel_level" not in entity_ids
+    assert "sensor.pellet_stove_wircu_module" not in entity_ids
     assert "sensor.pellet_stove_temperature" not in entity_ids
     assert "sensor.pellet_stove_time_to_service" not in entity_ids
 

--- a/tests/components/fumis/test_sensor.py
+++ b/tests/components/fumis/test_sensor.py
@@ -1,0 +1,91 @@
+"""Tests for the Fumis sensor entities."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+pytestmark = pytest.mark.parametrize(
+    "init_integration", [Platform.SENSOR], indirect=True
+)
+
+
+@pytest.mark.freeze_time("2026-04-20 12:00:00+00:00")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Fumis sensor entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        "sensor.clou_duo_fan_1_speed",
+        "sensor.clou_duo_fan_2_speed",
+        "sensor.clou_duo_wi_fi_rssi",
+        "sensor.clou_duo_combustion_chamber_pressure",
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_sensors_disabled_by_default(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    entity_id: str,
+) -> None:
+    """Test sensors that are disabled by default."""
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get(entity_id) is None
+
+
+@pytest.mark.parametrize("device_fixture", ["info_minimal"])
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_sensors_unknown_status(
+    hass: HomeAssistant,
+) -> None:
+    """Test sensor returns unknown when stove status is unmapped."""
+    assert (state := hass.states.get("sensor.pellet_stove_stove_status"))
+    assert state.state == STATE_UNKNOWN
+
+    assert (state := hass.states.get("sensor.pellet_stove_detailed_stove_status"))
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize("device_fixture", ["info_minimal"])
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_sensors_conditional_creation(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors with has_fn are not created when data is missing."""
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    entity_ids = {entry.entity_id for entry in entity_entries}
+
+    # These should NOT exist with the minimal fixture
+    assert "sensor.pellet_stove_combustion_chamber_pressure" not in entity_ids
+    assert "sensor.pellet_stove_combustion_chamber_temperature" not in entity_ids
+    assert "sensor.pellet_stove_fan_1_speed" not in entity_ids
+    assert "sensor.pellet_stove_fan_2_speed" not in entity_ids
+    assert "sensor.pellet_stove_fuel_quantity" not in entity_ids
+    assert "sensor.pellet_stove_module_temperature" not in entity_ids
+    assert "sensor.pellet_stove_temperature" not in entity_ids
+    assert "sensor.pellet_stove_time_to_service" not in entity_ids
+
+    # These should still exist
+    assert "sensor.pellet_stove_detailed_stove_status" in entity_ids
+    assert "sensor.pellet_stove_power_output" in entity_ids
+    assert "sensor.pellet_stove_stove_status" in entity_ids
+    assert "sensor.pellet_stove_wi_fi_rssi" in entity_ids
+    assert "sensor.pellet_stove_wi_fi_signal_strength" in entity_ids

--- a/tests/components/fumis/test_sensor.py
+++ b/tests/components/fumis/test_sensor.py
@@ -76,7 +76,7 @@ async def test_sensors_conditional_creation(
 
     # These should NOT exist with the minimal fixture
     assert "sensor.pellet_stove_combustion_chamber_pressure" not in entity_ids
-    assert "sensor.pellet_stove_combustion_chamber_temperature" not in entity_ids
+    assert "sensor.pellet_stove_combustion_chamber" not in entity_ids
     assert "sensor.pellet_stove_fan_1_speed" not in entity_ids
     assert "sensor.pellet_stove_fan_2_speed" not in entity_ids
     assert "sensor.pellet_stove_fuel_quantity" not in entity_ids

--- a/tests/components/fumis/test_sensor.py
+++ b/tests/components/fumis/test_sensor.py
@@ -9,6 +9,8 @@ from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+UNIQUE_ID_PREFIX = "aa:bb:cc:dd:ee:ff"
+
 pytestmark = pytest.mark.parametrize(
     "init_integration", [Platform.SENSOR], indirect=True
 )
@@ -27,44 +29,46 @@ async def test_sensors(
 
 
 @pytest.mark.parametrize(
-    "entity_id",
+    "unique_id",
     [
-        "sensor.clou_duo_combustion_chamber_pressure",
-        "sensor.clou_duo_fan_1_speed",
-        "sensor.clou_duo_fan_2_speed",
-        "sensor.clou_duo_wircu_module",
-        "sensor.clou_duo_wi_fi_rssi",
+        f"{UNIQUE_ID_PREFIX}_fan_1_speed",
+        f"{UNIQUE_ID_PREFIX}_fan_2_speed",
+        f"{UNIQUE_ID_PREFIX}_module_temperature",
+        f"{UNIQUE_ID_PREFIX}_pressure",
+        f"{UNIQUE_ID_PREFIX}_wifi_rssi",
     ],
 )
 @pytest.mark.usefixtures("init_integration")
 async def test_sensors_disabled_by_default(
-    hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    entity_id: str,
+    unique_id: str,
 ) -> None:
     """Test sensors that are disabled by default."""
-    assert (entry := entity_registry.async_get(entity_id))
-    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
-    assert hass.states.get(entity_id) is None
+    entry = entity_registry.async_get_entity_id("sensor", "fumis", unique_id)
+    assert entry is not None, f"Entity with unique_id {unique_id} not found"
+    assert (entity_entry := entity_registry.async_get(entry))
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.parametrize("device_fixture", ["info_minimal"])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_sensors_unknown_status(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test sensor returns unknown when stove status is unmapped."""
-    assert (state := hass.states.get("sensor.pellet_stove_stove_status"))
-    assert state.state == STATE_UNKNOWN
-
-    assert (state := hass.states.get("sensor.pellet_stove_detailed_stove_status"))
-    assert state.state == STATE_UNKNOWN
+    for key in ("stove_status", "detailed_stove_status"):
+        entry = entity_registry.async_get_entity_id(
+            "sensor", "fumis", f"{UNIQUE_ID_PREFIX}_{key}"
+        )
+        assert entry is not None
+        assert (state := hass.states.get(entry))
+        assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize("device_fixture", ["info_minimal"])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_sensors_conditional_creation(
-    hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -72,21 +76,27 @@ async def test_sensors_conditional_creation(
     entity_entries = er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
-    entity_ids = {entry.entity_id for entry in entity_entries}
+    unique_ids = {entry.unique_id for entry in entity_entries}
 
     # These should NOT exist with the minimal fixture
-    assert "sensor.pellet_stove_combustion_chamber_pressure" not in entity_ids
-    assert "sensor.pellet_stove_combustion_chamber" not in entity_ids
-    assert "sensor.pellet_stove_fan_1_speed" not in entity_ids
-    assert "sensor.pellet_stove_fan_2_speed" not in entity_ids
-    assert "sensor.pellet_stove_fuel_level" not in entity_ids
-    assert "sensor.pellet_stove_wircu_module" not in entity_ids
-    assert "sensor.pellet_stove_temperature" not in entity_ids
-    assert "sensor.pellet_stove_time_to_service" not in entity_ids
+    for key in (
+        "combustion_chamber_temperature",
+        "fan_1_speed",
+        "fan_2_speed",
+        "fuel_quantity",
+        "module_temperature",
+        "pressure",
+        "temperature",
+        "time_to_service",
+    ):
+        assert f"{UNIQUE_ID_PREFIX}_{key}" not in unique_ids, key
 
     # These should still exist
-    assert "sensor.pellet_stove_detailed_stove_status" in entity_ids
-    assert "sensor.pellet_stove_power_output" in entity_ids
-    assert "sensor.pellet_stove_stove_status" in entity_ids
-    assert "sensor.pellet_stove_wi_fi_rssi" in entity_ids
-    assert "sensor.pellet_stove_wi_fi_signal_strength" in entity_ids
+    for key in (
+        "detailed_stove_status",
+        "power_output",
+        "stove_status",
+        "wifi_rssi",
+        "wifi_signal_strength",
+    ):
+        assert f"{UNIQUE_ID_PREFIX}_{key}" in unique_ids, key


### PR DESCRIPTION
## Proposed change

Add a sensor platform to the Fumis pellet stove integration with 19 sensors covering stove status, temperatures, fan speeds, fuel level, Wi-Fi connectivity, operational statistics, and service information.

Sensors enabled by default:

- Temperature (room)
- Stove status (simplified enum)
- Detailed stove status (diagnostic, full status enum)
- Combustion chamber temperature
- Fuel level
- Wi-Fi signal strength
- Power output
- Statistics (igniter starts, overheatings, misfires, uptime, burning time, fuel consumed, time to service)

Sensors disabled by default:
- Fan 1/2 speed
- Wi-Fi RSSI
- Combustion chamber pressure
- WiRCU module temperature

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44891
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr