### PR TITLE
Use runtime_data in wilight integration

### DIFF
--- a/homeassistant/components/wilight/__init__.py
+++ b/homeassistant/components/wilight/__init__.py
@@ -1,18 +1,16 @@
 """The WiLight integration."""
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
-from .parent_device import WiLightParent
+from .parent_device import WiLightConfigEntry, WiLightParent
 
 # List the platforms that you want to support.
 PLATFORMS = [Platform.COVER, Platform.FAN, Platform.LIGHT, Platform.SWITCH]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: WiLightConfigEntry) -> bool:
     """Set up a wilight config entry."""
 
     parent = WiLightParent(hass, entry)
@@ -20,8 +18,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not await parent.async_setup():
         raise ConfigEntryNotReady
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = parent
+    entry.runtime_data = parent
 
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -29,15 +26,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WiLightConfigEntry) -> bool:
     """Unload WiLight config entry."""
 
     # Unload entities for this entry/device.
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     # Cleanup
-    parent = hass.data[DOMAIN][entry.entry_id]
-    await parent.async_reset()
-    del hass.data[DOMAIN][entry.entry_id]
+    await entry.runtime_data.async_reset()
 
     return unload_ok

--- a/homeassistant/components/wilight/cover.py
+++ b/homeassistant/components/wilight/cover.py
@@ -16,22 +16,20 @@ from pywilight.const import (
 )
 
 from homeassistant.components.cover import ATTR_POSITION, CoverEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .entity import WiLightDevice
-from .parent_device import WiLightParent
+from .parent_device import WiLightConfigEntry
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: WiLightConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WiLight covers from a config entry."""
-    parent: WiLightParent = hass.data[DOMAIN][entry.entry_id]
+    parent = entry.runtime_data
 
     # Handle a discovered WiLight device.
     entities = []

--- a/homeassistant/components/wilight/fan.py
+++ b/homeassistant/components/wilight/fan.py
@@ -17,7 +17,6 @@ from pywilight.const import (
 from pywilight.wilight_device import PyWiLightDevice
 
 from homeassistant.components.fan import DIRECTION_FORWARD, FanEntity, FanEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.percentage import (
@@ -25,20 +24,19 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from .const import DOMAIN
 from .entity import WiLightDevice
-from .parent_device import WiLightParent
+from .parent_device import WiLightConfigEntry
 
 ORDERED_NAMED_FAN_SPEEDS = [WL_SPEED_LOW, WL_SPEED_MEDIUM, WL_SPEED_HIGH]
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: WiLightConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WiLight lights from a config entry."""
-    parent: WiLightParent = hass.data[DOMAIN][entry.entry_id]
+    parent = entry.runtime_data
 
     # Handle a discovered WiLight device.
     entities = []

--- a/homeassistant/components/wilight/light.py
+++ b/homeassistant/components/wilight/light.py
@@ -13,13 +13,11 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .entity import WiLightDevice
-from .parent_device import WiLightParent
+from .parent_device import WiLightConfigEntry
 
 
 def entities_from_discovered_wilight(api_device: PyWiLightDevice) -> list[LightEntity]:
@@ -42,11 +40,11 @@ def entities_from_discovered_wilight(api_device: PyWiLightDevice) -> list[LightE
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: WiLightConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WiLight lights from a config entry."""
-    parent: WiLightParent = hass.data[DOMAIN][entry.entry_id]
+    parent = entry.runtime_data
 
     # Handle a discovered WiLight device.
     assert parent.api

--- a/homeassistant/components/wilight/parent_device.py
+++ b/homeassistant/components/wilight/parent_device.py
@@ -16,11 +16,13 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 _LOGGER = logging.getLogger(__name__)
 
+type WiLightConfigEntry = ConfigEntry[WiLightParent]
+
 
 class WiLightParent:
     """Manages a single WiLight Parent Device."""
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, config_entry: WiLightConfigEntry) -> None:
         """Initialize the system."""
         self._host: str = config_entry.data[CONF_HOST]
         self._hass = hass

--- a/homeassistant/components/wilight/switch.py
+++ b/homeassistant/components/wilight/switch.py
@@ -9,14 +9,12 @@ from pywilight.wilight_device import PyWiLightDevice
 import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .entity import WiLightDevice
-from .parent_device import WiLightParent
+from .parent_device import WiLightConfigEntry
 from .support import wilight_to_hass_trigger, wilight_trigger as wl_trigger
 
 # Attr of features supported by the valve switch entities
@@ -76,11 +74,11 @@ def entities_from_discovered_wilight(api_device: PyWiLightDevice) -> tuple[Any]:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: WiLightConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up WiLight switches from a config entry."""
-    parent: WiLightParent = hass.data[DOMAIN][entry.entry_id]
+    parent = entry.runtime_data
 
     # Handle a discovered WiLight device.
     assert parent.api

--- a/tests/components/wilight/test_init.py
+++ b/tests/components/wilight/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import pytest
 import pywilight
-from pywilight.const import DOMAIN
 import requests
 
 from homeassistant.config_entries import ConfigEntryState
@@ -56,12 +55,9 @@ async def test_unload_config_entry(hass: HomeAssistant, dummy_device_from_host) 
     """Test the WiLight configuration entry unloading."""
     entry = await setup_integration(hass)
 
-    assert entry.entry_id in hass.data[DOMAIN]
     assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    if DOMAIN in hass.data:
-        assert entry.entry_id not in hass.data[DOMAIN]
-        assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/wilight/test_switch.py
+++ b/tests/components/wilight/test_switch.py
@@ -6,7 +6,7 @@ import pytest
 import pywilight
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.wilight import DOMAIN
+from homeassistant.components.wilight.const import DOMAIN
 from homeassistant.components.wilight.switch import (
     ATTR_PAUSE_TIME,
     ATTR_TRIGGER,


### PR DESCRIPTION
## Proposed change

Migrate the `wilight` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`.

- Add a `WiLightConfigEntry` typed alias in `parent_device.py`.
- Update `__init__.py` and all platform files (`cover.py`, `fan.py`, `light.py`, `switch.py`) to use the typed config entry and `entry.runtime_data`.
- Update `test_switch.py` to import `DOMAIN` from `const.py` instead of `__init__.py`.
- Update `test_init.py` to assert `ConfigEntryState` instead of inspecting `hass.data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr