### PR TITLE
Use runtime_data in wiffi integration

### DIFF
--- a/homeassistant/components/wiffi/__init__.py
+++ b/homeassistant/components/wiffi/__init__.py
@@ -13,12 +13,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import (
-    CHECK_ENTITIES_SIGNAL,
-    CREATE_ENTITY_SIGNAL,
-    DOMAIN,
-    UPDATE_ENTITY_SIGNAL,
-)
+from .const import CHECK_ENTITIES_SIGNAL, CREATE_ENTITY_SIGNAL, UPDATE_ENTITY_SIGNAL
 from .entity import generate_unique_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,8 +21,10 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
+type WiffiConfigEntry = ConfigEntry[WiffiIntegrationApi]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+async def async_setup_entry(hass: HomeAssistant, entry: WiffiConfigEntry) -> bool:
     """Set up wiffi from a config entry, config_entry contains data from config entry database."""
 
     # create api object
@@ -35,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api.async_setup(entry)
 
     # store api object
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = api
+    entry.runtime_data = api
 
     try:
         await api.server.start_server()
@@ -51,14 +48,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WiffiConfigEntry) -> bool:
     """Unload a config entry."""
-    api: WiffiIntegrationApi = hass.data[DOMAIN][entry.entry_id]
+    api = entry.runtime_data
     await api.server.close_server()
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        api = hass.data[DOMAIN].pop(entry.entry_id)
         api.shutdown()
 
     return unload_ok

--- a/homeassistant/components/wiffi/__init__.py
+++ b/homeassistant/components/wiffi/__init__.py
@@ -61,7 +61,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: WiffiConfigEntry) -> bo
 
 
 class WiffiIntegrationApi:
-    """API object for wiffi handling. Stored in hass.data."""
+    """API object for wiffi handling."""
 
     def __init__(self, hass):
         """Initialize the instance."""

--- a/homeassistant/components/wiffi/binary_sensor.py
+++ b/homeassistant/components/wiffi/binary_sensor.py
@@ -1,18 +1,18 @@
 """Binary sensor platform support for wiffi devices."""
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import WiffiConfigEntry
 from .const import CREATE_ENTITY_SIGNAL
 from .entity import WiffiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WiffiConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform for a new integration.

--- a/homeassistant/components/wiffi/config_flow.py
+++ b/homeassistant/components/wiffi/config_flow.py
@@ -12,7 +12,6 @@ import voluptuous as vol
 from wiffi import WiffiTcpServer
 
 from homeassistant.config_entries import (
-    ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlowWithReload,
@@ -20,6 +19,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import callback
 
+from . import WiffiConfigEntry
 from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
 
 
@@ -31,7 +31,7 @@ class WiffiFlowHandler(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: WiffiConfigEntry,
     ) -> OptionsFlowHandler:
         """Create Wiffi server setup option flow."""
         return OptionsFlowHandler()

--- a/homeassistant/components/wiffi/sensor.py
+++ b/homeassistant/components/wiffi/sensor.py
@@ -5,12 +5,12 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEGREE, LIGHT_LUX, UnitOfPressure, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import WiffiConfigEntry
 from .const import CREATE_ENTITY_SIGNAL
 from .entity import WiffiEntity
 from .wiffi_strings import (
@@ -40,7 +40,7 @@ UOM_MAP = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: WiffiConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up platform for a new integration.


### PR DESCRIPTION
## Proposed change

Migrate the `wiffi` integration to use `ConfigEntry.runtime_data` instead of storing the API object in `hass.data[DOMAIN][entry.entry_id]`.

- Add a `WiffiConfigEntry` typed alias (`ConfigEntry[WiffiIntegrationApi]`) in `__init__.py`.
- Update `async_setup_entry` and `async_unload_entry` to use the typed config entry and store/retrieve the API object via `entry.runtime_data`.
- Remove the now-unused `DOMAIN` import from `__init__.py`.

This follows the pattern used by modern Home Assistant integrations and removes manual bookkeeping in `hass.data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr