### PR TITLE
Deprecate continue_on_error for non service related script actions

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1471,13 +1471,16 @@ SCRIPT_ACTION_BASE_SCHEMA: VolDictType = {
     vol.Optional(CONF_ENABLED): vol.Any(boolean, template),
 }
 
-EVENT_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_EVENT): string,
-        vol.Optional(CONF_EVENT_DATA): vol.All(dict, template_complex),
-        vol.Optional(CONF_EVENT_DATA_TEMPLATE): vol.All(dict, template_complex),
-    }
+EVENT_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_EVENT): string,
+            vol.Optional(CONF_EVENT_DATA): vol.All(dict, template_complex),
+            vol.Optional(CONF_EVENT_DATA_TEMPLATE): vol.All(dict, template_complex),
+        }
+    ),
 )
 
 
@@ -1900,20 +1903,26 @@ TRIGGER_SCHEMA = vol.All(
     [vol.All(_trigger_pre_validator, _base_trigger_validator)],
 )
 
-_SCRIPT_DELAY_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_DELAY): positive_time_period_template,
-    }
+_SCRIPT_DELAY_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_DELAY): positive_time_period_template,
+        }
+    ),
 )
 
-_SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_WAIT_TEMPLATE): template,
-        vol.Optional(CONF_TIMEOUT): positive_time_period_template,
-        vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
-    }
+_SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_WAIT_TEMPLATE): template,
+            vol.Optional(CONF_TIMEOUT): positive_time_period_template,
+            vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
+        }
+    ),
 )
 
 DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
@@ -1927,99 +1936,128 @@ DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
 
 DEVICE_ACTION_SCHEMA = DEVICE_ACTION_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
 
-_SCRIPT_SCENE_SCHEMA = vol.Schema(
-    {**SCRIPT_ACTION_BASE_SCHEMA, vol.Required(CONF_SCENE): entity_domain("scene")}
+_SCRIPT_SCENE_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {**SCRIPT_ACTION_BASE_SCHEMA, vol.Required(CONF_SCENE): entity_domain("scene")}
+    ),
 )
 
-_SCRIPT_REPEAT_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_REPEAT): vol.All(
-            {
-                vol.Exclusive(CONF_COUNT, "repeat"): vol.Any(vol.Coerce(int), template),
-                vol.Exclusive(CONF_FOR_EACH, "repeat"): vol.Any(
-                    dynamic_template, vol.All(list, template_complex)
-                ),
-                vol.Exclusive(CONF_WHILE, "repeat"): CONDITIONS_SCHEMA,
-                vol.Exclusive(CONF_UNTIL, "repeat"): CONDITIONS_SCHEMA,
-                vol.Required(CONF_SEQUENCE): SCRIPT_SCHEMA,
-            },
-            has_at_least_one_key(CONF_COUNT, CONF_FOR_EACH, CONF_WHILE, CONF_UNTIL),
-        ),
-    }
-)
-
-_SCRIPT_CHOOSE_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_CHOOSE): vol.All(
-            ensure_list,
-            [
+_SCRIPT_REPEAT_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_REPEAT): vol.All(
                 {
-                    vol.Optional(CONF_ALIAS): string,
-                    vol.Required(CONF_CONDITIONS): CONDITIONS_SCHEMA,
+                    vol.Exclusive(CONF_COUNT, "repeat"): vol.Any(
+                        vol.Coerce(int), template
+                    ),
+                    vol.Exclusive(CONF_FOR_EACH, "repeat"): vol.Any(
+                        dynamic_template, vol.All(list, template_complex)
+                    ),
+                    vol.Exclusive(CONF_WHILE, "repeat"): CONDITIONS_SCHEMA,
+                    vol.Exclusive(CONF_UNTIL, "repeat"): CONDITIONS_SCHEMA,
                     vol.Required(CONF_SEQUENCE): SCRIPT_SCHEMA,
-                }
-            ],
-        ),
-        vol.Optional(CONF_DEFAULT): SCRIPT_SCHEMA,
-    }
+                },
+                has_at_least_one_key(CONF_COUNT, CONF_FOR_EACH, CONF_WHILE, CONF_UNTIL),
+            ),
+        }
+    ),
 )
 
-_SCRIPT_WAIT_FOR_TRIGGER_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_WAIT_FOR_TRIGGER): TRIGGER_SCHEMA,
-        vol.Optional(CONF_TIMEOUT): positive_time_period_template,
-        vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
-    }
+_SCRIPT_CHOOSE_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_CHOOSE): vol.All(
+                ensure_list,
+                [
+                    {
+                        vol.Optional(CONF_ALIAS): string,
+                        vol.Required(CONF_CONDITIONS): CONDITIONS_SCHEMA,
+                        vol.Required(CONF_SEQUENCE): SCRIPT_SCHEMA,
+                    }
+                ],
+            ),
+            vol.Optional(CONF_DEFAULT): SCRIPT_SCHEMA,
+        }
+    ),
 )
 
-_SCRIPT_IF_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_IF): CONDITIONS_SCHEMA,
-        vol.Required(CONF_THEN): SCRIPT_SCHEMA,
-        vol.Optional(CONF_ELSE): SCRIPT_SCHEMA,
-    }
+_SCRIPT_WAIT_FOR_TRIGGER_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_WAIT_FOR_TRIGGER): TRIGGER_SCHEMA,
+            vol.Optional(CONF_TIMEOUT): positive_time_period_template,
+            vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
+        }
+    ),
 )
 
-_SCRIPT_SET_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_VARIABLES): SCRIPT_VARIABLES_SCHEMA,
-    }
+_SCRIPT_IF_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_IF): CONDITIONS_SCHEMA,
+            vol.Required(CONF_THEN): SCRIPT_SCHEMA,
+            vol.Optional(CONF_ELSE): SCRIPT_SCHEMA,
+        }
+    ),
 )
 
-_SCRIPT_SET_CONVERSATION_RESPONSE_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(
-            CONF_SET_CONVERSATION_RESPONSE
-        ): SCRIPT_CONVERSATION_RESPONSE_SCHEMA,
-    }
+_SCRIPT_SET_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_VARIABLES): SCRIPT_VARIABLES_SCHEMA,
+        }
+    ),
 )
 
-_SCRIPT_STOP_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_STOP): vol.Any(None, string),
-        vol.Exclusive(CONF_ERROR, "error_or_response"): boolean,
-        vol.Exclusive(
-            CONF_RESPONSE_VARIABLE,
-            "error_or_response",
-            msg="not allowed to add a response to an error stop action",
-        ): str,
-    }
+_SCRIPT_SET_CONVERSATION_RESPONSE_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(
+                CONF_SET_CONVERSATION_RESPONSE
+            ): SCRIPT_CONVERSATION_RESPONSE_SCHEMA,
+        }
+    ),
 )
 
-_SCRIPT_SEQUENCE_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        # The frontend stores data here. Don't use in core.
-        vol.Remove("metadata"): dict,
-        vol.Required(CONF_SEQUENCE): SCRIPT_SCHEMA,
-    }
+_SCRIPT_STOP_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_STOP): vol.Any(None, string),
+            vol.Exclusive(CONF_ERROR, "error_or_response"): boolean,
+            vol.Exclusive(
+                CONF_RESPONSE_VARIABLE,
+                "error_or_response",
+                msg="not allowed to add a response to an error stop action",
+            ): str,
+        }
+    ),
+)
+
+_SCRIPT_SEQUENCE_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            # The frontend stores data here. Don't use in core.
+            vol.Remove("metadata"): dict,
+            vol.Required(CONF_SEQUENCE): SCRIPT_SCHEMA,
+        }
+    ),
 )
 
 _parallel_sequence_action = vol.All(
@@ -2030,13 +2068,17 @@ _parallel_sequence_action = vol.All(
     },
 )
 
-_SCRIPT_PARALLEL_SCHEMA = vol.Schema(
-    {
-        **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_PARALLEL): vol.All(
-            ensure_list, [vol.Any(_SCRIPT_SEQUENCE_SCHEMA, _parallel_sequence_action)]
-        ),
-    }
+_SCRIPT_PARALLEL_SCHEMA = vol.All(
+    deprecated(CONF_CONTINUE_ON_ERROR),
+    vol.Schema(
+        {
+            **SCRIPT_ACTION_BASE_SCHEMA,
+            vol.Required(CONF_PARALLEL): vol.All(
+                ensure_list,
+                [vol.Any(_SCRIPT_SEQUENCE_SCHEMA, _parallel_sequence_action)],
+            ),
+        }
+    ),
 )
 
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -6898,3 +6898,84 @@ async def test_enabled_sequence_in_parallel(
         ],
     }
     assert_action_trace(expected_trace)
+
+
+@pytest.mark.parametrize(
+    "action_config",
+    [
+        {"event": "test_event", "continue_on_error": True},
+        {"delay": "00:00:05", "continue_on_error": True},
+        {"wait_template": "{{ true }}", "continue_on_error": True},
+        {"scene": "scene.test", "continue_on_error": True},
+        {
+            "repeat": {"count": 1, "sequence": []},
+            "continue_on_error": True,
+        },
+        {
+            "choose": [{"conditions": [], "sequence": []}],
+            "continue_on_error": True,
+        },
+        {
+            "wait_for_trigger": {"platform": "state", "entity_id": "sensor.test"},
+            "continue_on_error": True,
+        },
+        {"if": [], "then": [], "continue_on_error": True},
+        {"variables": {"hello": "world"}, "continue_on_error": True},
+        {
+            "set_conversation_response": "Hello",
+            "continue_on_error": True,
+        },
+        {"stop": "Done", "continue_on_error": True},
+        {"sequence": [], "continue_on_error": True},
+        {"parallel": [], "continue_on_error": True},
+    ],
+)
+async def test_continue_on_error_deprecated(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    action_config: dict,
+) -> None:
+    """Test continue_on_error is deprecated for non-service-call script actions."""
+    with caplog.at_level(logging.WARNING):
+        cv.SCRIPT_SCHEMA([action_config])
+    assert (
+        "The 'continue_on_error' option is deprecated, "
+        "please remove it from your configuration"
+    ) in caplog.text
+
+
+@pytest.mark.parametrize(
+    "action_config",
+    [
+        {"action": "test.test", "continue_on_error": True},
+        {"service": "test.test", "continue_on_error": True},
+        {"service_template": "test.test", "continue_on_error": True},
+        {
+            "device_id": "test",
+            "domain": "test",
+            "continue_on_error": True,
+        },
+    ],
+)
+async def test_continue_on_error_not_deprecated(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    action_config: dict,
+) -> None:
+    """Test continue_on_error is not deprecated for service and device action script actions."""
+    with caplog.at_level(logging.WARNING):
+        cv.SCRIPT_SCHEMA([action_config])
+    assert "continue_on_error" not in caplog.text
+
+
+async def test_condition_action_rejects_continue_on_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test CONDITION_ACTION_SCHEMA does not accept continue_on_error."""
+    action_config = {
+        "condition": "template",
+        "value_template": "{{ true }}",
+    }
+    cv.CONDITION_ACTION_SCHEMA(action_config)
+    with pytest.raises(vol.Invalid):
+        cv.CONDITION_ACTION_SCHEMA(action_config | {"continue_on_error": True})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate `continue_on_error` for script actions which do not call service actions.

The following script actions still support `continue_on_error`:
- `action`
- `service` (deprecated alias for `action`)
- `service_template`
- Device actions

Note that `continue_on_error` allows script execution to continue if a sub script fails (although this is not documented and not asserted by tests). If this is an intentional and wanted behavior, we should not deprecate `continue_on_error` on such actions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
