### PR TITLE
Use runtime_data in yamaha_musiccast

### DIFF
--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -8,13 +8,12 @@ from aiohttp import DummyCookieJar
 from aiomusiccast.musiccast_device import MusicCastDevice
 
 from homeassistant.components import ssdp
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import CONF_SERIAL, CONF_UPNP_DESC, DOMAIN
-from .coordinator import MusicCastDataUpdateCoordinator
+from .const import CONF_SERIAL, CONF_UPNP_DESC
+from .coordinator import MusicCastConfigEntry, MusicCastDataUpdateCoordinator
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.NUMBER, Platform.SELECT, Platform.SWITCH]
 
@@ -38,7 +37,7 @@ async def get_upnp_desc(hass: HomeAssistant, host: str):
     return upnp_desc
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: MusicCastConfigEntry) -> bool:
     """Set up MusicCast from a config entry."""
 
     if entry.data.get(CONF_UPNP_DESC) is None:
@@ -60,8 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
     coordinator.musiccast.build_capabilities()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await coordinator.musiccast.device.enable_polling()
 
@@ -71,16 +69,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: MusicCastConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN][entry.entry_id].musiccast.device.disable_polling()
-        hass.data[DOMAIN].pop(entry.entry_id)
+        entry.runtime_data.musiccast.device.disable_polling()
 
     return unload_ok
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(hass: HomeAssistant, entry: MusicCastConfigEntry) -> None:
     """Reload config entry."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/yamaha_musiccast/coordinator.py
+++ b/homeassistant/components/yamaha_musiccast/coordinator.py
@@ -22,14 +22,19 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
+type MusicCastConfigEntry = ConfigEntry[MusicCastDataUpdateCoordinator]
+
 
 class MusicCastDataUpdateCoordinator(DataUpdateCoordinator[MusicCastData]):
     """Class to manage fetching data from the API."""
 
-    config_entry: ConfigEntry
+    config_entry: MusicCastConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, client: MusicCastDevice
+        self,
+        hass: HomeAssistant,
+        config_entry: MusicCastConfigEntry,
+        client: MusicCastDevice,
     ) -> None:
         """Initialize."""
         self.musiccast = client

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -21,7 +21,6 @@ from homeassistant.components.media_player import (
     RepeatMode,
     async_process_play_media_url,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
@@ -38,7 +37,7 @@ from .const import (
     MEDIA_CLASS_MAPPING,
     NULL_GROUP,
 )
-from .coordinator import MusicCastDataUpdateCoordinator
+from .coordinator import MusicCastConfigEntry
 from .entity import MusicCastDeviceEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,11 +54,11 @@ MUSIC_PLAYER_BASE_SUPPORT = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: MusicCastConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up MusicCast sensor based on a config entry."""
-    coordinator: MusicCastDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     name = coordinator.data.network_name
 
@@ -614,11 +613,14 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     def get_all_mc_entities(self) -> list[MusicCastMediaPlayer]:
         """Return all media player entities of the musiccast system."""
+        entries: list[MusicCastConfigEntry] = (
+            self.hass.config_entries.async_loaded_entries(DOMAIN)
+        )
         entities = []
-        for coordinator in self.hass.data[DOMAIN].values():
+        for entry in entries:
             entities += [
                 entity
-                for entity in coordinator.entities
+                for entity in entry.runtime_data.entities
                 if isinstance(entity, MusicCastMediaPlayer)
             ]
         return entities

--- a/homeassistant/components/yamaha_musiccast/number.py
+++ b/homeassistant/components/yamaha_musiccast/number.py
@@ -5,22 +5,20 @@ from __future__ import annotations
 from aiomusiccast.capabilities import NumberSetter
 
 from homeassistant.components.number import NumberEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import MusicCastDataUpdateCoordinator
+from .coordinator import MusicCastConfigEntry, MusicCastDataUpdateCoordinator
 from .entity import MusicCastCapabilityEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: MusicCastConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up MusicCast number entities based on a config entry."""
-    coordinator: MusicCastDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     number_entities = [
         NumberCapability(coordinator, capability)

--- a/homeassistant/components/yamaha_musiccast/select.py
+++ b/homeassistant/components/yamaha_musiccast/select.py
@@ -5,22 +5,21 @@ from __future__ import annotations
 from aiomusiccast.capabilities import OptionSetter
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, TRANSLATION_KEY_MAPPING
-from .coordinator import MusicCastDataUpdateCoordinator
+from .const import TRANSLATION_KEY_MAPPING
+from .coordinator import MusicCastConfigEntry, MusicCastDataUpdateCoordinator
 from .entity import MusicCastCapabilityEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: MusicCastConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up MusicCast select entities based on a config entry."""
-    coordinator: MusicCastDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     select_entities = [
         SelectableCapability(coordinator, capability)

--- a/homeassistant/components/yamaha_musiccast/switch.py
+++ b/homeassistant/components/yamaha_musiccast/switch.py
@@ -5,22 +5,20 @@ from typing import Any
 from aiomusiccast.capabilities import BinarySetter
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import MusicCastDataUpdateCoordinator
+from .coordinator import MusicCastConfigEntry
 from .entity import MusicCastCapabilityEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: MusicCastConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up MusicCast sensor based on a config entry."""
-    coordinator: MusicCastDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     switch_entities = [
         SwitchCapability(coordinator, capability)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `yamaha_musiccast` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`.

- Added a `MusicCastConfigEntry` typed alias in `coordinator.py` (`ConfigEntry[MusicCastDataUpdateCoordinator]`).
- Updated `__init__.py` and all platform modules (`media_player.py`, `number.py`, `select.py`, `switch.py`) to use the typed config entry and `entry.runtime_data`.
- Updated the `get_all_mc_entities` helper in `media_player.py` to iterate `hass.config_entries.async_loaded_entries(DOMAIN)` instead of walking `hass.data[DOMAIN]`.

This is a non-functional refactor aligning the integration with the current recommended pattern for storing per-entry runtime data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr