### PR TITLE
Use runtime_data in yolink

### DIFF
--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -64,14 +64,13 @@ class YoLinkHomeMessageListener(MessageListener):
 
     def on_message(self, device: YoLinkDevice, msg_data: dict[str, Any]) -> None:
         """On YoLink home message received."""
-        if self._entry.state is not ConfigEntryState.LOADED:
+        if self._entry.state is not ConfigEntryState.LOADED or not (
+            device_coordinator := self._entry.runtime_data.device_coordinators.get(
+                device.device_id
+            )
+        ):
             return
-        device_coordinators = self._entry.runtime_data.device_coordinators
-        if not device_coordinators:
-            return
-        device_coordinator = device_coordinators.get(device.device_id)
-        if device_coordinator is None:
-            return
+
         device_coordinator.dev_online = True
         if (loraInfo := msg_data.get(ATTR_LORA_INFO)) is not None:
             device_coordinator.dev_net_type = loraInfo.get("devNetType")

--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
@@ -13,7 +12,6 @@ from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 from yolink.home_manager import YoLinkHome
 from yolink.message_listener import MessageListener
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -31,7 +29,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import api
 from .const import ATTR_LORA_INFO, DOMAIN, SUPPORTED_REMOTERS, YOLINK_EVENT
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator, YoLinkHomeStore
 from .device_trigger import CONF_LONG_PRESS, CONF_SHORT_PRESS
 from .services import async_setup_services
 
@@ -58,22 +56,20 @@ PLATFORMS = [
 class YoLinkHomeMessageListener(MessageListener):
     """YoLink home message listener."""
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, entry: YoLinkConfigEntry) -> None:
         """Init YoLink home message listener."""
         self._hass = hass
         self._entry = entry
 
     def on_message(self, device: YoLinkDevice, msg_data: dict[str, Any]) -> None:
         """On YoLink home message received."""
-        entry_data = self._hass.data[DOMAIN].get(self._entry.entry_id)
+        entry_data = self._entry.runtime_data
         if not entry_data:
             return
         device_coordinators = entry_data.device_coordinators
         if not device_coordinators:
             return
-        device_coordinator: YoLinkCoordinator = device_coordinators.get(
-            device.device_id
-        )
+        device_coordinator = device_coordinators.get(device.device_id)
         if device_coordinator is None:
             return
         device_coordinator.dev_online = True
@@ -105,14 +101,6 @@ class YoLinkHomeMessageListener(MessageListener):
             self._hass.bus.async_fire(YOLINK_EVENT, event_data)
 
 
-@dataclass
-class YoLinkHomeStore:
-    """YoLink home store."""
-
-    home_instance: YoLinkHome
-    device_coordinators: dict[str, YoLinkCoordinator]
-
-
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up YoLink."""
 
@@ -121,9 +109,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: YoLinkConfigEntry) -> bool:
     """Set up yolink from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
     try:
         implementation = await async_get_config_entry_implementation(hass, entry)
     except ImplementationUnavailableError as err:
@@ -174,9 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Not failure by fetching device state
             device_coordinator.data = {}
         device_coordinators[device.device_id] = device_coordinator
-    hass.data[DOMAIN][entry.entry_id] = YoLinkHomeStore(
-        yolink_home, device_coordinators
-    )
+    entry.runtime_data = YoLinkHomeStore(yolink_home, device_coordinators)
 
     # Clean up yolink devices which are not associated to the account anymore.
     device_registry = dr.async_get(hass)
@@ -204,9 +189,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: YoLinkConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        await hass.data[DOMAIN][entry.entry_id].home_instance.async_unload()
-        hass.data[DOMAIN].pop(entry.entry_id)
+        await entry.runtime_data.home_instance.async_unload()
     return unload_ok

--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -12,6 +12,7 @@ from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 from yolink.home_manager import YoLinkHome
 from yolink.message_listener import MessageListener
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -63,10 +64,9 @@ class YoLinkHomeMessageListener(MessageListener):
 
     def on_message(self, device: YoLinkDevice, msg_data: dict[str, Any]) -> None:
         """On YoLink home message received."""
-        entry_data = self._entry.runtime_data
-        if not entry_data:
+        if self._entry.state is not ConfigEntryState.LOADED:
             return
-        device_coordinators = entry_data.device_coordinators
+        device_coordinators = self._entry.runtime_data.device_coordinators
         if not device_coordinators:
             return
         device_coordinator = device_coordinators.get(device.device_id)

--- a/homeassistant/components/yolink/binary_sensor.py
+++ b/homeassistant/components/yolink/binary_sensor.py
@@ -23,16 +23,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import (
-    DEV_MODEL_WATER_METER_YS5018_EC,
-    DEV_MODEL_WATER_METER_YS5018_UC,
-    DOMAIN,
-)
-from .coordinator import YoLinkCoordinator
+from .const import DEV_MODEL_WATER_METER_YS5018_EC, DEV_MODEL_WATER_METER_YS5018_UC
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
@@ -181,11 +176,11 @@ SENSOR_TYPES: tuple[YoLinkBinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink Sensor from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     binary_sensor_device_coordinators = [
         device_coordinator
         for device_coordinator in device_coordinators.values()
@@ -208,7 +203,7 @@ class YoLinkBinarySensorEntity(YoLinkEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
         description: YoLinkBinarySensorEntityDescription,
     ) -> None:

--- a/homeassistant/components/yolink/climate.py
+++ b/homeassistant/components/yolink/climate.py
@@ -19,13 +19,11 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 YOLINK_MODEL_2_HA = {
@@ -46,11 +44,11 @@ YOLINK_ACTION_2_HA = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink Thermostat from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     entities = [
         YoLinkClimateEntity(config_entry, device_coordinator)
         for device_coordinator in device_coordinators.values()
@@ -66,7 +64,7 @@ class YoLinkClimateEntity(YoLinkEntity, ClimateEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
     ) -> None:
         """Init YoLink Thermostat."""

--- a/homeassistant/components/yolink/coordinator.py
+++ b/homeassistant/components/yolink/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 import logging
 from typing import Any
@@ -10,6 +11,7 @@ from typing import Any
 from yolink.client_request import ClientRequest
 from yolink.device import YoLinkDevice
 from yolink.exception import YoLinkAuthFailError, YoLinkClientError
+from yolink.home_manager import YoLinkHome
 from yolink.model import BRDP
 
 from homeassistant.config_entries import ConfigEntry
@@ -22,15 +24,26 @@ from .const import ATTR_DEVICE_STATE, ATTR_LORA_INFO, DOMAIN, YOLINK_OFFLINE_TIM
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class YoLinkHomeStore:
+    """YoLink home store."""
+
+    home_instance: YoLinkHome
+    device_coordinators: dict[str, YoLinkCoordinator]
+
+
+type YoLinkConfigEntry = ConfigEntry[YoLinkHomeStore]
+
+
 class YoLinkCoordinator(DataUpdateCoordinator[dict]):
     """YoLink DataUpdateCoordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: YoLinkConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         device: YoLinkDevice,
         paired_device: YoLinkDevice | None = None,
     ) -> None:

--- a/homeassistant/components/yolink/cover.py
+++ b/homeassistant/components/yolink/cover.py
@@ -12,22 +12,20 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink garage door from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     entities = [
         YoLinkCoverEntity(config_entry, device_coordinator)
         for device_coordinator in device_coordinators.values()
@@ -44,7 +42,7 @@ class YoLinkCoverEntity(YoLinkEntity, CoverEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
     ) -> None:
         """Init YoLink garage door entity."""

--- a/homeassistant/components/yolink/entity.py
+++ b/homeassistant/components/yolink/entity.py
@@ -7,13 +7,12 @@ from typing import Any
 
 from yolink.client_request import ClientRequest
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 
 
 class YoLinkEntity(CoordinatorEntity[YoLinkCoordinator]):
@@ -23,7 +22,7 @@ class YoLinkEntity(CoordinatorEntity[YoLinkCoordinator]):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
     ) -> None:
         """Init YoLink Entity."""

--- a/homeassistant/components/yolink/light.py
+++ b/homeassistant/components/yolink/light.py
@@ -8,22 +8,20 @@ from yolink.client_request import ClientRequest
 from yolink.const import ATTR_DEVICE_DIMMER
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink Dimmer from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     entities = [
         YoLinkDimmerEntity(config_entry, device_coordinator)
         for device_coordinator in device_coordinators.values()
@@ -41,7 +39,7 @@ class YoLinkDimmerEntity(YoLinkEntity, LightEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
     ) -> None:
         """Init YoLink Dimmer entity."""

--- a/homeassistant/components/yolink/lock.py
+++ b/homeassistant/components/yolink/lock.py
@@ -8,22 +8,20 @@ from yolink.client_request import ClientRequest
 from yolink.const import ATTR_DEVICE_LOCK, ATTR_DEVICE_LOCK_V2
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink lock from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     entities = [
         YoLinkLockEntity(config_entry, device_coordinator)
         for device_coordinator in device_coordinators.values()
@@ -40,7 +38,7 @@ class YoLinkLockEntity(YoLinkEntity, LockEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
     ) -> None:
         """Init YoLink Lock."""

--- a/homeassistant/components/yolink/number.py
+++ b/homeassistant/components/yolink/number.py
@@ -15,12 +15,10 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 OPTIONS_VOLUME = "options_volume"
@@ -65,11 +63,11 @@ DEVICE_CONFIG_DESCRIPTIONS: tuple[YoLinkNumberTypeConfigEntityDescription, ...] 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device number type config option entity from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     config_device_coordinators = [
         device_coordinator
         for device_coordinator in device_coordinators.values()
@@ -94,7 +92,7 @@ class YoLinkNumberTypeConfigEntity(YoLinkEntity, NumberEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
         description: YoLinkNumberTypeConfigEntityDescription,
     ) -> None:

--- a/homeassistant/components/yolink/select.py
+++ b/homeassistant/components/yolink/select.py
@@ -12,12 +12,10 @@ from yolink.device import YoLinkDevice
 from yolink.message_resolver import sprinkler_message_resolve
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
@@ -66,11 +64,11 @@ SELECTOR_MAPPINGS: tuple[YoLinkSelectEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink select from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     async_add_entities(
         YoLinkSelectEntity(config_entry, selector_device_coordinator, description)
         for selector_device_coordinator in device_coordinators.values()
@@ -87,7 +85,7 @@ class YoLinkSelectEntity(YoLinkEntity, SelectEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
         description: YoLinkSelectEntityDescription,
     ) -> None:

--- a/homeassistant/components/yolink/sensor.py
+++ b/homeassistant/components/yolink/sensor.py
@@ -44,7 +44,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
@@ -76,9 +75,8 @@ from .const import (
     DEV_MODEL_TH_SENSOR_YS8014_UC,
     DEV_MODEL_TH_SENSOR_YS8017_EC,
     DEV_MODEL_TH_SENSOR_YS8017_UC,
-    DOMAIN,
 )
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
@@ -423,11 +421,11 @@ SENSOR_TYPES: tuple[YoLinkSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink Sensor from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     sensor_device_coordinators = [
         device_coordinator
         for device_coordinator in device_coordinators.values()
@@ -452,7 +450,7 @@ class YoLinkSensorEntity(YoLinkEntity, SensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
         description: YoLinkSensorEntityDescription,
     ) -> None:

--- a/homeassistant/components/yolink/services.py
+++ b/homeassistant/components/yolink/services.py
@@ -45,7 +45,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                     translation_domain=DOMAIN,
                     translation_key="invalid_config_entry",
                 )
-            home_store = hass.data[DOMAIN][entry.entry_id]
+            home_store = entry.runtime_data
             for identifier in device_entry.identifiers:
                 if (
                     device_coordinator := home_store.device_coordinators.get(

--- a/homeassistant/components/yolink/siren.py
+++ b/homeassistant/components/yolink/siren.py
@@ -15,12 +15,10 @@ from homeassistant.components.siren import (
     SirenEntityDescription,
     SirenEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
@@ -45,11 +43,11 @@ DEVICE_TYPE = [ATTR_DEVICE_SIREN]
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink siren from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     siren_device_coordinators = [
         device_coordinator
         for device_coordinator in device_coordinators.values()
@@ -72,7 +70,7 @@ class YoLinkSirenEntity(YoLinkEntity, SirenEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
         description: YoLinkSirenEntityDescription,
     ) -> None:

--- a/homeassistant/components/yolink/switch.py
+++ b/homeassistant/components/yolink/switch.py
@@ -21,12 +21,11 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DEV_MODEL_MULTI_OUTLET_YS6801, DOMAIN
-from .coordinator import YoLinkCoordinator
+from .const import DEV_MODEL_MULTI_OUTLET_YS6801
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
@@ -121,11 +120,11 @@ DEVICE_TYPE = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink switch from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     switch_device_coordinators = [
         device_coordinator
         for device_coordinator in device_coordinators.values()
@@ -146,7 +145,7 @@ class YoLinkSwitchEntity(YoLinkEntity, SwitchEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
         description: YoLinkSwitchEntityDescription,
     ) -> None:

--- a/homeassistant/components/yolink/valve.py
+++ b/homeassistant/components/yolink/valve.py
@@ -22,13 +22,12 @@ from homeassistant.components.valve import (
     ValveEntityDescription,
     ValveEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DEV_MODEL_WATER_METER_YS5007, DOMAIN
-from .coordinator import YoLinkCoordinator
+from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
 
 
@@ -109,11 +108,11 @@ DEVICE_TYPE = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: YoLinkConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up YoLink valve from a config entry."""
-    device_coordinators = hass.data[DOMAIN][config_entry.entry_id].device_coordinators
+    device_coordinators = config_entry.runtime_data.device_coordinators
     valve_device_coordinators = [
         device_coordinator
         for device_coordinator in device_coordinators.values()
@@ -134,7 +133,7 @@ class YoLinkValveEntity(YoLinkEntity, ValveEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: YoLinkConfigEntry,
         coordinator: YoLinkCoordinator,
         description: YoLinkValveEntityDescription,
     ) -> None:


### PR DESCRIPTION
## Proposed change

Migrate the `yolink` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`.

The `YoLinkHomeStore` dataclass is moved from `__init__.py` to `coordinator.py` alongside a new `YoLinkConfigEntry` typed alias. `__init__.py`, `entity.py`, `services.py`, and all platform files (`binary_sensor.py`, `climate.py`, `cover.py`, `light.py`, `lock.py`, `number.py`, `select.py`, `sensor.py`, `siren.py`, `switch.py`, `valve.py`) are updated to use the typed config entry and `entry.runtime_data`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr