### PR TITLE
Use runtime_data in youless

### DIFF
--- a/homeassistant/components/youless/__init__.py
+++ b/homeassistant/components/youless/__init__.py
@@ -5,20 +5,18 @@ from urllib.error import URLError
 
 from youless_api import YoulessAPI
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
-from .coordinator import YouLessCoordinator
+from .coordinator import YouLessConfigEntry, YouLessCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: YouLessConfigEntry) -> bool:
     """Set up youless from a config entry."""
     api = YoulessAPI(entry.data[CONF_HOST])
 
@@ -30,17 +28,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     youless_coordinator = YouLessCoordinator(hass, entry, api)
     await youless_coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = youless_coordinator
+    entry.runtime_data = youless_coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: YouLessConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/youless/coordinator.py
+++ b/homeassistant/components/youless/coordinator.py
@@ -11,14 +11,16 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+type YouLessConfigEntry = ConfigEntry[YouLessCoordinator]
+
 
 class YouLessCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching YouLess data."""
 
-    config_entry: ConfigEntry
+    config_entry: YouLessConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, device: YoulessAPI
+        self, hass: HomeAssistant, config_entry: YouLessConfigEntry, device: YoulessAPI
     ) -> None:
         """Initialize global YouLess data provider."""
         super().__init__(

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -308,7 +308,7 @@ async def async_setup_entry(
     """Initialize the integration."""
     coordinator = entry.runtime_data
     device = entry.data[CONF_DEVICE]
-    if (device := entry.data[CONF_DEVICE]) is None:
+    if device is None:
         device = entry.entry_id
 
     async_add_entities(

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE,
     UnitOfElectricCurrent,
@@ -26,8 +25,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import DOMAIN
-from .coordinator import YouLessCoordinator
+from .const import DOMAIN
+from .coordinator import YouLessConfigEntry, YouLessCoordinator
 from .entity import YouLessEntity
 
 
@@ -303,11 +302,11 @@ SENSOR_TYPES: tuple[YouLessSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: YouLessConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Initialize the integration."""
-    coordinator: YouLessCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     device = entry.data[CONF_DEVICE]
     if (device := entry.data[CONF_DEVICE]) is None:
         device = entry.entry_id

--- a/tests/components/youless/__init__.py
+++ b/tests/components/youless/__init__.py
@@ -2,7 +2,7 @@
 
 import requests_mock
 
-from homeassistant.components import youless
+from homeassistant.components.youless.const import DOMAIN
 from homeassistant.const import CONF_DEVICE, CONF_HOST
 from homeassistant.core import HomeAssistant
 
@@ -18,27 +18,21 @@ async def init_component(hass: HomeAssistant) -> MockConfigEntry:
     with requests_mock.Mocker() as mock:
         mock.get(
             "http://1.1.1.1/d",
-            json=await async_load_json_object_fixture(
-                hass, "device.json", youless.DOMAIN
-            ),
+            json=await async_load_json_object_fixture(hass, "device.json", DOMAIN),
         )
         mock.get(
             "http://1.1.1.1/e",
-            json=await async_load_json_array_fixture(
-                hass, "enologic.json", youless.DOMAIN
-            ),
+            json=await async_load_json_array_fixture(hass, "enologic.json", DOMAIN),
             headers={"Content-Type": "application/json"},
         )
         mock.get(
             "http://1.1.1.1/f",
-            json=await async_load_json_object_fixture(
-                hass, "phase.json", youless.DOMAIN
-            ),
+            json=await async_load_json_object_fixture(hass, "phase.json", DOMAIN),
             headers={"Content-Type": "application/json"},
         )
 
         entry = MockConfigEntry(
-            domain=youless.DOMAIN,
+            domain=DOMAIN,
             title="localhost",
             data={CONF_HOST: "1.1.1.1", CONF_DEVICE: "localhost"},
         )

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, patch
 from urllib.error import URLError
 
-from homeassistant.components.youless import DOMAIN
+from homeassistant.components.youless.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType

--- a/tests/components/youless/test_init.py
+++ b/tests/components/youless/test_init.py
@@ -1,7 +1,7 @@
 """Test the setup of the Youless integration."""
 
 from homeassistant import setup
-from homeassistant.components import youless
+from homeassistant.components.youless.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -13,6 +13,6 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
 
     entry = await init_component(hass)
 
-    assert await setup.async_setup_component(hass, youless.DOMAIN, {})
+    assert await setup.async_setup_component(hass, DOMAIN, {})
     assert entry.state is ConfigEntryState.LOADED
     assert len(hass.states.async_entity_ids()) == 22


### PR DESCRIPTION
## Proposed change

Migrate the `youless` integration to use `ConfigEntry.runtime_data` instead of storing the coordinator in `hass.data[DOMAIN][entry.entry_id]`.

- Introduce a `YouLessConfigEntry` typed alias (`ConfigEntry[YouLessCoordinator]`) in `coordinator.py`.
- Update `async_setup_entry` / `async_unload_entry` in `__init__.py` to use `YouLessConfigEntry` and store the coordinator on `entry.runtime_data`. Unload no longer needs to manage `hass.data`, so it simplifies to `async_unload_platforms`.
- Update `sensor.py` to accept the typed config entry and read the coordinator from `entry.runtime_data`.
- Update tests (`tests/components/youless/__init__.py`, `test_config_flows.py`, `test_init.py`) to import `DOMAIN` from `homeassistant.components.youless.const` instead of the integration's `__init__.py`.

No functional changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr