### PR TITLE
Use runtime_data in youtube

### DIFF
--- a/homeassistant/components/youtube/__init__.py
+++ b/homeassistant/components/youtube/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from aiohttp.client_exceptions import ClientError, ClientResponseError
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -16,13 +15,13 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 )
 
 from .api import AsyncConfigEntryAuth
-from .const import AUTH, COORDINATOR, DOMAIN
-from .coordinator import YouTubeDataUpdateCoordinator
+from .const import DOMAIN
+from .coordinator import YouTubeConfigEntry, YouTubeDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: YouTubeConfigEntry) -> bool:
     """Set up YouTube from a config entry."""
     try:
         implementation = await async_get_config_entry_implementation(hass, entry)
@@ -49,25 +48,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await delete_devices(hass, entry, coordinator)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        COORDINATOR: coordinator,
-        AUTH: auth,
-    }
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: YouTubeConfigEntry) -> bool:
     """Unload a config entry."""
-
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def delete_devices(
-    hass: HomeAssistant, entry: ConfigEntry, coordinator: YouTubeDataUpdateCoordinator
+    hass: HomeAssistant,
+    entry: YouTubeConfigEntry,
+    coordinator: YouTubeDataUpdateCoordinator,
 ) -> None:
     """Delete all devices created by integration."""
     channel_ids = list(coordinator.data)

--- a/homeassistant/components/youtube/config_flow.py
+++ b/homeassistant/components/youtube/config_flow.py
@@ -10,12 +10,7 @@ import voluptuous as vol
 from youtubeaio.types import AuthScope, ForbiddenError
 from youtubeaio.youtube import YouTube
 
-from homeassistant.config_entries import (
-    SOURCE_REAUTH,
-    ConfigEntry,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -33,6 +28,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
+from .coordinator import YouTubeConfigEntry
 
 
 class OAuth2FlowHandler(
@@ -50,7 +46,7 @@ class OAuth2FlowHandler(
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: YouTubeConfigEntry,
     ) -> YouTubeOptionsFlowHandler:
         """Get the options flow for this handler."""
         return YouTubeOptionsFlowHandler()

--- a/homeassistant/components/youtube/const.py
+++ b/homeassistant/components/youtube/const.py
@@ -9,8 +9,6 @@ CHANNEL_CREATION_HELP_URL = "https://support.google.com/youtube/answer/1646861"
 
 CONF_CHANNELS = "channels"
 CONF_UPLOAD_PLAYLIST = "upload_playlist_id"
-COORDINATOR = "coordinator"
-AUTH = "auth"
 
 LOGGER = logging.getLogger(__package__)
 

--- a/homeassistant/components/youtube/coordinator.py
+++ b/homeassistant/components/youtube/coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from . import AsyncConfigEntryAuth
+from .api import AsyncConfigEntryAuth
 from .const import (
     ATTR_DESCRIPTION,
     ATTR_LATEST_VIDEO,
@@ -29,14 +29,19 @@ from .const import (
     LOGGER,
 )
 
+type YouTubeConfigEntry = ConfigEntry[YouTubeDataUpdateCoordinator]
+
 
 class YouTubeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """A YouTube Data Update Coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: YouTubeConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, auth: AsyncConfigEntryAuth
+        self,
+        hass: HomeAssistant,
+        config_entry: YouTubeConfigEntry,
+        auth: AsyncConfigEntryAuth,
     ) -> None:
         """Initialize the YouTube data coordinator."""
         self._auth = auth

--- a/homeassistant/components/youtube/diagnostics.py
+++ b/homeassistant/components/youtube/diagnostics.py
@@ -4,20 +4,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import ATTR_DESCRIPTION, ATTR_LATEST_VIDEO, COORDINATOR, DOMAIN
-from .coordinator import YouTubeDataUpdateCoordinator
+from .const import ATTR_DESCRIPTION, ATTR_LATEST_VIDEO
+from .coordinator import YouTubeConfigEntry
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: YouTubeConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: YouTubeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator = entry.runtime_data
     sensor_data: dict[str, Any] = {}
     for channel_id, channel_data in coordinator.data.items():
         channel_data.get(ATTR_LATEST_VIDEO, {}).pop(ATTR_DESCRIPTION)

--- a/homeassistant/components/youtube/sensor.py
+++ b/homeassistant/components/youtube/sensor.py
@@ -11,13 +11,11 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ICON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import YouTubeDataUpdateCoordinator
 from .const import (
     ATTR_LATEST_VIDEO,
     ATTR_PUBLISHED_AT,
@@ -26,9 +24,8 @@ from .const import (
     ATTR_TITLE,
     ATTR_TOTAL_VIEWS,
     ATTR_VIDEO_ID,
-    COORDINATOR,
-    DOMAIN,
 )
+from .coordinator import YouTubeConfigEntry
 from .entity import YouTubeChannelEntity
 
 
@@ -79,13 +76,11 @@ SENSOR_TYPES = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: YouTubeConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the YouTube sensor."""
-    coordinator: YouTubeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator = entry.runtime_data
     async_add_entities(
         YouTubeSensor(coordinator, sensor_type, channel_id)
         for channel_id in coordinator.data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `youtube` integration to use `ConfigEntry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`.

- Add a `YouTubeConfigEntry` typed alias in `coordinator.py` (`ConfigEntry[YouTubeDataUpdateCoordinator]`).
- Update `__init__.py`, `sensor.py`, and `diagnostics.py` to use the typed config entry and read the coordinator from `entry.runtime_data`.
- Store the coordinator directly as `entry.runtime_data` (the separate `auth` reference is no longer stashed in `hass.data`; it is already held by the coordinator).
- Simplify `async_unload_entry` now that there is no `hass.data` bookkeeping.
- Remove the now-unused `AUTH` and `COORDINATOR` string constants from `const.py`.
- Fix `coordinator.py` to import `AsyncConfigEntryAuth` directly from `.api` instead of via `__init__`, avoiding a circular re-export.

This is a pure refactor; runtime behavior is unchanged and existing tests still pass.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr