### PR TITLE
Use runtime_data in zamg

### DIFF
--- a/homeassistant/components/zamg/__init__.py
+++ b/homeassistant/components/zamg/__init__.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 
-from .const import CONF_STATION_ID, DOMAIN, LOGGER
-from .coordinator import ZamgDataUpdateCoordinator
+from .const import CONF_STATION_ID, LOGGER
+from .coordinator import ZamgConfigEntry, ZamgDataUpdateCoordinator
 
 PLATFORMS = (Platform.SENSOR, Platform.WEATHER)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ZamgConfigEntry) -> bool:
     """Set up Zamg from config entry."""
     await _async_migrate_entries(hass, entry)
 
@@ -22,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator.zamg.set_default_station(station_id)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -30,15 +29,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ZamgConfigEntry) -> bool:
     """Unload ZAMG config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def _async_migrate_entries(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: ZamgConfigEntry
 ) -> bool:
     """Migrate old entry."""
     entity_registry = er.async_get(hass)

--- a/homeassistant/components/zamg/coordinator.py
+++ b/homeassistant/components/zamg/coordinator.py
@@ -12,11 +12,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import CONF_STATION_ID, DOMAIN, LOGGER, MIN_TIME_BETWEEN_UPDATES
 
+type ZamgConfigEntry = ConfigEntry[ZamgDataUpdateCoordinator]
+
 
 class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
     """Class to manage fetching ZAMG weather data."""
 
-    config_entry: ConfigEntry
+    config_entry: ZamgConfigEntry
     data: dict = {}
     api_fields: list[str] | None = None
 
@@ -24,7 +26,7 @@ class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
         self,
         hass: HomeAssistant,
         *,
-        entry: ConfigEntry,
+        entry: ZamgConfigEntry,
     ) -> None:
         """Initialize global ZAMG data updater."""
         self.zamg = ZamgDevice(session=async_get_clientsession(hass))

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DEGREE,
     PERCENTAGE,
@@ -36,7 +35,7 @@ from .const import (
     DOMAIN,
     MANUFACTURER_URL,
 )
-from .coordinator import ZamgDataUpdateCoordinator
+from .coordinator import ZamgConfigEntry, ZamgDataUpdateCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -174,11 +173,11 @@ API_FIELDS: list[str] = [desc.para_name for desc in SENSOR_TYPES]
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ZamgConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the ZAMG sensor platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     async_add_entities(
         ZamgSensor(coordinator, entry.title, entry.data[CONF_STATION_ID], description)

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from homeassistant.components.weather import WeatherEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     UnitOfPrecipitationDepth,
     UnitOfPressure,
@@ -16,16 +15,16 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, CONF_STATION_ID, DOMAIN, MANUFACTURER_URL
-from .coordinator import ZamgDataUpdateCoordinator
+from .coordinator import ZamgConfigEntry, ZamgDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ZamgConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the ZAMG weather platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_entities(
         [ZamgWeather(coordinator, entry.title, entry.data[CONF_STATION_ID])]
     )


### PR DESCRIPTION
## Proposed change

Migrate the `zamg` integration to use `ConfigEntry.runtime_data` instead of storing the coordinator in `hass.data[DOMAIN][entry.entry_id]`.

- Add a `ZamgConfigEntry` typed alias (`ConfigEntry[ZamgDataUpdateCoordinator]`) in `coordinator.py`.
- Update `__init__.py`, `sensor.py`, and `weather.py` to use the typed config entry and `entry.runtime_data`.
- Simplify `async_unload_entry` now that `hass.data` bookkeeping is no longer required.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr