### PR TITLE
Use HassKey in zeroconf

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -26,9 +26,8 @@ from homeassistant.loader import async_get_homekit, async_get_zeroconf
 from homeassistant.setup import async_when_setup_or_start
 
 from . import websocket_api
-from .const import DATA_COMPONENT, DOMAIN, ZEROCONF_TYPE
+from .const import DATA_DISCOVERY, DATA_INSTANCE, DOMAIN, ZEROCONF_TYPE
 from .discovery import (  # noqa: F401
-    DATA_DISCOVERY,
     ZeroconfDiscovery,
     build_homekit_model_lookups,
     info_from_service,
@@ -89,8 +88,8 @@ def async_get_async_zeroconf(hass: HomeAssistant) -> HaAsyncZeroconf:
 
 
 def _async_get_instance(hass: HomeAssistant) -> HaAsyncZeroconf:
-    if DATA_COMPONENT in hass.data:
-        return hass.data[DATA_COMPONENT]
+    if DATA_INSTANCE in hass.data:
+        return hass.data[DATA_INSTANCE]
 
     zeroconf = HaZeroconf(**_async_get_zc_args(hass))
     aio_zc = HaAsyncZeroconf(zc=zeroconf)
@@ -104,7 +103,7 @@ def _async_get_instance(hass: HomeAssistant) -> HaAsyncZeroconf:
     # Wait to the close event to shutdown zeroconf to give
     # integrations time to send a good bye message
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_stop_zeroconf)
-    hass.data[DATA_COMPONENT] = aio_zc
+    hass.data[DATA_INSTANCE] = aio_zc
 
     return aio_zc
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.loader import async_get_homekit, async_get_zeroconf
 from homeassistant.setup import async_when_setup_or_start
 
 from . import websocket_api
-from .const import DOMAIN, ZEROCONF_TYPE
+from .const import DATA_COMPONENT, DOMAIN, ZEROCONF_TYPE
 from .discovery import (  # noqa: F401
     DATA_DISCOVERY,
     ZeroconfDiscovery,
@@ -89,8 +89,8 @@ def async_get_async_zeroconf(hass: HomeAssistant) -> HaAsyncZeroconf:
 
 
 def _async_get_instance(hass: HomeAssistant) -> HaAsyncZeroconf:
-    if DOMAIN in hass.data:
-        return cast(HaAsyncZeroconf, hass.data[DOMAIN])
+    if DATA_COMPONENT in hass.data:
+        return hass.data[DATA_COMPONENT]
 
     zeroconf = HaZeroconf(**_async_get_zc_args(hass))
     aio_zc = HaAsyncZeroconf(zc=zeroconf)
@@ -104,7 +104,7 @@ def _async_get_instance(hass: HomeAssistant) -> HaAsyncZeroconf:
     # Wait to the close event to shutdown zeroconf to give
     # integrations time to send a good bye message
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_stop_zeroconf)
-    hass.data[DOMAIN] = aio_zc
+    hass.data[DATA_COMPONENT] = aio_zc
 
     return aio_zc
 

--- a/homeassistant/components/zeroconf/const.py
+++ b/homeassistant/components/zeroconf/const.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.util.hass_dict import HassKey
 
 if TYPE_CHECKING:
+    from .discovery import ZeroconfDiscovery
     from .models import HaAsyncZeroconf
 
 DOMAIN = "zeroconf"
@@ -15,4 +16,5 @@ ZEROCONF_TYPE = "_home-assistant._tcp.local."
 
 REQUEST_TIMEOUT = 10000  # 10 seconds
 
-DATA_COMPONENT: HassKey[HaAsyncZeroconf] = HassKey(DOMAIN)
+DATA_INSTANCE: HassKey[HaAsyncZeroconf] = HassKey(DOMAIN)
+DATA_DISCOVERY: HassKey[ZeroconfDiscovery] = HassKey(f"{DOMAIN}_discovery")

--- a/homeassistant/components/zeroconf/const.py
+++ b/homeassistant/components/zeroconf/const.py
@@ -1,7 +1,18 @@
 """Zeroconf constants."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from .models import HaAsyncZeroconf
+
 DOMAIN = "zeroconf"
 
 ZEROCONF_TYPE = "_home-assistant._tcp.local."
 
 REQUEST_TIMEOUT = 10000  # 10 seconds
+
+DATA_COMPONENT: HassKey[HaAsyncZeroconf] = HassKey(DOMAIN)

--- a/homeassistant/components/zeroconf/discovery.py
+++ b/homeassistant/components/zeroconf/discovery.py
@@ -26,9 +26,7 @@ from homeassistant.helpers.service_info.zeroconf import (
 from homeassistant.loader import HomeKitDiscoveredIntegration, ZeroconfMatcher
 
 from .const import DOMAIN, REQUEST_TIMEOUT
-
-if TYPE_CHECKING:
-    from .models import HaZeroconf
+from .models import HaZeroconf
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zeroconf/discovery.py
+++ b/homeassistant/components/zeroconf/discovery.py
@@ -24,7 +24,6 @@ from homeassistant.helpers.service_info.zeroconf import (
     ZeroconfServiceInfo as _ZeroconfServiceInfo,
 )
 from homeassistant.loader import HomeKitDiscoveredIntegration, ZeroconfMatcher
-from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN, REQUEST_TIMEOUT
 
@@ -51,9 +50,6 @@ ATTR_NAME: Final = "name"
 ATTR_PROPERTIES: Final = "properties"
 
 DUPLICATE_INSTANCE_ID_ISSUE_ID = "duplicate_instance_id"
-
-
-DATA_DISCOVERY: HassKey[ZeroconfDiscovery] = HassKey("zeroconf_discovery")
 
 
 def build_homekit_model_lookups(

--- a/homeassistant/components/zeroconf/websocket_api.py
+++ b/homeassistant/components/zeroconf/websocket_api.py
@@ -17,8 +17,8 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.json import json_bytes
 
-from .const import DATA_COMPONENT, REQUEST_TIMEOUT
-from .discovery import DATA_DISCOVERY, ZeroconfDiscovery
+from .const import DATA_DISCOVERY, DATA_INSTANCE, REQUEST_TIMEOUT
+from .discovery import ZeroconfDiscovery
 from .models import HaAsyncZeroconf
 
 _LOGGER = logging.getLogger(__name__)
@@ -157,7 +157,7 @@ async def ws_subscribe_discovery(
 ) -> None:
     """Handle subscribe advertisements websocket command."""
     discovery = hass.data[DATA_DISCOVERY]
-    aiozc = hass.data[DATA_COMPONENT]
+    aiozc = hass.data[DATA_INSTANCE]
     await _DiscoverySubscription(
         hass, connection, msg["id"], aiozc, discovery
     ).async_start()

--- a/homeassistant/components/zeroconf/websocket_api.py
+++ b/homeassistant/components/zeroconf/websocket_api.py
@@ -17,7 +17,7 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.json import json_bytes
 
-from .const import DOMAIN, REQUEST_TIMEOUT
+from .const import DATA_COMPONENT, REQUEST_TIMEOUT
 from .discovery import DATA_DISCOVERY, ZeroconfDiscovery
 from .models import HaAsyncZeroconf
 
@@ -157,7 +157,7 @@ async def ws_subscribe_discovery(
 ) -> None:
     """Handle subscribe advertisements websocket command."""
     discovery = hass.data[DATA_DISCOVERY]
-    aiozc: HaAsyncZeroconf = hass.data[DOMAIN]
+    aiozc = hass.data[DATA_COMPONENT]
     await _DiscoverySubscription(
         hass, connection, msg["id"], aiozc, discovery
     ).async_start()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use a typed `HassKey` for the shared `HaAsyncZeroconf` instance stored in `hass.data`, following the pattern recently applied to `hassio` (see #168400). This drops the `cast(HaAsyncZeroconf, ...)` and manual type annotations at each access site.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->