### PR TITLE
Improve Supervisor update entity progress and data refresh

### DIFF
--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -31,16 +31,21 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     ATTR_ADDONS,
     ATTR_AUTO_UPDATE,
+    ATTR_DATA,
     ATTR_REPOSITORIES,
     ATTR_REPOSITORY,
     ATTR_SLUG,
+    ATTR_STARTUP,
+    ATTR_UPDATE_KEY,
     ATTR_URL,
     ATTR_VERSION,
+    ATTR_WS_EVENT,
     CONTAINER_STATS,
     CORE_CONTAINER,
     DATA_ADDONS_INFO,
@@ -63,11 +68,15 @@ from .const import (
     DATA_SUPERVISOR_INFO,
     DATA_SUPERVISOR_STATS,
     DOMAIN,
+    EVENT_SUPERVISOR_EVENT,
+    EVENT_SUPERVISOR_UPDATE,
     HASSIO_ADDON_UPDATE_INTERVAL,
     HASSIO_MAIN_UPDATE_INTERVAL,
     HASSIO_STATS_UPDATE_INTERVAL,
     REQUEST_REFRESH_DELAY,
+    STARTUP_COMPLETE,
     SUPERVISOR_CONTAINER,
+    UPDATE_KEY_SUPERVISOR,
     SupervisorEntityModel,
 )
 from .handler import get_supervisor_client
@@ -658,6 +667,19 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.is_hass_os = False
         self.supervisor_client = get_supervisor_client(hass)
         self.jobs = SupervisorJobs(hass)
+        self._dispatcher_disconnect = async_dispatcher_connect(
+            hass, EVENT_SUPERVISOR_EVENT, self._supervisor_event
+        )
+
+    @callback
+    def _supervisor_event(self, event: dict[str, Any]) -> None:
+        """Refresh coordinator data when Supervisor restarts after an update."""
+        if (
+            event.get(ATTR_WS_EVENT) == EVENT_SUPERVISOR_UPDATE
+            and event.get(ATTR_UPDATE_KEY) == UPDATE_KEY_SUPERVISOR
+            and event.get(ATTR_DATA, {}).get(ATTR_STARTUP) == STARTUP_COMPLETE
+        ):
+            self.config_entry.async_create_task(self.hass, self.async_request_refresh())
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
@@ -797,4 +819,5 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     @callback
     def unload(self) -> None:
         """Clean up when config entry unloaded."""
+        self._dispatcher_disconnect()
         self.jobs.unload()

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -315,6 +315,12 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
     def _update_job_changed(self, job: Job) -> None:
         """Process update for this entity's update job."""
         if job.done is False:
+            # Also covers updates not initiated via async_install (CLI,
+            # Supervisor self-update): capture the baseline so the installing
+            # state survives the Supervisor restart phase.
+            if not self._update_ongoing:
+                self._version_before_update = self.installed_version
+                self._update_ongoing = True
             self._attr_in_progress = True
             self._attr_update_percentage = job.progress
         else:

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -229,10 +229,29 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
 
 
 class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
-    """Update entity to handle updates for the Home Assistant Supervisor."""
+    """Update entity to handle updates for the Home Assistant Supervisor.
 
-    _attr_supported_features = UpdateEntityFeature.INSTALL
+    The Supervisor update API blocks for the entire container download, then
+    Supervisor restarts itself. The base UpdateEntity always resets
+    ``_attr_in_progress`` after ``async_install`` returns, but at that point the
+    restart is still ongoing. ``_update_ongoing`` survives that reset so the UI
+    keeps showing the installing state until the coordinator refreshes with the
+    new version after Supervisor comes back.
+    """
+
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
+    )
     _attr_title = "Home Assistant Supervisor"
+    _update_ongoing: bool = False
+    _version_before_update: str | None = None
+
+    @property
+    def in_progress(self) -> bool | None:
+        """Return combined progress from the update job and restart phase."""
+        if self._update_ongoing:
+            return True
+        return self._attr_in_progress
 
     @property
     def latest_version(self) -> str:
@@ -266,12 +285,51 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
+        self._version_before_update = self.installed_version
+        self._update_ongoing = True
+        self._attr_in_progress = True
+        self.async_write_ha_state()
         try:
             await self.coordinator.supervisor_client.supervisor.update()
         except SupervisorError as err:
+            self._update_ongoing = False
+            self._version_before_update = None
+            self._attr_in_progress = False
+            self.async_write_ha_state()
             raise HomeAssistantError(
                 f"Error updating Home Assistant Supervisor: {err}"
             ) from err
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Clear the ongoing flag once the installed version has changed."""
+        if (
+            self._update_ongoing
+            and self.installed_version != self._version_before_update
+        ):
+            self._update_ongoing = False
+            self._version_before_update = None
+        super()._handle_coordinator_update()
+
+    @callback
+    def _update_job_changed(self, job: Job) -> None:
+        """Process update for this entity's update job."""
+        if job.done is False:
+            self._attr_in_progress = True
+            self._attr_update_percentage = job.progress
+        else:
+            self._attr_in_progress = False
+            self._attr_update_percentage = None
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to progress updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.jobs.subscribe(
+                JobSubscription(self._update_job_changed, name="supervisor_update")
+            )
+        )
 
 
 class SupervisorCoreUpdateEntity(HassioCoreEntity, UpdateEntity):

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -1165,6 +1165,197 @@ async def test_update_supervisor(
     supervisor_client.supervisor.update.assert_called_once()
 
 
+async def test_update_supervisor_progress(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test progress reporting for supervisor update via the update job."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(
+            hass,
+            "hassio",
+            {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
+        )
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    message_id = 0
+    job_uuid = uuid4().hex
+    entity_id = "update.home_assistant_supervisor_update"
+
+    def make_job_message(progress: float, done: bool | None) -> dict[str, Any]:
+        nonlocal message_id
+        message_id += 1
+        return {
+            "id": message_id,
+            "type": "supervisor/event",
+            "data": {
+                "event": "job",
+                "data": {
+                    "uuid": job_uuid,
+                    "created": "2025-09-29T00:00:00.000000+00:00",
+                    "name": "supervisor_update",
+                    "reference": None,
+                    "progress": progress,
+                    "done": done,
+                    "stage": None,
+                    "extra": {"total": 1234567890} if progress > 0 else None,
+                    "errors": [],
+                },
+            },
+        }
+
+    await client.send_json(make_job_message(progress=0, done=None))
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).attributes.get("in_progress") is False
+    assert hass.states.get(entity_id).attributes.get("update_percentage") is None
+
+    await client.send_json(make_job_message(progress=5, done=False))
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).attributes.get("in_progress") is True
+    assert hass.states.get(entity_id).attributes.get("update_percentage") == 5
+
+    await client.send_json(make_job_message(progress=50, done=False))
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).attributes.get("update_percentage") == 50
+
+    await client.send_json(make_job_message(progress=100, done=True))
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).attributes.get("in_progress") is False
+    assert hass.states.get(entity_id).attributes.get("update_percentage") is None
+
+
+async def test_update_supervisor_stays_in_progress_until_restart(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    supervisor_client: AsyncMock,
+    supervisor_info: AsyncMock,
+) -> None:
+    """Test in_progress stays True after install returns, until Supervisor restart."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(
+            hass,
+            "hassio",
+            {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
+        )
+    await hass.async_block_till_done()
+
+    entity_id = "update.home_assistant_supervisor_update"
+    assert hass.states.get(entity_id).attributes.get("in_progress") is False
+
+    supervisor_client.supervisor.update.return_value = None
+    await hass.services.async_call(
+        "update", "install", {"entity_id": entity_id}, blocking=True
+    )
+
+    # The install HTTP call returned, but Supervisor is still restarting.
+    # The base UpdateEntity reset _attr_in_progress; _update_ongoing keeps us in progress.
+    assert hass.states.get(entity_id).attributes.get("in_progress") is True
+
+    # Supervisor comes up with the new version and fires STARTUP_COMPLETE.
+    supervisor_info.return_value = replace(
+        supervisor_info.return_value,
+        version="1.0.1dev222",
+        update_available=False,
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "supervisor/event",
+            "data": {
+                "event": "supervisor_update",
+                "update_key": "supervisor",
+                "data": {"startup": "complete"},
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DELAY + 1)
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).attributes.get("in_progress") is False
+
+
+async def test_update_supervisor_completes_on_any_version_change(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    supervisor_client: AsyncMock,
+    supervisor_info: AsyncMock,
+) -> None:
+    """Test completion is detected when installed version changes from the pre-install one.
+
+    If upstream publishes an even newer release between install-start and the
+    post-restart refresh, installed_version will not equal latest_version but
+    will differ from the pre-install version. _update_ongoing must still clear.
+    """
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(
+            hass,
+            "hassio",
+            {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
+        )
+    await hass.async_block_till_done()
+
+    entity_id = "update.home_assistant_supervisor_update"
+
+    supervisor_client.supervisor.update.return_value = None
+    await hass.services.async_call(
+        "update", "install", {"entity_id": entity_id}, blocking=True
+    )
+    assert hass.states.get(entity_id).attributes.get("in_progress") is True
+
+    supervisor_info.return_value = replace(
+        supervisor_info.return_value,
+        version="1.0.1dev222",
+        version_latest="1.0.2dev223",
+        update_available=True,
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "supervisor/event",
+            "data": {
+                "event": "supervisor_update",
+                "update_key": "supervisor",
+                "data": {"startup": "complete"},
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DELAY + 1)
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).attributes.get("in_progress") is False
+
+
 async def test_update_addon_with_error(
     hass: HomeAssistant,
     update_addon: AsyncMock,

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -1166,9 +1166,17 @@ async def test_update_supervisor(
 
 
 async def test_update_supervisor_progress(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    supervisor_info: AsyncMock,
 ) -> None:
-    """Test progress reporting for supervisor update via the update job."""
+    """Test progress reporting for a Supervisor update that was not initiated via the entity.
+
+    Covers CLI-triggered and Supervisor self-update flows: the entity must
+    show download progress from job events and stay in the installing state
+    across the Supervisor restart until the coordinator observes the new
+    installed version.
+    """
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
 
@@ -1227,12 +1235,41 @@ async def test_update_supervisor_progress(
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).attributes.get("update_percentage") == 50
 
+    # Job done: download finished, Supervisor is about to restart. The entity
+    # must stay in the installing state until the new version is observed.
     await client.send_json(make_job_message(progress=100, done=True))
     msg = await client.receive_json()
     assert msg["success"]
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).attributes.get("in_progress") is False
+    assert hass.states.get(entity_id).attributes.get("in_progress") is True
     assert hass.states.get(entity_id).attributes.get("update_percentage") is None
+
+    # New Supervisor comes up and fires STARTUP_COMPLETE.
+    supervisor_info.return_value = replace(
+        supervisor_info.return_value,
+        version="1.0.1dev222",
+        update_available=False,
+    )
+    await client.send_json(
+        {
+            "id": message_id + 1,
+            "type": "supervisor/event",
+            "data": {
+                "event": "supervisor_update",
+                "update_key": "supervisor",
+                "data": {"startup": "complete"},
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DELAY + 1)
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).attributes.get("in_progress") is False
 
 
 async def test_update_supervisor_stays_in_progress_until_restart(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After a Supervisor update completes, the Supervisor restarts. However, the hassio coordinator still serves stale version data until its next 5-minute scheduled refresh. During that window the Supervisor update entity reports the just-installed version as an available update, and pressing Update again triggers an install against a restarting Supervisor which fails with a confusing error.

Listen for the Supervisor `STARTUP_COMPLETE` event on the coordinator and trigger a debounced refresh, so all entities reflect the real state within seconds of Supervisor coming back online.

Also add progress tracking for Supervisor updates, which previously showed no download progress or installing state (unlike Core and add-on updates). Subscribe to the `supervisor_update` job to surface download progress. The Supervisor update HTTP call returns after the container download completes but while Supervisor is still restarting; the base UpdateEntity resets `_attr_in_progress` at that point. A separate `_update_ongoing flag` - cleared once the coordinator observes a changed installed version - keeps the installing state visible across the restart.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
