### PR TITLE
Drop redundant BackupManager annotation in aws_s3/google_drive diagnostics

### DIFF
--- a/homeassistant/components/aws_s3/diagnostics.py
+++ b/homeassistant/components/aws_s3/diagnostics.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
-from homeassistant.components.backup import (
-    DATA_MANAGER as BACKUP_DATA_MANAGER,
-    BackupManager,
-)
+from homeassistant.components.backup import DATA_MANAGER as BACKUP_DATA_MANAGER
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
@@ -31,7 +28,7 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
-    backup_manager: BackupManager = hass.data[BACKUP_DATA_MANAGER]
+    backup_manager = hass.data[BACKUP_DATA_MANAGER]
     backups = await async_list_backups_from_s3(
         coordinator.client,
         bucket=entry.data[CONF_BUCKET],

--- a/homeassistant/components/google_drive/diagnostics.py
+++ b/homeassistant/components/google_drive/diagnostics.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
-from homeassistant.components.backup import (
-    DATA_MANAGER as BACKUP_DATA_MANAGER,
-    BackupManager,
-)
+from homeassistant.components.backup import DATA_MANAGER as BACKUP_DATA_MANAGER
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
@@ -26,7 +23,7 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
 
     coordinator = entry.runtime_data
-    backup_manager: BackupManager = hass.data[BACKUP_DATA_MANAGER]
+    backup_manager = hass.data[BACKUP_DATA_MANAGER]
 
     backups = await coordinator.client.async_list_backups()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`DATA_MANAGER` in the `backup` integration is already a typed `HassKey[BackupManager]`, so the explicit `BackupManager` annotation on `hass.data[BACKUP_DATA_MANAGER]` in the `aws_s3` and `google_drive` diagnostics modules is redundant. Drop the annotation (and the unused `BackupManager` import) — the type is inferred from the key.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->