### PR TITLE
Add ScorpionTrack integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1522,6 +1522,8 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/schlage/ @dknowles2
 /tests/components/schlage/ @dknowles2
 /homeassistant/components/schluter/ @prairieapps
+/homeassistant/components/scorpiontrack/ @Herbertmt978
+/tests/components/scorpiontrack/ @Herbertmt978
 /homeassistant/components/scrape/ @fabaff @gjohansson-ST
 /tests/components/scrape/ @fabaff @gjohansson-ST
 /homeassistant/components/screenlogic/ @dieselrabbit @bdraco

--- a/homeassistant/components/scorpiontrack/__init__.py
+++ b/homeassistant/components/scorpiontrack/__init__.py
@@ -1,0 +1,54 @@
+"""The ScorpionTrack integration."""
+
+from __future__ import annotations
+
+from pyscorpiontrack import (
+    ScorpionTrackClient,
+    ScorpionTrackConnectionError,
+    ScorpionTrackInvalidTokenError,
+    ScorpionTrackShareUnavailableError,
+)
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import CONF_SHARE_TOKEN, PLATFORMS
+from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ScorpionTrackConfigEntry
+) -> bool:
+    """Set up ScorpionTrack from a config entry."""
+    client = ScorpionTrackClient(
+        session=async_get_clientsession(hass),
+        token=entry.data[CONF_SHARE_TOKEN],
+    )
+    coordinator = ScorpionTrackCoordinator(hass, client, entry)
+
+    try:
+        coordinator.async_set_updated_data(await client.async_get_share())
+    except ScorpionTrackConnectionError as err:
+        raise ConfigEntryNotReady(
+            "Could not reach ScorpionTrack share service"
+        ) from err
+    except ScorpionTrackInvalidTokenError as err:
+        raise ConfigEntryError(
+            "The configured ScorpionTrack share token is invalid"
+        ) from err
+    except ScorpionTrackShareUnavailableError as err:
+        raise ConfigEntryError(
+            "The configured ScorpionTrack share is expired, revoked, or unavailable"
+        ) from err
+
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: ScorpionTrackConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/scorpiontrack/config_flow.py
+++ b/homeassistant/components/scorpiontrack/config_flow.py
@@ -1,0 +1,102 @@
+"""Config flow for ScorpionTrack."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pyscorpiontrack import (
+    ScorpionTrackClient,
+    ScorpionTrackConnectionError,
+    ScorpionTrackInvalidTokenError,
+    ScorpionTrackShareUnavailableError,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import CONF_SHARE_TOKEN, DEFAULT_NAME, DOMAIN
+from .utils import mask_token
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_validate_input(
+    hass: HomeAssistant, user_input: dict[str, Any]
+) -> dict[str, str]:
+    """Validate the provided share token or share URL."""
+    client = ScorpionTrackClient(
+        session=async_get_clientsession(hass),
+        token=user_input[CONF_SHARE_TOKEN],
+    )
+    share = await client.async_get_share()
+
+    if share.title:
+        title = share.title
+    elif share.vehicles:
+        title = share.vehicles[0].display_name
+    else:
+        title = DEFAULT_NAME
+
+    return {
+        "token": share.token,
+        "title": title,
+        "unique_id": str(share.id),
+    }
+
+
+class ScorpionTrackConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for ScorpionTrack."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info = await _async_validate_input(self.hass, user_input)
+            except ScorpionTrackConnectionError as err:
+                _LOGGER.warning(
+                    "ScorpionTrack share validation could not connect for token %s: %s",
+                    mask_token(user_input[CONF_SHARE_TOKEN]),
+                    err,
+                )
+                errors["base"] = "cannot_connect"
+            except ScorpionTrackInvalidTokenError as err:
+                _LOGGER.warning(
+                    "ScorpionTrack share validation rejected token %s: %s",
+                    mask_token(user_input[CONF_SHARE_TOKEN]),
+                    err,
+                )
+                errors["base"] = "invalid_token"
+            except ScorpionTrackShareUnavailableError as err:
+                _LOGGER.warning(
+                    "ScorpionTrack share validation found unavailable share for token %s: %s",
+                    mask_token(user_input[CONF_SHARE_TOKEN]),
+                    err,
+                )
+                errors["base"] = "share_unavailable"
+            except Exception:  # pragma: no cover - defensive logging
+                _LOGGER.exception(
+                    "Unexpected exception while validating ScorpionTrack share"
+                )
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(info["unique_id"])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=info["title"],
+                    data={CONF_SHARE_TOKEN: info["token"]},
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_SHARE_TOKEN): str}),
+            errors=errors,
+        )

--- a/homeassistant/components/scorpiontrack/const.py
+++ b/homeassistant/components/scorpiontrack/const.py
@@ -1,0 +1,19 @@
+"""Constants for the ScorpionTrack integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.const import Platform
+
+DOMAIN = "scorpiontrack"
+DEFAULT_NAME = "ScorpionTrack"
+SHARE_DEVICE_DEFAULT_NAME = "ScorpionTrack Share"
+MANUFACTURER = "ScorpionTrack"
+
+CONF_SHARE_TOKEN = "share_token"
+
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=2)
+STALE_POSITION_THRESHOLD = timedelta(hours=24)
+
+PLATFORMS: tuple[Platform, ...] = (Platform.DEVICE_TRACKER,)

--- a/homeassistant/components/scorpiontrack/coordinator.py
+++ b/homeassistant/components/scorpiontrack/coordinator.py
@@ -1,0 +1,58 @@
+"""Coordinator for ScorpionTrack."""
+
+from __future__ import annotations
+
+import logging
+
+from pyscorpiontrack import (
+    ScorpionTrackClient,
+    ScorpionTrackConnectionError,
+    ScorpionTrackInvalidTokenError,
+    ScorpionTrackShare,
+    ScorpionTrackShareUnavailableError,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+type ScorpionTrackConfigEntry = ConfigEntry[ScorpionTrackCoordinator]
+
+
+class ScorpionTrackCoordinator(DataUpdateCoordinator[ScorpionTrackShare]):
+    """Coordinate shared-location updates."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: ScorpionTrackClient,
+        entry: ScorpionTrackConfigEntry,
+    ) -> None:
+        """Initialize the coordinator."""
+        self.client = client
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN}_{entry.entry_id}",
+            update_interval=DEFAULT_SCAN_INTERVAL,
+            always_update=False,
+        )
+
+    async def _async_update_data(self) -> ScorpionTrackShare:
+        """Fetch updated share data."""
+        try:
+            return await self.client.async_get_share()
+        except ScorpionTrackConnectionError as err:
+            raise UpdateFailed(f"Could not reach ScorpionTrack: {err}") from err
+        except ScorpionTrackInvalidTokenError as err:
+            raise UpdateFailed(
+                f"ScorpionTrack rejected the configured share token: {err}"
+            ) from err
+        except ScorpionTrackShareUnavailableError as err:
+            raise UpdateFailed(f"Shared location is unavailable: {err}") from err

--- a/homeassistant/components/scorpiontrack/device_tracker.py
+++ b/homeassistant/components/scorpiontrack/device_tracker.py
@@ -1,0 +1,116 @@
+"""Device tracker platform for ScorpionTrack."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ScorpionTrackConfigEntry
+from .entity import ScorpionTrackEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ScorpionTrackConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up ScorpionTrack tracker entities."""
+    coordinator = entry.runtime_data
+    known_vehicle_ids: set[int] = set()
+
+    @callback
+    def _async_add_missing_entities() -> None:
+        new_vehicle_ids = [
+            vehicle.id
+            for vehicle in coordinator.data.vehicles
+            if vehicle.id not in known_vehicle_ids
+        ]
+        if not new_vehicle_ids:
+            return
+
+        known_vehicle_ids.update(new_vehicle_ids)
+        async_add_entities(
+            ScorpionTrackTrackerEntity(coordinator, vehicle_id)
+            for vehicle_id in new_vehicle_ids
+        )
+
+    _async_add_missing_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_async_add_missing_entities))
+
+
+class ScorpionTrackTrackerEntity(ScorpionTrackEntity, TrackerEntity):
+    """Represent the latest shared GPS location for a vehicle."""
+
+    _attr_has_entity_name = False
+    _attr_icon = "mdi:car"
+    _attr_location_accuracy = 0.0
+    _attr_source_type = SourceType.GPS
+
+    def __init__(self, coordinator, vehicle_id: int) -> None:
+        """Initialize the tracker."""
+        super().__init__(coordinator, vehicle_id)
+        self._attr_unique_id = f"{coordinator.data.id}_{vehicle_id}_tracker"
+
+    @property
+    def name(self) -> str:
+        """Return the vehicle-facing tracker label used on the map."""
+        vehicle = self.get_vehicle()
+        if vehicle is None:
+            return self._cached_registration or self._cached_display_name
+        return vehicle.registration or vehicle.display_name
+
+    @property
+    def available(self) -> bool:
+        """Return if the tracker is available."""
+        vehicle = self.get_vehicle()
+        return (
+            super().available
+            and vehicle is not None
+            and vehicle.position.latitude is not None
+            and vehicle.position.longitude is not None
+        )
+
+    @property
+    def latitude(self) -> float | None:
+        """Return the latitude."""
+        vehicle = self.get_vehicle()
+        if vehicle is None:
+            return None
+        return vehicle.position.latitude
+
+    @property
+    def longitude(self) -> float | None:
+        """Return the longitude."""
+        vehicle = self.get_vehicle()
+        if vehicle is None:
+            return None
+        return vehicle.position.longitude
+
+    @property
+    def location_accuracy(self) -> float:
+        """Return the location accuracy in meters."""
+        return 0.0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        vehicle = self.get_vehicle()
+        position = vehicle.position if vehicle else None
+        converted_speed = self.share.convert_speed(
+            position.speed_kmh if position else None
+        )
+        attributes = self.common_location_attributes()
+        attributes.update(
+            {
+                "speed": converted_speed,
+                "speed_unit": "mph" if self.share.uses_miles else "km/h",
+                "speed_kmh": position.speed_kmh if position else None,
+                "distance_units": self.share.distance_units,
+            }
+        )
+        return attributes

--- a/homeassistant/components/scorpiontrack/entity.py
+++ b/homeassistant/components/scorpiontrack/entity.py
@@ -1,0 +1,156 @@
+"""Shared entity helpers for ScorpionTrack."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from pyscorpiontrack import ScorpionTrackShare, ScorpionTrackVehicle
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN, MANUFACTURER, STALE_POSITION_THRESHOLD
+from .coordinator import ScorpionTrackCoordinator
+
+
+class ScorpionTrackEntity(CoordinatorEntity[ScorpionTrackCoordinator]):
+    """Base class for ScorpionTrack vehicle entities."""
+
+    def __init__(self, coordinator: ScorpionTrackCoordinator, vehicle_id: int) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._vehicle_id = vehicle_id
+        self._device_identifier = (DOMAIN, f"{self.share.id}_{vehicle_id}")
+        self._cached_display_name = f"Vehicle {vehicle_id}"
+        self._cached_registration: str | None = None
+        self._cached_manufacturer = MANUFACTURER
+        self._cached_model: str | None = None
+
+        if vehicle := self.get_vehicle():
+            self._cache_vehicle_metadata(vehicle)
+
+    def _cache_vehicle_metadata(self, vehicle: ScorpionTrackVehicle) -> None:
+        """Cache the latest immutable vehicle metadata."""
+        self._cached_display_name = vehicle.display_name
+        self._cached_registration = vehicle.registration
+        self._cached_manufacturer = vehicle.make or MANUFACTURER
+        self._cached_model = vehicle.model
+
+    @property
+    def share(self) -> ScorpionTrackShare:
+        """Return the active share data."""
+        return self.coordinator.data
+
+    def get_vehicle(self) -> ScorpionTrackVehicle | None:
+        """Return the matching vehicle, if present."""
+        for vehicle in self.share.vehicles:
+            if vehicle.id == self._vehicle_id:
+                self._cache_vehicle_metadata(vehicle)
+                return vehicle
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return if the entity is available."""
+        return super().available and self.get_vehicle() is not None
+
+    def position_age(self) -> timedelta | None:
+        """Return the age of the latest reported position."""
+        vehicle = self.get_vehicle()
+        if vehicle is None:
+            return None
+
+        timestamp = vehicle.position.timestamp
+        if timestamp is None:
+            return None
+
+        age = dt_util.utcnow() - timestamp
+        if age.total_seconds() < 0:
+            return timedelta(seconds=0)
+        return age
+
+    def position_is_stale(self) -> bool:
+        """Return True if the latest reported position is stale."""
+        age = self.position_age()
+        return age is None or age >= STALE_POSITION_THRESHOLD
+
+    def common_location_attributes(
+        self,
+        *,
+        include_coordinates: bool = False,
+    ) -> dict[str, Any]:
+        """Return shared location-related attributes."""
+        vehicle = self.get_vehicle()
+        position = vehicle.position if vehicle else None
+        age = self.position_age()
+        age_seconds = max(0, int(age.total_seconds())) if age is not None else None
+
+        attributes = {
+            "registration": vehicle.registration
+            if vehicle
+            else self._cached_registration,
+            "make": vehicle.make if vehicle else self._cached_manufacturer,
+            "model": vehicle.model if vehicle else self._cached_model,
+            "status": vehicle.status if vehicle else None,
+            "bearing": position.bearing if position else None,
+            "heading_cardinal": _bearing_to_cardinal(
+                position.bearing if position else None
+            ),
+            "address": position.address if position else None,
+            "ignition": position.ignition if position else None,
+            "last_reported": position.timestamp.isoformat()
+            if position and position.timestamp
+            else None,
+            "last_reported_age_seconds": age_seconds,
+            "stale": self.position_is_stale(),
+            "stale_after_hours": int(STALE_POSITION_THRESHOLD.total_seconds() // 3600),
+            "removed_from_share": vehicle is None,
+            "share_title": self.share.title,
+            "shared_by": self.share.owner_name,
+            "share_expires": self.share.expires_at.isoformat()
+            if self.share.expires_at
+            else None,
+        }
+        if include_coordinates:
+            attributes["latitude"] = position.latitude if position else None
+            attributes["longitude"] = position.longitude if position else None
+        return attributes
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device metadata for the vehicle."""
+        return DeviceInfo(
+            identifiers={self._device_identifier},
+            manufacturer=self._cached_manufacturer,
+            model=self._cached_model,
+            name=self._cached_display_name,
+        )
+
+
+def _bearing_to_cardinal(bearing: float | None) -> str | None:
+    """Convert a numeric bearing into a cardinal heading."""
+    if bearing is None:
+        return None
+
+    directions = (
+        "N",
+        "NNE",
+        "NE",
+        "ENE",
+        "E",
+        "ESE",
+        "SE",
+        "SSE",
+        "S",
+        "SSW",
+        "SW",
+        "WSW",
+        "W",
+        "WNW",
+        "NW",
+        "NNW",
+    )
+    index = int((bearing % 360) / 22.5 + 0.5) % len(directions)
+    return directions[index]

--- a/homeassistant/components/scorpiontrack/manifest.json
+++ b/homeassistant/components/scorpiontrack/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "scorpiontrack",
+  "name": "ScorpionTrack",
+  "codeowners": ["@Herbertmt978"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/scorpiontrack",
+  "integration_type": "hub",
+  "iot_class": "cloud_polling",
+  "loggers": ["pyscorpiontrack"],
+  "quality_scale": "bronze",
+  "requirements": ["pyscorpiontrack==0.1.0"]
+}

--- a/homeassistant/components/scorpiontrack/quality_scale.yaml
+++ b/homeassistant/components/scorpiontrack/quality_scale.yaml
@@ -1,0 +1,83 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not provide actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: This integration does not provide actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: This integration does not provide actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration does not provide an options flow.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      ScorpionTrack share links are public tokens rather than account credentials.
+      Replacing an expired or revoked share requires configuring a new share link.
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery:
+    status: exempt
+    comment: This cloud polling integration has no discovery mechanism.
+  discovery-update-info:
+    status: exempt
+    comment: This cloud polling integration has no discovery mechanism.
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category:
+    status: exempt
+    comment: The integration only creates primary device_tracker entities.
+  entity-device-class:
+    status: exempt
+    comment: Device tracker entities do not use device classes.
+  entity-disabled-by-default:
+    status: exempt
+    comment: The device_tracker entity is the primary entity and should be enabled by default.
+  entity-translations: done
+  exception-translations: todo
+  icon-translations:
+    status: exempt
+    comment: The integration uses a static icon and has no translated icon states.
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: done
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/scorpiontrack/strings.json
+++ b/homeassistant/components/scorpiontrack/strings.json
@@ -1,0 +1,25 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "This shared location is already configured."
+    },
+    "error": {
+      "cannot_connect": "The ScorpionTrack share could not be reached right now.",
+      "invalid_token": "Your shared-location link is invalid or incomplete.",
+      "share_unavailable": "Your shared-location link is invalid, expired, has been revoked, or no longer returns data.",
+      "unknown": "An unexpected error occurred."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "share_token": "Share URL or token"
+        },
+        "data_description": {
+          "share_token": "Paste the full ScorpionTrack shared-location URL or just the token itself."
+        },
+        "description": "Paste a ScorpionTrack shared-location URL or the token from that URL.",
+        "title": "Connect a ScorpionTrack share"
+      }
+    }
+  }
+}

--- a/homeassistant/components/scorpiontrack/utils.py
+++ b/homeassistant/components/scorpiontrack/utils.py
@@ -1,0 +1,13 @@
+"""Small shared helpers for ScorpionTrack."""
+
+from __future__ import annotations
+
+
+def mask_token(value: str, *, visible: int = 4) -> str:
+    """Return a lightly redacted token for logging."""
+    cleaned = value.strip()
+    if not cleaned:
+        return "<empty>"
+    if len(cleaned) <= visible * 2:
+        return "*" * len(cleaned)
+    return f"{cleaned[:visible]}...{cleaned[-visible:]}"

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -633,6 +633,7 @@ FLOWS = {
         "satel_integra",
         "saunum",
         "schlage",
+        "scorpiontrack",
         "scrape",
         "screenlogic",
         "season",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6081,6 +6081,12 @@
       "integration_type": "virtual",
       "supported_by": "opower"
     },
+    "scorpiontrack": {
+      "name": "ScorpionTrack",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "scrape": {
       "name": "Scrape",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2472,6 +2472,9 @@ pysaunum==0.6.0
 # homeassistant.components.schlage
 pyschlage==2025.9.0
 
+# homeassistant.components.scorpiontrack
+pyscorpiontrack==0.1.0
+
 # homeassistant.components.sensibo
 pysensibo==1.2.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2116,6 +2116,9 @@ pysaunum==0.6.0
 # homeassistant.components.schlage
 pyschlage==2025.9.0
 
+# homeassistant.components.scorpiontrack
+pyscorpiontrack==0.1.0
+
 # homeassistant.components.sensibo
 pysensibo==1.2.1
 

--- a/tests/components/scorpiontrack/__init__.py
+++ b/tests/components/scorpiontrack/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for the ScorpionTrack integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the ScorpionTrack integration."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/scorpiontrack/conftest.py
+++ b/tests/components/scorpiontrack/conftest.py
@@ -1,0 +1,98 @@
+"""Test fixtures for the ScorpionTrack integration."""
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from pyscorpiontrack import (
+    ScorpionTrackPosition,
+    ScorpionTrackShare,
+    ScorpionTrackVehicle,
+)
+import pytest
+
+from homeassistant.components.scorpiontrack.const import CONF_SHARE_TOKEN, DOMAIN
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_share() -> ScorpionTrackShare:
+    """Return a representative ScorpionTrack share."""
+    return ScorpionTrackShare(
+        id=101,
+        token="canonical-token",
+        title="Family Cars",
+        owner_name="Ashby Herbert",
+        distance_units="miles",
+        created_at=datetime(2026, 4, 20, 19, 0, tzinfo=UTC),
+        expires_at=datetime(2026, 5, 20, 19, 0, tzinfo=UTC),
+        vehicles=(
+            ScorpionTrackVehicle(
+                id=1,
+                name="Golf R",
+                registration="AB12 CDE",
+                make="Volkswagen",
+                model="Golf R",
+                position=ScorpionTrackPosition(
+                    latitude=51.5074,
+                    longitude=-0.1278,
+                    timestamp=datetime(2026, 4, 21, 7, 0, tzinfo=UTC),
+                    speed_kmh=48.3,
+                    ignition=True,
+                    bearing=182.0,
+                    address="Westminster, London",
+                ),
+                status="Moving",
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Family Cars",
+        data={CONF_SHARE_TOKEN: "canonical-token"},
+        unique_id="101",
+        entry_id="01SCORPIONTRACK_TEST_ENTRY",
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_scorpiontrack_client(mock_share: ScorpionTrackShare) -> Generator[AsyncMock]:
+    """Mock the ScorpionTrack client."""
+    with (
+        patch(
+            "homeassistant.components.scorpiontrack.ScorpionTrackClient",
+            autospec=True,
+        ) as mock_client,
+        patch(
+            "homeassistant.components.scorpiontrack.config_flow.ScorpionTrackClient",
+            new=mock_client,
+        ),
+    ):
+        client = mock_client.return_value
+        client.token = "canonical-token"
+        client.async_get_share.return_value = mock_share
+        yield client
+
+
+@pytest.fixture
+def ignore_missing_translations(request: pytest.FixtureRequest) -> list[str]:
+    """Ignore known core translation gaps only for tests that set up platforms."""
+    if request.node.originalname in {
+        "test_user_flow_creates_entry",
+        "test_setup_entry",
+        "test_device_tracker_state",
+        "test_device_is_registered",
+        "test_removed_vehicle_becomes_unavailable",
+    }:
+        return [
+            "component.device_tracker.services.see.",
+            "component.zone.services.reload.",
+        ]
+
+    return []

--- a/tests/components/scorpiontrack/test_config_flow.py
+++ b/tests/components/scorpiontrack/test_config_flow.py
@@ -1,0 +1,104 @@
+"""Test the ScorpionTrack config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from pyscorpiontrack import (
+    ScorpionTrackConnectionError,
+    ScorpionTrackInvalidTokenError,
+    ScorpionTrackShareUnavailableError,
+)
+import pytest
+
+from homeassistant.components.scorpiontrack.const import CONF_SHARE_TOKEN, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+VALIDATION_INFO = {
+    "token": "canonical-token",
+    "title": "Family Cars",
+    "unique_id": "101",
+}
+
+
+async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
+    """A valid token should create a config entry."""
+    with patch(
+        "homeassistant.components.scorpiontrack.config_flow._async_validate_input",
+        return_value=VALIDATION_INFO,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data={
+                CONF_SHARE_TOKEN: "https://app.scorpiontrack.com/shared/location?token=abc"
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Family Cars"
+    assert result["data"] == {CONF_SHARE_TOKEN: "canonical-token"}
+
+
+async def test_user_flow_aborts_for_existing_share(hass: HomeAssistant) -> None:
+    """The same share should not be configured twice."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Family Cars",
+        unique_id="101",
+        data={CONF_SHARE_TOKEN: "existing-token"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.scorpiontrack.config_flow._async_validate_input",
+        return_value=VALIDATION_INFO,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data={CONF_SHARE_TOKEN: "new-token"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (
+            ScorpionTrackConnectionError("Connection failed"),
+            "cannot_connect",
+        ),
+        (ScorpionTrackInvalidTokenError("Invalid token"), "invalid_token"),
+        (
+            ScorpionTrackShareUnavailableError("Share expired"),
+            "share_unavailable",
+        ),
+        (Exception("Unexpected error"), "unknown"),
+    ],
+)
+async def test_user_flow_shows_validation_errors(
+    hass: HomeAssistant,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Validation errors should surface the correct base error."""
+    with patch(
+        "homeassistant.components.scorpiontrack.config_flow._async_validate_input",
+        side_effect=side_effect,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data={CONF_SHARE_TOKEN: "canonical-token"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": expected_error}

--- a/tests/components/scorpiontrack/test_device_tracker.py
+++ b/tests/components/scorpiontrack/test_device_tracker.py
@@ -1,0 +1,73 @@
+"""Test the ScorpionTrack device tracker platform."""
+
+from dataclasses import replace
+
+from pyscorpiontrack import ScorpionTrackShare
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_device_tracker_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the ScorpionTrack device tracker state and attributes."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("device_tracker.ab12_cde")
+    assert state is not None
+    assert state.state == "not_home"
+    assert state.attributes["latitude"] == 51.5074
+    assert state.attributes["longitude"] == -0.1278
+    assert state.attributes["gps_accuracy"] == 0.0
+    assert state.attributes["source_type"] == "gps"
+    assert state.attributes["address"] == "Westminster, London"
+    assert state.attributes["speed"] == 30.0
+    assert state.attributes["speed_unit"] == "mph"
+
+    entity_entry = entity_registry.async_get("device_tracker.ab12_cde")
+    assert entity_entry is not None
+    assert entity_entry.original_name == "AB12 CDE"
+
+
+async def test_device_is_registered(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the ScorpionTrack vehicle device is registered."""
+    await setup_integration(hass, mock_config_entry)
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={("scorpiontrack", "101_1")})
+    assert device is not None
+    assert device.name == "AB12 CDE"
+    assert device.manufacturer == "Volkswagen"
+    assert device.model == "Golf R"
+
+
+async def test_removed_vehicle_becomes_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+) -> None:
+    """Test a tracker becomes unavailable if its vehicle leaves the share."""
+    await setup_integration(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    coordinator.async_set_updated_data(replace(mock_share, vehicles=()))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.ab12_cde")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={("scorpiontrack", "101_1")})
+    assert device is not None
+    assert device.name == "AB12 CDE"

--- a/tests/components/scorpiontrack/test_init.py
+++ b/tests/components/scorpiontrack/test_init.py
@@ -1,0 +1,61 @@
+"""Test ScorpionTrack integration setup."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from pyscorpiontrack import (
+    ScorpionTrackConnectionError,
+    ScorpionTrackInvalidTokenError,
+    ScorpionTrackShareUnavailableError,
+)
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test successful setup and unload of entry."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_state"),
+    [
+        (ScorpionTrackInvalidTokenError("Invalid token"), ConfigEntryState.SETUP_ERROR),
+        (
+            ScorpionTrackShareUnavailableError("Share expired"),
+            ConfigEntryState.SETUP_ERROR,
+        ),
+        (
+            ScorpionTrackConnectionError("Connection failed"),
+            ConfigEntryState.SETUP_RETRY,
+        ),
+    ],
+)
+async def test_setup_entry_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+    exception: Exception,
+    expected_state: ConfigEntryState,
+) -> None:
+    """Test setup with token and connection errors."""
+    mock_scorpiontrack_client.async_get_share.side_effect = exception
+
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is expected_state


### PR DESCRIPTION
## Summary
- add a new `scorpiontrack` integration for ScorpionTrack shared-location links
- expose one `device_tracker` per shared vehicle so each vehicle appears directly on the Home Assistant map
- handle vehicles being removed from a share without crashing entity updates, and add the quality scale metadata needed for the initial Core submission

## Context
ScorpionTrack offers public shared-location links for vehicles. This PR intentionally keeps the first Core submission focused on that share-link flow instead of the larger account-login surface so the initial review stays small, understandable, and easy to validate.

## External library
- repo: https://github.com/Herbertmt978/python-scorpiontrack
- PyPI: https://pypi.org/project/pyscorpiontrack/0.1.0/

## Related PRs
- docs: home-assistant/home-assistant.io#44885
- brands: home-assistant/brands#10182

## Local validation
- `python -m ruff check homeassistant/components/scorpiontrack tests/components/scorpiontrack`
- `python -m compileall homeassistant/components/scorpiontrack tests/components/scorpiontrack`
- `python -m script.hassfest --integration-path homeassistant/components/scorpiontrack`
- `python -m pytest tests/components/scorpiontrack -q` in an isolated Linux Docker Home Assistant test environment