### PR TITLE
Deprecate firing events to event bus in HTML5 integration

### DIFF
--- a/homeassistant/components/html5/issue.py
+++ b/homeassistant/components/html5/issue.py
@@ -52,3 +52,47 @@ def deprecated_dismiss_action_call(hass: HomeAssistant) -> None:
             "new_action": "html5.dismiss_message",
         },
     )
+
+
+@callback
+def deprecated_event_bus(hass: HomeAssistant, event: str) -> None:
+    """Raise a deprecation issue for listeners on the event bus."""
+
+    if listeners := hass.bus.async_listeners().get(event):
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"deprecated_event_bus_{event}",
+            breaks_in_ha_version="2026.11.0",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_event_bus",
+            translation_placeholders={
+                "event": event,
+                "listeners": str(listeners),
+                "example_yaml": """
+```yaml
+triggers:
+  - trigger: state
+    entity_id:
+      - event.my_device
+    not_from:
+      - unavailable
+conditions:
+  - condition: template
+    value_template: |
+      "{{ trigger.to_state.attributes.event_type == 'clicked' }}"
+```
+""",
+                "example_yaml_trigger": """```yaml
+triggers:
+  - trigger: event.received
+    target:
+      entity_id: event.my_device
+    options:
+      event_type:
+        - received
+```
+""",
+            },
+        )

--- a/homeassistant/components/html5/issue.py
+++ b/homeassistant/components/html5/issue.py
@@ -63,28 +63,14 @@ def deprecated_event_bus(hass: HomeAssistant, event: str) -> None:
             hass,
             DOMAIN,
             f"deprecated_event_bus_{event}",
-            breaks_in_ha_version="2026.11.0",
+            breaks_in_ha_version="2027.1.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_event_bus",
             translation_placeholders={
                 "event": event,
                 "listeners": str(listeners),
-                "example_yaml": """
-```yaml
-triggers:
-  - trigger: state
-    entity_id:
-      - event.my_device
-    not_from:
-      - unavailable
-conditions:
-  - condition: template
-    value_template: |
-      "{{ trigger.to_state.attributes.event_type == 'clicked' }}"
-```
-""",
-                "example_yaml_trigger": """```yaml
+                "example_yaml": """```yaml
 triggers:
   - trigger: event.received
     target:

--- a/homeassistant/components/html5/issue.py
+++ b/homeassistant/components/html5/issue.py
@@ -63,7 +63,7 @@ def deprecated_event_bus(hass: HomeAssistant, event: str) -> None:
             hass,
             DOMAIN,
             f"deprecated_event_bus_{event}",
-            breaks_in_ha_version="2027.1.0",
+            breaks_in_ha_version="2027.2.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_event_bus",

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -60,7 +60,11 @@ from .const import (
     SERVICE_DISMISS,
 )
 from .entity import HTML5Entity, Registration
-from .issue import deprecated_dismiss_action_call, deprecated_notify_action_call
+from .issue import (
+    deprecated_dismiss_action_call,
+    deprecated_event_bus,
+    deprecated_notify_action_call,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -408,6 +412,9 @@ class HTML5PushCallbackView(HomeAssistantView):
             event_payload[ATTR_TYPE],
             event_payload,
         )
+
+        deprecated_event_bus(hass, event_name)
+
         return self.json({"status": "ok", "event": event_payload[ATTR_TYPE]})
 
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -60,7 +60,11 @@ from .const import (
     SERVICE_DISMISS,
 )
 from .entity import HTML5Entity, Registration
-from .issue import deprecated_dismiss_action_call, deprecated_notify_action_call
+from .issue import (
+    deprecated_dismiss_action_call,
+    deprecated_event_bus,
+    deprecated_notify_action_call,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -409,6 +413,9 @@ class HTML5PushCallbackView(HomeAssistantView):
             event_payload[ATTR_TYPE],
             event_payload,
         )
+
+        deprecated_event_bus(hass, event_name)
+
         return self.json({"status": "ok", "event": event_payload[ATTR_TYPE]})
 
 

--- a/homeassistant/components/html5/strings.json
+++ b/homeassistant/components/html5/strings.json
@@ -55,6 +55,10 @@
       "description": "The action `{action}` is deprecated and will be removed in a future release.\n\nPlease update your automations and scripts to use the notify entities with the `{new_action}` action instead.",
       "title": "[%key:component::html5::issues::deprecated_notify_action::title%]"
     },
+    "deprecated_event_bus": {
+      "description": "Detected **{listeners}** listener(s) for the event `{event}`.\n\nThe HTML5 Push Notifications integration firing events on the event bus is deprecated and this functionality will be removed in a future release.\n\nPlease update your automations and scripts to use the event entities instead.\n\n## Example automation:\n\n{example_yaml}\n\n## Example using a purpose-specific trigger:\n\n{example_yaml_trigger}",
+      "title": "Detected use of deprecated event {event}"
+    },
     "deprecated_notify_action": {
       "description": "The action `{action}` is deprecated and will be removed in a future release.\n\nPlease update your automations and scripts to use the notify entities with the `{new_action_1}` or `{new_action_2}` actions instead.",
       "title": "Detected use of deprecated action {action}"

--- a/homeassistant/components/html5/strings.json
+++ b/homeassistant/components/html5/strings.json
@@ -56,7 +56,7 @@
       "title": "[%key:component::html5::issues::deprecated_notify_action::title%]"
     },
     "deprecated_event_bus": {
-      "description": "Detected **{listeners}** listener(s) for the event `{event}`.\n\nThe HTML5 Push Notifications integration firing events on the event bus is deprecated and this functionality will be removed in a future release.\n\nPlease update your automations and scripts to use the event entities instead.\n\n## Example automation:\n\n{example_yaml}\n\n## Example using a purpose-specific trigger:\n\n{example_yaml_trigger}",
+      "description": "Detected **{listeners}** listener(s) for the event `{event}`.\n\nThe HTML5 Push Notifications integration firing events on the event bus is deprecated and this functionality will be removed in a future release.\n\nPlease update your automations and scripts to use the event entities instead.\n\n## Example automation:\n\n{example_yaml}",
       "title": "Detected use of deprecated event {event}"
     },
     "deprecated_notify_action": {

--- a/tests/components/html5/test_event.py
+++ b/tests/components/html5/test_event.py
@@ -9,12 +9,13 @@ from aiohttp.hdrs import AUTHORIZATION
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.html5.const import DOMAIN
 from homeassistant.components.html5.notify import ATTR_ACTION, ATTR_TAG, ATTR_TYPE
 from homeassistant.components.notify import ATTR_DATA, ATTR_TARGET
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from .test_notify import SUBSCRIPTION_1
@@ -118,3 +119,44 @@ async def test_events(
     assert state.attributes.get("action") == event_payload.get(ATTR_ACTION)
     assert state.attributes.get("tag") == event_payload[ATTR_TAG]
     assert state.attributes.get("customKey") == event_payload[ATTR_DATA]["customKey"]
+
+
+@pytest.mark.parametrize("event_type", ["clicked", "received", "closed"])
+@pytest.mark.usefixtures("mock_wp", "mock_jwt", "mock_vapid", "mock_uuid")
+async def test_deprecation_event_bus(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    load_config: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    hass_client: ClientSessionGenerator,
+    event_type: str,
+) -> None:
+    """Test deprecation of events on the event bus."""
+    load_config.return_value = {"device": SUBSCRIPTION_1}
+    await async_setup_component(hass, "http", {})
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    config_entry.async_on_unload(
+        hass.bus.async_listen(f"html5_notification.{event_type}", lambda _: None)
+    )
+    client = await hass_client()
+
+    resp = await client.post(
+        "/api/notify.html5/callback",
+        json={"type": event_type, "tag": "12345", "target": "device"},
+        headers={AUTHORIZATION: "Bearer JWT"},
+    )
+
+    assert resp.status == HTTPStatus.OK
+    body = await resp.json()
+    assert body == {"event": event_type, "status": "ok"}
+
+    assert issue_registry.async_get_issue(
+        domain=DOMAIN,
+        issue_id=f"deprecated_event_bus_html5_notification.{event_type}",
+    )

--- a/tests/components/html5/test_event.py
+++ b/tests/components/html5/test_event.py
@@ -160,3 +160,41 @@ async def test_deprecation_event_bus(
         domain=DOMAIN,
         issue_id=f"deprecated_event_bus_html5_notification.{event_type}",
     )
+
+
+@pytest.mark.parametrize("event_type", ["clicked", "received", "closed"])
+@pytest.mark.usefixtures("mock_wp", "mock_jwt", "mock_vapid", "mock_uuid")
+async def test_deprecation_event_bus_no_listeners(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    load_config: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    hass_client: ClientSessionGenerator,
+    event_type: str,
+) -> None:
+    """Test no issue is created when there are no listeners."""
+    load_config.return_value = {"device": SUBSCRIPTION_1}
+    await async_setup_component(hass, "http", {})
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    client = await hass_client()
+
+    resp = await client.post(
+        "/api/notify.html5/callback",
+        json={"type": event_type, "tag": "12345", "target": "device"},
+        headers={AUTHORIZATION: "Bearer JWT"},
+    )
+
+    assert resp.status == HTTPStatus.OK
+    body = await resp.json()
+    assert body == {"event": event_type, "status": "ok"}
+
+    assert not issue_registry.async_get_issue(
+        domain=DOMAIN,
+        issue_id=f"deprecated_event_bus_html5_notification.{event_type}",
+    )


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The HTML5 Push Notifications integration fires events for notifications received, clicked, and closed to the Home Assistant event bus.

The issue is only raised when there are active listeners for an event, so it will only affect users who are actually using these callback events in automations or scripts.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46411
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
