### PR TITLE
ViCare: Add setting domestic hot water circulation schedule service

### DIFF
--- a/homeassistant/components/vicare/icons.json
+++ b/homeassistant/components/vicare/icons.json
@@ -155,6 +155,9 @@
     }
   },
   "services": {
+    "set_domestic_hot_water_circulation_schedule": {
+      "service": "mdi:clock-edit-outline"
+    },
     "set_vicare_mode": {
       "service": "mdi:cog"
     }

--- a/homeassistant/components/vicare/services.yaml
+++ b/homeassistant/components/vicare/services.yaml
@@ -16,3 +16,14 @@ set_vicare_mode:
             - "forcedReduced"
             - "heating"
             - "standby"
+
+set_domestic_hot_water_circulation_schedule:
+  target:
+    entity:
+      integration: vicare
+      domain: water_heater
+  fields:
+    schedule:
+      required: true
+      selector:
+        object:

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -677,6 +677,16 @@
         }
       },
       "name": "Set ViCare mode"
+    },
+    "set_domestic_hot_water_circulation_schedule": {
+      "description": "Sets the domestic hot water circulation pump schedule.",
+      "fields": {
+        "schedule": {
+          "description": "The schedule for the domestic hot water circulation pump.",
+          "name": "Schedule"
+        }
+      },
+      "name": "Set domestic hot water circulation schedule"
     }
   }
 }

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -668,16 +668,6 @@
     }
   },
   "services": {
-    "set_vicare_mode": {
-      "description": "Sets the mode of the climate device as defined by Viessmann.",
-      "fields": {
-        "vicare_mode": {
-          "description": "For supported values, see the `vicare_modes` attribute of the climate entity.",
-          "name": "ViCare mode"
-        }
-      },
-      "name": "Set ViCare mode"
-    },
     "set_domestic_hot_water_circulation_schedule": {
       "description": "Sets the domestic hot water circulation pump schedule.",
       "fields": {
@@ -687,6 +677,16 @@
         }
       },
       "name": "Set domestic hot water circulation schedule"
+    },
+    "set_vicare_mode": {
+      "description": "Sets the mode of the climate device as defined by Viessmann.",
+      "fields": {
+        "vicare_mode": {
+          "description": "For supported values, see the `vicare_modes` attribute of the climate entity.",
+          "name": "ViCare mode"
+        }
+      },
+      "name": "Set ViCare mode"
     }
   }
 }

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -140,11 +140,6 @@ class ViCareWater(ViCareEntity, WaterHeaterEntity):
             with suppress(PyViCareNotSupportedFeatureError):
                 self._dhw_active = self._api.getDomesticHotWaterActive()
 
-            with suppress(PyViCareNotSupportedFeatureError):
-                self._attributes[ATTR_SCHEDULE] = (
-                    self._api.getDomesticHotWaterCirculationSchedule()
-                )
-
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -8,6 +8,7 @@ from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import HeatingCircuit as PyViCareHeatingCircuit
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+import voluptuous as vol
 
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
@@ -15,6 +16,7 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .entity import ViCareEntity
@@ -22,6 +24,9 @@ from .types import ViCareConfigEntry, ViCareDevice
 from .utils import get_circuits, get_device_serial
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_SET_DHW_CIRCULATION_SCHEDULE = "set_domestic_hot_water_circulation_schedule"
+ATTR_SCHEDULE = "schedule"
 
 VICARE_MODE_DHW = "dhw"
 VICARE_MODE_HEATING = "heating"
@@ -76,6 +81,13 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the ViCare water heater platform."""
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_SET_DHW_CIRCULATION_SCHEDULE,
+        {vol.Required(ATTR_SCHEDULE): dict},
+        "set_domestic_hot_water_circulation_schedule",
+    )
+
     async_add_entities(
         await hass.async_add_executor_job(
             _build_entities,
@@ -128,6 +140,11 @@ class ViCareWater(ViCareEntity, WaterHeaterEntity):
             with suppress(PyViCareNotSupportedFeatureError):
                 self._dhw_active = self._api.getDomesticHotWaterActive()
 
+            with suppress(PyViCareNotSupportedFeatureError):
+                self._attributes[ATTR_SCHEDULE] = (
+                    self._api.getDomesticHotWaterCirculationSchedule()
+                )
+
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
@@ -142,3 +159,14 @@ class ViCareWater(ViCareEntity, WaterHeaterEntity):
         if self._current_mode is None:
             return None
         return VICARE_TO_HA_HVAC_DHW.get(self._current_mode)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the optional state attributes."""
+        return self._attributes
+
+    def set_domestic_hot_water_circulation_schedule(
+        self, schedule: dict[str, Any]
+    ) -> None:
+        """Set the domestic hot water circulation schedule."""
+        self._api.setDomesticHotWaterCirculationSchedule(schedule)

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -16,7 +16,7 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .entity import ViCareEntity

--- a/tests/components/vicare/test_water_heater.py
+++ b/tests/components/vicare/test_water_heater.py
@@ -29,7 +29,15 @@ async def test_dhw_circulation_schedule(
 ) -> None:
     """Test water heater domestic hot water circulation schedule."""
     fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
-    mock_schedule = {"mon": [{"start": "06:00", "end": "08:00"}]}
+    mock_schedule = {
+        "mon": [{"mode": "on", "start": "00:00", "end": "24:00", "position": 0}],
+        "tue": [{"mode": "on", "start": "00:00", "end": "24:00", "position": 0}],
+        "wed": [{"mode": "on", "start": "00:00", "end": "24:00", "position": 0}],
+        "thu": [{"mode": "on", "start": "00:00", "end": "24:00", "position": 0}],
+        "fri": [{"mode": "on", "start": "00:00", "end": "24:00", "position": 0}],
+        "sat": [{"mode": "on", "start": "00:00", "end": "24:00", "position": 0}],
+        "sun": [{"mode": "on", "start": "00:00", "end": "24:00", "position": 0}],
+    }
 
     mock_device = MagicMock()
     mock_device.getDomesticHotWaterCirculationSchedule.return_value = mock_schedule

--- a/tests/components/vicare/test_water_heater.py
+++ b/tests/components/vicare/test_water_heater.py
@@ -20,9 +20,6 @@ from .conftest import Fixture, MockPyViCare
 from tests.common import MockConfigEntry, snapshot_platform
 
 ENTITY_WATER_HEATER = "water_heater.model0_domestic_hot_water"
-...
-    state = hass.states.get(ENTITY_WATER_HEATER)
-    assert state.state == "on"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -38,13 +35,16 @@ async def test_dhw_circulation_schedule(
     mock_device.getDomesticHotWaterCirculationSchedule.return_value = mock_schedule
 
     with (
-        patch(f"{MODULE}.login", return_value=MockPyViCare(fixtures)) as mock_login,
+        patch(f"{MODULE}.login", return_value=MockPyViCare(fixtures)),
         patch(f"{MODULE}.PLATFORMS", [Platform.WATER_HEATER]),
         patch(
             "PyViCare.PyViCareDeviceConfig.PyViCareDeviceConfig.asAutoDetectDevice",
             return_value=mock_device,
         ),
     ):
+        state = hass.states.get(ENTITY_WATER_HEATER)
+        assert state.state == "on"
+
         await setup_integration(hass, mock_config_entry)
         await async_update_entity(hass, ENTITY_WATER_HEATER)
 
@@ -62,6 +62,7 @@ async def test_dhw_circulation_schedule(
         mock_device.setDomesticHotWaterCirculationSchedule.assert_called_once_with(
             mock_schedule
         )
+
 
 async def test_all_entities(
     hass: HomeAssistant,

--- a/tests/components/vicare/test_water_heater.py
+++ b/tests/components/vicare/test_water_heater.py
@@ -1,10 +1,14 @@
 """Test ViCare water heater entity."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.vicare.water_heater import (
+    ATTR_SCHEDULE,
+    SERVICE_SET_DHW_CIRCULATION_SCHEDULE,
+)
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -16,9 +20,49 @@ from .conftest import Fixture, MockPyViCare
 from tests.common import MockConfigEntry, snapshot_platform
 
 ENTITY_WATER_HEATER = "water_heater.model0_domestic_hot_water"
+...
+    state = hass.states.get(ENTITY_WATER_HEATER)
+    assert state.state == "on"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dhw_circulation_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test water heater domestic hot water circulation schedule."""
+    fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
+    mock_schedule = {"mon": [{"start": "06:00", "end": "08:00"}]}
+
+    mock_device = MagicMock()
+    mock_device.getDomesticHotWaterCirculationSchedule.return_value = mock_schedule
+
+    with (
+        patch(f"{MODULE}.login", return_value=MockPyViCare(fixtures)) as mock_login,
+        patch(f"{MODULE}.PLATFORMS", [Platform.WATER_HEATER]),
+        patch(
+            "PyViCare.PyViCareDeviceConfig.PyViCareDeviceConfig.asAutoDetectDevice",
+            return_value=mock_device,
+        ),
+    ):
+        await setup_integration(hass, mock_config_entry)
+        await async_update_entity(hass, ENTITY_WATER_HEATER)
+
+        state = hass.states.get(ENTITY_WATER_HEATER)
+        assert state.attributes.get(ATTR_SCHEDULE) == mock_schedule
+
+        await hass.services.async_call(
+            Platform.WATER_HEATER,
+            SERVICE_SET_DHW_CIRCULATION_SCHEDULE,
+            {ATTR_SCHEDULE: mock_schedule},
+            target={"entity_id": ENTITY_WATER_HEATER},
+            blocking=True,
+        )
+
+        mock_device.setDomesticHotWaterCirculationSchedule.assert_called_once_with(
+            mock_schedule
+        )
+
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds the ability to set the domestic hot water circulation schedule via service to the ViCare integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
