### PR TITLE
Add DHCP discovery to Duco integration

### DIFF
--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
@@ -34,6 +35,27 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _host: str
     _box_name: str
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery."""
+        await self.async_set_unique_id(format_mac(discovery_info.macaddress))
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+
+        try:
+            box_name, _ = await self._validate_input(discovery_info.ip)
+        except DucoConnectionError:
+            return self.async_abort(reason="cannot_connect")
+        except DucoError:
+            _LOGGER.exception("Unexpected error discovering Duco box via DHCP")
+            return self.async_abort(reason="unknown")
+
+        self._host = discovery_info.ip
+        self._box_name = box_name
+        self.context["title_placeholders"] = {"name": box_name}
+
+        return await self.async_step_discovery_confirm()
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo

--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -3,6 +3,11 @@
   "name": "Duco",
   "codeowners": ["@ronaldvdmeer"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "hostname": "duco_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/duco",
   "integration_type": "hub",
   "iot_class": "local_polling",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -174,6 +174,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "hostname": "dsp-w215",
     },
     {
+        "domain": "duco",
+        "hostname": "duco_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]",
+    },
+    {
         "domain": "elgato",
         "registered_devices": True,
     },

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -415,3 +415,41 @@ async def test_dhcp_discovery_exceptions(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
+
+
+async def test_dhcp_discovery_exception_recovery(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test DHCP discovery recovers after an initial exception and creates the entry."""
+    mock_duco_client.async_get_board_info.side_effect = DucoConnectionError(
+        "Connection refused"
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DHCP_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+    mock_duco_client.async_get_board_info.side_effect = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DHCP_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == TEST_MAC

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -336,6 +336,7 @@ async def test_dhcp_discovery_new_device(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
+    assert result["description_placeholders"] == {"name": "SILENT_CONNECT"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -10,10 +10,11 @@ from duco.models import LanInfo
 import pytest
 
 from homeassistant.components.duco.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .conftest import TEST_HOST, TEST_MAC, USER_INPUT
@@ -28,6 +29,12 @@ ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
     type="_http._tcp.local.",
     name="DUCO [a0dd6c061293]._http._tcp.local.",
     properties={},
+)
+
+DHCP_DISCOVERY = DhcpServiceInfo(
+    ip=TEST_HOST,
+    hostname="duco_ddeeff",
+    macaddress="aabbccddeeff",
 )
 
 
@@ -313,3 +320,98 @@ async def test_reconfigure_flow_error(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+async def test_dhcp_discovery_new_device(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test DHCP discovery of a new device shows confirmation form and creates entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DHCP_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "SILENT_CONNECT"
+    assert result["data"] == USER_INPUT
+    assert result["result"].unique_id == TEST_MAC
+
+
+async def test_dhcp_discovery_updates_host(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test DHCP discovery updates the host of an existing entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    new_ip = "192.168.1.200"
+    discovery = DhcpServiceInfo(
+        ip=new_ip,
+        hostname="duco_ddeeff",
+        macaddress="aabbccddeeff",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=discovery,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == new_ip
+
+
+async def test_dhcp_discovery_already_configured_same_ip(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test DHCP discovery with unchanged IP aborts as already_configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DHCP_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_reason"),
+    [
+        (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (DucoError("Unexpected error"), "unknown"),
+    ],
+)
+async def test_dhcp_discovery_exceptions(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    exception: Exception,
+    expected_reason: str,
+) -> None:
+    """Test DHCP discovery aborts on connection and unknown errors."""
+    mock_duco_client.async_get_board_info.side_effect = exception
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DHCP_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == expected_reason


### PR DESCRIPTION
## Proposed change

Some networks block mDNS multicast traffic, which prevents zeroconf discovery from working. In those environments the Duco ventilation box is not automatically discovered and the user has to configure the IP address manually.

This PR adds DHCP discovery as a fallback. When the Duco box receives an IP address from DHCP, Home Assistant picks it up via the DHCP watcher. This works even when multicast is blocked, because DHCP broadcasts are handled at the network layer before any multicast filtering takes effect.

> [!NOTE]
> **On the hostname pattern choice:** The Duco box always advertises a hostname of the form `duco_XXXXXX`, where the six-character suffix is the last three bytes of its MAC address (of the ethernet interface) in lowercase hex (for example `duco_061293`). A simple `duco_*` wildcard would work, but the pattern `duco_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]` is more precise: it matches exactly six hex characters and will not trigger on a hypothetical future hostname like `duco_box` or `duco_v2_something`. The character-class style is also consistent with how the existing zeroconf entry matches the MAC in the service name.

Implementation details:

- The MAC address is available directly from `DhcpServiceInfo.macaddress`, so `async_set_unique_id` can be called without an API round trip. This means already-configured devices are identified and their host entry updated before any network call is made.
- For a new device, `_validate_input` is called to fetch `box_name` for the entry title, then the existing `async_step_discovery_confirm` step is reused - the same confirmation step already used by zeroconf discovery.
- `homeassistant/generated/dhcp.py` regenerated via `python3 -m script.hassfest`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44888
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect_pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest