### PR TITLE
Remove arbitrary single iAquaLink account limitation

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -32,6 +32,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
 
+from .config_flow import _username_unique_id
 from .const import DOMAIN
 from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
@@ -71,6 +72,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
     """Set up Aqualink from a config entry."""
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
+
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(
+            entry, unique_id=_username_unique_id(username)
+        )
 
     aqualink = AqualinkClient(
         username,

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -68,42 +68,10 @@ class AqualinkRuntimeData:
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate old entries using username-based unique IDs."""
+    """Migrate old config entries."""
     if entry.version == 1 and entry.minor_version < 2:
-        account_id = entry.unique_id
-
-        username = entry.data[CONF_USERNAME]
-        if account_id == username.casefold():
-            aqualink = AqualinkClient(
-                username,
-                entry.data[CONF_PASSWORD],
-                httpx_client=get_async_client(
-                    hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2
-                ),
-            )
-            try:
-                await aqualink.login()
-            except AqualinkServiceUnauthorizedException as auth_exception:
-                await aqualink.close()
-                raise ConfigEntryAuthFailed(
-                    "Invalid credentials for iAquaLink"
-                ) from auth_exception
-            except (
-                AqualinkServiceException,
-                TimeoutError,
-                httpx.HTTPError,
-            ) as aio_exception:
-                await aqualink.close()
-                raise ConfigEntryNotReady(
-                    f"Error while attempting login: {aio_exception}"
-                ) from aio_exception
-
-            account_id = aqualink.user_id
-            await aqualink.close()
-
         hass.config_entries.async_update_entry(
             entry,
-            unique_id=account_id,
             minor_version=2,
         )
 

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -141,6 +141,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
     account_id = aqualink.user_id
     if entry.unique_id != account_id:
+        conflicting_entry = next(
+            (
+                existing_entry
+                for existing_entry in hass.config_entries.async_entries(DOMAIN)
+                if existing_entry.entry_id != entry.entry_id
+                and existing_entry.unique_id == account_id
+            ),
+            None,
+        )
+        if conflicting_entry is not None:
+            await aqualink.close()
+            raise ConfigEntryError(
+                "Another iAquaLink config entry already uses this account"
+            )
         hass.config_entries.async_update_entry(entry, unique_id=account_id)
 
     try:

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -32,7 +32,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
 
-from .config_flow import _username_unique_id
 from .const import DOMAIN
 from .coordinator import AqualinkDataUpdateCoordinator
 from .entity import AqualinkEntity
@@ -73,11 +72,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
 
-    if entry.unique_id is None:
-        hass.config_entries.async_update_entry(
-            entry, unique_id=_username_unique_id(username)
-        )
-
     aqualink = AqualinkClient(
         username,
         password,
@@ -95,6 +89,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
         raise ConfigEntryNotReady(
             f"Error while attempting login: {error_detail(aio_exception)}"
         ) from aio_exception
+
+    if entry.unique_id != aqualink._user_id:
+        hass.config_entries.async_update_entry(entry, unique_id=aqualink._user_id)
 
     try:
         systems = await aqualink.get_systems()

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -67,6 +67,55 @@ class AqualinkRuntimeData:
     thermostats: list[AqualinkThermostat]
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entries using username-based unique IDs."""
+    if entry.version == 1 and entry.minor_version < 2:
+        account_id = entry.unique_id
+
+        username = entry.data[CONF_USERNAME]
+        if account_id == username.casefold():
+            aqualink = AqualinkClient(
+                username,
+                entry.data[CONF_PASSWORD],
+                httpx_client=get_async_client(
+                    hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2
+                ),
+            )
+            try:
+                await aqualink.login()
+            except AqualinkServiceUnauthorizedException as auth_exception:
+                await aqualink.close()
+                raise ConfigEntryAuthFailed(
+                    "Invalid credentials for iAquaLink"
+                ) from auth_exception
+            except (
+                AqualinkServiceException,
+                TimeoutError,
+                httpx.HTTPError,
+            ) as aio_exception:
+                await aqualink.close()
+                raise ConfigEntryNotReady(
+                    f"Error while attempting login: {aio_exception}"
+                ) from aio_exception
+
+            account_id = aqualink.user_id
+            await aqualink.close()
+
+        hass.config_entries.async_update_entry(
+            entry,
+            unique_id=account_id,
+            minor_version=2,
+        )
+
+    _LOGGER.info(
+        "Migration to configuration version %s.%s successful",
+        entry.version,
+        entry.minor_version,
+    )
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> bool:
     """Set up Aqualink from a config entry."""
     username = entry.data[CONF_USERNAME]
@@ -90,8 +139,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
             f"Error while attempting login: {error_detail(aio_exception)}"
         ) from aio_exception
 
-    if entry.unique_id != aqualink._user_id:
-        hass.config_entries.async_update_entry(entry, unique_id=aqualink._user_id)
+    account_id = aqualink.user_id
+    if entry.unique_id != account_id:
+        hass.config_entries.async_update_entry(entry, unique_id=account_id)
 
     try:
         systems = await aqualink.get_systems()

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -70,16 +70,37 @@ class AqualinkRuntimeData:
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old config entries."""
     if entry.version == 1 and entry.minor_version < 2:
-        hass.config_entries.async_update_entry(
-            entry,
-            minor_version=2,
+        aqualink = AqualinkClient(
+            entry.data[CONF_USERNAME],
+            entry.data[CONF_PASSWORD],
+            httpx_client=get_async_client(hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2),
         )
+        account_id: str | None = None
+        try:
+            await aqualink.login()
+            account_id = aqualink.user_id or None
+        except (
+            AqualinkServiceException,
+            AqualinkServiceUnauthorizedException,
+            TimeoutError,
+            httpx.HTTPError,
+        ):
+            pass
+        finally:
+            await aqualink.close()
 
-    _LOGGER.info(
-        "Migration to configuration version %s.%s successful",
-        entry.version,
-        entry.minor_version,
-    )
+        if account_id:
+            hass.config_entries.async_update_entry(
+                entry, unique_id=account_id, minor_version=2
+            )
+        else:
+            hass.config_entries.async_update_entry(entry, minor_version=2)
+
+        _LOGGER.info(
+            "Migration to configuration version %s.%s successful",
+            entry.version,
+            entry.minor_version,
+        )
 
     return True
 
@@ -109,16 +130,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: AqualinkConfigEntry) -> 
 
     account_id = aqualink.user_id
     if entry.unique_id != account_id:
-        conflicting_entry = next(
-            (
-                existing_entry
-                for existing_entry in hass.config_entries.async_entries(DOMAIN)
-                if existing_entry.entry_id != entry.entry_id
-                and existing_entry.unique_id == account_id
-            ),
-            None,
+        conflicting_entry = hass.config_entries.async_entry_for_domain_unique_id(
+            DOMAIN, account_id
         )
-        if conflicting_entry is not None:
+        if (
+            conflicting_entry is not None
+            and conflicting_entry.entry_id != entry.entry_id
+        ):
             await aqualink.close()
             raise ConfigEntryError(
                 "Another iAquaLink config entry already uses this account"

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -112,8 +112,8 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             errors, account_id = await self._async_validate_credentials(user_input)
             if not errors and account_id is not None:
-                legacy_unique_id = _username_unique_id(reauth_entry.data[CONF_USERNAME])
-                if reauth_entry.unique_id in (None, legacy_unique_id):
+                legacy_unique_id = _username_unique_id(config_entry.data[CONF_USERNAME])
+                if config_entry.unique_id in (None, legacy_unique_id):
                     if (
                         _username_unique_id(user_input[CONF_USERNAME])
                         != legacy_unique_id
@@ -128,11 +128,11 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
                         DOMAIN, account_id
                     )
                 )
-                if existing_entry and existing_entry.entry_id != reauth_entry.entry_id:
+                if existing_entry and existing_entry.entry_id != config_entry.entry_id:
                     return self.async_abort(reason="already_configured")
 
                 self.hass.config_entries.async_update_entry(
-                    reauth_entry, unique_id=account_id
+                    config_entry, unique_id=account_id
                 )
                 return self.async_update_reload_and_abort(
                     config_entry,

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -30,6 +30,11 @@ CREDENTIALS_DATA_SCHEMA = vol.Schema(
 )
 
 
+def _username_unique_id(username: str) -> str:
+    """Normalize a username for config entry deduplication."""
+    return username.casefold()
+
+
 class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
     """iAquaLink config flow."""
 
@@ -64,6 +69,10 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             errors = await self._async_test_credentials(user_input)
             if not errors:
+                await self.async_set_unique_id(
+                    _username_unique_id(user_input[CONF_USERNAME])
+                )
+                self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=user_input[CONF_USERNAME], data=user_input
                 )
@@ -94,6 +103,10 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             errors = await self._async_test_credentials(user_input)
             if not errors:
+                await self.async_set_unique_id(
+                    _username_unique_id(user_input[CONF_USERNAME])
+                )
+                self._abort_if_unique_id_mismatch(reason="account_mismatch")
                 return self.async_update_reload_and_abort(
                     config_entry,
                     title=user_input[CONF_USERNAME],

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -40,10 +40,10 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def _async_test_credentials(
+    async def _async_validate_credentials(
         self, user_input: dict[str, Any]
-    ) -> dict[str, str]:
-        """Validate credentials against iAquaLink."""
+    ) -> tuple[dict[str, str], str | None]:
+        """Validate credentials and return the stable account ID."""
         try:
             async with AqualinkClient(
                 user_input[CONF_USERNAME],
@@ -51,14 +51,21 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
                 httpx_client=get_async_client(
                     self.hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2
                 ),
-            ):
-                pass
+            ) as client:
+                return {}, client._user_id
         except AqualinkServiceUnauthorizedException:
-            return {"base": "invalid_auth"}
+            return {"base": "invalid_auth"}, None
         except AqualinkServiceException, TimeoutError, httpx.HTTPError:
-            return {"base": "cannot_connect"}
+            return {"base": "cannot_connect"}, None
 
-        return {}
+    def _find_existing_entry_by_username(self, username: str) -> str | None:
+        """Find an existing entry using the legacy username-based identity."""
+        normalized_username = _username_unique_id(username)
+        for entry in self._async_current_entries():
+            if _username_unique_id(entry.data[CONF_USERNAME]) == normalized_username:
+                return entry.entry_id
+
+        return None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -67,11 +74,12 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            errors = await self._async_test_credentials(user_input)
-            if not errors:
-                await self.async_set_unique_id(
-                    _username_unique_id(user_input[CONF_USERNAME])
-                )
+            errors, account_id = await self._async_validate_credentials(user_input)
+            if not errors and account_id is not None:
+                if self._find_existing_entry_by_username(user_input[CONF_USERNAME]):
+                    return self.async_abort(reason="already_configured")
+
+                await self.async_set_unique_id(account_id)
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=user_input[CONF_USERNAME], data=user_input
@@ -101,12 +109,30 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
             else self._get_reauth_entry()
         )
         if user_input is not None:
-            errors = await self._async_test_credentials(user_input)
-            if not errors:
-                await self.async_set_unique_id(
-                    _username_unique_id(user_input[CONF_USERNAME])
+            errors, account_id = await self._async_validate_credentials(user_input)
+            if not errors and account_id is not None:
+                legacy_unique_id = _username_unique_id(reauth_entry.data[CONF_USERNAME])
+                if reauth_entry.unique_id in (None, legacy_unique_id):
+                    if (
+                        _username_unique_id(user_input[CONF_USERNAME])
+                        != legacy_unique_id
+                    ):
+                        return self.async_abort(reason="account_mismatch")
+                else:
+                    await self.async_set_unique_id(account_id)
+                    self._abort_if_unique_id_mismatch(reason="account_mismatch")
+
+                existing_entry = (
+                    self.hass.config_entries.async_entry_for_domain_unique_id(
+                        DOMAIN, account_id
+                    )
                 )
-                self._abort_if_unique_id_mismatch(reason="account_mismatch")
+                if existing_entry and existing_entry.entry_id != reauth_entry.entry_id:
+                    return self.async_abort(reason="already_configured")
+
+                self.hass.config_entries.async_update_entry(
+                    reauth_entry, unique_id=account_id
+                )
                 return self.async_update_reload_and_abort(
                     config_entry,
                     title=user_input[CONF_USERNAME],

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -39,6 +39,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
     """iAquaLink config flow."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     async def _async_validate_credentials(
         self, user_input: dict[str, Any]
@@ -52,7 +53,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
                     self.hass, alpn_protocols=SSL_ALPN_HTTP11_HTTP2
                 ),
             ) as client:
-                return {}, client._user_id
+                return {}, client.user_id
         except AqualinkServiceUnauthorizedException:
             return {"base": "invalid_auth"}, None
         except AqualinkServiceException, TimeoutError, httpx.HTTPError:
@@ -71,7 +72,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow start."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             errors, account_id = await self._async_validate_credentials(user_input)
@@ -101,7 +102,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle confirmation of reauthentication."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         config_entry = (
             self._get_reconfigure_entry()

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -113,15 +113,11 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
             errors, account_id = await self._async_validate_credentials(user_input)
             if not errors and account_id is not None:
                 legacy_unique_id = _username_unique_id(config_entry.data[CONF_USERNAME])
-                if config_entry.unique_id in (None, legacy_unique_id):
-                    if (
-                        _username_unique_id(user_input[CONF_USERNAME])
-                        != legacy_unique_id
-                    ):
-                        return self.async_abort(reason="account_mismatch")
-                else:
+                if config_entry.unique_id not in (None, legacy_unique_id):
                     await self.async_set_unique_id(account_id)
                     self._abort_if_unique_id_mismatch(reason="account_mismatch")
+                elif _username_unique_id(user_input[CONF_USERNAME]) != legacy_unique_id:
+                    return self.async_abort(reason="account_mismatch")
 
                 existing_entry = (
                     self.hass.config_entries.async_entry_for_domain_unique_id(

--- a/homeassistant/components/iaqualink/manifest.json
+++ b/homeassistant/components/iaqualink/manifest.json
@@ -9,6 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["iaqualink"],
   "quality_scale": "silver",
-  "requirements": ["iaqualink==0.7.0", "h2==4.3.0"],
-  "single_config_entry": true
+  "requirements": ["iaqualink==0.7.0", "h2==4.3.0"]
 }

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "account_mismatch": "The authenticated account does not match the configured account.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3125,8 +3125,7 @@
       "name": "Jandy iAquaLink",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling",
-      "single_config_entry": true
+      "iot_class": "cloud_polling"
     },
     "idrive_e2": {
       "name": "IDrive e2",

--- a/tests/components/iaqualink/conftest.py
+++ b/tests/components/iaqualink/conftest.py
@@ -47,20 +47,7 @@ class SystemDevices:
 @pytest.fixture(name="client")
 def client_fixture():
     """Create client fixture."""
-    client = AqualinkClient(username=MOCK_USERNAME, password=MOCK_PASSWORD)
-    client.user_id = MOCK_USER_ID
-    return client
-
-
-@pytest.fixture(autouse=True)
-def user_id_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Expose a default public user_id on the test client class.
-
-    The installed library (0.7.0) uses _user_id internally. This fixture
-    provides the public user_id attribute expected by the integration code
-    until the library exposes it natively.
-    """
-    monkeypatch.setattr(AqualinkClient, "user_id", MOCK_USER_ID, raising=False)
+    return AqualinkClient(username=MOCK_USERNAME, password=MOCK_PASSWORD)
 
 
 def get_aqualink_system(aqualink, cls=None, data=None):

--- a/tests/components/iaqualink/conftest.py
+++ b/tests/components/iaqualink/conftest.py
@@ -26,6 +26,7 @@ from tests.common import MockConfigEntry
 
 MOCK_USERNAME = "test@example.com"
 MOCK_PASSWORD = "password"
+MOCK_USER_ID = "account-123"
 MOCK_DATA = {CONF_USERNAME: MOCK_USERNAME, CONF_PASSWORD: MOCK_PASSWORD}
 
 
@@ -46,7 +47,15 @@ class SystemDevices:
 @pytest.fixture(name="client")
 def client_fixture():
     """Create client fixture."""
-    return AqualinkClient(username=MOCK_USERNAME, password=MOCK_PASSWORD)
+    client = AqualinkClient(username=MOCK_USERNAME, password=MOCK_PASSWORD)
+    client.user_id = MOCK_USER_ID
+    return client
+
+
+@pytest.fixture(autouse=True)
+def user_id_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expose a default public user_id on the test client class."""
+    monkeypatch.setattr(AqualinkClient, "user_id", MOCK_USER_ID, raising=False)
 
 
 def get_aqualink_system(aqualink, cls=None, data=None):

--- a/tests/components/iaqualink/conftest.py
+++ b/tests/components/iaqualink/conftest.py
@@ -54,7 +54,12 @@ def client_fixture():
 
 @pytest.fixture(autouse=True)
 def user_id_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Expose a default public user_id on the test client class."""
+    """Expose a default public user_id on the test client class.
+
+    The installed library (0.7.0) uses _user_id internally. This fixture
+    provides the public user_id attribute expected by the integration code
+    until the library exposes it natively.
+    """
     monkeypatch.setattr(AqualinkClient, "user_id", MOCK_USER_ID, raising=False)
 
 

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -31,12 +31,12 @@ MOCK_USER_ID_2 = "account-456"
 
 async def _async_mock_login(self: Any) -> None:
     """Mock a successful login with a stable account ID."""
-    self._user_id = MOCK_USER_ID
+    self.user_id = MOCK_USER_ID
 
 
 async def _async_mock_login_other(self: Any) -> None:
     """Mock a successful login for a different account."""
-    self._user_id = MOCK_USER_ID_2
+    self.user_id = MOCK_USER_ID_2
 
 
 async def _async_mock_login(self: Any) -> None:

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -390,3 +390,60 @@ async def test_reauth_account_mismatch(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "account_mismatch"
+
+
+async def test_reauth_account_mismatch_with_unique_id(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test reauth aborts when login returns a different account ID for an entry that already has a proper unique ID."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        unique_id=MOCK_USER_ID,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        _async_mock_login_other,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: config_data[CONF_USERNAME], CONF_PASSWORD: "new_password"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "account_mismatch"
+
+
+async def test_reauth_already_configured(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test reauth aborts when credentials belong to an account already used by another entry."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_USER_ID,
+    ).add_to_hass(hass)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        unique_id=config_data[CONF_USERNAME].casefold(),
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        _async_mock_login,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: config_data[CONF_USERNAME], CONF_PASSWORD: "new_password"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -29,11 +29,6 @@ MOCK_USER_ID = "account-123"
 MOCK_USER_ID_2 = "account-456"
 
 
-async def _async_mock_login(self: Any) -> None:
-    """Mock a successful login with a stable account ID."""
-    self.user_id = MOCK_USER_ID
-
-
 async def _async_mock_login_other(self: Any) -> None:
     """Mock a successful login for a different account."""
     self.user_id = MOCK_USER_ID_2
@@ -43,7 +38,7 @@ async def _async_mock_login(self: Any) -> None:
     """Mock a successful login."""
 
 
-async def test_single_instance_allowed(
+async def test_multiple_accounts_allowed(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
 ) -> None:

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -25,6 +25,19 @@ DHCP_DISCOVERY = DhcpServiceInfo(
     macaddress="001122334455",
 )
 
+MOCK_USER_ID = "account-123"
+MOCK_USER_ID_2 = "account-456"
+
+
+async def _async_mock_login(self: Any) -> None:
+    """Mock a successful login with a stable account ID."""
+    self._user_id = MOCK_USER_ID
+
+
+async def _async_mock_login_other(self: Any) -> None:
+    """Mock a successful login for a different account."""
+    self._user_id = MOCK_USER_ID_2
+
 
 async def _async_mock_login(self: Any) -> None:
     """Mock a successful login."""
@@ -54,7 +67,7 @@ async def test_duplicate_account_aborts(
         domain=DOMAIN,
         title=config_data[CONF_USERNAME],
         data=config_data,
-        unique_id=config_data[CONF_USERNAME].casefold(),
+        unique_id=MOCK_USER_ID,
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -65,7 +78,7 @@ async def test_duplicate_account_aborts(
 
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
-        return_value=None,
+        _async_mock_login,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], config_data
@@ -245,6 +258,7 @@ async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert entry.title == config_data[CONF_USERNAME]
+    assert entry.unique_id == MOCK_USER_ID
     assert dict(entry.data) == {
         **config_data,
         CONF_PASSWORD: "new_password",
@@ -300,7 +314,7 @@ async def test_reauth_invalid_auth(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=config_data,
-        unique_id=config_data[CONF_USERNAME].casefold(),
+        unique_id=MOCK_USER_ID,
     )
     entry.add_to_hass(hass)
 
@@ -372,7 +386,7 @@ async def test_reauth_account_mismatch(
 
     with patch(
         "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
-        return_value=None,
+        _async_mock_login_other,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -36,6 +36,7 @@ async def _async_mock_login_other(self: Any) -> None:
 
 async def _async_mock_login(self: Any) -> None:
     """Mock a successful login."""
+    self.user_id = MOCK_USER_ID
 
 
 async def test_multiple_accounts_allowed(
@@ -81,6 +82,37 @@ async def test_duplicate_account_aborts(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_second_account_creates_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    config_data: dict[str, str],
+) -> None:
+    """Test config flow creates a second entry when a different account logs in."""
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+
+    other_data = {
+        CONF_USERNAME: "other@example.com",
+        CONF_PASSWORD: "other_password",
+    }
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        _async_mock_login_other,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], other_data
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "other@example.com"
+    assert result["data"] == other_data
 
 
 async def test_without_config(hass: HomeAssistant) -> None:

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -34,15 +34,45 @@ async def test_single_instance_allowed(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
 ) -> None:
-    """Test config flow aborts when an entry already exists."""
+    """Test config flow allows adding another iaqualink account."""
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+
+async def test_duplicate_account_aborts(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test config flow aborts when the same account is configured twice."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        title=config_data[CONF_USERNAME],
+        data=config_data,
+        unique_id=config_data[CONF_USERNAME].casefold(),
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        return_value=None,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], config_data
+        )
+
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured"
 
 
 async def test_without_config(hass: HomeAssistant) -> None:
@@ -174,7 +204,7 @@ async def test_dhcp_discovery_aborts_if_already_configured(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured"
 
 
 async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) -> None:
@@ -183,6 +213,7 @@ async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) 
         domain=DOMAIN,
         title=config_data[CONF_USERNAME],
         data=config_data,
+        unique_id=config_data[CONF_USERNAME].casefold(),
     )
     entry.add_to_hass(hass)
 
@@ -269,6 +300,7 @@ async def test_reauth_invalid_auth(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=config_data,
+        unique_id=config_data[CONF_USERNAME].casefold(),
     )
     entry.add_to_hass(hass)
 
@@ -305,6 +337,7 @@ async def test_reauth_cannot_connect(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=config_data,
+        unique_id=config_data[CONF_USERNAME].casefold(),
     )
     entry.add_to_hass(hass)
 
@@ -322,3 +355,29 @@ async def test_reauth_cannot_connect(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_reauth_account_mismatch(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test reauthentication aborts when credentials belong to another account."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        unique_id=config_data[CONF_USERNAME].casefold(),
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        return_value=None,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "other@example.com", CONF_PASSWORD: "new_password"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "account_mismatch"

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -212,6 +212,35 @@ async def test_setup_login_retry_exceptions(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_setup_backfills_unique_id(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+) -> None:
+    """Test setup assigns a unique ID to existing entries."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
+    system.get_devices = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value={system.serial: system},
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.unique_id == config_entry.data["username"].casefold()
+
+
 async def test_setup_login_unauthorized(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -34,7 +34,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from .conftest import get_aqualink_device, get_aqualink_system, setup_integration
+from .conftest import MOCK_USER_ID, get_aqualink_device, get_aqualink_system, setup_integration
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -284,6 +284,62 @@ async def test_migrate_legacy_unique_id(
     assert config_entry.unique_id == "account-123"
 
 
+async def _mock_login_unauthorized(self: AqualinkClient) -> None:
+    raise AqualinkServiceUnauthorizedException("Invalid credentials")
+
+
+async def _mock_login_exception(self: AqualinkClient) -> None:
+    raise AqualinkServiceException("Service error")
+
+
+async def test_migrate_login_unauthorized(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+) -> None:
+    """Test migration fails when login is unauthorized."""
+    config_entry = MockConfigEntry(
+        domain="iaqualink",
+        title=config_data["username"],
+        data=config_data,
+        unique_id=config_data["username"].casefold(),
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        _mock_login_unauthorized,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+async def test_migrate_login_exception(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+) -> None:
+    """Test migration fails when login raises a service exception."""
+    config_entry = MockConfigEntry(
+        domain="iaqualink",
+        title=config_data["username"],
+        data=config_data,
+        unique_id=config_data["username"].casefold(),
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        _mock_login_exception,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
 async def test_setup_login_unauthorized(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
@@ -397,6 +453,26 @@ async def test_setup_first_refresh_unauthorized_closes_client(
     assert flows[0]["context"]["source"] == SOURCE_REAUTH
 
 
+async def test_setup_conflicting_account(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test setup fails when another entry already uses the same account."""
+    MockConfigEntry(
+        domain="iaqualink",
+        unique_id=MOCK_USER_ID,
+    ).add_to_hass(hass)
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
 async def test_setup_no_systems_recognized(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
@@ -467,7 +543,7 @@ async def test_setup_devices_unauthorized(
     config_entry: MockConfigEntry,
     client: AqualinkClient,
 ) -> None:
-    """Test setup encountering an unauthorized exception while retrieving devices."""
+    """Test setup encountering an unauthorized error when retrieving devices."""
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
@@ -487,9 +563,9 @@ async def test_setup_devices_unauthorized(
         patch.object(
             system,
             "get_devices",
-            side_effect=AqualinkServiceUnauthorizedException,
-        ),
+        ) as mock_get_devices,
     ):
+        mock_get_devices.side_effect = AqualinkServiceUnauthorizedException
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -226,7 +226,7 @@ async def test_setup_backfills_unique_id(
     system.get_devices = AsyncMock(return_value={})
 
     async def mock_login(aqualink_client: AqualinkClient) -> None:
-        aqualink_client._user_id = "account-123"
+        aqualink_client.user_id = "account-123"
 
     with (
         patch(
@@ -241,6 +241,46 @@ async def test_setup_backfills_unique_id(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
+    assert config_entry.unique_id == "account-123"
+
+
+async def test_migrate_legacy_unique_id(
+    hass: HomeAssistant,
+    config_data: dict[str, str],
+    client: AqualinkClient,
+) -> None:
+    """Test setup migrates legacy username unique IDs to account IDs."""
+    config_entry = MockConfigEntry(
+        domain="iaqualink",
+        title=config_data["username"],
+        data=config_data,
+        unique_id=config_data["username"].casefold(),
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
+    system.get_devices = AsyncMock(return_value={})
+
+    async def mock_login(aqualink_client: AqualinkClient) -> None:
+        aqualink_client.user_id = "account-123"
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            mock_login,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value={system.serial: system},
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.minor_version == 2
     assert config_entry.unique_id == "account-123"
 
 

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -44,6 +44,11 @@ from .conftest import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+async def _async_mock_login(self: AqualinkClient) -> None:
+    """Mock a successful login that sets the account user_id."""
+    self.user_id = MOCK_USER_ID
+
+
 async def _advance_coordinator_time(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
@@ -230,13 +235,10 @@ async def test_setup_backfills_unique_id(
     system.update = AsyncMock()
     system.get_devices = AsyncMock(return_value={})
 
-    async def mock_login(aqualink_client: AqualinkClient) -> None:
-        aqualink_client.user_id = "account-123"
-
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            mock_login,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -246,7 +248,7 @@ async def test_setup_backfills_unique_id(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.unique_id == "account-123"
+    assert config_entry.unique_id == MOCK_USER_ID
 
 
 async def test_migrate_legacy_unique_id(
@@ -269,13 +271,10 @@ async def test_migrate_legacy_unique_id(
     system.update = AsyncMock()
     system.get_devices = AsyncMock(return_value={})
 
-    async def mock_login(aqualink_client: AqualinkClient) -> None:
-        aqualink_client.user_id = "account-123"
-
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            mock_login,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -286,7 +285,7 @@ async def test_migrate_legacy_unique_id(
         await hass.async_block_till_done()
 
     assert config_entry.minor_version == 2
-    assert config_entry.unique_id == "account-123"
+    assert config_entry.unique_id == MOCK_USER_ID
 
 
 async def test_setup_login_unauthorized(
@@ -395,16 +394,11 @@ async def test_setup_first_refresh_unauthorized_closes_client(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
-    mock_close.assert_awaited_once()
+    mock_close.assert_awaited()
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
     assert flows[0]["context"]["source"] == SOURCE_REAUTH
-
-
-async def _async_mock_login(self: AqualinkClient) -> None:
-    """Mock a successful login that sets the account user_id."""
-    self.user_id = MOCK_USER_ID
 
 
 async def test_setup_conflicting_account(

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -34,7 +34,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from .conftest import MOCK_USER_ID, get_aqualink_device, get_aqualink_system, setup_integration
+from .conftest import (
+    MOCK_USER_ID,
+    get_aqualink_device,
+    get_aqualink_system,
+    setup_integration,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -112,7 +117,7 @@ async def test_system_rate_limited_keeps_entities_available(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -284,62 +289,6 @@ async def test_migrate_legacy_unique_id(
     assert config_entry.unique_id == "account-123"
 
 
-async def _mock_login_unauthorized(self: AqualinkClient) -> None:
-    raise AqualinkServiceUnauthorizedException("Invalid credentials")
-
-
-async def _mock_login_exception(self: AqualinkClient) -> None:
-    raise AqualinkServiceException("Service error")
-
-
-async def test_migrate_login_unauthorized(
-    hass: HomeAssistant,
-    config_data: dict[str, str],
-) -> None:
-    """Test migration fails when login is unauthorized."""
-    config_entry = MockConfigEntry(
-        domain="iaqualink",
-        title=config_data["username"],
-        data=config_data,
-        unique_id=config_data["username"].casefold(),
-        minor_version=1,
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login",
-        _mock_login_unauthorized,
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
-
-
-async def test_migrate_login_exception(
-    hass: HomeAssistant,
-    config_data: dict[str, str],
-) -> None:
-    """Test migration fails when login raises a service exception."""
-    config_entry = MockConfigEntry(
-        domain="iaqualink",
-        title=config_data["username"],
-        data=config_data,
-        unique_id=config_data["username"].casefold(),
-        minor_version=1,
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login",
-        _mock_login_exception,
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
-
-
 async def test_setup_login_unauthorized(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
@@ -379,7 +328,7 @@ async def test_setup_systems_exception(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -401,7 +350,7 @@ async def test_setup_systems_unauthorized(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -431,7 +380,7 @@ async def test_setup_first_refresh_unauthorized_closes_client(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -453,6 +402,11 @@ async def test_setup_first_refresh_unauthorized_closes_client(
     assert flows[0]["context"]["source"] == SOURCE_REAUTH
 
 
+async def _async_mock_login(self: AqualinkClient) -> None:
+    """Mock a successful login that sets the account user_id."""
+    self.user_id = MOCK_USER_ID
+
+
 async def test_setup_conflicting_account(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
@@ -465,7 +419,7 @@ async def test_setup_conflicting_account(
 
     with patch(
         "homeassistant.components.iaqualink.AqualinkClient.login",
-        return_value=None,
+        _async_mock_login,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -482,7 +436,7 @@ async def test_setup_no_systems_recognized(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -520,7 +474,7 @@ async def test_setup_devices_exception(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -554,7 +508,7 @@ async def test_setup_devices_unauthorized(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -595,7 +549,7 @@ async def test_setup_all_good_no_recognized_devices(
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            _async_mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -225,10 +225,13 @@ async def test_setup_backfills_unique_id(
     system.update = AsyncMock()
     system.get_devices = AsyncMock(return_value={})
 
+    async def mock_login(aqualink_client: AqualinkClient) -> None:
+        aqualink_client._user_id = "account-123"
+
     with (
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.login",
-            return_value=None,
+            mock_login,
         ),
         patch(
             "homeassistant.components.iaqualink.AqualinkClient.get_systems",
@@ -238,7 +241,7 @@ async def test_setup_backfills_unique_id(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.unique_id == config_entry.data["username"].casefold()
+    assert config_entry.unique_id == "account-123"
 
 
 async def test_setup_login_unauthorized(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for multiple iAquaLink accounts to be added. The previous limitation was largely arbitrary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
