### PR TITLE
Add DHCP discovery to Fumis integration

### DIFF
--- a/homeassistant/components/fumis/config_flow.py
+++ b/homeassistant/components/fumis/config_flow.py
@@ -22,12 +22,71 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DOMAIN, LOGGER
 
 
 class FumisFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Fumis config flow."""
+
+    _discovered_mac: str
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery of a Fumis WiRCU module."""
+        mac = discovery_info.macaddress.replace(":", "").replace("-", "").upper()
+
+        await self.async_set_unique_id(format_mac(mac))
+        self._abort_if_unique_id_configured()
+
+        self._discovered_mac = mac
+        return await self.async_step_dhcp_confirm()
+
+    async def async_step_dhcp_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery confirmation."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            fumis = Fumis(
+                mac=self._discovered_mac,
+                password=user_input[CONF_PIN],
+                session=async_get_clientsession(self.hass),
+            )
+            try:
+                info = await fumis.update_info()
+            except FumisAuthenticationError:
+                errors[CONF_PIN] = "invalid_auth"
+            except FumisStoveOfflineError:
+                errors["base"] = "device_offline"
+            except FumisConnectionError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title=info.controller.model_name or "Fumis",
+                    data={
+                        CONF_MAC: self._discovered_mac,
+                        CONF_PIN: user_input[CONF_PIN],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="dhcp_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PIN): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
+            ),
+            errors=errors,
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/fumis/manifest.json
+++ b/homeassistant/components/fumis/manifest.json
@@ -3,6 +3,11 @@
   "name": "Fumis",
   "codeowners": ["@frenck"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "macaddress": "0016D0*"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/fumis",
   "integration_type": "device",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/fumis/quality_scale.yaml
+++ b/homeassistant/components/fumis/quality_scale.yaml
@@ -42,12 +42,10 @@ rules:
   # Gold
   devices: done
   diagnostics: todo
-  discovery:
-    status: todo
-    comment: DHCP discovery can be added.
+  discovery: done
   discovery-update-info:
-    status: todo
-    comment: DHCP discovery based update can be added.
+    status: exempt
+    comment: Cloud-only API, no local device information to update.
   docs-data-update: done
   docs-examples: done
   docs-known-limitations: done

--- a/homeassistant/components/fumis/strings.json
+++ b/homeassistant/components/fumis/strings.json
@@ -11,6 +11,15 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "dhcp_confirm": {
+        "data": {
+          "pin": "[%key:component::fumis::config::step::user::data::pin%]"
+        },
+        "data_description": {
+          "pin": "[%key:component::fumis::config::step::user::data_description::pin%]"
+        },
+        "description": "A Fumis WiRCU Wi-Fi module was discovered on your network. Enter the PIN code from the label on the module to set up your pellet stove."
+      },
       "reauth_confirm": {
         "data": {
           "pin": "[%key:component::fumis::config::step::user::data::pin%]"

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -267,6 +267,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "registered_devices": True,
     },
     {
+        "domain": "fumis",
+        "macaddress": "0016D0*",
+    },
+    {
         "domain": "fyta",
         "hostname": "fyta*",
     },

--- a/tests/components/fumis/test_config_flow.py
+++ b/tests/components/fumis/test_config_flow.py
@@ -6,10 +6,11 @@ from fumis import FumisAuthenticationError, FumisConnectionError, FumisStoveOffl
 import pytest
 
 from homeassistant.components.fumis.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
 from homeassistant.const import CONF_MAC, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -205,3 +206,97 @@ async def test_reauth_flow_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+
+
+@pytest.mark.usefixtures("mock_fumis")
+async def test_dhcp_discovery(hass: HomeAssistant) -> None:
+    """Test DHCP discovery of a Fumis WiRCU module."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            ip="192.168.1.2",
+            macaddress="0016d0aabbcc",
+            hostname="wircu",
+        ),
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "dhcp_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "1234"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MAC] == "0016D0AABBCC"
+    assert result["data"][CONF_PIN] == "1234"
+    assert result["result"].unique_id == "00:16:d0:aa:bb:cc"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (FumisAuthenticationError, {CONF_PIN: "invalid_auth"}),
+        (FumisStoveOfflineError, {"base": "device_offline"}),
+        (FumisConnectionError, {"base": "cannot_connect"}),
+        (Exception, {"base": "unknown"}),
+    ],
+)
+async def test_dhcp_discovery_errors(
+    hass: HomeAssistant,
+    mock_fumis: MagicMock,
+    side_effect: type[Exception],
+    expected_error: dict[str, str],
+) -> None:
+    """Test DHCP discovery with errors."""
+    mock_fumis.update_info.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            ip="192.168.1.2",
+            macaddress="0016d0aabbcc",
+            hostname="wircu",
+        ),
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "1234"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == expected_error
+
+    mock_fumis.update_info.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "1234"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.usefixtures("mock_fumis")
+async def test_dhcp_discovery_already_configured(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test DHCP discovery when the device is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    discovery = DhcpServiceInfo(
+        ip="192.168.1.99",
+        macaddress="aabbccddeeff",
+        hostname="wircu",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=discovery
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
## Proposed change

Add DHCP discovery to the Fumis integration using the ATech Electronics OUI prefix (`00:16:D0`). Any WiRCU Wi-Fi module on the local network is automatically detected, and the user is prompted to enter only the PIN code to complete setup (the MAC address is already known from discovery).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr