### PR TITLE
Rename SerialSelector to SerialPortSelector

### DIFF
--- a/homeassistant/components/denon_rs232/config_flow.py
+++ b/homeassistant/components/denon_rs232/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
-    SerialSelector,
+    SerialPortSelector,
 )
 
 from .const import DOMAIN, LOGGER
@@ -110,7 +110,7 @@ class DenonRS232ConfigFlow(ConfigFlow, domain=DOMAIN):
                                 translation_key="model",
                             )
                         ),
-                        vol.Required(CONF_DEVICE): SerialSelector(),
+                        vol.Required(CONF_DEVICE): SerialPortSelector(),
                     }
                 ),
                 user_input or {},

--- a/homeassistant/components/russound_rio/config_flow.py
+++ b/homeassistant/components/russound_rio/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
-    SerialSelector,
+    SerialPortSelector,
 )
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
@@ -58,7 +58,7 @@ TCP_SCHEMA = vol.Schema(
 
 SERIAL_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_DEVICE): SerialSelector(),
+        vol.Required(CONF_DEVICE): SerialPortSelector(),
         vol.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE): vol.All(
             vol.Coerce(int),
             vol.Range(min=1),

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1771,19 +1771,20 @@ class SelectSelector(Selector[SelectSelectorConfig]):
         return [parent_schema(vol.Schema(str)(val)) for val in data]
 
 
-class SerialSelectorConfig(BaseSelectorConfig):
-    """Class to represent a serial selector config."""
+class SerialPortSelectorConfig(BaseSelectorConfig):
+    """Class to represent a serial port selector config."""
 
 
+@SELECTORS.register("serial_port")
 @SELECTORS.register("serial")
-class SerialSelector(Selector[SerialSelectorConfig]):
+class SerialPortSelector(Selector[SerialPortSelectorConfig]):
     """Selector for a serial port."""
 
-    selector_type = "serial"
+    selector_type = "serial_port"
 
     CONFIG_SCHEMA = make_selector_config_schema()
 
-    def __init__(self, config: SerialSelectorConfig | None = None) -> None:
+    def __init__(self, config: SerialPortSelectorConfig | None = None) -> None:
         """Instantiate a selector."""
         super().__init__(config)
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1776,7 +1776,6 @@ class SerialPortSelectorConfig(BaseSelectorConfig):
 
 
 @SELECTORS.register("serial_port")
-@SELECTORS.register("serial")
 class SerialPortSelector(Selector[SerialPortSelectorConfig]):
     """Selector for a serial port."""
 

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1129,15 +1129,13 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
         ({}, ("/dev/ttyUSB0",), (None,)),
     ],
 )
-@pytest.mark.parametrize("selector_type", ["serial", "serial_port"])
 def test_serial_port_selector_schema(
-    selector_type: str,
     schema: dict | None,
     valid_selections: tuple[Any, ...],
     invalid_selections: tuple[Any, ...],
 ) -> None:
     """Test serial port selector."""
-    _test_selector(selector_type, schema, valid_selections, invalid_selections)
+    _test_selector("serial_port", schema, valid_selections, invalid_selections)
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1129,13 +1129,15 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
         ({}, ("/dev/ttyUSB0",), (None,)),
     ],
 )
-def test_serial_selector_schema(
+@pytest.mark.parametrize("selector_type", ["serial", "serial_port"])
+def test_serial_port_selector_schema(
+    selector_type: str,
     schema: dict | None,
     valid_selections: tuple[Any, ...],
     invalid_selections: tuple[Any, ...],
 ) -> None:
-    """Test serial selector."""
-    _test_selector("serial", schema, valid_selections, invalid_selections)
+    """Test serial port selector."""
+    _test_selector(selector_type, schema, valid_selections, invalid_selections)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Rename the `SerialSelector` class to `SerialPortSelector` to better reflect its purpose of selecting serial ports. The associated config class is also renamed from `SerialSelectorConfig` to `SerialPortSelectorConfig`, and the selector type is renamed from `"serial"` to `"serial_port"`.

The legacy `"serial"` selector type was never released, so the old registration is dropped outright — this is not a breaking change. The two in-tree integrations using the selector (`russound_rio` and `denon_rs232`) are updated to use the new class name, and the selector test is updated accordingly.

Frontend: https://github.com/home-assistant/frontend/pull/51655

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01Qqp3pfEjcnHBmCVgZDL7od