### PR TITLE
Validate local_only user property during ws auth phase

### DIFF
--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
-from ipaddress import ip_address
 import logging
 import secrets
 import time
@@ -24,16 +23,14 @@ from yarl import URL
 
 from homeassistant.auth import jwt_wrapper
 from homeassistant.auth.const import GROUP_ID_READ_ONLY
-from homeassistant.auth.models import User
 from homeassistant.components import websocket_api
 from homeassistant.const import HASSIO_USER_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.http import current_request
 from homeassistant.helpers.json import json_bytes
-from homeassistant.helpers.network import is_cloud_connection
 from homeassistant.helpers.storage import Store
-from homeassistant.util.network import is_local
 
+from .auth_util import async_user_not_allowed_do_auth
 from .const import (
     KEY_AUTHENTICATED,
     KEY_HASS_REFRESH_TOKEN_ID,
@@ -97,38 +94,6 @@ def async_sign_path(
     params.append((SIGN_QUERY_PARAM, encoded))
     url = url.with_query(params)
     return f"{url.path}?{url.query_string}"
-
-
-@callback
-def async_user_not_allowed_do_auth(
-    hass: HomeAssistant, user: User, request: Request | None = None
-) -> str | None:
-    """Validate that user is not allowed to do auth things."""
-    if not user.is_active:
-        return "User is not active"
-
-    if not user.local_only:
-        return None
-
-    # User is marked as local only, check if they are allowed to do auth
-    if request is None:
-        request = current_request.get()
-
-    if not request:
-        return "No request available to validate local access"
-
-    if is_cloud_connection(hass):
-        return "User is local only"
-
-    try:
-        remote_address = ip_address(request.remote)  # type: ignore[arg-type]
-    except ValueError:
-        return "Invalid remote IP"
-
-    if is_local(remote_address):
-        return None
-
-    return "User cannot authenticate remotely"
 
 
 async def async_setup_auth(  # noqa: C901

--- a/homeassistant/components/http/auth_util.py
+++ b/homeassistant/components/http/auth_util.py
@@ -1,0 +1,45 @@
+"""Auth utilities for the HTTP component."""
+
+from __future__ import annotations
+
+from ipaddress import ip_address
+
+from aiohttp.web import Request
+
+from homeassistant.auth.models import User
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.http import current_request
+from homeassistant.helpers.network import is_cloud_connection
+from homeassistant.util.network import is_local
+
+
+@callback
+def async_user_not_allowed_do_auth(
+    hass: HomeAssistant, user: User, request: Request | None = None
+) -> str | None:
+    """Validate that user is not allowed to do auth things."""
+    if not user.is_active:
+        return "User is not active"
+
+    if not user.local_only:
+        return None
+
+    # User is marked as local only, check if they are allowed to do auth
+    if request is None:
+        request = current_request.get()
+
+    if not request:
+        return "No request available to validate local access"
+
+    if is_cloud_connection(hass):
+        return "User is local only"
+
+    try:
+        remote_address = ip_address(request.remote)  # type: ignore[arg-type]
+    except ValueError:
+        return "Invalid remote IP"
+
+    if is_local(remote_address):
+        return None
+
+    return "User cannot authenticate remotely"

--- a/homeassistant/components/websocket_api/auth.py
+++ b/homeassistant/components/websocket_api/auth.py
@@ -9,6 +9,7 @@ from aiohttp.web import Request
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
+from homeassistant.components.http.auth_util import async_user_not_allowed_do_auth
 from homeassistant.components.http.ban import process_success_login, process_wrong_login
 from homeassistant.components.http.const import KEY_HASS_USER
 from homeassistant.const import __version__
@@ -97,6 +98,13 @@ class AuthPhase:
         if (access_token := valid_msg.get("access_token")) and (
             refresh_token := self._hass.auth.async_validate_access_token(access_token)
         ):
+            if user_access_error := async_user_not_allowed_do_auth(
+                self._hass, refresh_token.user, self._request
+            ):
+                await self._send_bytes_text(auth_invalid_message(user_access_error))
+                await process_wrong_login(self._request)
+                raise Disconnect
+
             conn = ActiveConnection(
                 self._logger,
                 self._hass,

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
 
+from tests.test_util import mock_real_ip
 from tests.typing import ClientSessionGenerator
 
 
@@ -149,6 +150,66 @@ async def test_auth_active_user_inactive(
 
         auth_msg = await ws.receive_json()
         assert auth_msg["type"] == TYPE_AUTH_INVALID
+
+
+async def test_auth_local_only_user_rejected_remote(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
+    """Test that a local-only user cannot authenticate from a remote IP."""
+    refresh_token = hass.auth.async_validate_access_token(hass_access_token)
+    refresh_token.user.local_only = True
+
+    assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
+
+    set_mock_ip = mock_real_ip(hass.http.app)
+    set_mock_ip("198.51.100.1")
+
+    client = await hass_client_no_auth()
+
+    with patch(
+        "homeassistant.components.websocket_api.auth.process_wrong_login",
+    ) as mock_process_wrong_login:
+        async with client.ws_connect(URL) as ws:
+            auth_msg = await ws.receive_json()
+            assert auth_msg["type"] == TYPE_AUTH_REQUIRED
+
+            await ws.send_json({"type": TYPE_AUTH, "access_token": hass_access_token})
+
+            auth_msg = await ws.receive_json()
+            assert auth_msg["type"] == TYPE_AUTH_INVALID
+            assert auth_msg["message"] == "User cannot authenticate remotely"
+
+    assert mock_process_wrong_login.called
+
+
+async def test_auth_local_only_user_allowed_local(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
+    """Test that a local-only user can authenticate from a local IP."""
+    refresh_token = hass.auth.async_validate_access_token(hass_access_token)
+    refresh_token.user.local_only = True
+
+    assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
+
+    set_mock_ip = mock_real_ip(hass.http.app)
+    set_mock_ip("192.168.1.100")
+
+    client = await hass_client_no_auth()
+
+    async with client.ws_connect(URL) as ws:
+        auth_msg = await ws.receive_json()
+        assert auth_msg["type"] == TYPE_AUTH_REQUIRED
+
+        await ws.send_json({"type": TYPE_AUTH, "access_token": hass_access_token})
+
+        auth_msg = await ws.receive_json()
+        assert auth_msg["type"] == TYPE_AUTH_OK
 
 
 async def test_auth_active_with_password_not_allow(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add validation of user `local_only` property to websocket auth phase similar the one we have  on http.
Create `auth_util.py` to avoid circular import

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
