### PR TITLE
Register optimized ESPHome serial proxy transport with serialx

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -57,7 +57,7 @@ def _async_scan_serial_ports(
 
         ports.extend(
             SerialDevice(
-                device=serial_proxy.build_url(entry.entry_id, proxy.name),
+                device=str(serial_proxy.build_url(entry.entry_id, proxy.name)),
                 serial_number=device_info.mac_address,
                 manufacturer=device_info.manufacturer,
                 description=f"{device_info.model} ({proxy.name})",

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -77,8 +77,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     await assist_satellite.async_setup(hass)
     await dashboard.async_setup(hass)
     async_setup_websocket_api(hass)
-    async_register_serial_port_scanner(hass, _async_scan_serial_ports)
-    serial_proxy.set_hass_loop(hass.loop)
+
+    if "usb" in hass.config.components:
+        async_register_serial_port_scanner(hass, _async_scan_serial_ports)
+        serial_proxy.set_hass_loop(hass.loop)
+
     return True
 
 

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -8,18 +8,23 @@ from aioesphomeapi import APIClient, APIConnectionError
 
 from homeassistant.components import zeroconf
 from homeassistant.components.bluetooth import async_remove_scanner
+from homeassistant.components.usb import (
+    SerialDevice,
+    USBDevice,
+    async_register_serial_port_scanner,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
     __version__ as ha_version,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.issue_registry import async_delete_issue
 from homeassistant.helpers.typing import ConfigType
 
-from . import assist_satellite, dashboard, ffmpeg_proxy
+from . import assist_satellite, dashboard, ffmpeg_proxy, serial_proxy
 from .const import CONF_BLUETOOTH_MAC_ADDRESS, CONF_NOISE_PSK, DOMAIN
 from .domain_data import DomainData
 from .encryption_key_storage import async_get_encryption_key_storage
@@ -34,12 +39,43 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 CLIENT_INFO = f"Home Assistant {ha_version}"
 
 
+@callback
+def _async_scan_serial_ports(
+    hass: HomeAssistant,
+) -> list[USBDevice | SerialDevice]:
+    """Return serial-proxy ports exposed by connected ESPHome devices."""
+    ports: list[USBDevice | SerialDevice] = []
+
+    for entry in hass.config_entries.async_loaded_entries(DOMAIN):
+        entry_data = entry.runtime_data
+        if not entry_data.available:
+            continue
+
+        device_info = entry_data.device_info
+        if device_info is None:
+            continue
+
+        ports.extend(
+            SerialDevice(
+                device=serial_proxy.build_url(entry.entry_id, proxy.name),
+                serial_number=device_info.mac_address,
+                manufacturer=device_info.manufacturer,
+                description=f"{device_info.model} ({proxy.name})",
+            )
+            for proxy in device_info.serial_proxies
+        )
+
+    return ports
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the esphome component."""
     ffmpeg_proxy.async_setup(hass)
     await assist_satellite.async_setup(hass)
     await dashboard.async_setup(hass)
     async_setup_websocket_api(hass)
+    async_register_serial_port_scanner(hass, _async_scan_serial_ports)
+    serial_proxy.set_hass_loop(hass.loop)
     return True
 
 

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.issue_registry import async_delete_issue
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import slugify
 
 from . import assist_satellite, dashboard, ffmpeg_proxy, serial_proxy
 from .const import CONF_BLUETOOTH_MAC_ADDRESS, CONF_NOISE_PSK, DOMAIN
@@ -58,7 +59,9 @@ def _async_scan_serial_ports(
         ports.extend(
             SerialDevice(
                 device=str(serial_proxy.build_url(entry.entry_id, proxy.name)),
-                serial_number=device_info.mac_address,
+                serial_number=(
+                    device_info.mac_address.replace(":", "") + "-" + slugify(proxy.name)
+                ),
                 manufacturer=device_info.manufacturer,
                 description=f"{device_info.model} ({proxy.name})",
             )

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "esphome",
   "name": "ESPHome",
-  "after_dependencies": ["hassio", "zeroconf", "tag"],
+  "after_dependencies": ["hassio", "tag", "usb", "zeroconf"],
   "codeowners": ["@jesserockz", "@kbx81", "@bdraco"],
   "config_flow": true,
   "dependencies": ["assist_pipeline", "bluetooth", "intent", "ffmpeg", "http"],

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import cast
 
 from aioesphomeapi import APIClient
 from serialx import register_uri_handler
@@ -45,15 +46,12 @@ def build_url(entry_id: str, port_name: str) -> URL:
 async def _resolve_client(entry_id: str) -> APIClient:
     """Look up the `APIClient` for a specific config entry."""
 
+    entry_id = entry_id.upper()
+
     # This function is async specifically so that we can get a reference to the Home
     # Assistant Core instance from its own thread
     hass: HomeAssistant = async_get_hass()
-
-    # Config entry ids can be upper or lower case; yarl always lowercases the
-    # URL host so we need to look for the entry in both cases.
-    entry: ESPHomeConfigEntry | None = hass.config_entries.async_get_entry(
-        entry_id
-    ) or hass.config_entries.async_get_entry(entry_id.upper())
+    entry = cast(ESPHomeConfigEntry, hass.config_entries.async_get_entry(entry_id))
 
     if entry is None or entry.domain != DOMAIN:
         raise InvalidSettingsError(f"No ESPHome config entry with id {entry_id!r}")

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -1,0 +1,113 @@
+"""Home Assistant-aware ESPHome serial proxy URI handler for serialx."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+import urllib.parse
+
+from aioesphomeapi import APIClient
+from serialx import register_uri_handler
+from serialx.platforms.serial_esphome import (
+    ESPHomeSerial,
+    ESPHomeSerialTransport,
+    InvalidSettingsError,
+)
+
+from homeassistant.core import HomeAssistant, async_get_hass
+
+from .const import DOMAIN
+from .entry_data import ESPHomeConfigEntry
+
+SCHEME = "esphome-hass://"
+
+# This is required so that serialx can safely query Core for an instance of an
+# aioesphomeapi client. We cannot make any assumptions here, some packages run separate
+# asyncio event loops in dedicated threads.
+_HASS_LOOP: asyncio.AbstractEventLoop | None = None
+
+
+def set_hass_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Store a reference to the Core event loop."""
+    global _HASS_LOOP  # noqa: PLW0603  # pylint: disable=global-statement
+    _HASS_LOOP = loop
+
+
+def build_url(entry_id: str, port_name: str) -> str:
+    """Build a canonical `esphome-hass://` URL."""
+    return urllib.parse.urlunparse(
+        urllib.parse.ParseResult(
+            scheme="esphome-hass",
+            netloc=entry_id,
+            path="",
+            params="",
+            query=urllib.parse.urlencode({"port_name": port_name}),
+            fragment="",
+        )
+    )
+
+
+async def _resolve_client(entry_id: str) -> APIClient:
+    """Look up the `APIClient` for a specific config entry."""
+
+    # This function is async specifically so that we can get a reference to the Home
+    # Assistant Core instance from its own thread
+    hass: HomeAssistant = async_get_hass()
+    entry = cast(ESPHomeConfigEntry, hass.config_entries.async_get_entry(entry_id))
+    if entry is None or entry.domain != DOMAIN:
+        raise InvalidSettingsError(f"No ESPHome config entry with id {entry_id!r}")
+
+    runtime_data = entry.runtime_data
+    if runtime_data is None:
+        raise InvalidSettingsError(f"ESPHome config entry {entry_id!r} is not loaded")
+
+    return runtime_data.client
+
+
+class HassESPHomeSerial(ESPHomeSerial):
+    """ESPHomeSerial that resolves an HA config entry's APIClient from the URL."""
+
+    _api: APIClient | None
+    _path: str | None
+
+    async def _async_open(self) -> None:
+        """Resolve the HA config entry's APIClient, then open the proxy."""
+        if self._api is None and self._path is not None:
+            parsed = urllib.parse.urlparse(str(self._path))
+            entry_id = parsed.netloc
+            if not entry_id:
+                raise InvalidSettingsError(
+                    f"No ESPHome config entry id in URL {self._path!r}"
+                )
+
+            params = urllib.parse.parse_qs(parsed.query)
+            if "port_name" in params:
+                self._port_name = params["port_name"][0]
+
+            hass_loop = _HASS_LOOP
+            if hass_loop is None:
+                raise InvalidSettingsError(
+                    "ESPHome integration has not registered its event loop"
+                )
+
+            self._api = await asyncio.wrap_future(
+                asyncio.run_coroutine_threadsafe(_resolve_client(entry_id), hass_loop)
+            )
+            self._client_loop = self._api._loop  # noqa: SLF001
+
+        await super()._async_open()
+
+
+class HassESPHomeSerialTransport(ESPHomeSerialTransport):
+    """Transport variant that constructs :class:`HassESPHomeSerial`."""
+
+    transport_name = "esphome-hass"
+    _serial_cls = HassESPHomeSerial
+
+
+register_uri_handler(
+    scheme=SCHEME,
+    unique_scheme=SCHEME,
+    sync_cls=HassESPHomeSerial,
+    async_transport_cls=HassESPHomeSerialTransport,
+)

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -55,11 +55,7 @@ async def _resolve_client(entry_id: str) -> APIClient:
     if entry is None or entry.domain != DOMAIN:
         raise InvalidSettingsError(f"No ESPHome config entry with id {entry_id!r}")
 
-    runtime_data = entry.runtime_data
-    if runtime_data is None:
-        raise InvalidSettingsError(f"ESPHome config entry {entry_id!r} is not loaded")
-
-    return runtime_data.client
+    return entry.runtime_data.client
 
 
 class HassESPHomeSerial(ESPHomeSerial):
@@ -72,14 +68,17 @@ class HassESPHomeSerial(ESPHomeSerial):
         """Resolve the HA config entry's APIClient, then open the proxy."""
         if self._api is None and self._path is not None:
             parsed = URL(str(self._path))
+
             entry_id = parsed.host
             if not entry_id:
                 raise InvalidSettingsError(
                     f"No ESPHome config entry id in URL {self._path!r}"
                 )
 
-            if "port_name" in parsed.query:
-                self._port_name = parsed.query["port_name"]
+            if "port_name" not in parsed.query:
+                raise InvalidSettingsError("Port name is required")
+
+            self._port_name = parsed.query["port_name"]
 
             hass_loop = _HASS_LOOP
             if hass_loop is None:

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -38,15 +38,14 @@ def build_url(entry_id: str, port_name: str) -> URL:
     """Build a canonical `esphome-hass://` URL."""
     return URL.build(
         scheme="esphome-hass",
-        host=entry_id,
+        host="esphome",
+        path=f"/{entry_id}",
         query={"port_name": port_name},
     )
 
 
 async def _resolve_client(entry_id: str) -> APIClient:
     """Look up the `APIClient` for a specific config entry."""
-
-    entry_id = entry_id.upper()
 
     # This function is async specifically so that we can get a reference to the Home
     # Assistant Core instance from its own thread
@@ -73,7 +72,7 @@ class HassESPHomeSerial(ESPHomeSerial):
         if self._api is None and self._path is not None:
             parsed = URL(str(self._path))
 
-            entry_id = parsed.host
+            entry_id = parsed.path.lstrip("/")
             if not entry_id:
                 raise InvalidSettingsError(
                     f"No ESPHome config entry id in URL {self._path!r}"

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from typing import cast
-import urllib.parse
 
 from aioesphomeapi import APIClient
 from serialx import register_uri_handler
@@ -13,6 +12,7 @@ from serialx.platforms.serial_esphome import (
     ESPHomeSerialTransport,
     InvalidSettingsError,
 )
+from yarl import URL
 
 from homeassistant.core import HomeAssistant, async_get_hass
 
@@ -33,27 +33,25 @@ def set_hass_loop(loop: asyncio.AbstractEventLoop) -> None:
     _HASS_LOOP = loop
 
 
-def build_url(entry_id: str, port_name: str) -> str:
+def build_url(entry_id: str, port_name: str) -> URL:
     """Build a canonical `esphome-hass://` URL."""
-    return urllib.parse.urlunparse(
-        urllib.parse.ParseResult(
-            scheme="esphome-hass",
-            netloc=entry_id,
-            path="",
-            params="",
-            query=urllib.parse.urlencode({"port_name": port_name}),
-            fragment="",
-        )
+    return URL.build(
+        scheme="esphome-hass",
+        host=entry_id,
+        query={"port_name": port_name},
     )
 
 
 async def _resolve_client(entry_id: str) -> APIClient:
     """Look up the `APIClient` for a specific config entry."""
 
+    entry_id = entry_id.upper()
+
     # This function is async specifically so that we can get a reference to the Home
     # Assistant Core instance from its own thread
     hass: HomeAssistant = async_get_hass()
     entry = cast(ESPHomeConfigEntry, hass.config_entries.async_get_entry(entry_id))
+
     if entry is None or entry.domain != DOMAIN:
         raise InvalidSettingsError(f"No ESPHome config entry with id {entry_id!r}")
 
@@ -73,16 +71,15 @@ class HassESPHomeSerial(ESPHomeSerial):
     async def _async_open(self) -> None:
         """Resolve the HA config entry's APIClient, then open the proxy."""
         if self._api is None and self._path is not None:
-            parsed = urllib.parse.urlparse(str(self._path))
-            entry_id = parsed.netloc
+            parsed = URL(str(self._path))
+            entry_id = parsed.host
             if not entry_id:
                 raise InvalidSettingsError(
                     f"No ESPHome config entry id in URL {self._path!r}"
                 )
 
-            params = urllib.parse.parse_qs(parsed.query)
-            if "port_name" in params:
-                self._port_name = params["port_name"][0]
+            if "port_name" in parsed.query:
+                self._port_name = parsed.query["port_name"]
 
             hass_loop = _HASS_LOOP
             if hass_loop is None:
@@ -90,6 +87,7 @@ class HassESPHomeSerial(ESPHomeSerial):
                     "ESPHome integration has not registered its event loop"
                 )
 
+            # Fetch the `APIClient` from the Core via the appropriate event loop
             self._api = await asyncio.wrap_future(
                 asyncio.run_coroutine_threadsafe(_resolve_client(entry_id), hass_loop)
             )

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -14,6 +14,7 @@ from serialx.platforms.serial_esphome import (
 )
 from yarl import URL
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, async_get_hass
 
 from .const import DOMAIN
@@ -54,6 +55,9 @@ async def _resolve_client(entry_id: str) -> APIClient:
 
     if entry is None or entry.domain != DOMAIN:
         raise InvalidSettingsError(f"No ESPHome config entry with id {entry_id!r}")
+
+    if entry.state is not ConfigEntryState.LOADED:
+        raise InvalidSettingsError(f"ESPHome config entry {entry_id!r} is not loaded")
 
     return entry.runtime_data.client
 

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import cast
 
 from aioesphomeapi import APIClient
 from serialx import register_uri_handler
@@ -46,12 +45,15 @@ def build_url(entry_id: str, port_name: str) -> URL:
 async def _resolve_client(entry_id: str) -> APIClient:
     """Look up the `APIClient` for a specific config entry."""
 
-    entry_id = entry_id.upper()
-
     # This function is async specifically so that we can get a reference to the Home
     # Assistant Core instance from its own thread
     hass: HomeAssistant = async_get_hass()
-    entry = cast(ESPHomeConfigEntry, hass.config_entries.async_get_entry(entry_id))
+
+    # Config entry ids can be upper or lower case; yarl always lowercases the
+    # URL host so we need to look for the entry in both cases.
+    entry: ESPHomeConfigEntry | None = hass.config_entries.async_get_entry(
+        entry_id
+    ) or hass.config_entries.async_get_entry(entry_id.upper())
 
     if entry is None or entry.domain != DOMAIN:
         raise InvalidSettingsError(f"No ESPHome config entry with id {entry_id!r}")

--- a/tests/components/esphome/test_serial_proxy.py
+++ b/tests/components/esphome/test_serial_proxy.py
@@ -92,6 +92,24 @@ async def test_resolve_client_loaded_entry(
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
+async def test_resolve_client_lowercased_entry_id(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """A yarl-lowercased uppercase entry_id still resolves."""
+    device = await mock_esphome_device(mock_client=mock_client)
+    # yarl lowercases URL hosts, so _resolve_client may be passed the
+    # lowercased form of an uppercase config entry id.
+    assert device.entry.entry_id == device.entry.entry_id.upper()
+
+    with patch.object(serial_proxy, "async_get_hass", return_value=hass):
+        client = await serial_proxy._resolve_client(device.entry.entry_id.lower())
+
+    assert client is mock_client
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_scan_serial_ports_no_entries(hass: HomeAssistant) -> None:
     """No loaded ESPHome entries yields no ports."""
     assert _async_scan_serial_ports(hass) == []

--- a/tests/components/esphome/test_serial_proxy.py
+++ b/tests/components/esphome/test_serial_proxy.py
@@ -23,8 +23,8 @@ from tests.common import MockConfigEntry
 
 def test_build_url_basic() -> None:
     """Build a URL with a simple port name."""
-    url = serial_proxy.build_url("abc123", "uart0")
-    assert url == URL("esphome-hass://abc123?port_name=uart0")
+    url = serial_proxy.build_url("abc123DEF456", "uart0")
+    assert url == URL("esphome-hass://esphome/abc123DEF456?port_name=uart0")
 
 
 def test_build_url_escapes_port_name() -> None:

--- a/tests/components/esphome/test_serial_proxy.py
+++ b/tests/components/esphome/test_serial_proxy.py
@@ -64,6 +64,18 @@ async def test_resolve_client_wrong_domain(hass: HomeAssistant) -> None:
         await serial_proxy._resolve_client(entry.entry_id)
 
 
+async def test_resolve_client_unloaded_entry(hass: HomeAssistant) -> None:
+    """An ESPHome entry that isn't loaded raises InvalidSettingsError."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(serial_proxy, "async_get_hass", return_value=hass),
+        pytest.raises(InvalidSettingsError),
+    ):
+        await serial_proxy._resolve_client(entry.entry_id)
+
+
 @pytest.mark.usefixtures("mock_zeroconf")
 async def test_resolve_client_loaded_entry(
     hass: HomeAssistant,

--- a/tests/components/esphome/test_serial_proxy.py
+++ b/tests/components/esphome/test_serial_proxy.py
@@ -92,24 +92,6 @@ async def test_resolve_client_loaded_entry(
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_resolve_client_lowercased_entry_id(
-    hass: HomeAssistant,
-    mock_client: APIClient,
-    mock_esphome_device: MockESPHomeDeviceType,
-) -> None:
-    """A yarl-lowercased uppercase entry_id still resolves."""
-    device = await mock_esphome_device(mock_client=mock_client)
-    # yarl lowercases URL hosts, so _resolve_client may be passed the
-    # lowercased form of an uppercase config entry id.
-    assert device.entry.entry_id == device.entry.entry_id.upper()
-
-    with patch.object(serial_proxy, "async_get_hass", return_value=hass):
-        client = await serial_proxy._resolve_client(device.entry.entry_id.lower())
-
-    assert client is mock_client
-
-
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_scan_serial_ports_no_entries(hass: HomeAssistant) -> None:
     """No loaded ESPHome entries yields no ports."""
     assert _async_scan_serial_ports(hass) == []

--- a/tests/components/esphome/test_serial_proxy.py
+++ b/tests/components/esphome/test_serial_proxy.py
@@ -1,0 +1,208 @@
+"""Tests for the ESPHome serial proxy helper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call, patch
+
+from aioesphomeapi import APIClient
+from aioesphomeapi.model import SerialProxyInfo, SerialProxyPortType
+import pytest
+from serialx.platforms.serial_esphome import InvalidSettingsError
+from yarl import URL
+
+from homeassistant.components.esphome import _async_scan_serial_ports, serial_proxy
+from homeassistant.components.esphome.const import DOMAIN
+from homeassistant.components.usb import SerialDevice
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import MockESPHomeDeviceType
+
+from tests.common import MockConfigEntry
+
+
+def test_build_url_basic() -> None:
+    """Build a URL with a simple port name."""
+    url = serial_proxy.build_url("abc123", "uart0")
+    assert url == URL("esphome-hass://abc123?port_name=uart0")
+
+
+def test_build_url_escapes_port_name() -> None:
+    """Port names with special characters are URL-encoded."""
+    url = serial_proxy.build_url("abc123", "uart 0/main")
+    # Round-trip via yarl recovers the original port name
+    assert URL(str(url)).query["port_name"] == "uart 0/main"
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_async_setup_stores_event_loop(
+    hass: HomeAssistant,
+) -> None:
+    """async_setup registers hass.loop on the serial_proxy module."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    assert serial_proxy._HASS_LOOP is hass.loop
+
+
+async def test_resolve_client_unknown_entry(hass: HomeAssistant) -> None:
+    """An unknown entry_id raises InvalidSettingsError."""
+    with (
+        patch.object(serial_proxy, "async_get_hass", return_value=hass),
+        pytest.raises(InvalidSettingsError),
+    ):
+        await serial_proxy._resolve_client("does-not-exist")
+
+
+async def test_resolve_client_wrong_domain(hass: HomeAssistant) -> None:
+    """A config entry from a different domain raises InvalidSettingsError."""
+    entry = MockConfigEntry(domain="other", data={})
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(serial_proxy, "async_get_hass", return_value=hass),
+        pytest.raises(InvalidSettingsError),
+    ):
+        await serial_proxy._resolve_client(entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_resolve_client_loaded_entry(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """A loaded ESPHome entry returns its APIClient."""
+    device = await mock_esphome_device(mock_client=mock_client)
+
+    with patch.object(serial_proxy, "async_get_hass", return_value=hass):
+        client = await serial_proxy._resolve_client(device.entry.entry_id)
+
+    assert client is mock_client
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_scan_serial_ports_no_entries(hass: HomeAssistant) -> None:
+    """No loaded ESPHome entries yields no ports."""
+    assert _async_scan_serial_ports(hass) == []
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_scan_serial_ports_happy_path(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """A loaded entry with serial proxies emits a SerialDevice per proxy."""
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "manufacturer": "Espressif",
+            "model": "ESP32",
+            "serial_proxies": [
+                SerialProxyInfo(name="Left Port", port_type=SerialProxyPortType.TTL),
+                SerialProxyInfo(name="Right Port", port_type=SerialProxyPortType.TTL),
+            ],
+        },
+    )
+
+    ports = _async_scan_serial_ports(hass)
+
+    entry_id = device.entry.entry_id
+    assert ports == [
+        SerialDevice(
+            device=str(serial_proxy.build_url(entry_id, "Left Port")),
+            serial_number="AABBCCDDEEFF-left_port",
+            manufacturer="Espressif",
+            description="ESP32 (Left Port)",
+        ),
+        SerialDevice(
+            device=str(serial_proxy.build_url(entry_id, "Right Port")),
+            serial_number="AABBCCDDEEFF-right_port",
+            manufacturer="Espressif",
+            description="ESP32 (Right Port)",
+        ),
+    ]
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_scan_serial_ports_skips_unavailable(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Unavailable entries are skipped by the scanner."""
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "serial_proxies": [
+                SerialProxyInfo(name="uart0", port_type=SerialProxyPortType.TTL)
+            ],
+        },
+    )
+    # Mark the entry as unavailable
+    device.entry.runtime_data.available = False
+
+    assert _async_scan_serial_ports(hass) == []
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_async_open_missing_host(hass: HomeAssistant) -> None:
+    """A URL with an invalid entry_id raises InvalidSettingsError."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    proxy = serial_proxy.HassESPHomeSerial("esphome-hass://unknown/?port_name=uart0")
+
+    with pytest.raises(InvalidSettingsError):
+        await proxy._async_open()
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_async_open_missing_port_name(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """A URL with a missing port name raises InvalidSettingsError."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "manufacturer": "Espressif",
+            "model": "ESP32",
+            "serial_proxies": [
+                SerialProxyInfo(name="uart0", port_type=SerialProxyPortType.TTL),
+            ],
+        },
+    )
+
+    entry_id = device.entry.entry_id
+    proxy = serial_proxy.HassESPHomeSerial(f"esphome-hass://{entry_id}")
+
+    with pytest.raises(InvalidSettingsError):
+        await proxy._async_open()
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_async_open_happy_path(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Happy path sets _api from the loaded entry and applies port_name from query."""
+    device = await mock_esphome_device(mock_client=mock_client)
+    mock_client._loop = hass.loop
+
+    url = str(serial_proxy.build_url(device.entry.entry_id, "uart0"))
+    proxy = serial_proxy.HassESPHomeSerial(url)
+
+    with patch(
+        "homeassistant.components.esphome.serial_proxy.ESPHomeSerial._async_open",
+        AsyncMock(),
+    ) as mock_super_open:
+        await proxy._async_open()
+
+    assert proxy._api is mock_client
+    assert proxy._port_name == "uart0"
+    assert proxy._client_loop is hass.loop
+    assert mock_super_open.mock_calls == [call()]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR registers a `esphome-hass://` protocol handler to serialx that allows us to optimize connections to ESPHome serial proxies by sharing `APIClient`s with Core and keeping encryption keys out of URIs. This:
```
esphome://1.2.3.4:5678/?port_name=Some+Port&key=noise_encryption_key
```

Turns into this:
```
esphome-hass://esphome/01KEA18HJC04A8KECEQ6E6HBRP?port_name=Some+Port
```

The `esphome` host is required to maintain case sensitivity.

This PR also registers these new serial ports via the new serial port scanning API.

<img width="606" height="343" alt="image" src="https://github.com/user-attachments/assets/94a22aea-70d6-4819-a65f-a69ef27778dd" />

The long serial port URIs will be adjusted in the frontend in a later PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
