### PR TITLE
Revert Tuya camera quirk changes

### DIFF
--- a/homeassistant/components/tuya/camera.py
+++ b/homeassistant/components/tuya/camera.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.definition.camera import (
-    CameraQuirk,
     TuyaCameraDefinition,
     get_default_definition,
 )
@@ -30,20 +28,6 @@ CAMERAS: dict[DeviceCategory, CameraEntityDescription] = {
 }
 
 
-def _get_quirk_entities(
-    manager: Manager, device: CustomerDevice
-) -> list[TuyaCameraEntity] | None:
-    if (quirk := TUYA_QUIRKS_REGISTRY.get_quirk_for_device(device)) is None or (
-        entity_quirks := quirk.camera_quirks
-    ) is None:
-        return None
-    return [
-        TuyaCameraEntity(device, manager, definition, quirk=entity_quirk)
-        for entity_quirk in entity_quirks
-        if (definition := entity_quirk.definition_fn(device))
-    ]
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: TuyaConfigEntry,
@@ -58,13 +42,10 @@ async def async_setup_entry(
         entities: list[TuyaCameraEntity] = []
         for device_id in device_ids:
             device = manager.device_map[device_id]
-            if (quirk_entities := _get_quirk_entities(manager, device)) is not None:
-                entities.extend(quirk_entities)
-                continue
             if description := CAMERAS.get(device.category):
                 entities.append(
                     TuyaCameraEntity(
-                        device, manager, get_default_definition(device), description
+                        device, manager, description, get_default_definition(device)
                     )
                 )
 
@@ -88,10 +69,8 @@ class TuyaCameraEntity(TuyaEntity, CameraEntity):
         self,
         device: CustomerDevice,
         device_manager: Manager,
+        description: CameraEntityDescription,
         definition: TuyaCameraDefinition,
-        description: CameraEntityDescription | None = None,
-        *,
-        quirk: CameraQuirk | None = None,
     ) -> None:
         """Init Tuya Camera."""
         super().__init__(device, device_manager, description)
@@ -99,8 +78,6 @@ class TuyaCameraEntity(TuyaEntity, CameraEntity):
         self._attr_model = device.product_name
         self._motion_detection_switch = definition.motion_detection_switch
         self._recording_status = definition.recording_status
-        if quirk and quirk.key:
-            self._attr_unique_id = f"tuya.{device.id}_{quirk.key}"
 
     @property
     def is_recording(self) -> bool:

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -24,13 +24,11 @@ class TuyaEntity(Entity):
         self,
         device: CustomerDevice,
         device_manager: Manager,
-        description: EntityDescription | None,
+        description: EntityDescription,
     ) -> None:
         """Init TuyaEntity."""
-        self._attr_unique_id = f"tuya.{device.id}"
-        if description:
-            self.entity_description = description
-            self._attr_unique_id = f"tuya.{device.id}{description.key}"
+        self._attr_unique_id = f"tuya.{device.id}{description.key}"
+        self.entity_description = description
         # TuyaEntity initialize mq can subscribe
         device.set_up = True
         self.device = device

--- a/tests/components/tuya/test_camera.py
+++ b/tests/components/tuya/test_camera.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
-from tuya_device_handlers.definition.camera import CameraQuirk, get_default_definition
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.camera import (
@@ -57,34 +55,6 @@ async def test_platform_setup_and_discovery(
         snapshot,
         mock_config_entry.entry_id,
     )
-
-
-@pytest.mark.parametrize("mock_device_code", ["sp_rudejjigkywujjvs"])
-@pytest.mark.parametrize(
-    ("get_quirks", "available"),
-    [
-        (None, True),
-        ([], False),
-        ([CameraQuirk(key="", definition_fn=get_default_definition)], True),
-        ([CameraQuirk(key="", definition_fn=lambda d: None)], False),
-    ],
-)
-async def test_empty_quirk(
-    hass: HomeAssistant,
-    mock_manager: Manager,
-    mock_config_entry: MockConfigEntry,
-    mock_device: CustomerDevice,
-    get_quirks: list | None,
-    available: bool,
-) -> None:
-    """Test None quirks use defaults and empty quirk list skips default entities."""
-    with patch.object(TUYA_QUIRKS_REGISTRY, "get_quirk_for_device") as mock_get_quirk:
-        mock_get_quirk.return_value = Mock()
-        mock_get_quirk.return_value.camera_quirks = get_quirks
-        await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-
-    state = hass.states.get("camera.burocam")
-    assert (state is not None) is available
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Partial revert of #166952, based on comments from @MartinHjelmare

> Going forward I think the quirk usage should be redesigned so that the entity definition is moved back to Home Assistant

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
