### PR TITLE
Reduce context switching in Tuya initialisation

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -39,7 +39,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool:
     """Async setup hass config entry."""
     listener = DeviceListener(hass, entry)
-    await hass.async_add_executor_job(listener.initialise)
+    await hass.async_add_executor_job(listener.initialize)
 
     # Connection is successful, store the listener in runtime_data
     entry.runtime_data = listener

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
-from tuya_device_handlers.devices import register_tuya_quirks
 from tuya_sharing import Manager
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -23,7 +20,7 @@ from .const import (
     PLATFORMS,
     TUYA_CLIENT_ID,
 )
-from .coordinator import DeviceListener, TokenListener, TuyaConfigEntry, create_manager
+from .coordinator import DeviceListener, TuyaConfigEntry
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -41,32 +38,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool:
     """Async setup hass config entry."""
-    await hass.async_add_executor_job(
-        register_tuya_quirks, str(Path(hass.config.config_dir, "tuya_quirks"))
-    )
-
-    token_listener = TokenListener(hass, entry)
-
-    # Move to executor as it makes blocking call to import_module
-    # with args ('.system', 'urllib3.contrib.resolver')
-    manager = await hass.async_add_executor_job(create_manager, entry, token_listener)
-
-    listener = DeviceListener(hass, manager)
-    manager.add_device_listener(listener)
-
-    # Get all devices from Tuya
-    try:
-        await hass.async_add_executor_job(manager.update_device_cache)
-    except Exception as exc:
-        # While in general, we should avoid catching broad exceptions,
-        # we have no other way of detecting this case.
-        if "sign invalid" in str(exc):
-            msg = "Authentication failed. Please re-authenticate"
-            raise ConfigEntryAuthFailed(msg) from exc
-        raise
+    listener = DeviceListener(hass, entry)
+    await hass.async_add_executor_job(listener.initialise)
 
     # Connection is successful, store the listener in runtime_data
     entry.runtime_data = listener
+    manager = listener.manager
 
     # Cleanup device registry
     await cleanup_device_registry(hass, manager, entry)

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -57,6 +57,7 @@ class DeviceListener(SharingDeviceListener):
         entry = self._entry
         hass = self.hass
 
+        # Makes blocking call to load files from disk
         register_tuya_quirks(str(Path(hass.config.config_dir, "tuya_quirks")))
 
         token_listener = _TokenListener(hass, entry)
@@ -75,7 +76,7 @@ class DeviceListener(SharingDeviceListener):
         listener = DeviceListener(hass, manager)
         manager.add_device_listener(listener)
 
-        # Get all devices from Tuya
+        # Get all devices from Tuya, makes block web calls
         try:
             manager.update_device_cache()
         except Exception as exc:

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -61,7 +61,7 @@ class DeviceListener(SharingDeviceListener):
 
         token_listener = _TokenListener(hass, entry)
 
-        # Move to executor as it makes blocking call to import_module
+        # Makes blocking call to import_module
         # with args ('.system', 'urllib3.contrib.resolver')
         manager = Manager(
             TUYA_CLIENT_ID,

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -73,8 +73,7 @@ class DeviceListener(SharingDeviceListener):
             token_listener,
         )
 
-        listener = DeviceListener(hass, manager)
-        manager.add_device_listener(listener)
+        manager.add_device_listener(self)
 
         # Get all devices from Tuya, makes block web calls
         try:

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -46,12 +46,12 @@ class DeviceListener(SharingDeviceListener):
         self.hass = hass
         self._entry = entry
 
-    def initialise(self) -> None:
-        """Initialise device listener.
+    def initialize(self) -> None:
+        """Initialize device listener.
 
         Needs to be called in executor as these make blocking calls:
         - `register_tuya_quirks`
-        - `Manager` initialisation
+        - `Manager` initialization
         - `manager.update_device_cache`
         """
         entry = self._entry
@@ -75,7 +75,7 @@ class DeviceListener(SharingDeviceListener):
 
         manager.add_device_listener(self)
 
-        # Get all devices from Tuya, makes block web calls
+        # Get all devices from Tuya, makes blocking web calls
         try:
             manager.update_device_cache()
         except Exception as exc:

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -1,7 +1,9 @@
 """Support for Tuya Smart devices."""
 
+from pathlib import Path
 from typing import Any
 
+from tuya_device_handlers.devices import register_tuya_quirks
 from tuya_sharing import (
     CustomerDevice,
     Manager,
@@ -11,6 +13,7 @@ from tuya_sharing import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
 
@@ -29,28 +32,60 @@ from .const import (
 type TuyaConfigEntry = ConfigEntry[DeviceListener]
 
 
-def create_manager(entry: TuyaConfigEntry, token_listener: TokenListener) -> Manager:
-    """Create a Tuya Manager instance."""
-    return Manager(
-        TUYA_CLIENT_ID,
-        entry.data[CONF_USER_CODE],
-        entry.data[CONF_TERMINAL_ID],
-        entry.data[CONF_ENDPOINT],
-        entry.data[CONF_TOKEN_INFO],
-        token_listener,
-    )
-
-
 class DeviceListener(SharingDeviceListener):
     """Device Update Listener."""
+
+    manager: Manager
 
     def __init__(
         self,
         hass: HomeAssistant,
-        manager: Manager,
+        entry: TuyaConfigEntry,
     ) -> None:
         """Init DeviceListener."""
         self.hass = hass
+        self._entry = entry
+
+    def initialise(self) -> None:
+        """Initialise device listener.
+
+        Needs to be called in executor as these make blocking calls:
+        - `register_tuya_quirks`
+        - `Manager` initialisation
+        - `manager.update_device_cache`
+        """
+        entry = self._entry
+        hass = self.hass
+
+        register_tuya_quirks(str(Path(hass.config.config_dir, "tuya_quirks")))
+
+        token_listener = _TokenListener(hass, entry)
+
+        # Move to executor as it makes blocking call to import_module
+        # with args ('.system', 'urllib3.contrib.resolver')
+        manager = Manager(
+            TUYA_CLIENT_ID,
+            entry.data[CONF_USER_CODE],
+            entry.data[CONF_TERMINAL_ID],
+            entry.data[CONF_ENDPOINT],
+            entry.data[CONF_TOKEN_INFO],
+            token_listener,
+        )
+
+        listener = DeviceListener(hass, manager)
+        manager.add_device_listener(listener)
+
+        # Get all devices from Tuya
+        try:
+            manager.update_device_cache()
+        except Exception as exc:
+            # While in general, we should avoid catching broad exceptions,
+            # we have no other way of detecting this case.
+            if "sign invalid" in str(exc):
+                msg = "Authentication failed. Please re-authenticate"
+                raise ConfigEntryAuthFailed(msg) from exc
+            raise
+
         self.manager = manager
 
     def update_device(
@@ -108,7 +143,7 @@ class DeviceListener(SharingDeviceListener):
             device_registry.async_remove_device(device_entry.id)
 
 
-class TokenListener(SharingTokenListener):
+class _TokenListener(SharingTokenListener):
     """Token listener for upstream token updates."""
 
     def __init__(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are currently four calls to async_add_executor_job during Tuya config entry setup.

This reduces it to just two (once before platform setup, and once after platform setup)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
