### PR TITLE
Fix UniFi Access video intercom (UA Intercom) doorbell support

### DIFF
--- a/homeassistant/components/unifi_access/coordinator.py
+++ b/homeassistant/components/unifi_access/coordinator.py
@@ -29,6 +29,7 @@ from unifi_access_api.models.websocket import (
     LocationUpdateState,
     LocationUpdateV2,
     LogAdd,
+    RemoteView,
     SettingUpdate,
     ThumbnailInfo,
     V2LocationState,
@@ -173,6 +174,7 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             "access.data.device.location_update_v2": self._handle_location_update,
             "access.data.v2.location.update": self._handle_v2_location_update,
             "access.hw.door_bell": self._handle_doorbell,
+            "access.remote_view": self._handle_remote_view,
             "access.logs.insights.add": self._handle_insights_add,
             "access.logs.add": self._handle_logs_add,
             "access.data.setting.update": self._handle_setting_update,
@@ -427,6 +429,18 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             "ring",
             {},
         )
+
+    async def _handle_remote_view(self, msg: WebsocketMessage) -> None:
+        """Handle remote view (video intercom doorbell) press events."""
+        remote_view = cast(RemoteView, msg)
+        device_id = remote_view.data.device_id
+        if device_id in self._device_to_door:
+            door_id = self._device_to_door[device_id]
+            self._dispatch_door_event(door_id, "doorbell", "ring", {})
+        else:
+            _LOGGER.debug(
+                "Received access.remote_view for unknown device %s", device_id
+            )
 
     async def _handle_insights_add(self, msg: WebsocketMessage) -> None:
         """Handle access insights events (entry/exit)."""


### PR DESCRIPTION
## Problem

UA Intercom (video doorbell) devices send `access.remote_view` WebSocket events when the doorbell button is pressed. The current integration only registers a handler for `access.hw.door_bell`, which is sent by standard hardware doorbells (e.g. UA-Reader Pro with doorbell button). As a result, **doorbell automations never trigger for video intercom devices**.

## Root Cause

In `coordinator.py`, `_async_setup` registers WebSocket handlers but `access.remote_view` is missing:

```python
handlers: dict[str, WsMessageHandler] = {
    "access.data.device.location_update_v2": self._handle_location_update,
    "access.data.v2.location.update": self._handle_v2_location_update,
    "access.hw.door_bell": self._handle_doorbell,
    # access.remote_view is NOT handled → video intercoms silently ignored
    ...
}
```

The `py-unifi-access` library already has a fully typed `RemoteView` model for this event (since v1.0.0).

## Fix

Register a `_handle_remote_view` handler for `access.remote_view` events. The handler maps `device_id` from the event payload to a `door_id` using the existing `_device_to_door` lookup and dispatches the same `doorbell/ring` event as the hardware doorbell handler.

## Testing

Tested with a UA Intercom G2 connected via UCG-Ultra. Pressing the doorbell button now correctly fires `event.haustur_turklingel` with event type `ring`, triggering all configured automations.

## Checklist

- [ ] The code change is tested and works locally
- [ ] Local tests pass with `pytest tests/components/unifi_access/`