### PR TITLE
Fix incorrect sensor definition for Indevolt Gen-1 devices

### DIFF
--- a/homeassistant/components/indevolt/number.py
+++ b/homeassistant/components/indevolt/number.py
@@ -43,7 +43,6 @@ NUMBERS: Final = (
         native_max_value=100,
         native_step=1,
         native_unit_of_measurement=PERCENTAGE,
-        device_class=NumberDeviceClass.BATTERY,
     ),
     IndevoltNumberEntityDescription(
         key="max_ac_output_power",

--- a/homeassistant/components/indevolt/sensor.py
+++ b/homeassistant/components/indevolt/sensor.py
@@ -69,10 +69,9 @@ SENSORS: Final = (
     IndevoltSensorEntityDescription(
         key="6105",
         generation=[1],
-        translation_key="rated_capacity",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        translation_key="discharge_limit",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
     ),
     IndevoltSensorEntityDescription(
         key="2101",

--- a/homeassistant/components/indevolt/sensor.py
+++ b/homeassistant/components/indevolt/sensor.py
@@ -71,7 +71,6 @@ SENSORS: Final = (
         generation=[1],
         translation_key="discharge_limit",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
     ),
     IndevoltSensorEntityDescription(
         key="2101",

--- a/homeassistant/components/indevolt/strings.json
+++ b/homeassistant/components/indevolt/strings.json
@@ -224,7 +224,7 @@
         "name": "DC output power"
       },
       "discharge_limit": {
-        "name": "Discharge limit"
+        "name": "[%key:component::indevolt::entity::number::discharge_limit::name%]"
       },
       "energy_mode": {
         "name": "Energy mode",

--- a/homeassistant/components/indevolt/strings.json
+++ b/homeassistant/components/indevolt/strings.json
@@ -223,6 +223,9 @@
       "dc_output_power": {
         "name": "DC output power"
       },
+      "discharge_limit": {
+        "name": "Discharge limit"
+      },
       "energy_mode": {
         "name": "Energy mode",
         "state": {

--- a/tests/components/indevolt/snapshots/test_number.ambr
+++ b/tests/components/indevolt/snapshots/test_number.ambr
@@ -29,6 +29,7 @@
     'object_id_base': 'Discharge limit',
     'options': dict({
     }),
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Discharge limit',
     'platform': 'indevolt',

--- a/tests/components/indevolt/snapshots/test_number.ambr
+++ b/tests/components/indevolt/snapshots/test_number.ambr
@@ -29,7 +29,6 @@
     'object_id_base': 'Discharge limit',
     'options': dict({
     }),
-    'original_device_class': <NumberDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
     'original_name': 'Discharge limit',
     'platform': 'indevolt',
@@ -44,7 +43,6 @@
 # name: test_number[2][number.cms_sf2000_discharge_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
       'friendly_name': 'CMS-SF2000 Discharge limit',
       'max': 100,
       'min': 0,

--- a/tests/components/indevolt/snapshots/test_sensor.ambr
+++ b/tests/components/indevolt/snapshots/test_sensor.ambr
@@ -670,7 +670,6 @@
     'object_id_base': 'Discharge limit',
     'options': dict({
     }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
     'original_name': 'Discharge limit',
     'platform': 'indevolt',
@@ -685,7 +684,6 @@
 # name: test_sensor[1][sensor.bk1600_discharge_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
       'friendly_name': 'BK1600 Discharge limit',
       'unit_of_measurement': '%',
     }),

--- a/tests/components/indevolt/snapshots/test_sensor.ambr
+++ b/tests/components/indevolt/snapshots/test_sensor.ambr
@@ -670,6 +670,7 @@
     'object_id_base': 'Discharge limit',
     'options': dict({
     }),
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Discharge limit',
     'platform': 'indevolt',

--- a/tests/components/indevolt/snapshots/test_sensor.ambr
+++ b/tests/components/indevolt/snapshots/test_sensor.ambr
@@ -115,6 +115,58 @@
     'state': '0',
   })
 # ---
+# name: test_sensor[1][sensor.bk1600_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bk1600_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'indevolt',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'discharge_limit',
+    'unique_id': 'BK1600-12345678_6105',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[1][sensor.bk1600_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'BK1600 Battery',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bk1600_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
+  })
+# ---
 # name: test_sensor[1][sensor.bk1600_battery_charge_discharge_state-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -765,64 +817,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
-  })
-# ---
-# name: test_sensor[1][sensor.bk1600_rated_capacity-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.bk1600_rated_capacity',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Rated capacity',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
-    'original_icon': None,
-    'original_name': 'Rated capacity',
-    'platform': 'indevolt',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'rated_capacity',
-    'unique_id': 'BK1600-12345678_6105',
-    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-  })
-# ---
-# name: test_sensor[1][sensor.bk1600_rated_capacity-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'BK1600 Rated capacity',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bk1600_rated_capacity',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '5',
   })
 # ---
 # name: test_sensor[1][sensor.bk1600_total_ac_input_energy-entry]

--- a/tests/components/indevolt/snapshots/test_sensor.ambr
+++ b/tests/components/indevolt/snapshots/test_sensor.ambr
@@ -115,58 +115,6 @@
     'state': '0',
   })
 # ---
-# name: test_sensor[1][sensor.bk1600_battery-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.bk1600_battery',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Battery',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-    'original_icon': None,
-    'original_name': 'Battery',
-    'platform': 'indevolt',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'discharge_limit',
-    'unique_id': 'BK1600-12345678_6105',
-    'unit_of_measurement': '%',
-  })
-# ---
-# name: test_sensor[1][sensor.bk1600_battery-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'BK1600 Battery',
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bk1600_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '5',
-  })
-# ---
 # name: test_sensor[1][sensor.bk1600_battery_charge_discharge_state-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -695,6 +643,58 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'main',
+  })
+# ---
+# name: test_sensor[1][sensor.bk1600_discharge_limit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bk1600_discharge_limit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Discharge limit',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Discharge limit',
+    'platform': 'indevolt',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'discharge_limit',
+    'unique_id': 'BK1600-12345678_6105',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[1][sensor.bk1600_discharge_limit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'BK1600 Discharge limit',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bk1600_discharge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
   })
 # ---
 # name: test_sensor[1][sensor.bk1600_energy_mode-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixed sensor name, device class, and native unit for Gen-1 device to show "discharge limit" (currently incorrectly named / configured as "rated capacity").

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
