### PR TITLE
Add button platform to HP iLO integration for power control

### DIFF
--- a/homeassistant/components/hp_ilo/button.py
+++ b/homeassistant/components/hp_ilo/button.py
@@ -14,7 +14,13 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/homeassistant/components/hp_ilo/button.py
+++ b/homeassistant/components/hp_ilo/button.py
@@ -1,0 +1,145 @@
+"""Support for HP iLO buttons."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+import hpilo
+import voluptuous as vol
+
+from homeassistant.components.button import (
+    PLATFORM_SCHEMA as BUTTON_PLATFORM_SCHEMA,
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "HP ILO"
+DEFAULT_PORT = 443
+
+PLATFORM_SCHEMA = BUTTON_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    }
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HpIloButtonEntityDescription(ButtonEntityDescription):
+    """Describes an HP iLO button entity."""
+
+    ilo_method: str
+    ilo_method_kwargs: dict | None = None
+
+
+BUTTON_TYPES: tuple[HpIloButtonEntityDescription, ...] = (
+    HpIloButtonEntityDescription(
+        key="power_on",
+        name="Power On",
+        ilo_method="set_host_power",
+        ilo_method_kwargs={"host_power": True},
+    ),
+    HpIloButtonEntityDescription(
+        key="power_off",
+        name="Power Off",
+        ilo_method="set_host_power",
+        ilo_method_kwargs={"host_power": False},
+    ),
+    HpIloButtonEntityDescription(
+        key="press_power_button",
+        name="Press Power Button",
+        ilo_method="press_pwr_btn",
+    ),
+    HpIloButtonEntityDescription(
+        key="cold_boot",
+        name="Cold Boot",
+        device_class=ButtonDeviceClass.RESTART,
+        ilo_method="cold_boot_server",
+    ),
+    HpIloButtonEntityDescription(
+        key="warm_boot",
+        name="Warm Boot",
+        device_class=ButtonDeviceClass.RESTART,
+        ilo_method="warm_boot_server",
+    ),
+)
+
+
+def setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the HP iLO button platform."""
+    hostname = config[CONF_HOST]
+    port = config[CONF_PORT]
+    login = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    name = config[CONF_NAME]
+
+    add_entities(
+        HpIloButton(
+            description=description,
+            name=f"{name} {description.name}",
+            hostname=hostname,
+            port=port,
+            login=login,
+            password=password,
+        )
+        for description in BUTTON_TYPES
+    )
+
+
+class HpIloButton(ButtonEntity):
+    """Representation of an HP iLO button."""
+
+    entity_description: HpIloButtonEntityDescription
+
+    def __init__(
+        self,
+        description: HpIloButtonEntityDescription,
+        name: str,
+        hostname: str,
+        port: int,
+        login: str,
+        password: str,
+    ) -> None:
+        """Initialize the HP iLO button."""
+        self.entity_description = description
+        self._attr_name = name
+        self._hostname = hostname
+        self._port = port
+        self._login = login
+        self._password = password
+
+    def press(self) -> None:
+        """Execute the button action via HP iLO."""
+        try:
+            ilo = hpilo.Ilo(
+                hostname=self._hostname,
+                login=self._login,
+                password=self._password,
+                port=self._port,
+            )
+            method = getattr(ilo, self.entity_description.ilo_method)
+            kwargs = self.entity_description.ilo_method_kwargs or {}
+            method(**kwargs)
+        except (
+            hpilo.IloError,
+            hpilo.IloCommunicationError,
+            hpilo.IloLoginFailed,
+        ) as error:
+            _LOGGER.error("Unable to perform HP iLO action: %s", error)

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2224,6 +2224,9 @@ python-homeassistant-analytics==0.9.0
 # homeassistant.components.homewizard
 python-homewizard-energy==10.0.1
 
+# homeassistant.components.hp_ilo
+python-hpilo==4.4.3
+
 # homeassistant.components.izone
 python-izone==1.2.9
 

--- a/tests/components/hp_ilo/__init__.py
+++ b/tests/components/hp_ilo/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the HP iLO integration."""

--- a/tests/components/hp_ilo/test_button.py
+++ b/tests/components/hp_ilo/test_button.py
@@ -1,0 +1,144 @@
+"""Tests for the HP iLO button platform."""
+
+from unittest.mock import MagicMock, patch
+
+import hpilo
+import pytest
+
+from homeassistant.components import button
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+VALID_CONFIG = {
+    "button": {
+        "platform": "hp_ilo",
+        "host": "192.168.1.1",
+        "username": "admin",
+        "password": "secret",
+        "port": 443,
+        "name": "Test Server",
+    }
+}
+
+
+@pytest.fixture
+def mock_ilo() -> MagicMock:
+    """Return a mock hpilo.Ilo instance."""
+    mock = MagicMock()
+    with patch("homeassistant.components.hp_ilo.button.hpilo.Ilo", return_value=mock):
+        yield mock
+
+
+async def test_setup_creates_all_buttons(
+    hass: HomeAssistant, mock_ilo: MagicMock
+) -> None:
+    """All five power buttons are created with correct names."""
+    assert await async_setup_component(hass, "button", VALID_CONFIG)
+    await hass.async_block_till_done()
+
+    expected = [
+        "button.test_server_power_on",
+        "button.test_server_power_off",
+        "button.test_server_press_power_button",
+        "button.test_server_cold_boot",
+        "button.test_server_warm_boot",
+    ]
+    for entity_id in expected:
+        state = hass.states.get(entity_id)
+        assert state is not None, f"{entity_id} was not created"
+
+
+async def test_press_power_on(hass: HomeAssistant, mock_ilo: MagicMock) -> None:
+    """Pressing Power On calls set_host_power(host_power=True)."""
+    assert await async_setup_component(hass, "button", VALID_CONFIG)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        button.DOMAIN,
+        button.SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_server_power_on"},
+        blocking=True,
+    )
+
+    mock_ilo.set_host_power.assert_called_once_with(host_power=True)
+
+
+async def test_press_power_off(hass: HomeAssistant, mock_ilo: MagicMock) -> None:
+    """Pressing Power Off calls set_host_power(host_power=False)."""
+    assert await async_setup_component(hass, "button", VALID_CONFIG)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        button.DOMAIN,
+        button.SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_server_power_off"},
+        blocking=True,
+    )
+
+    mock_ilo.set_host_power.assert_called_once_with(host_power=False)
+
+
+async def test_press_power_button(hass: HomeAssistant, mock_ilo: MagicMock) -> None:
+    """Pressing Press Power Button calls press_pwr_btn()."""
+    assert await async_setup_component(hass, "button", VALID_CONFIG)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        button.DOMAIN,
+        button.SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_server_press_power_button"},
+        blocking=True,
+    )
+
+    mock_ilo.press_pwr_btn.assert_called_once_with()
+
+
+async def test_press_cold_boot(hass: HomeAssistant, mock_ilo: MagicMock) -> None:
+    """Pressing Cold Boot calls cold_boot_server()."""
+    assert await async_setup_component(hass, "button", VALID_CONFIG)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        button.DOMAIN,
+        button.SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_server_cold_boot"},
+        blocking=True,
+    )
+
+    mock_ilo.cold_boot_server.assert_called_once_with()
+
+
+async def test_press_warm_boot(hass: HomeAssistant, mock_ilo: MagicMock) -> None:
+    """Pressing Warm Boot calls warm_boot_server()."""
+    assert await async_setup_component(hass, "button", VALID_CONFIG)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        button.DOMAIN,
+        button.SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_server_warm_boot"},
+        blocking=True,
+    )
+
+    mock_ilo.warm_boot_server.assert_called_once_with()
+
+
+async def test_press_logs_error_on_ilo_failure(
+    hass: HomeAssistant, mock_ilo: MagicMock
+) -> None:
+    """A failed iLO call is logged and does not raise."""
+    mock_ilo.set_host_power.side_effect = hpilo.IloError("connection refused")
+
+    assert await async_setup_component(hass, "button", VALID_CONFIG)
+    await hass.async_block_till_done()
+
+    # Should not raise despite the iLO error
+    await hass.services.async_call(
+        button.DOMAIN,
+        button.SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_server_power_on"},
+        blocking=True,
+    )
+
+    mock_ilo.set_host_power.assert_called_once_with(host_power=True)


### PR DESCRIPTION
## Proposed change

Adds a `button` platform to the HP iLO integration, exposing five server power-control actions as Home Assistant button entities:

- **Power On** — calls `set_host_power(host_power=True)`
- **Power Off** — calls `set_host_power(host_power=False)`
- **Press Power Button** — calls `press_pwr_btn()`
- **Cold Boot** — calls `cold_boot_server()`
- **Warm Boot** — calls `warm_boot_server()`

The platform follows the same YAML-based configuration pattern as the existing `sensor` platform in this integration and uses the already-declared `python-hpilo` dependency — no new dependencies are introduced.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44961
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr