### PR TITLE
Add pylint plugin to detect polling interval fields in config flows

### DIFF
--- a/homeassistant/components/control4/config_flow.py
+++ b/homeassistant/components/control4/config_flow.py
@@ -169,6 +169,8 @@ class OptionsFlowHandler(OptionsFlowWithReload):
 
         data_schema = vol.Schema(
             {
+                # Polling interval is user-configurable, which is no longer allowed
+                # pylint: disable-next=hass-config-flow-polling-field
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
                     default=self.config_entry.options.get(

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -219,6 +219,8 @@ class HiveOptionsFlowHandler(OptionsFlow):
 
         schema = vol.Schema(
             {
+                # Polling interval is user-configurable, which is no longer allowed
+                # pylint: disable-next=hass-config-flow-polling-field
                 vol.Optional(CONF_SCAN_INTERVAL, default=self.interval): vol.All(
                     vol.Coerce(int), vol.Range(min=30)
                 )

--- a/homeassistant/components/keenetic_ndms2/config_flow.py
+++ b/homeassistant/components/keenetic_ndms2/config_flow.py
@@ -198,6 +198,8 @@ class KeeneticOptionsFlowHandler(OptionsFlowWithReload):
 
         options = vol.Schema(
             {
+                # Polling interval is user-configurable, which is no longer allowed
+                # pylint: disable-next=hass-config-flow-polling-field
                 vol.Required(
                     CONF_SCAN_INTERVAL,
                     default=self.config_entry.options.get(

--- a/homeassistant/components/kraken/config_flow.py
+++ b/homeassistant/components/kraken/config_flow.py
@@ -79,6 +79,8 @@ class KrakenOptionsFlowHandler(OptionsFlow):
         )
 
         options = {
+            # Polling interval is user-configurable, which is no longer allowed
+            # pylint: disable-next=hass-config-flow-polling-field
             vol.Optional(
                 CONF_SCAN_INTERVAL,
                 default=self.config_entry.options.get(

--- a/homeassistant/components/nmap_tracker/config_flow.py
+++ b/homeassistant/components/nmap_tracker/config_flow.py
@@ -167,6 +167,8 @@ async def _async_build_schema_with_user_input(
     if include_options:
         schema.update(
             {
+                # Approved exemption: nmap scan interval is user-configurable
+                # pylint: disable-next=hass-config-flow-polling-field
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
                     default=user_input.get(CONF_SCAN_INTERVAL, TRACKER_SCAN_INTERVAL),

--- a/homeassistant/components/omnilogic/config_flow.py
+++ b/homeassistant/components/omnilogic/config_flow.py
@@ -90,6 +90,8 @@ class OptionsFlowHandler(OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
+                    # Polling interval is user-configurable, which is no longer allowed
+                    # pylint: disable-next=hass-config-flow-polling-field
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
                         default=self.config_entry.options.get(

--- a/homeassistant/components/plaato/config_flow.py
+++ b/homeassistant/components/plaato/config_flow.py
@@ -210,6 +210,8 @@ class PlaatoOptionsFlowHandler(OptionsFlow):
             step_id="user",
             data_schema=vol.Schema(
                 {
+                    # Polling interval is user-configurable, which is no longer allowed
+                    # pylint: disable-next=hass-config-flow-polling-field
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
                         default=self.config_entry.options.get(

--- a/homeassistant/components/risco/config_flow.py
+++ b/homeassistant/components/risco/config_flow.py
@@ -234,6 +234,8 @@ class RiscoOptionsFlowHandler(OptionsFlow):
             self._data = {**DEFAULT_ADVANCED_OPTIONS, **self._data}
             schema = schema.extend(
                 {
+                    # Polling interval is user-configurable, which is no longer allowed
+                    # pylint: disable-next=hass-config-flow-polling-field
                     vol.Required(
                         CONF_SCAN_INTERVAL, default=self._data[CONF_SCAN_INTERVAL]
                     ): int,

--- a/homeassistant/components/screenlogic/config_flow.py
+++ b/homeassistant/components/screenlogic/config_flow.py
@@ -206,6 +206,8 @@ class ScreenLogicOptionsFlowHandler(OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
+                    # Polling interval is user-configurable, which is no longer allowed
+                    # pylint: disable-next=hass-config-flow-polling-field
                     vol.Required(
                         CONF_SCAN_INTERVAL,
                         default=current_interval,

--- a/homeassistant/components/upcloud/config_flow.py
+++ b/homeassistant/components/upcloud/config_flow.py
@@ -107,6 +107,8 @@ class UpCloudOptionsFlow(OptionsFlow):
 
         data_schema = vol.Schema(
             {
+                # Polling interval is user-configurable, which is no longer allowed
+                # pylint: disable-next=hass-config-flow-polling-field
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
                     default=self.config_entry.options.get(CONF_SCAN_INTERVAL)

--- a/pylint/plugins/hass_enforce_config_flow_no_polling.py
+++ b/pylint/plugins/hass_enforce_config_flow_no_polling.py
@@ -1,0 +1,103 @@
+"""Plugin for detecting polling interval fields in config flow schemas.
+
+Polling intervals (scan_interval, update_interval, etc.) should be fixed
+by the integration, not exposed as user-configurable fields. The integration
+author determines the appropriate polling frequency based on API rate limits,
+device capabilities, and data freshness needs.
+
+Found in 3.5% of new-integration PRs across 1,100+ analyzed PRs.
+"""
+
+from __future__ import annotations
+
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+# Field names that indicate a polling/scan interval.
+_POLLING_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "CONF_POLLING_INTERVAL",
+        "CONF_REFRESH_INTERVAL",
+        "CONF_SCAN_INTERVAL",
+        "CONF_UPDATE_FREQUENCY",
+        "CONF_UPDATE_INTERVAL",
+        "polling_interval",
+        "refresh_interval",
+        "scan_interval",
+        "update_frequency",
+        "update_interval",
+    }
+)
+
+
+class HassEnforceConfigFlowNoPollingChecker(BaseChecker):
+    """Checker for polling interval fields in config flow schemas.
+
+    Config flows should not include polling interval fields
+    (CONF_SCAN_INTERVAL, "scan_interval", "update_interval", etc.) -- these
+    should be fixed by the integration author, not user-configurable.
+    """
+
+    name = "hass_enforce_config_flow_no_polling"
+    priority = -1
+    msgs = {
+        "W7492": (
+            "Config flow should not include a '%s' field -- polling intervals "
+            "should be fixed by the integration, not user-configurable "
+            "(https://developers.home-assistant.io/docs/core/"
+            "integration-quality-scale/rules/appropriate-polling)",
+            "hass-config-flow-polling-field",
+            "Used when a config flow schema includes a polling/scan interval "
+            "field. The integration author should determine the appropriate "
+            "polling frequency based on API rate limits and data freshness "
+            "needs. Polling intervals should not be user-configurable. "
+            "See https://developers.home-assistant.io/docs/core/"
+            "integration-quality-scale/rules/appropriate-polling",
+        ),
+    }
+    options = ()
+
+    def visit_call(self, node: nodes.Call) -> None:
+        """Check for polling interval fields in vol.Required/Optional calls."""
+        root_name = node.root().name
+        if not root_name.startswith("homeassistant.components."):
+            return
+
+        parts = root_name.split(".")
+        current_module = parts[3] if len(parts) > 3 else ""
+        if current_module != "config_flow":
+            return
+
+        field_name = _get_schema_field_name(node)
+        if field_name is None:
+            return
+
+        if field_name in _POLLING_FIELD_NAMES:
+            self.add_message(
+                "hass-config-flow-polling-field",
+                node=node,
+                args=(field_name,),
+            )
+
+
+def _get_schema_field_name(node: nodes.Call) -> str | None:
+    """Extract the field name from vol.Required(...) or vol.Optional(...)."""
+    if not isinstance(node.func, nodes.Attribute):
+        return None
+    if node.func.attrname not in {"Required", "Optional"}:
+        return None
+    if not node.args:
+        return None
+
+    first_arg = node.args[0]
+    if isinstance(first_arg, nodes.Const) and isinstance(first_arg.value, str):
+        return first_arg.value
+    if isinstance(first_arg, nodes.Name):
+        return str(first_arg.name)
+    return None
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(HassEnforceConfigFlowNoPollingChecker(linter))

--- a/pylint/plugins/hass_enforce_config_flow_no_polling.py
+++ b/pylint/plugins/hass_enforce_config_flow_no_polling.py
@@ -5,7 +5,7 @@ by the integration, not exposed as user-configurable fields. The integration
 author determines the appropriate polling frequency based on API rate limits,
 device capabilities, and data freshness needs.
 
-Found in 3.5% of new-integration PRs across 1,100+ analyzed PRs.
+Found in 3.5% of new-integration PRs across 1,100+ analyzed PRs, April 2026.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ load-plugins = [
   "hass_async_load_fixtures",
   "hass_decorator",
   "hass_enforce_class_module",
+  "hass_enforce_config_flow_no_polling",
   "hass_enforce_greek_micro_char",
   "hass_enforce_runtime_data",
   "hass_enforce_sorted_platforms",

--- a/tests/pylint/conftest.py
+++ b/tests/pylint/conftest.py
@@ -140,6 +140,27 @@ def decorator_checker_fixture(hass_decorator, linter) -> BaseChecker:
     return type_hint_checker
 
 
+@pytest.fixture(name="hass_enforce_config_flow_no_polling", scope="package")
+def hass_enforce_config_flow_no_polling_fixture() -> ModuleType:
+    """Fixture to the content for the config_flow_no_polling check."""
+    return _load_plugin_from_file(
+        "hass_enforce_config_flow_no_polling",
+        "pylint/plugins/hass_enforce_config_flow_no_polling.py",
+    )
+
+
+@pytest.fixture(name="enforce_config_flow_no_polling_checker")
+def enforce_config_flow_no_polling_checker_fixture(
+    hass_enforce_config_flow_no_polling, linter
+) -> BaseChecker:
+    """Fixture to provide a config_flow_no_polling checker."""
+    checker = hass_enforce_config_flow_no_polling.HassEnforceConfigFlowNoPollingChecker(
+        linter
+    )
+    checker.module = "homeassistant.components.pylint_test"
+    return checker
+
+
 @pytest.fixture(name="hass_enforce_runtime_data", scope="package")
 def hass_enforce_runtime_data_fixture() -> ModuleType:
     """Fixture to the content for the hass_enforce_runtime_data check."""

--- a/tests/pylint/test_enforce_config_flow_no_polling.py
+++ b/tests/pylint/test_enforce_config_flow_no_polling.py
@@ -1,0 +1,144 @@
+"""Tests for pylint hass_enforce_config_flow_no_polling plugin."""
+
+from __future__ import annotations
+
+import astroid
+from pylint.checkers import BaseChecker
+from pylint.testutils.unittest_linter import UnittestLinter
+from pylint.utils.ast_walker import ASTWalker
+import pytest
+
+from . import assert_no_messages
+
+
+@pytest.mark.parametrize(
+    ("code", "module_name"),
+    [
+        pytest.param(
+            """
+        vol.Required(CONF_HOST)
+        """,
+            "homeassistant.components.test.config_flow",
+            id="non_polling_field",
+        ),
+        pytest.param(
+            """
+        vol.Optional("username")
+        """,
+            "homeassistant.components.test.config_flow",
+            id="non_polling_string_field",
+        ),
+        pytest.param(
+            """
+        vol.Optional(CONF_SCAN_INTERVAL)
+        """,
+            "homeassistant.components.test.sensor",
+            id="polling_in_sensor_not_flagged",
+        ),
+        pytest.param(
+            """
+        vol.Optional(CONF_SCAN_INTERVAL)
+        """,
+            "some.other.module",
+            id="outside_components",
+        ),
+        pytest.param(
+            """
+        vol.Optional("scan_interval", default=30)
+        """,
+            "homeassistant.components.test",
+            id="polling_in_init_not_flagged",
+        ),
+        pytest.param(
+            """
+        vol.Optional("check_interval")
+        """,
+            "homeassistant.components.test.config_flow",
+            id="unknown_interval_field",
+        ),
+        pytest.param(
+            """
+        vol.Optional("poll_frequency")
+        """,
+            "homeassistant.components.test.config_flow",
+            id="unknown_frequency_field",
+        ),
+    ],
+)
+def test_enforce_config_flow_no_polling(
+    linter: UnittestLinter,
+    enforce_config_flow_no_polling_checker: BaseChecker,
+    code: str,
+    module_name: str,
+) -> None:
+    """Good test cases."""
+    root_node = astroid.parse(code, module_name)
+    walker = ASTWalker(linter)
+    walker.add_checker(enforce_config_flow_no_polling_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+@pytest.mark.parametrize(
+    ("code", "module_name"),
+    [
+        pytest.param(
+            """
+        vol.Optional(CONF_SCAN_INTERVAL)
+        """,
+            "homeassistant.components.test.config_flow",
+            id="conf_scan_interval",
+        ),
+        pytest.param(
+            """
+        vol.Optional("scan_interval", default=30)
+        """,
+            "homeassistant.components.test.config_flow",
+            id="string_scan_interval",
+        ),
+        pytest.param(
+            """
+        vol.Required("update_interval")
+        """,
+            "homeassistant.components.test.config_flow",
+            id="update_interval",
+        ),
+        pytest.param(
+            """
+        vol.Optional("update_frequency", default=60)
+        """,
+            "homeassistant.components.test.config_flow",
+            id="update_frequency",
+        ),
+        pytest.param(
+            """
+        vol.Optional("refresh_interval")
+        """,
+            "homeassistant.components.test.config_flow",
+            id="refresh_interval",
+        ),
+        pytest.param(
+            """
+        vol.Optional(CONF_UPDATE_INTERVAL)
+        """,
+            "homeassistant.components.test.config_flow",
+            id="conf_update_interval",
+        ),
+    ],
+)
+def test_enforce_config_flow_no_polling_bad(
+    linter: UnittestLinter,
+    enforce_config_flow_no_polling_checker: BaseChecker,
+    code: str,
+    module_name: str,
+) -> None:
+    """Bad test cases."""
+    root_node = astroid.parse(code, module_name)
+    walker = ASTWalker(linter)
+    walker.add_checker(enforce_config_flow_no_polling_checker)
+
+    walker.walk(root_node)
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].msg_id == "hass-config-flow-polling-field"


### PR DESCRIPTION
## Proposed change

Add a new custom pylint plugin (`hass_enforce_config_flow_no_polling`) that detects polling interval fields in config flow schemas. Polling intervals should be fixed by the integration author, not exposed as user-configurable fields.

This was found in 3.5% of new-integration PRs across 1,100+ analyzed PRs.

The checker flags `vol.Required()` and `vol.Optional()` calls in `config_flow.py` where the field name matches known polling interval patterns: `CONF_SCAN_INTERVAL`, `scan_interval`, `update_interval`, `update_frequency`, `polling_interval`, `refresh_interval`, and their `CONF_` variants.

It only checks `config_flow.py` inside `homeassistant/components/` and does not flag other files.

10 existing violations across 10 integrations have been suppressed with inline `disable-next` comments. `nmap_tracker` has an approved exemption.

The violations have been documented as Tasks to clean up this technical dept here: https://github.com/home-assistant/epics/issues/45

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/epics/issues/45
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr