### PR TITLE
Fix invalid notification/event handling in Tuya tests

### DIFF
--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -13,10 +13,10 @@ from tuya_sharing import (
     DeviceFunction,
     DeviceStatusRange,
     Manager,
+    SharingDeviceListener,
 )
 
 from homeassistant.components.tuya.const import DOMAIN
-from homeassistant.components.tuya.coordinator import DeviceListener
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import json_dumps
@@ -31,63 +31,74 @@ DEVICE_MOCKS = sorted(
 )
 
 
-class MockDeviceListener(DeviceListener):
-    """Mocked DeviceListener for testing."""
+async def _async_update_device(
+    hass: HomeAssistant,
+    manager: Manager,
+    device: CustomerDevice,
+    updated_status_properties: list[str] | None,
+    dp_timestamps: dict[str, int] | None,
+) -> None:
+    """Trigger dispatcher_send for device update and wait for entity tasks to complete."""
+    for listener in manager.device_listeners:
+        listener.update_device(device, updated_status_properties, dp_timestamps)
+    await hass.async_block_till_done()
 
-    async def _async_update_device(
-        self,
-        device: CustomerDevice,
-        updated_status_properties: list[str] | None,
-        dp_timestamps: dict[str, int] | None,
-    ) -> None:
-        """Trigger dispatcher_send for device update and wait for entity tasks to complete."""
-        self.update_device(device, updated_status_properties, dp_timestamps)
-        await self.hass.async_block_till_done()
 
-    async def async_send_add_device(
-        self, manager: Manager, device: CustomerDevice
-    ) -> None:
-        """Mock add device from the manager."""
-        manager.device_map[device.id] = device
-        self.add_device(device)
-        await self.hass.async_block_till_done()
+async def async_send_add_device(
+    hass: HomeAssistant, manager: Manager, device: CustomerDevice
+) -> None:
+    """Mock add device from the manager."""
+    manager.device_map[device.id] = device
+    for listener in manager.device_listeners:
+        listener.add_device(device)
+    await hass.async_block_till_done()
 
-    async def async_send_remove_device(
-        self, manager: Manager, device: CustomerDevice
-    ) -> None:
-        """Mock remove device from the manager."""
-        manager.device_map.pop(device.id, None)
-        self.remove_device(device.id)
-        await self.hass.async_block_till_done()
 
-    async def async_mock_online(self, device: CustomerDevice) -> None:
-        """Mock online event from the manager."""
-        device.online = True
-        await self._async_update_device(device, None, None)
+async def async_send_remove_device(
+    hass: HomeAssistant, manager: Manager, device: CustomerDevice
+) -> None:
+    """Mock remove device from the manager."""
+    manager.device_map.pop(device.id, None)
+    for listener in manager.device_listeners:
+        listener.remove_device(device.id)
+    await hass.async_block_till_done()
 
-    async def async_mock_offline(self, device: CustomerDevice) -> None:
-        """Mock offline event from the manager."""
-        device.online = False
-        await self._async_update_device(device, None, None)
 
-    async def async_send_device_update(
-        self,
-        device: CustomerDevice,
-        updated_status_properties: dict[str, Any] | None = None,
-        dp_timestamps: dict[str, int] | None = None,
-    ) -> None:
-        """Mock update device method."""
-        property_list: list[str] | None = None
-        if updated_status_properties is not None:
-            property_list = []
-            for key, value in updated_status_properties.items():
-                if key not in device.status:
-                    raise ValueError(
-                        f"Property {key} not found in device status: {device.status}"
-                    )
-                device.status[key] = value
-                property_list.append(key)
-        await self._async_update_device(device, property_list, dp_timestamps)
+async def async_mock_online(
+    hass: HomeAssistant, manager: Manager, device: CustomerDevice
+) -> None:
+    """Mock online event from the manager."""
+    device.online = True
+    await _async_update_device(hass, manager, device, None, None)
+
+
+async def async_mock_offline(
+    hass: HomeAssistant, manager: Manager, device: CustomerDevice
+) -> None:
+    """Mock offline event from the manager."""
+    device.online = False
+    await _async_update_device(hass, manager, device, None, None)
+
+
+async def async_send_device_update(
+    hass: HomeAssistant,
+    manager: Manager,
+    device: CustomerDevice,
+    updated_status_properties: dict[str, Any] | None = None,
+    dp_timestamps: dict[str, int] | None = None,
+) -> None:
+    """Mock update device method."""
+    property_list: list[str] | None = None
+    if updated_status_properties is not None:
+        property_list = []
+        for key, value in updated_status_properties.items():
+            if key not in device.status:
+                raise ValueError(
+                    f"Property {key} not found in device status: {device.status}"
+                )
+            device.status[key] = value
+            property_list.append(key)
+    await _async_update_device(hass, manager, device, property_list, dp_timestamps)
 
 
 async def create_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDevice:
@@ -159,19 +170,13 @@ async def create_device(hass: HomeAssistant, mock_device_code: str) -> CustomerD
     return device
 
 
-def create_listener(hass: HomeAssistant, manager: Manager) -> MockDeviceListener:
-    """Create a DeviceListener for testing."""
-    listener = MockDeviceListener(hass, manager)
-    manager.add_device_listener(listener)
-    return listener
-
-
 def create_manager(
     terminal_id: str = "7cd96aff-6ec8-4006-b093-3dbff7947591",
 ) -> Manager:
     """Create a Manager for testing."""
     manager = MagicMock(spec=Manager)
     manager.device_map = {}
+    manager.device_listeners = set()
     manager.mq = MagicMock()
     manager.mq.client = MagicMock()
     manager.mq.client.is_connected = MagicMock(return_value=True)
@@ -179,6 +184,12 @@ def create_manager(
     # Meaningless URL / UUIDs
     manager.customer_api.endpoint = "https://apigw.tuyaeu.com"
     manager.terminal_id = terminal_id
+
+    def _add_device_listener(listener: SharingDeviceListener):
+        """Add device listener."""
+        manager.device_listeners.add(listener)
+
+    manager.add_device_listener.side_effect = _add_device_listener
     return manager
 
 
@@ -207,7 +218,7 @@ async def initialize_entry(
 async def check_selective_state_update(
     hass: HomeAssistant,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    mock_manager: Manager,
     freezer: FrozenDateTimeFactory,
     *,
     entity_id: str,
@@ -231,13 +242,13 @@ async def check_selective_state_update(
 
     # Trigger device offline
     freezer.tick(10)
-    await mock_listener.async_mock_offline(mock_device)
+    await async_mock_offline(hass, mock_manager, mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
     assert hass.states.get(entity_id).last_reported.isoformat() == unavailable_reported
 
     # Trigger device online
     freezer.tick(10)
-    await mock_listener.async_mock_online(mock_device)
+    await async_mock_online(hass, mock_manager, mock_device)
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
@@ -245,12 +256,12 @@ async def check_selective_state_update(
     # in updated properties - state should not change
     freezer.tick(10)
     mock_device.status[dpcode] = None
-    await mock_listener.async_send_device_update(mock_device, {})
+    await async_send_device_update(hass, mock_manager, mock_device, {})
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
     # Trigger device update with provided updates
     freezer.tick(30)
-    await mock_listener.async_send_device_update(mock_device, updates)
+    await async_send_device_update(hass, mock_manager, mock_device, updates)
     assert hass.states.get(entity_id).state == expected_state
     assert hass.states.get(entity_id).last_reported.isoformat() == last_reported

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -31,7 +31,7 @@ DEVICE_MOCKS = sorted(
 )
 
 
-class MockDeviceListener:
+class TuyaNotificationHelper:
     """Helper to raise manager events to device listener."""
 
     def __init__(self, hass: HomeAssistant, manager: Manager) -> None:
@@ -217,7 +217,7 @@ async def initialize_entry(
 async def check_selective_state_update(
     hass: HomeAssistant,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     *,
     entity_id: str,
@@ -241,13 +241,13 @@ async def check_selective_state_update(
 
     # Trigger device offline
     freezer.tick(10)
-    await mock_listener.async_mock_offline(mock_device)
+    await notification_helper.async_mock_offline(mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
     assert hass.states.get(entity_id).last_reported.isoformat() == unavailable_reported
 
     # Trigger device online
     freezer.tick(10)
-    await mock_listener.async_mock_online(mock_device)
+    await notification_helper.async_mock_online(mock_device)
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
@@ -255,12 +255,12 @@ async def check_selective_state_update(
     # in updated properties - state should not change
     freezer.tick(10)
     mock_device.status[dpcode] = None
-    await mock_listener.async_send_device_update(mock_device, {})
+    await notification_helper.async_send_device_update(mock_device, {})
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
     # Trigger device update with provided updates
     freezer.tick(30)
-    await mock_listener.async_send_device_update(mock_device, updates)
+    await notification_helper.async_send_device_update(mock_device, updates)
     assert hass.states.get(entity_id).state == expected_state
     assert hass.states.get(entity_id).last_reported.isoformat() == last_reported

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -32,7 +32,7 @@ DEVICE_MOCKS = sorted(
 
 
 class TuyaNotificationHelper:
-    """Helper to raise manager events to device listener."""
+    """Helper to raise manager events to device listeners."""
 
     def __init__(self, hass: HomeAssistant, manager: Manager) -> None:
         """Initialize the helper."""

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -189,7 +189,13 @@ def create_manager(
         """Add device listener."""
         manager.device_listeners.add(listener)
 
+    def _remove_device_listener(listener: SharingDeviceListener):
+        """Remove device listener."""
+        manager.device_listeners.discard(listener)
+
     manager.add_device_listener.side_effect = _add_device_listener
+    manager.remove_device_listener.side_effect = _remove_device_listener
+
     return manager
 
 

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -31,74 +31,67 @@ DEVICE_MOCKS = sorted(
 )
 
 
-async def _async_update_device(
-    hass: HomeAssistant,
-    manager: Manager,
-    device: CustomerDevice,
-    updated_status_properties: list[str] | None,
-    dp_timestamps: dict[str, int] | None,
-) -> None:
-    """Trigger dispatcher_send for device update and wait for entity tasks to complete."""
-    for listener in manager.device_listeners:
-        listener.update_device(device, updated_status_properties, dp_timestamps)
-    await hass.async_block_till_done()
+class MockDeviceListener:
+    """Helper to raise manager events to device listener."""
 
+    def __init__(self, hass: HomeAssistant, manager: Manager) -> None:
+        """Initialize the helper."""
+        self.hass = hass
+        self.manager = manager
 
-async def async_send_add_device(
-    hass: HomeAssistant, manager: Manager, device: CustomerDevice
-) -> None:
-    """Mock add device from the manager."""
-    manager.device_map[device.id] = device
-    for listener in manager.device_listeners:
-        listener.add_device(device)
-    await hass.async_block_till_done()
+    async def _async_update_device(
+        self,
+        device: CustomerDevice,
+        updated_status_properties: list[str] | None,
+        dp_timestamps: dict[str, int] | None,
+    ) -> None:
+        """Trigger dispatcher_send for device update and wait for entity tasks to complete."""
+        for listener in self.manager.device_listeners:
+            listener.update_device(device, updated_status_properties, dp_timestamps)
+        await self.hass.async_block_till_done()
 
+    async def async_send_add_device(self, device: CustomerDevice) -> None:
+        """Mock add device from the manager."""
+        self.manager.device_map[device.id] = device
+        for listener in self.manager.device_listeners:
+            listener.add_device(device)
+        await self.hass.async_block_till_done()
 
-async def async_send_remove_device(
-    hass: HomeAssistant, manager: Manager, device: CustomerDevice
-) -> None:
-    """Mock remove device from the manager."""
-    manager.device_map.pop(device.id, None)
-    for listener in manager.device_listeners:
-        listener.remove_device(device.id)
-    await hass.async_block_till_done()
+    async def async_send_remove_device(self, device: CustomerDevice) -> None:
+        """Mock remove device from the manager."""
+        self.manager.device_map.pop(device.id, None)
+        for listener in self.manager.device_listeners:
+            listener.remove_device(device.id)
+        await self.hass.async_block_till_done()
 
+    async def async_mock_online(self, device: CustomerDevice) -> None:
+        """Mock online event from the manager."""
+        device.online = True
+        await self._async_update_device(device, None, None)
 
-async def async_mock_online(
-    hass: HomeAssistant, manager: Manager, device: CustomerDevice
-) -> None:
-    """Mock online event from the manager."""
-    device.online = True
-    await _async_update_device(hass, manager, device, None, None)
+    async def async_mock_offline(self, device: CustomerDevice) -> None:
+        """Mock offline event from the manager."""
+        device.online = False
+        await self._async_update_device(device, None, None)
 
-
-async def async_mock_offline(
-    hass: HomeAssistant, manager: Manager, device: CustomerDevice
-) -> None:
-    """Mock offline event from the manager."""
-    device.online = False
-    await _async_update_device(hass, manager, device, None, None)
-
-
-async def async_send_device_update(
-    hass: HomeAssistant,
-    manager: Manager,
-    device: CustomerDevice,
-    updated_status_properties: dict[str, Any] | None = None,
-    dp_timestamps: dict[str, int] | None = None,
-) -> None:
-    """Mock update device method."""
-    property_list: list[str] | None = None
-    if updated_status_properties is not None:
-        property_list = []
-        for key, value in updated_status_properties.items():
-            if key not in device.status:
-                raise ValueError(
-                    f"Property {key} not found in device status: {device.status}"
-                )
-            device.status[key] = value
-            property_list.append(key)
-    await _async_update_device(hass, manager, device, property_list, dp_timestamps)
+    async def async_send_device_update(
+        self,
+        device: CustomerDevice,
+        updated_status_properties: dict[str, Any] | None = None,
+        dp_timestamps: dict[str, int] | None = None,
+    ) -> None:
+        """Mock update device method."""
+        property_list: list[str] | None = None
+        if updated_status_properties is not None:
+            property_list = []
+            for key, value in updated_status_properties.items():
+                if key not in device.status:
+                    raise ValueError(
+                        f"Property {key} not found in device status: {device.status}"
+                    )
+                device.status[key] = value
+                property_list.append(key)
+        await self._async_update_device(device, property_list, dp_timestamps)
 
 
 async def create_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDevice:
@@ -224,7 +217,7 @@ async def initialize_entry(
 async def check_selective_state_update(
     hass: HomeAssistant,
     mock_device: CustomerDevice,
-    mock_manager: Manager,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     *,
     entity_id: str,
@@ -248,13 +241,13 @@ async def check_selective_state_update(
 
     # Trigger device offline
     freezer.tick(10)
-    await async_mock_offline(hass, mock_manager, mock_device)
+    await mock_listener.async_mock_offline(mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
     assert hass.states.get(entity_id).last_reported.isoformat() == unavailable_reported
 
     # Trigger device online
     freezer.tick(10)
-    await async_mock_online(hass, mock_manager, mock_device)
+    await mock_listener.async_mock_online(mock_device)
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
@@ -262,12 +255,12 @@ async def check_selective_state_update(
     # in updated properties - state should not change
     freezer.tick(10)
     mock_device.status[dpcode] = None
-    await async_send_device_update(hass, mock_manager, mock_device, {})
+    await mock_listener.async_send_device_update(mock_device, {})
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
     # Trigger device update with provided updates
     freezer.tick(30)
-    await async_send_device_update(hass, mock_manager, mock_device, updates)
+    await mock_listener.async_send_device_update(mock_device, updates)
     assert hass.states.get(entity_id).state == expected_state
     assert hass.states.get(entity_id).last_reported.isoformat() == last_reported

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -17,7 +17,7 @@ from homeassistant.components.tuya.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import DEVICE_MOCKS, MockDeviceListener, create_device, create_manager
+from . import DEVICE_MOCKS, TuyaNotificationHelper, create_device, create_manager
 
 from tests.common import MockConfigEntry
 
@@ -136,6 +136,8 @@ async def mock_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDev
 
 
 @pytest.fixture
-def mock_listener(hass: HomeAssistant, mock_manager: Manager) -> MockDeviceListener:
-    """Fixture for Tuya DeviceListener."""
-    return MockDeviceListener(hass, mock_manager)
+def notification_helper(
+    hass: HomeAssistant, mock_manager: Manager
+) -> TuyaNotificationHelper:
+    """Fixture for Tuya NotificationHelper."""
+    return TuyaNotificationHelper(hass, mock_manager)

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -17,13 +17,7 @@ from homeassistant.components.tuya.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import (
-    DEVICE_MOCKS,
-    MockDeviceListener,
-    create_device,
-    create_listener,
-    create_manager,
-)
+from . import DEVICE_MOCKS, create_device, create_manager
 
 from tests.common import MockConfigEntry
 
@@ -139,9 +133,3 @@ async def mock_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDev
     Use this for testing behavior on a specific device.
     """
     return await create_device(hass, mock_device_code)
-
-
-@pytest.fixture
-def mock_listener(hass: HomeAssistant, mock_manager: Manager) -> MockDeviceListener:
-    """Fixture for Tuya DeviceListener."""
-    return create_listener(hass, mock_manager)

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -17,7 +17,7 @@ from homeassistant.components.tuya.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import DEVICE_MOCKS, create_device, create_manager
+from . import DEVICE_MOCKS, MockDeviceListener, create_device, create_manager
 
 from tests.common import MockConfigEntry
 
@@ -133,3 +133,9 @@ async def mock_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDev
     Use this for testing behavior on a specific device.
     """
     return await create_device(hass, mock_device_code)
+
+
+@pytest.fixture
+def mock_listener(hass: HomeAssistant, mock_manager: Manager) -> MockDeviceListener:
+    """Fixture for Tuya DeviceListener."""
+    return MockDeviceListener(hass, mock_manager)

--- a/tests/components/tuya/test_binary_sensor.py
+++ b/tests/components/tuya/test_binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import TuyaNotificationHelper, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -67,7 +67,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -78,7 +78,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        notification_helper,
         freezer,
         entity_id="binary_sensor.window_downstairs_door",
         dpcode="doorcontact_state",
@@ -108,7 +108,7 @@ async def test_bitmap(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     fault_value: int,
     tankfull: str,
     defrost: str,
@@ -121,7 +121,9 @@ async def test_bitmap(
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == "off"
     assert hass.states.get("binary_sensor.dehumidifier_wet").state == "off"
 
-    await mock_listener.async_send_device_update(mock_device, {"fault": fault_value})
+    await notification_helper.async_send_device_update(
+        mock_device, {"fault": fault_value}
+    )
 
     assert hass.states.get("binary_sensor.dehumidifier_tank_full").state == tankfull
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == defrost

--- a/tests/components/tuya/test_binary_sensor.py
+++ b/tests/components/tuya/test_binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import async_send_device_update, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -67,7 +67,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -78,7 +77,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        mock_manager,
         freezer,
         entity_id="binary_sensor.window_downstairs_door",
         dpcode="doorcontact_state",
@@ -108,7 +107,6 @@ async def test_bitmap(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     fault_value: int,
     tankfull: str,
     defrost: str,
@@ -121,7 +119,9 @@ async def test_bitmap(
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == "off"
     assert hass.states.get("binary_sensor.dehumidifier_wet").state == "off"
 
-    await mock_listener.async_send_device_update(mock_device, {"fault": fault_value})
+    await async_send_device_update(
+        hass, mock_manager, mock_device, {"fault": fault_value}
+    )
 
     assert hass.states.get("binary_sensor.dehumidifier_tank_full").state == tankfull
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == defrost

--- a/tests/components/tuya/test_binary_sensor.py
+++ b/tests/components/tuya/test_binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import async_send_device_update, check_selective_state_update, initialize_entry
+from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -67,6 +67,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -77,7 +78,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_manager,
+        mock_listener,
         freezer,
         entity_id="binary_sensor.window_downstairs_door",
         dpcode="doorcontact_state",
@@ -107,6 +108,7 @@ async def test_bitmap(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     fault_value: int,
     tankfull: str,
     defrost: str,
@@ -119,9 +121,7 @@ async def test_bitmap(
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == "off"
     assert hass.states.get("binary_sensor.dehumidifier_wet").state == "off"
 
-    await async_send_device_update(
-        hass, mock_manager, mock_device, {"fault": fault_value}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"fault": fault_value})
 
     assert hass.states.get("binary_sensor.dehumidifier_tank_full").state == tankfull
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == defrost

--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -14,7 +14,7 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, initialize_entry
+from . import TuyaNotificationHelper, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -32,7 +32,7 @@ async def test_platform_setup_and_discovery(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -41,7 +41,9 @@ async def test_platform_setup_and_discovery(
 
     for mock_device in mock_devices:
         # Simulate an initial device update to generate events
-        await mock_listener.async_send_device_update(mock_device, mock_device.status)
+        await notification_helper.async_send_device_update(
+            mock_device, mock_device.status
+        )
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -70,7 +72,7 @@ async def test_alarm_message_event(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     snapshot: SnapshotAssertion,
     entity_id: str,
     dpcode: str,
@@ -81,7 +83,7 @@ async def test_alarm_message_event(
 
     mock_device.status[dpcode] = value
 
-    await mock_listener.async_send_device_update(mock_device, mock_device.status)
+    await notification_helper.async_send_device_update(mock_device, mock_device.status)
 
     # Verify event was triggered with correct type and decoded URL
     state = hass.states.get(entity_id)
@@ -99,7 +101,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Ensure event is only triggered when device reports actual data."""
@@ -111,27 +113,33 @@ async def test_selective_state_update(
 
     # Device receives a data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
+    await notification_helper.async_send_device_update(
+        mock_device, {"switch_mode1": "click"}
+    )
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device goes offline
     freezer.tick(10)
-    await mock_listener.async_mock_offline(mock_device)
+    await notification_helper.async_mock_offline(mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # Device comes back online - state should go back to last known value,
     # not new datetime since no new data update has come in
     freezer.tick(10)
-    await mock_listener.async_mock_online(mock_device)
+    await notification_helper.async_mock_online(mock_device)
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device receives a new data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
+    await notification_helper.async_send_device_update(
+        mock_device, {"switch_mode1": "click"}
+    )
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"
 
     # Device receives a data update on a different datapoint - event doesn't
     # get triggered and state doesn't get updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(mock_device, {"switch_mode2": "click"})
+    await notification_helper.async_send_device_update(
+        mock_device, {"switch_mode2": "click"}
+    )
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"

--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -14,7 +14,12 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, initialize_entry
+from . import (
+    async_mock_offline,
+    async_mock_online,
+    async_send_device_update,
+    initialize_entry,
+)
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -32,7 +37,6 @@ async def test_platform_setup_and_discovery(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
-    mock_listener: MockDeviceListener,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -41,7 +45,9 @@ async def test_platform_setup_and_discovery(
 
     for mock_device in mock_devices:
         # Simulate an initial device update to generate events
-        await mock_listener.async_send_device_update(mock_device, mock_device.status)
+        await async_send_device_update(
+            hass, mock_manager, mock_device, mock_device.status
+        )
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -70,7 +76,6 @@ async def test_alarm_message_event(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     snapshot: SnapshotAssertion,
     entity_id: str,
     dpcode: str,
@@ -81,7 +86,7 @@ async def test_alarm_message_event(
 
     mock_device.status[dpcode] = value
 
-    await mock_listener.async_send_device_update(mock_device, mock_device.status)
+    await async_send_device_update(hass, mock_manager, mock_device, mock_device.status)
 
     # Verify event was triggered with correct type and decoded URL
     state = hass.states.get(entity_id)
@@ -99,7 +104,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Ensure event is only triggered when device reports actual data."""
@@ -111,27 +115,33 @@ async def test_selective_state_update(
 
     # Device receives a data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
+    await async_send_device_update(
+        hass, mock_manager, mock_device, {"switch_mode1": "click"}
+    )
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device goes offline
     freezer.tick(10)
-    await mock_listener.async_mock_offline(mock_device)
+    await async_mock_offline(hass, mock_manager, mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # Device comes back online - state should go back to last known value,
     # not new datetime since no new data update has come in
     freezer.tick(10)
-    await mock_listener.async_mock_online(mock_device)
+    await async_mock_online(hass, mock_manager, mock_device)
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device receives a new data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
+    await async_send_device_update(
+        hass, mock_manager, mock_device, {"switch_mode1": "click"}
+    )
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"
 
     # Device receives a data update on a different datapoint - event doesn't
     # get triggered and state doesn't get updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(mock_device, {"switch_mode2": "click"})
+    await async_send_device_update(
+        hass, mock_manager, mock_device, {"switch_mode2": "click"}
+    )
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"

--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -14,12 +14,7 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import (
-    async_mock_offline,
-    async_mock_online,
-    async_send_device_update,
-    initialize_entry,
-)
+from . import MockDeviceListener, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -37,6 +32,7 @@ async def test_platform_setup_and_discovery(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
+    mock_listener: MockDeviceListener,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -45,9 +41,7 @@ async def test_platform_setup_and_discovery(
 
     for mock_device in mock_devices:
         # Simulate an initial device update to generate events
-        await async_send_device_update(
-            hass, mock_manager, mock_device, mock_device.status
-        )
+        await mock_listener.async_send_device_update(mock_device, mock_device.status)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -76,6 +70,7 @@ async def test_alarm_message_event(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     snapshot: SnapshotAssertion,
     entity_id: str,
     dpcode: str,
@@ -86,7 +81,7 @@ async def test_alarm_message_event(
 
     mock_device.status[dpcode] = value
 
-    await async_send_device_update(hass, mock_manager, mock_device, mock_device.status)
+    await mock_listener.async_send_device_update(mock_device, mock_device.status)
 
     # Verify event was triggered with correct type and decoded URL
     state = hass.states.get(entity_id)
@@ -104,6 +99,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Ensure event is only triggered when device reports actual data."""
@@ -115,33 +111,27 @@ async def test_selective_state_update(
 
     # Device receives a data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await async_send_device_update(
-        hass, mock_manager, mock_device, {"switch_mode1": "click"}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device goes offline
     freezer.tick(10)
-    await async_mock_offline(hass, mock_manager, mock_device)
+    await mock_listener.async_mock_offline(mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # Device comes back online - state should go back to last known value,
     # not new datetime since no new data update has come in
     freezer.tick(10)
-    await async_mock_online(hass, mock_manager, mock_device)
+    await mock_listener.async_mock_online(mock_device)
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device receives a new data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await async_send_device_update(
-        hass, mock_manager, mock_device, {"switch_mode1": "click"}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"
 
     # Device receives a data update on a different datapoint - event doesn't
     # get triggered and state doesn't get updated
     freezer.tick(10)
-    await async_send_device_update(
-        hass, mock_manager, mock_device, {"switch_mode2": "click"}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"switch_mode2": "click"})
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
     DEVICE_MOCKS,
-    MockDeviceListener,
+    TuyaNotificationHelper,
     create_device,
     create_manager,
     initialize_entry,
@@ -146,7 +146,7 @@ async def test_dynamic_add_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_manager: Manager,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Ensure add device event works correctly."""
@@ -160,7 +160,7 @@ async def test_dynamic_add_device(
     assert len(all_entries) == 1
 
     # Trigger add second device from the manager
-    await mock_listener.async_send_add_device(second_device)
+    await notification_helper.async_send_add_device(second_device)
 
     # Should now have two devices in the registry
     all_entries = dr.async_entries_for_config_entry(
@@ -177,7 +177,7 @@ async def test_dynamic_remove_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_manager: Manager,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Ensure remove device event works correctly."""
@@ -193,7 +193,7 @@ async def test_dynamic_remove_device(
     assert len(all_entries) == 2
 
     # Trigger remove second device from the manager
-    await mock_listener.async_send_remove_device(second_device)
+    await notification_helper.async_send_remove_device(second_device)
 
     # Only the main device should remain
     all_entries = dr.async_entries_for_config_entry(

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -20,7 +20,8 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
     DEVICE_MOCKS,
-    MockDeviceListener,
+    async_send_add_device,
+    async_send_remove_device,
     create_device,
     create_manager,
     initialize_entry,
@@ -146,7 +147,6 @@ async def test_dynamic_add_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_manager: Manager,
-    mock_listener: MockDeviceListener,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Ensure add device event works correctly."""
@@ -160,7 +160,7 @@ async def test_dynamic_add_device(
     assert len(all_entries) == 1
 
     # Trigger add second device from the manager
-    await mock_listener.async_send_add_device(mock_manager, second_device)
+    await async_send_add_device(hass, mock_manager, second_device)
 
     # Should now have two devices in the registry
     all_entries = dr.async_entries_for_config_entry(
@@ -177,7 +177,6 @@ async def test_dynamic_remove_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_manager: Manager,
-    mock_listener: MockDeviceListener,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Ensure remove device event works correctly."""
@@ -193,7 +192,7 @@ async def test_dynamic_remove_device(
     assert len(all_entries) == 2
 
     # Trigger remove second device from the manager
-    await mock_listener.async_send_remove_device(mock_manager, second_device)
+    await async_send_remove_device(hass, mock_manager, second_device)
 
     # Only the main device should remain
     all_entries = dr.async_entries_for_config_entry(

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -20,8 +20,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
     DEVICE_MOCKS,
-    async_send_add_device,
-    async_send_remove_device,
+    MockDeviceListener,
     create_device,
     create_manager,
     initialize_entry,
@@ -147,6 +146,7 @@ async def test_dynamic_add_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_manager: Manager,
+    mock_listener: MockDeviceListener,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Ensure add device event works correctly."""
@@ -160,7 +160,7 @@ async def test_dynamic_add_device(
     assert len(all_entries) == 1
 
     # Trigger add second device from the manager
-    await async_send_add_device(hass, mock_manager, second_device)
+    await mock_listener.async_send_add_device(second_device)
 
     # Should now have two devices in the registry
     all_entries = dr.async_entries_for_config_entry(
@@ -177,6 +177,7 @@ async def test_dynamic_remove_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_manager: Manager,
+    mock_listener: MockDeviceListener,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Ensure remove device event works correctly."""
@@ -192,7 +193,7 @@ async def test_dynamic_remove_device(
     assert len(all_entries) == 2
 
     # Trigger remove second device from the manager
-    await async_send_remove_device(hass, mock_manager, second_device)
+    await mock_listener.async_send_remove_device(second_device)
 
     # Only the main device should remain
     all_entries = dr.async_entries_for_config_entry(

--- a/tests/components/tuya/test_number.py
+++ b/tests/components/tuya/test_number.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import TuyaNotificationHelper, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        notification_helper,
         freezer,
         entity_id="number.multifunction_alarm_arm_delay",
         dpcode="delay_set",

--- a/tests/components/tuya/test_number.py
+++ b/tests/components/tuya/test_number.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +81,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        mock_manager,
         freezer,
         entity_id="number.multifunction_alarm_arm_delay",
         dpcode="delay_set",

--- a/tests/components/tuya/test_number.py
+++ b/tests/components/tuya/test_number.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import check_selective_state_update, initialize_entry
+from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,6 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -81,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_manager,
+        mock_listener,
         freezer,
         entity_id="number.multifunction_alarm_arm_delay",
         dpcode="delay_set",

--- a/tests/components/tuya/test_select.py
+++ b/tests/components/tuya/test_select.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import TuyaNotificationHelper, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -72,7 +72,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -83,7 +83,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        notification_helper,
         freezer,
         entity_id="select.kitchen_blinds_motor_mode",
         dpcode="control_back_mode",

--- a/tests/components/tuya/test_select.py
+++ b/tests/components/tuya/test_select.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -72,7 +72,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -83,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        mock_manager,
         freezer,
         entity_id="select.kitchen_blinds_motor_mode",
         dpcode="control_back_mode",

--- a/tests/components/tuya/test_select.py
+++ b/tests/components/tuya/test_select.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from . import check_selective_state_update, initialize_entry
+from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -72,6 +72,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +83,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_manager,
+        mock_listener,
         freezer,
         entity_id="select.kitchen_blinds_motor_mode",
         dpcode="control_back_mode",

--- a/tests/components/tuya/test_sensor.py
+++ b/tests/components/tuya/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import TuyaNotificationHelper, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -68,7 +68,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -79,7 +79,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        notification_helper,
         freezer,
         entity_id="sensor.boite_aux_lettres_arriere_battery",
         dpcode="battery_percentage",
@@ -96,7 +96,7 @@ async def test_delta_report_sensor(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
 ) -> None:
     """Test delta report sensor behavior."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
@@ -110,7 +110,7 @@ async def test_delta_report_sensor(
     assert state.attributes["state_class"] == SensorStateClass.TOTAL_INCREASING
 
     # Send delta update
-    await mock_listener.async_send_device_update(
+    await notification_helper.async_send_device_update(
         mock_device,
         {"add_ele": 200},
         {"add_ele": timestamp},
@@ -121,7 +121,7 @@ async def test_delta_report_sensor(
 
     # Send delta update (multiple dpcode)
     timestamp += 100
-    await mock_listener.async_send_device_update(
+    await notification_helper.async_send_device_update(
         mock_device,
         {"add_ele": 300, "switch_1": True},
         {"add_ele": timestamp, "switch_1": timestamp},
@@ -131,7 +131,7 @@ async def test_delta_report_sensor(
     assert float(state.state) == pytest.approx(0.5)
 
     # Send delta update (timestamp not incremented)
-    await mock_listener.async_send_device_update(
+    await notification_helper.async_send_device_update(
         mock_device,
         {"add_ele": 500},
         {"add_ele": timestamp},  # same timestamp
@@ -141,7 +141,7 @@ async def test_delta_report_sensor(
     assert float(state.state) == pytest.approx(0.5)  # unchanged
 
     # Send delta update (unrelated dpcode)
-    await mock_listener.async_send_device_update(
+    await notification_helper.async_send_device_update(
         mock_device,
         {"switch_1": False},
         {"switch_1": timestamp + 100},
@@ -152,7 +152,7 @@ async def test_delta_report_sensor(
 
     # Send delta update
     timestamp += 100
-    await mock_listener.async_send_device_update(
+    await notification_helper.async_send_device_update(
         mock_device,
         {"add_ele": 100},
         {"add_ele": timestamp},
@@ -164,7 +164,7 @@ async def test_delta_report_sensor(
     # Send delta update (None value)
     timestamp += 100
     mock_device.status["add_ele"] = None
-    await mock_listener.async_send_device_update(
+    await notification_helper.async_send_device_update(
         mock_device,
         {"add_ele": None},
         {"add_ele": timestamp},
@@ -175,7 +175,7 @@ async def test_delta_report_sensor(
 
     # Send delta update (no timestamp - skipped)
     mock_device.status["add_ele"] = 200
-    await mock_listener.async_send_device_update(
+    await notification_helper.async_send_device_update(
         mock_device,
         {"add_ele": 200},
         None,

--- a/tests/components/tuya/test_sensor.py
+++ b/tests/components/tuya/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import async_send_device_update, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -68,7 +68,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -79,7 +78,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        mock_manager,
         freezer,
         entity_id="sensor.boite_aux_lettres_arriere_battery",
         dpcode="battery_percentage",
@@ -96,7 +95,6 @@ async def test_delta_report_sensor(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
 ) -> None:
     """Test delta report sensor behavior."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
@@ -110,7 +108,9 @@ async def test_delta_report_sensor(
     assert state.attributes["state_class"] == SensorStateClass.TOTAL_INCREASING
 
     # Send delta update
-    await mock_listener.async_send_device_update(
+    await async_send_device_update(
+        hass,
+        mock_manager,
         mock_device,
         {"add_ele": 200},
         {"add_ele": timestamp},
@@ -121,7 +121,9 @@ async def test_delta_report_sensor(
 
     # Send delta update (multiple dpcode)
     timestamp += 100
-    await mock_listener.async_send_device_update(
+    await async_send_device_update(
+        hass,
+        mock_manager,
         mock_device,
         {"add_ele": 300, "switch_1": True},
         {"add_ele": timestamp, "switch_1": timestamp},
@@ -131,7 +133,9 @@ async def test_delta_report_sensor(
     assert float(state.state) == pytest.approx(0.5)
 
     # Send delta update (timestamp not incremented)
-    await mock_listener.async_send_device_update(
+    await async_send_device_update(
+        hass,
+        mock_manager,
         mock_device,
         {"add_ele": 500},
         {"add_ele": timestamp},  # same timestamp
@@ -141,7 +145,9 @@ async def test_delta_report_sensor(
     assert float(state.state) == pytest.approx(0.5)  # unchanged
 
     # Send delta update (unrelated dpcode)
-    await mock_listener.async_send_device_update(
+    await async_send_device_update(
+        hass,
+        mock_manager,
         mock_device,
         {"switch_1": False},
         {"switch_1": timestamp + 100},
@@ -152,7 +158,9 @@ async def test_delta_report_sensor(
 
     # Send delta update
     timestamp += 100
-    await mock_listener.async_send_device_update(
+    await async_send_device_update(
+        hass,
+        mock_manager,
         mock_device,
         {"add_ele": 100},
         {"add_ele": timestamp},
@@ -164,7 +172,9 @@ async def test_delta_report_sensor(
     # Send delta update (None value)
     timestamp += 100
     mock_device.status["add_ele"] = None
-    await mock_listener.async_send_device_update(
+    await async_send_device_update(
+        hass,
+        mock_manager,
         mock_device,
         {"add_ele": None},
         {"add_ele": timestamp},
@@ -175,7 +185,9 @@ async def test_delta_report_sensor(
 
     # Send delta update (no timestamp - skipped)
     mock_device.status["add_ele"] = 200
-    await mock_listener.async_send_device_update(
+    await async_send_device_update(
+        hass,
+        mock_manager,
         mock_device,
         {"add_ele": 200},
         None,

--- a/tests/components/tuya/test_sensor.py
+++ b/tests/components/tuya/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import async_send_device_update, check_selective_state_update, initialize_entry
+from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -68,6 +68,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -78,7 +79,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_manager,
+        mock_listener,
         freezer,
         entity_id="sensor.boite_aux_lettres_arriere_battery",
         dpcode="battery_percentage",
@@ -95,6 +96,7 @@ async def test_delta_report_sensor(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
 ) -> None:
     """Test delta report sensor behavior."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
@@ -108,9 +110,7 @@ async def test_delta_report_sensor(
     assert state.attributes["state_class"] == SensorStateClass.TOTAL_INCREASING
 
     # Send delta update
-    await async_send_device_update(
-        hass,
-        mock_manager,
+    await mock_listener.async_send_device_update(
         mock_device,
         {"add_ele": 200},
         {"add_ele": timestamp},
@@ -121,9 +121,7 @@ async def test_delta_report_sensor(
 
     # Send delta update (multiple dpcode)
     timestamp += 100
-    await async_send_device_update(
-        hass,
-        mock_manager,
+    await mock_listener.async_send_device_update(
         mock_device,
         {"add_ele": 300, "switch_1": True},
         {"add_ele": timestamp, "switch_1": timestamp},
@@ -133,9 +131,7 @@ async def test_delta_report_sensor(
     assert float(state.state) == pytest.approx(0.5)
 
     # Send delta update (timestamp not incremented)
-    await async_send_device_update(
-        hass,
-        mock_manager,
+    await mock_listener.async_send_device_update(
         mock_device,
         {"add_ele": 500},
         {"add_ele": timestamp},  # same timestamp
@@ -145,9 +141,7 @@ async def test_delta_report_sensor(
     assert float(state.state) == pytest.approx(0.5)  # unchanged
 
     # Send delta update (unrelated dpcode)
-    await async_send_device_update(
-        hass,
-        mock_manager,
+    await mock_listener.async_send_device_update(
         mock_device,
         {"switch_1": False},
         {"switch_1": timestamp + 100},
@@ -158,9 +152,7 @@ async def test_delta_report_sensor(
 
     # Send delta update
     timestamp += 100
-    await async_send_device_update(
-        hass,
-        mock_manager,
+    await mock_listener.async_send_device_update(
         mock_device,
         {"add_ele": 100},
         {"add_ele": timestamp},
@@ -172,9 +164,7 @@ async def test_delta_report_sensor(
     # Send delta update (None value)
     timestamp += 100
     mock_device.status["add_ele"] = None
-    await async_send_device_update(
-        hass,
-        mock_manager,
+    await mock_listener.async_send_device_update(
         mock_device,
         {"add_ele": None},
         {"add_ele": timestamp},
@@ -185,9 +175,7 @@ async def test_delta_report_sensor(
 
     # Send delta update (no timestamp - skipped)
     mock_device.status["add_ele"] = 200
-    await async_send_device_update(
-        hass,
-        mock_manager,
+    await mock_listener.async_send_device_update(
         mock_device,
         {"add_ele": 200},
         None,

--- a/tests/components/tuya/test_siren.py
+++ b/tests/components/tuya/test_siren.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import TuyaNotificationHelper, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        notification_helper,
         freezer,
         entity_id="siren.c9",
         dpcode="siren_switch",

--- a/tests/components/tuya/test_siren.py
+++ b/tests/components/tuya/test_siren.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +81,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        mock_manager,
         freezer,
         entity_id="siren.c9",
         dpcode="siren_switch",

--- a/tests/components/tuya/test_siren.py
+++ b/tests/components/tuya/test_siren.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import check_selective_state_update, initialize_entry
+from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,6 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -81,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_manager,
+        mock_listener,
         freezer,
         entity_id="siren.c9",
         dpcode="siren_switch",

--- a/tests/components/tuya/test_switch.py
+++ b/tests/components/tuya/test_switch.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import TuyaNotificationHelper, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        notification_helper,
         freezer,
         entity_id="switch.din_socket",
         dpcode="switch",

--- a/tests/components/tuya/test_switch.py
+++ b/tests/components/tuya/test_switch.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +81,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        mock_manager,
         freezer,
         entity_id="switch.din_socket",
         dpcode="switch",

--- a/tests/components/tuya/test_switch.py
+++ b/tests/components/tuya/test_switch.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import check_selective_state_update, initialize_entry
+from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,6 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -81,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_manager,
+        mock_listener,
         freezer,
         entity_id="switch.din_socket",
         dpcode="switch",

--- a/tests/components/tuya/test_valve.py
+++ b/tests/components/tuya/test_valve.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import TuyaNotificationHelper, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
+    notification_helper: TuyaNotificationHelper,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        notification_helper,
         freezer,
         entity_id="valve.jie_hashui_fa_valve_1",
         dpcode="switch_1",

--- a/tests/components/tuya/test_valve.py
+++ b/tests/components/tuya/test_valve.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MockDeviceListener, check_selective_state_update, initialize_entry
+from . import check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,7 +71,6 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -82,7 +81,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_listener,
+        mock_manager,
         freezer,
         entity_id="valve.jie_hashui_fa_valve_1",
         dpcode="switch_1",

--- a/tests/components/tuya/test_valve.py
+++ b/tests/components/tuya/test_valve.py
@@ -19,7 +19,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import check_selective_state_update, initialize_entry
+from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -71,6 +71,7 @@ async def test_selective_state_update(
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
     updates: dict[str, Any],
     expected_state: str,
@@ -81,7 +82,7 @@ async def test_selective_state_update(
     await check_selective_state_update(
         hass,
         mock_device,
-        mock_manager,
+        mock_listener,
         freezer,
         entity_id="valve.jie_hashui_fa_valve_1",
         dpcode="switch_1",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current implementation of `MockDeviceListener` adds a second (unmanaged) listener to the manager, and uses that (invalid) listener to send dispatcher events.

This fixes the implementation, so that MockDeviceListener becomes just a helper class to trigger events via the proper registered manager listeners, as would happen in a real scenario.

Spotted in #168830, and needed for #168897

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
