### PR TITLE
Fix missing hue.activate_scene actions

### DIFF
--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from aiohue.v2 import HueBridgeV2
@@ -29,6 +30,8 @@ ATTR_DYNAMIC = "dynamic"
 ATTR_SPEED = "speed"
 ATTR_BRIGHTNESS = "brightness"
 
+LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -49,10 +52,17 @@ async def async_setup_entry(
         event_type: EventType, resource: HueScene | HueSmartScene
     ) -> None:
         """Add entity from Hue resource."""
-        if isinstance(resource, HueSmartScene):
-            async_add_entities([HueSmartSceneEntity(bridge, api.scenes, resource)])
-        else:
-            async_add_entities([HueSceneEntity(bridge, api.scenes, resource)])
+        try:
+            entity: HueSceneEntityBase
+            if isinstance(resource, HueSmartScene):
+                entity = HueSmartSceneEntity(bridge, api.scenes, resource)
+            else:
+                entity = HueSceneEntity(bridge, api.scenes, resource)
+        except KeyError, StopIteration:
+            LOGGER.exception("Unable to create Hue scene entity for %s", resource.id)
+            return
+
+        async_add_entities([entity])
 
     # add all current items in controller
     for item in api.scenes:

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -52,6 +52,7 @@ async def async_setup_entry(
         event_type: EventType, resource: HueScene | HueSmartScene
     ) -> None:
         """Add entity from Hue resource."""
+        # Catch creation errors to continue adding other scenes even if one fails
         try:
             entity: HueSceneEntityBase
             if isinstance(resource, HueSmartScene):

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -200,3 +202,27 @@ async def test_scene_updates(
     await hass.async_block_till_done()
     test_entity = hass.states.get(test_entity_id)
     assert test_entity is None
+
+
+async def test_scene_with_orphaned_group(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a scene referencing a non-existent group is skipped and logged."""
+    orphaned_scene = {
+        **FAKE_SCENE,
+        "id": "orphaned_scene_id",
+        "group": {"rid": "non-existent-group-id", "rtype": "room"},
+    }
+    await mock_bridge_v2.api.load_test_data([*v2_resources_test_data, orphaned_scene])
+
+    await setup_platform(hass, mock_bridge_v2, Platform.SCENE)
+
+    # the orphaned scene should not be created as an entity
+    assert hass.states.get("scene.test_room_mocked_scene_orphaned") is None
+    # the valid scenes should still be created
+    assert len(hass.states.async_all()) == 3
+    # an error should be logged for the orphaned scene
+    assert "Unable to create Hue scene entity for orphaned_scene_id" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR resolves issue #167889 where initialisation fails if a single scene contains corrupted data or an orphaned group reference from the Hue Bridge.

It wraps the initialization of `HueSceneEntity` and `HueSmartSceneEntity` in a `try...except` block during `async_setup_entry`. If an entity fails to initialise, the exception is caught and logged. This prevents one problematic scene from failing everything after it.

The reason for this failing is that Hue Bridge can return a scene with a non-existent group (there's exactly one such 'Concentrate' scene out of ~180 configured on my bridge. 

```
  {
  "id": "00000000-0000-0000-0000-000000000001",
  "id_v1": "/scenes/ABCD",
  "actions": [
    {
      "target": {
        "rid": "00000000-0000-0000-0000-000000000002",
        "rtype": "light"
      },
      "action": {
        "on": {
          "on": true
        },
        "dimming": {
          "brightness": 100.0
        },
        "color": {
          "xy": {
            "x": 0.369,
            "y": 0.3719
          }
        },
        "color_temperature": {
          "mirek": 233
        }
      }
    },
    ...
  ],
  "palette": {
    "color": [],
    "dimming": [],
    "color_temperature": [],
    "effects": [],
    "effects_v2": []
  },
  "recall": {},
  "metadata": {
    "name": "Concentrate",
    "image": {
      "rid": "00000000-0000-0000-0000-000000000003",
      "rtype": "public_image"
    },
    "appdata": "EFGH"
  },
  "group": {
    "rid": "00000000-0000-0000-0000-000000000004",
    "rtype": "bridge_home"
  },
  "speed": 0.5,
  "auto_dynamic": false,
  "status": {
    "active": "inactive"
  },
  "mapping": {
    "algorithm": "classic"
  },
  "last_actions_update": {
    "source": "clip"
  },
  "type": "scene"
}
```

Currently this leads to some scenes being initialised correctly, until the failing scene is encountered, from which point onwards nothing is initialised since the entire iteration crashes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167889
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr