### PR TITLE
Migrate kraken to use runtime_data

### DIFF
--- a/homeassistant/components/kraken/__init__.py
+++ b/homeassistant/components/kraken/__init__.py
@@ -1,41 +1,39 @@
 """The kraken integration."""
-# pylint: disable=hass-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DISPATCH_CONFIG_UPDATED, DOMAIN
-from .coordinator import KrakenData
+from .const import DISPATCH_CONFIG_UPDATED
+from .coordinator import KrakenConfigEntry, KrakenData
 
 PLATFORMS = [Platform.SENSOR]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: KrakenConfigEntry) -> bool:
     """Set up kraken from a config entry."""
     kraken_data = KrakenData(hass, entry)
     await kraken_data.async_setup()
-    hass.data[DOMAIN] = kraken_data
+    entry.runtime_data = kraken_data
     entry.async_on_unload(entry.add_update_listener(async_options_updated))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, config_entry: KrakenConfigEntry
+) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        config_entry, PLATFORMS
-    )
-    if unload_ok:
-        hass.data.pop(DOMAIN)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
 
-async def async_options_updated(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def async_options_updated(
+    hass: HomeAssistant, config_entry: KrakenConfigEntry
+) -> None:
     """Triggered by config entry options updates."""
-    hass.data[DOMAIN].set_update_interval(config_entry.options[CONF_SCAN_INTERVAL])
+    config_entry.runtime_data.set_update_interval(
+        config_entry.options[CONF_SCAN_INTERVAL]
+    )
     async_dispatcher_send(hass, DISPATCH_CONFIG_UPDATED, hass, config_entry)

--- a/homeassistant/components/kraken/config_flow.py
+++ b/homeassistant/components/kraken/config_flow.py
@@ -8,17 +8,13 @@ import krakenex
 from pykrakenapi.pykrakenapi import KrakenAPI
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
 from .const import CONF_TRACKED_ASSET_PAIRS, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .coordinator import KrakenConfigEntry
 from .utils import get_tradable_asset_pairs
 
 
@@ -30,7 +26,7 @@ class KrakenConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: KrakenConfigEntry,
     ) -> KrakenOptionsFlowHandler:
         """Get the options flow for this handler."""
         return KrakenOptionsFlowHandler()

--- a/homeassistant/components/kraken/coordinator.py
+++ b/homeassistant/components/kraken/coordinator.py
@@ -28,10 +28,13 @@ CALL_RATE_LIMIT_SLEEP = 1
 _LOGGER = logging.getLogger(__name__)
 
 
+type KrakenConfigEntry = ConfigEntry[KrakenData]
+
+
 class KrakenData:
     """Define an object to hold kraken data."""
 
-    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, config_entry: KrakenConfigEntry) -> None:
         """Initialize."""
         self._hass = hass
         self._config_entry = config_entry

--- a/homeassistant/components/kraken/sensor.py
+++ b/homeassistant/components/kraken/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -28,7 +27,7 @@ from .const import (
     DOMAIN,
     KrakenResponse,
 )
-from .coordinator import KrakenData
+from .coordinator import KrakenConfigEntry, KrakenData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,7 +137,7 @@ SENSOR_TYPES: tuple[KrakenSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: KrakenConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add kraken entities from a config_entry."""
@@ -149,9 +148,7 @@ async def async_setup_entry(
             entities.extend(
                 [
                     KrakenSensor(
-                        # Uses legacy hass.data[DOMAIN] pattern
-                        # pylint: disable-next=hass-use-runtime-data
-                        hass.data[DOMAIN],
+                        config_entry.runtime_data,
                         tracked_asset_pair,
                         description,
                     )
@@ -163,7 +160,9 @@ async def async_setup_entry(
     _async_add_kraken_sensors(config_entry.options[CONF_TRACKED_ASSET_PAIRS])
 
     @callback
-    def async_update_sensors(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    def async_update_sensors(
+        hass: HomeAssistant, config_entry: KrakenConfigEntry
+    ) -> None:
         """Add or remove sensors for configured tracked asset pairs."""
         dev_reg = dr.async_get(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the kraken integration to use the `ConfigEntry.runtime_data` pattern instead of the legacy `hass.data[DOMAIN]` pattern.

- `coordinator.py`: Added `type KrakenConfigEntry = ConfigEntry[KrakenData]` typed entry alias. Updated `KrakenData.__init__` to accept the typed `KrakenConfigEntry`.
- `__init__.py`: Removed the legacy `hass-use-runtime-data` pylint disable. `async_setup_entry` now stores `KrakenData` in `entry.runtime_data` instead of `hass.data[DOMAIN]`. `async_unload_entry` no longer needs to pop from `hass.data`. `async_options_updated` reads from `config_entry.runtime_data`. Function signatures updated to use `KrakenConfigEntry`.
- `sensor.py`: `async_setup_entry` and `async_update_sensors` typed with `KrakenConfigEntry`; `_async_add_kraken_sensors` reads `KrakenData` from `config_entry.runtime_data` instead of `hass.data[DOMAIN]`. Removed the legacy pylint disable comment.
- `config_flow.py`: `async_get_options_flow` typed with `KrakenConfigEntry`; removed unused `ConfigEntry` import.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168778
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr