### PR TITLE
Clean up leftover hass.data[DOMAIN] usage in keenetic_ndms2

### DIFF
--- a/homeassistant/components/keenetic_ndms2/__init__.py
+++ b/homeassistant/components/keenetic_ndms2/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL, Platform
+from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -17,7 +17,6 @@ from .const import (
     DEFAULT_CONSIDER_HOME,
     DEFAULT_INTERFACE,
     DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
 )
 from .router import KeeneticConfigEntry, KeeneticRouter
 
@@ -27,7 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: KeeneticConfigEntry) -> bool:
     """Set up the component."""
-    hass.data.setdefault(DOMAIN, {})
     async_add_defaults(hass, entry)
 
     router = KeeneticRouter(hass, entry)
@@ -85,12 +83,8 @@ async def async_unload_entry(
     return unload_ok
 
 
-def async_add_defaults(hass: HomeAssistant, entry: KeeneticConfigEntry):
+def async_add_defaults(hass: HomeAssistant, entry: KeeneticConfigEntry) -> None:
     """Populate default options."""
-    host: str = entry.data[CONF_HOST]
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    imported_options: dict = hass.data[DOMAIN].get(f"imported_options_{host}", {})
     options = {
         CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
         CONF_CONSIDER_HOME: DEFAULT_CONSIDER_HOME,
@@ -98,7 +92,6 @@ def async_add_defaults(hass: HomeAssistant, entry: KeeneticConfigEntry):
         CONF_TRY_HOTSPOT: True,
         CONF_INCLUDE_ARP: True,
         CONF_INCLUDE_ASSOCIATED: True,
-        **imported_options,
         **entry.options,
     }
 

--- a/tests/components/keenetic_ndms2/test_config_flow.py
+++ b/tests/components/keenetic_ndms2/test_config_flow.py
@@ -9,8 +9,8 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import keenetic_ndms2 as keenetic
 from homeassistant.components.keenetic_ndms2 import CONF_INTERFACES, const
+from homeassistant.components.keenetic_ndms2.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -62,7 +62,7 @@ async def test_flow_works(hass: HomeAssistant, connect) -> None:
     """Test config flow."""
 
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -84,7 +84,7 @@ async def test_flow_works(hass: HomeAssistant, connect) -> None:
 
 async def test_reconfigure(hass: HomeAssistant, connect) -> None:
     """Test reconfigure flow."""
-    entry = MockConfigEntry(domain=keenetic.DOMAIN, data=MOCK_DATA)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA)
     entry.add_to_hass(hass)
 
     result = await entry.start_reconfigure_flow(hass)
@@ -112,7 +112,7 @@ async def test_reconfigure(hass: HomeAssistant, connect) -> None:
 
 async def test_options(hass: HomeAssistant) -> None:
     """Test updating options."""
-    entry = MockConfigEntry(domain=keenetic.DOMAIN, data=MOCK_DATA)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA)
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.keenetic_ndms2.async_setup_entry", return_value=True
@@ -151,13 +151,11 @@ async def test_options(hass: HomeAssistant) -> None:
 async def test_host_already_configured(hass: HomeAssistant, connect) -> None:
     """Test host already configured."""
 
-    entry = MockConfigEntry(
-        domain=keenetic.DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS
-    )
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS)
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -172,7 +170,7 @@ async def test_connection_error(hass: HomeAssistant, connect_error) -> None:
     """Test error when connection is unsuccessful."""
 
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_DATA
@@ -184,7 +182,7 @@ async def test_connection_error(hass: HomeAssistant, connect_error) -> None:
 async def test_options_not_initialized(hass: HomeAssistant) -> None:
     """Test the error when the integration is not initialized."""
 
-    entry = MockConfigEntry(domain=keenetic.DOMAIN, data=MOCK_DATA)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA)
     entry.add_to_hass(hass)
 
     # not setting entry.runtime_data
@@ -198,7 +196,7 @@ async def test_options_not_initialized(hass: HomeAssistant) -> None:
 async def test_options_connection_error(hass: HomeAssistant) -> None:
     """Test updating options."""
 
-    entry = MockConfigEntry(domain=keenetic.DOMAIN, data=MOCK_DATA)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA)
     entry.add_to_hass(hass)
 
     def get_interfaces_error():
@@ -218,7 +216,7 @@ async def test_options_connection_error(hass: HomeAssistant) -> None:
 async def test_options_interface_filter(hass: HomeAssistant) -> None:
     """Test the case when the default Home interface is missing on the router."""
 
-    entry = MockConfigEntry(domain=keenetic.DOMAIN, data=MOCK_DATA)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA)
     entry.add_to_hass(hass)
 
     # fake interfaces
@@ -250,7 +248,7 @@ async def test_ssdp_works(hass: HomeAssistant, connect) -> None:
 
     discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN,
+        DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
         data=discovery_info,
     )
@@ -279,14 +277,12 @@ async def test_ssdp_works(hass: HomeAssistant, connect) -> None:
 async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
     """Test host already configured and discovered."""
 
-    entry = MockConfigEntry(
-        domain=keenetic.DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS
-    )
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA, options=MOCK_OPTIONS)
     entry.add_to_hass(hass)
 
     discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN,
+        DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
         data=discovery_info,
     )
@@ -299,7 +295,7 @@ async def test_ssdp_ignored(hass: HomeAssistant) -> None:
     """Test unique ID ignored and discovered."""
 
     entry = MockConfigEntry(
-        domain=keenetic.DOMAIN,
+        domain=DOMAIN,
         source=config_entries.SOURCE_IGNORE,
         unique_id=MOCK_SSDP_DISCOVERY_INFO.upnp[ATTR_UPNP_UDN],
     )
@@ -307,7 +303,7 @@ async def test_ssdp_ignored(hass: HomeAssistant) -> None:
 
     discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN,
+        DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
         data=discovery_info,
     )
@@ -320,7 +316,7 @@ async def test_ssdp_update_host(hass: HomeAssistant) -> None:
     """Test unique ID configured and discovered with the new host."""
 
     entry = MockConfigEntry(
-        domain=keenetic.DOMAIN,
+        domain=DOMAIN,
         data=MOCK_DATA,
         options=MOCK_OPTIONS,
         unique_id=MOCK_SSDP_DISCOVERY_INFO.upnp[ATTR_UPNP_UDN],
@@ -333,7 +329,7 @@ async def test_ssdp_update_host(hass: HomeAssistant) -> None:
     discovery_info.ssdp_location = f"http://{new_ip}/"
 
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN,
+        DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
         data=discovery_info,
     )
@@ -351,7 +347,7 @@ async def test_ssdp_reject_no_udn(hass: HomeAssistant) -> None:
     discovery_info.upnp.pop(ATTR_UPNP_UDN)
 
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN,
+        DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
         data=discovery_info,
     )
@@ -367,7 +363,7 @@ async def test_ssdp_reject_non_keenetic(hass: HomeAssistant) -> None:
     discovery_info.upnp = {**discovery_info.upnp}
     discovery_info.upnp[ATTR_UPNP_FRIENDLY_NAME] = "Suspicious device"
     result = await hass.config_entries.flow.async_init(
-        keenetic.DOMAIN,
+        DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
         data=discovery_info,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `keenetic_ndms2` integration had already been mostly migrated to `runtime_data`, but a leftover `hass.data[DOMAIN]` lookup was left behind in `async_add_defaults`:

```python
imported_options: dict = hass.data[DOMAIN].get(f"imported_options_{host}", {})
```

This `imported_options_{host}` key was only ever populated by the YAML import flow, which was removed in #63860. Since then, the lookup has always returned an empty dict and the accompanying `hass.data.setdefault(DOMAIN, {})` in `async_setup_entry` was effectively unused.

This PR removes the dead code and related plumbing:

- Drop `hass.data.setdefault(DOMAIN, {})` from `async_setup_entry`.
- Remove the dead `imported_options` lookup (and the `**imported_options` spread) from `async_add_defaults`, along with the now-unused `host` variable.
- Remove the `hass-use-runtime-data` pylint-disable comment that was guarding the legacy pattern.
- Clean up the unused `CONF_HOST` and `DOMAIN` imports in `__init__.py`.
- Add the missing `-> None` return annotation on `async_add_defaults`.
- Update `tests/components/keenetic_ndms2/test_config_flow.py` to import `DOMAIN` from `homeassistant.components.keenetic_ndms2.const` instead of relying on the package-level re-export that is no longer needed.

No functional change: the integration keeps reading options from `entry.options` via `runtime_data` exactly as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168777
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr