### PR TITLE
Migrate flux_led to use HassKey for FLUX_LED_DISCOVERY

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -87,8 +87,7 @@ def async_wifi_bulb_for_host(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the flux_led component."""
-    domain_data = hass.data.setdefault(DOMAIN, {})
-    domain_data[FLUX_LED_DISCOVERY] = []
+    hass.data[FLUX_LED_DISCOVERY] = []
 
     @callback
     def _async_start_background_discovery(*_: Any) -> None:

--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -36,7 +36,7 @@ DEFAULT_NETWORK_SCAN_INTERVAL: Final = 120
 DEFAULT_SCAN_INTERVAL: Final = 5
 DEFAULT_EFFECT_SPEED: Final = 50
 
-FLUX_LED_DISCOVERY: HassKey[list[FluxLEDDiscovery]] = HassKey("flux_led_discovery")
+FLUX_LED_DISCOVERY: HassKey[list[FluxLEDDiscovery]] = HassKey(DOMAIN)
 
 FLUX_LED_EXCEPTIONS: Final = (
     TimeoutError,

--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -9,8 +9,10 @@ from flux_led.const import (
     COLOR_MODE_RGBW as FLUX_COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW as FLUX_COLOR_MODE_RGBWW,
 )
+from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant.components.light import ColorMode
+from homeassistant.util.hass_dict import HassKey
 
 DOMAIN: Final = "flux_led"
 
@@ -34,7 +36,7 @@ DEFAULT_NETWORK_SCAN_INTERVAL: Final = 120
 DEFAULT_SCAN_INTERVAL: Final = 5
 DEFAULT_EFFECT_SPEED: Final = 50
 
-FLUX_LED_DISCOVERY: Final = "flux_led_discovery"
+FLUX_LED_DISCOVERY: HassKey[list[FluxLEDDiscovery]] = HassKey("flux_led_discovery")
 
 FLUX_LED_EXCEPTIONS: Final = (
     TimeoutError,

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -1,5 +1,4 @@
 """The Flux LED/MagicLight integration discovery."""
-# pylint: disable=hass-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from __future__ import annotations
 
@@ -154,8 +153,7 @@ def async_update_entry_from_discovery(
 @callback
 def async_get_discovery(hass: HomeAssistant, host: str) -> FluxLEDDiscovery | None:
     """Check if a device was already discovered via a broadcast discovery."""
-    discoveries: list[FluxLEDDiscovery] = hass.data[DOMAIN][FLUX_LED_DISCOVERY]
-    for discovery in discoveries:
+    for discovery in hass.data[FLUX_LED_DISCOVERY]:
         if discovery[ATTR_IPADDR] == host:
             return discovery
     return None
@@ -164,10 +162,10 @@ def async_get_discovery(hass: HomeAssistant, host: str) -> FluxLEDDiscovery | No
 @callback
 def async_clear_discovery_cache(hass: HomeAssistant, host: str) -> None:
     """Clear the host from the discovery cache."""
-    domain_data = hass.data[DOMAIN]
-    discoveries: list[FluxLEDDiscovery] = domain_data[FLUX_LED_DISCOVERY]
-    domain_data[FLUX_LED_DISCOVERY] = [
-        discovery for discovery in discoveries if discovery[ATTR_IPADDR] != host
+    hass.data[FLUX_LED_DISCOVERY] = [
+        discovery
+        for discovery in hass.data[FLUX_LED_DISCOVERY]
+        if discovery[ATTR_IPADDR] != host
     ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `flux_led` integration's domain-level discovery cache from the
legacy nested `hass.data[DOMAIN][FLUX_LED_DISCOVERY]` dict to a typed
`HassKey[list[FluxLEDDiscovery]]` stored directly on `hass.data`.

- `const.py`: `FLUX_LED_DISCOVERY` is now a `HassKey[list[FluxLEDDiscovery]]`
  instead of a plain string constant, giving callers static type information
  for the stored value.
- `__init__.py`: `async_setup` writes `hass.data[FLUX_LED_DISCOVERY] = []`
  directly, instead of creating and indexing into a per-domain nested dict.
- `discovery.py`: `async_get_discovery` and `async_clear_discovery_cache` now
  read and write through the `HassKey` directly, and the legacy
  `hass-use-runtime-data` pylint disable is removed.

Note: the referenced issue asks for `runtime_data`, but `FLUX_LED_DISCOVERY`
is shared across config entries and populated during `async_setup` (before any
entry is set up), so per-entry `runtime_data` is not appropriate. `HassKey`
is the idiomatic typed-storage pattern for this domain-level cache.

No behavior change is intended; this is a typed-storage refactor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168770
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr