### PR TITLE
Use runtime_data in Huawei LTE

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -51,7 +51,6 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     ADMIN_SERVICES,
@@ -64,6 +63,7 @@ from .const import (
     DEFAULT_MANUFACTURER,
     DEFAULT_NOTIFY_SERVICE_NAME,
     DOMAIN,
+    HUAWEI_LTE_CONFIG,
     KEY_DEVICE_BASIC_INFORMATION,
     KEY_DEVICE_INFORMATION,
     KEY_DEVICE_SIGNAL,
@@ -279,8 +279,6 @@ class Router:
 
 
 type HuaweiLteConfigEntry = ConfigEntry[Router]
-
-HUAWEI_LTE_CONFIG: HassKey[ConfigType] = HassKey(DOMAIN)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HuaweiLteConfigEntry) -> bool:

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -1,5 +1,4 @@
 """Support for Huawei LTE routers."""
-# pylint: disable=hass-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from __future__ import annotations
 
@@ -9,7 +8,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
-from typing import Any, NamedTuple, cast
+from typing import Any, cast
 from xml.parsers.expat import ExpatError
 
 from huawei_lte_api.Client import Client
@@ -52,6 +51,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     ADMIN_SERVICES,
@@ -108,7 +108,7 @@ class Router:
     """Class for router state."""
 
     hass: HomeAssistant
-    config_entry: ConfigEntry
+    config_entry: HuaweiLteConfigEntry
     connection: Connection
     url: str
 
@@ -278,14 +278,12 @@ class Router:
         self.connection.requests_session.close()
 
 
-class HuaweiLteData(NamedTuple):
-    """Shared state."""
+type HuaweiLteConfigEntry = ConfigEntry[Router]
 
-    hass_config: ConfigType
-    routers: dict[str, Router]
+HUAWEI_LTE_CONFIG: HassKey[ConfigType] = HassKey(DOMAIN)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: HuaweiLteConfigEntry) -> bool:
     """Set up Huawei LTE component from config entry."""
     url = entry.data[CONF_URL]
 
@@ -352,7 +350,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return False
 
     # Store reference to router
-    hass.data[DOMAIN].routers[entry.entry_id] = router
+    entry.runtime_data = router
 
     # Clear all subscriptions, enabled entities will push back theirs
     router.subscriptions.clear()
@@ -417,7 +415,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_NAME: entry.options.get(CONF_NAME, DEFAULT_NOTIFY_SERVICE_NAME),
             CONF_RECIPIENT: entry.options.get(CONF_RECIPIENT),
         },
-        hass.data[DOMAIN].hass_config,
+        hass.data[HUAWEI_LTE_CONFIG],
     )
 
     def _update_router(*_: Any) -> None:
@@ -440,15 +438,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, config_entry: HuaweiLteConfigEntry
+) -> bool:
     """Unload config entry."""
 
     # Forward config entry unload to platforms
     await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
-    # Forget about the router and invoke its cleanup
-    router = hass.data[DOMAIN].routers.pop(config_entry.entry_id)
-    await hass.async_add_executor_job(router.cleanup)
+    # Invoke router cleanup
+    await hass.async_add_executor_job(config_entry.runtime_data.cleanup)
 
     return True
 
@@ -456,8 +455,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Huawei LTE component."""
 
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = HuaweiLteData(hass_config=config, routers={})
+    hass.data[HUAWEI_LTE_CONFIG] = config
 
     def service_handler(service: ServiceCall) -> None:
         """Apply a service.
@@ -465,21 +463,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         We key this using the router URL instead of its unique id / serial number,
         because the latter is not available anywhere in the UI.
         """
-        routers = hass.data[DOMAIN].routers
+        routers = [
+            entry.runtime_data
+            for entry in hass.config_entries.async_loaded_entries(DOMAIN)
+        ]
         if url := service.data.get(CONF_URL):
-            router = next(
-                (router for router in routers.values() if router.url == url), None
-            )
+            router = next((router for router in routers if router.url == url), None)
         elif not routers:
             _LOGGER.error("%s: no routers configured", service.service)
             return
         elif len(routers) == 1:
-            router = next(iter(routers.values()))
+            router = routers[0]
         else:
             _LOGGER.error(
                 "%s: more than one router configured, must specify one of URLs %s",
                 service.service,
-                sorted(router.url for router in routers.values()),
+                sorted(router.url for router in routers),
             )
             return
         if not router:
@@ -509,7 +508,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: HuaweiLteConfigEntry
+) -> bool:
     """Migrate config entry to new version."""
     if config_entry.version == 1:
         options = dict(config_entry.options)

--- a/homeassistant/components/huawei_lte/binary_sensor.py
+++ b/homeassistant/components/huawei_lte/binary_sensor.py
@@ -12,13 +12,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import HuaweiLteConfigEntry
 from .const import (
-    DOMAIN,
     KEY_MONITORING_CHECK_NOTIFICATIONS,
     KEY_MONITORING_STATUS,
     KEY_WLAN_WIFI_FEATURE_SWITCH,
@@ -30,13 +29,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HuaweiLteConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up from config entry."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    router = hass.data[DOMAIN].routers[config_entry.entry_id]
+    router = config_entry.runtime_data
     entities: list[Entity] = []
 
     if router.data.get(KEY_MONITORING_STATUS):

--- a/homeassistant/components/huawei_lte/button.py
+++ b/homeassistant/components/huawei_lte/button.py
@@ -11,12 +11,11 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 
-from .const import DOMAIN
+from . import HuaweiLteConfigEntry
 from .entity import HuaweiLteBaseEntityWithDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,13 +23,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HuaweiLteConfigEntry,
     async_add_entities: entity_platform.AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Huawei LTE buttons."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    router = hass.data[DOMAIN].routers[config_entry.entry_id]
+    router = config_entry.runtime_data
     buttons = [
         ClearTrafficStatisticsButton(router),
         RestartButton(router),

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -21,12 +21,7 @@ from requests.exceptions import SSLError, Timeout
 from url_normalize import url_normalize
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import (
     CONF_MAC,
     CONF_NAME,
@@ -47,6 +42,7 @@ from homeassistant.helpers.service_info.ssdp import (
     SsdpServiceInfo,
 )
 
+from . import HuaweiLteConfigEntry
 from .const import (
     CONF_MANUFACTURER,
     CONF_TRACK_WIRED_CLIENTS,
@@ -76,7 +72,7 @@ class HuaweiLteConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: HuaweiLteConfigEntry,
     ) -> HuaweiLteOptionsFlow:
         """Get options flow."""
         return HuaweiLteOptionsFlow()

--- a/homeassistant/components/huawei_lte/const.py
+++ b/homeassistant/components/huawei_lte/const.py
@@ -1,6 +1,11 @@
 """Huawei LTE constants."""
 
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.hass_dict import HassKey
+
 DOMAIN = "huawei_lte"
+
+HUAWEI_LTE_CONFIG: HassKey[ConfigType] = HassKey(DOMAIN)
 
 CONF_MANUFACTURER = "manufacturer"
 CONF_TRACK_WIRED_CLIENTS = "track_wired_clients"

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -9,7 +9,6 @@ from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN,
     ScannerEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -17,11 +16,10 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import snakecase
 
-from . import Router
+from . import HuaweiLteConfigEntry, Router
 from .const import (
     CONF_TRACK_WIRED_CLIENTS,
     DEFAULT_TRACK_WIRED_CLIENTS,
-    DOMAIN,
     KEY_LAN_HOST_INFO,
     KEY_WLAN_HOST_LIST,
     UPDATE_SIGNAL,
@@ -50,7 +48,7 @@ def _get_hosts(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HuaweiLteConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up from config entry."""
@@ -58,9 +56,7 @@ async def async_setup_entry(
     # Grab hosts list once to examine whether the initial fetch has got some data for
     # us, i.e. if wlan host list is supported. Only set up a subscription and proceed
     # with adding and tracking entities if it is.
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    router = hass.data[DOMAIN].routers[config_entry.entry_id]
+    router = config_entry.runtime_data
     if (hosts := _get_hosts(router, True)) is None:
         return
 

--- a/homeassistant/components/huawei_lte/diagnostics.py
+++ b/homeassistant/components/huawei_lte/diagnostics.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from . import HuaweiLteConfigEntry
 
 ENTRY_FIELDS_DATA_TO_REDACT = {
     "mac",
@@ -74,13 +73,13 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: HuaweiLteConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     return async_redact_data(
         {
             "entry": entry.data,
-            "router": hass.data[DOMAIN].routers[entry.entry_id].data,
+            "router": entry.runtime_data.data,
         },
         TO_REDACT,
     )

--- a/homeassistant/components/huawei_lte/notify.py
+++ b/homeassistant/components/huawei_lte/notify.py
@@ -12,8 +12,7 @@ from homeassistant.const import ATTR_CONFIG_ENTRY_ID, CONF_RECIPIENT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import Router
-from .const import DOMAIN
+from . import HuaweiLteConfigEntry, Router
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,9 +26,11 @@ async def async_get_service(
     if discovery_info is None:
         return None
 
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    router = hass.data[DOMAIN].routers[discovery_info[ATTR_CONFIG_ENTRY_ID]]
+    entry: HuaweiLteConfigEntry | None = hass.config_entries.async_get_entry(
+        discovery_info[ATTR_CONFIG_ENTRY_ID]
+    )
+    assert entry is not None
+    router = entry.runtime_data
     default_targets = discovery_info[CONF_RECIPIENT] or []
 
     return HuaweiLteSmsNotificationService(router, default_targets)

--- a/homeassistant/components/huawei_lte/quality_scale.yaml
+++ b/homeassistant/components/huawei_lte/quality_scale.yaml
@@ -22,7 +22,7 @@ rules:
   entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done
-  runtime-data: todo
+  runtime-data: done
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done

--- a/homeassistant/components/huawei_lte/select.py
+++ b/homeassistant/components/huawei_lte/select.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
 import logging
+from typing import Any
 
 from huawei_lte_api.enums.net import LTEBandEnum, NetworkBandEnum, NetworkModeEnum
 
@@ -14,14 +15,13 @@ from homeassistant.components.select import (
     SelectEntity,
     SelectEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import Router
-from .const import DOMAIN, KEY_NET_NET_MODE
+from . import HuaweiLteConfigEntry, Router
+from .const import KEY_NET_NET_MODE
 from .entity import HuaweiLteBaseEntityWithDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,18 +31,16 @@ _LOGGER = logging.getLogger(__name__)
 class HuaweiSelectEntityDescription(SelectEntityDescription):
     """Class describing Huawei LTE select entities."""
 
-    setter_fn: Callable[[str], None]
+    setter_fn: Callable[[str], Any]
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HuaweiLteConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up from config entry."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    router = hass.data[DOMAIN].routers[config_entry.entry_id]
+    router = config_entry.runtime_data
     selects: list[Entity] = []
 
     desc = HuaweiSelectEntityDescription(

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -17,7 +17,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
@@ -31,9 +30,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import Router
+from . import HuaweiLteConfigEntry, Router
 from .const import (
-    DOMAIN,
     KEY_DEVICE_INFORMATION,
     KEY_DEVICE_SIGNAL,
     KEY_MONITORING_CHECK_NOTIFICATIONS,
@@ -795,13 +793,11 @@ SENSOR_META: dict[str, HuaweiSensorGroup] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HuaweiLteConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up from config entry."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    router = hass.data[DOMAIN].routers[config_entry.entry_id]
+    router = config_entry.runtime_data
     sensors: list[Entity] = []
     for key in SENSOR_KEYS:
         if not (items := router.data.get(key)):

--- a/homeassistant/components/huawei_lte/switch.py
+++ b/homeassistant/components/huawei_lte/switch.py
@@ -10,16 +10,12 @@ from homeassistant.components.switch import (
     SwitchDeviceClass,
     SwitchEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import (
-    DOMAIN,
-    KEY_DIALUP_MOBILE_DATASWITCH,
-    KEY_WLAN_WIFI_GUEST_NETWORK_SWITCH,
-)
+from . import HuaweiLteConfigEntry
+from .const import KEY_DIALUP_MOBILE_DATASWITCH, KEY_WLAN_WIFI_GUEST_NETWORK_SWITCH
 from .entity import HuaweiLteBaseEntityWithDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,13 +23,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HuaweiLteConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up from config entry."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    router = hass.data[DOMAIN].routers[config_entry.entry_id]
+    router = config_entry.runtime_data
     switches: list[Entity] = []
 
     if router.data.get(KEY_DIALUP_MOBILE_DATASWITCH):


### PR DESCRIPTION
## Proposed change

Migrate the `huawei_lte` integration away from the legacy `hass.data[DOMAIN]` pattern:

- Replace the `HuaweiLteData` `NamedTuple` with a typed `HuaweiLteConfigEntry = ConfigEntry[Router]` alias (per-entry `runtime_data` holds the `Router`) and a `HUAWEI_LTE_CONFIG: HassKey[ConfigType] = HassKey(DOMAIN)` for the shared YAML config that the notify discovery platform still needs.
- `async_setup` stores `hass.data[HUAWEI_LTE_CONFIG] = config`; `async_setup_entry` stores `entry.runtime_data = router`; `async_unload_entry` calls `config_entry.runtime_data.cleanup()` directly.
- The service handler iterates `hass.config_entries.async_loaded_entries(DOMAIN)` to find routers.
- Remove the legacy `hass-use-runtime-data` pylint-disable. Update all function signatures (`Router`, `async_migrate_entry`, etc.) to use `HuaweiLteConfigEntry`.
- Platform `async_setup_entry` functions (`binary_sensor`, `button`, `device_tracker`, `select`, `sensor`, `switch`) now take `HuaweiLteConfigEntry` and read `config_entry.runtime_data` instead of `hass.data[DOMAIN].routers[config_entry.entry_id]`. Remove the now-unused `DOMAIN` and `ConfigEntry` imports as well as legacy pylint-disable comments.
- `select.py`: additionally change `setter_fn: Callable[[str], None]` to `Callable[[str], Any]` — the underlying `router.client.net.set_net_mode` returns `str`, which mypy now catches once `router` is properly typed as `Router` (was masked when it was typed as `Any` via `hass.data[DOMAIN]`).
- `notify.py`: `async_get_service` now looks up the `HuaweiLteConfigEntry` via `hass.config_entries.async_get_entry(discovery_info[ATTR_CONFIG_ENTRY_ID])` and reads `entry.runtime_data`.
- `diagnostics.py`: `async_get_config_entry_diagnostics` takes `HuaweiLteConfigEntry` and reads `entry.runtime_data.data`.
- `config_flow.py`: `async_get_options_flow` typed with `HuaweiLteConfigEntry`; drop the now-unused `ConfigEntry` import.
- `quality_scale.yaml`: mark `runtime-data: done`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #168774
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr