### PR TITLE
Remove leftover hass.data[DOMAIN] usage from insteon

### DIFF
--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -77,7 +77,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up an Insteon entry."""
 
     api.async_load_api(hass)
-    await api.async_register_insteon_frontend(hass, entry.options.get(CONF_DEV_PATH))
+    await api.async_register_insteon_frontend(
+        hass, entry.options.get(CONF_DEV_PATH) or None
+    )
 
     if not devices.modem:
         try:

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -1,5 +1,4 @@
 """Support for INSTEON Modems (PLM and Hub)."""
-# pylint: disable=hass-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from contextlib import suppress
 import logging
@@ -7,7 +6,7 @@ import logging
 from pyinsteon import async_close, async_connect, devices
 from pyinsteon.constants import ReadWriteMode
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PLATFORM, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -34,7 +33,6 @@ from .utils import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-OPTIONS = "options"
 
 
 async def async_get_device_config(hass, config_entry):
@@ -78,12 +76,8 @@ async def close_insteon_connection(*args):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up an Insteon entry."""
 
-    if dev_path := entry.options.get(CONF_DEV_PATH):
-        hass.data[DOMAIN] = {}
-        hass.data[DOMAIN][CONF_DEV_PATH] = dev_path
-
     api.async_load_api(hass)
-    await api.async_register_insteon_frontend(hass)
+    await api.async_register_insteon_frontend(hass, entry.options.get(CONF_DEV_PATH))
 
     if not devices.modem:
         try:
@@ -99,19 +93,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await devices.async_load(
         workdir=hass.config.config_dir, id_devices=0, load_modem_aldb=0
     )
-
-    # If options existed in YAML and have not already been saved to the config entry
-    # add them now
-    if (
-        not entry.options
-        and entry.source == SOURCE_IMPORT
-        and hass.data.get(DOMAIN)
-        and hass.data[DOMAIN].get(OPTIONS)
-    ):
-        hass.config_entries.async_update_entry(
-            entry=entry,
-            options=hass.data[DOMAIN][OPTIONS],
-        )
 
     for device_override in entry.options.get(CONF_OVERRIDE, []):
         # Override the device default capabilities for a specific address

--- a/homeassistant/components/insteon/api/__init__.py
+++ b/homeassistant/components/insteon/api/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.components import panel_custom, websocket_api
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.core import HomeAssistant, callback
 
-from ..const import CONF_DEV_PATH, DOMAIN
+from ..const import DOMAIN
 from .aldb import (
     websocket_add_default_links,
     websocket_change_aldb_record,
@@ -90,11 +90,12 @@ def async_load_api(hass):
     websocket_api.async_register_command(hass, websocket_get_unknown_devices)
 
 
-async def async_register_insteon_frontend(hass: HomeAssistant):
+async def async_register_insteon_frontend(
+    hass: HomeAssistant, dev_path: str | None = None
+) -> None:
     """Register the Insteon frontend configuration panel."""
     # Add to sidepanel if needed
     if DOMAIN not in hass.data.get("frontend_panels", {}):
-        dev_path = hass.data.get(DOMAIN, {}).get(CONF_DEV_PATH)
         is_dev = dev_path is not None
         path = dev_path or locate_dir()
         build_id = get_build_id(is_dev)

--- a/tests/components/insteon/test_init.py
+++ b/tests/components/insteon/test_init.py
@@ -1,6 +1,6 @@
 """Test the init file for the Insteon component."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -78,6 +78,9 @@ async def test_import_frontend_dev_url(hass: HomeAssistant) -> None:
         patch.object(insteon, "async_connect", new=mock_successful_connection),
         patch.object(insteon, "async_close") as mock_close,
         patch.object(insteon, "devices", new=MockDevices()),
+        patch.object(
+            insteon.api, "async_register_insteon_frontend", new=AsyncMock()
+        ) as mock_register_frontend,
     ):
         assert await async_setup_component(
             hass,
@@ -85,7 +88,7 @@ async def test_import_frontend_dev_url(hass: HomeAssistant) -> None:
             {},
         )
         await hass.async_block_till_done()
-        assert hass.data[DOMAIN][CONF_DEV_PATH] == "/some/path"
+        mock_register_frontend.assert_called_once_with(hass, "/some/path")
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
         assert insteon.devices.async_save.call_count == 1

--- a/tests/components/insteon/test_init.py
+++ b/tests/components/insteon/test_init.py
@@ -88,7 +88,7 @@ async def test_import_frontend_dev_url(hass: HomeAssistant) -> None:
             {},
         )
         await hass.async_block_till_done()
-        mock_register_frontend.assert_called_once_with(hass, "/some/path")
+        mock_register_frontend.assert_awaited_once_with(hass, "/some/path")
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
         assert insteon.devices.async_save.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #93952, which removed YAML import for the `insteon` integration but left behind some now-dead uses of `hass.data[DOMAIN]`.

- `homeassistant/components/insteon/__init__.py`:
  - Removed the dead YAML-import migration block that checked `hass.data[DOMAIN][OPTIONS]` and called `async_update_entry`. `OPTIONS` was never populated after YAML import was removed in #93952.
  - Removed the `hass.data[DOMAIN] = {}` / `hass.data[DOMAIN][CONF_DEV_PATH] = dev_path` writes that were only used to pass `dev_path` to the frontend registration helper.
  - Pass `dev_path` directly to `api.async_register_insteon_frontend(hass, entry.options.get(CONF_DEV_PATH))`.
  - Dropped the unused `SOURCE_IMPORT` import and the module-level `OPTIONS` constant.
  - Removed the `# pylint: disable=hass-use-runtime-data` module-level comment, as `hass.data[DOMAIN]` is no longer used.
- `homeassistant/components/insteon/api/__init__.py`:
  - `async_register_insteon_frontend(hass, dev_path: str | None = None)` now takes `dev_path` as a parameter instead of reading it from `hass.data[DOMAIN][CONF_DEV_PATH]`.
  - Dropped the now-unused `CONF_DEV_PATH` import and added a `-> None` return annotation.
- `tests/components/insteon/test_init.py`:
  - `test_import_frontend_dev_url` now patches `async_register_insteon_frontend` and asserts it was called with `hass, "/some/path"` instead of reading the dev_path back from `hass.data[DOMAIN][CONF_DEV_PATH]` (which no longer exists).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168775
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr