### PR TITLE
Add optional compression to Store

### DIFF
--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from compression import zstd
 from contextlib import suppress
 from copy import deepcopy
 import inspect
@@ -46,6 +47,34 @@ STORAGE_SEMAPHORE: HassKey[asyncio.Semaphore] = HassKey("storage_semaphore")
 STORAGE_MANAGER: HassKey[_StoreManager] = HassKey("storage_manager")
 
 MANAGER_CLEANUP_DELAY = 60
+
+
+def _load_json_file(path: str | Path) -> json_util.JsonValueType:
+    """Load JSON from a file, transparently decompressing .zst files.
+
+    Returns ``{}`` (the same sentinel as :func:`json_util.load_json`) when
+    the file does not exist.  Raises :class:`HomeAssistantError` wrapping the
+    original exception when the file is corrupt or cannot be read.
+    """
+    if not str(path).endswith(".zst"):
+        return json_util.load_json(path)
+    try:
+        with open(path, "rb") as fh:
+            raw = zstd.decompress(fh.read())
+    except FileNotFoundError:
+        _LOGGER.debug("JSON file not found: %s", path)
+        return {}
+    except zstd.ZstdError as err:
+        _LOGGER.exception("Could not decompress storage file: %s", path)
+        raise HomeAssistantError(f"Error decompressing {path}: {err}") from err
+    except OSError as err:
+        _LOGGER.exception("Storage file reading failed: %s", path)
+        raise HomeAssistantError(f"Error while loading {path}: {err}") from err
+    try:
+        return json_util.json_loads(raw)
+    except json_util.JSON_DECODE_EXCEPTIONS as err:
+        _LOGGER.exception("Could not parse JSON content: %s", path)
+        raise HomeAssistantError(f"Error while loading {path}: {err}") from err
 
 
 async def async_migrator[_T: Mapping[str, Any] | Sequence[Any]](
@@ -214,7 +243,7 @@ class _StoreManager:
             storage_file: Path = storage_path.joinpath(key)
             try:
                 if storage_file.is_file():
-                    data_preload[key] = json_util.load_json(storage_file)
+                    data_preload[key] = _load_json_file(storage_file)
             except Exception as ex:  # noqa: BLE001
                 _LOGGER.debug("Error loading %s: %s", key, ex)
 
@@ -239,6 +268,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         max_readable_version: int | None = None,
         minor_version: int = 1,
         read_only: bool = False,
+        compress: bool = False,
         serialize_in_event_loop: bool = True,
     ) -> None:
         """Initialize storage class.
@@ -282,10 +312,36 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         self._next_write_time = 0.0
         self._manager = get_internal_store_manager(hass)
         self._serialize_in_event_loop = serialize_in_event_loop
+        self._compress = compress
 
     @cached_property
     def path(self):
         """Return the config path."""
+        if self._compress:
+            return self.hass.config.path(STORAGE_DIR, self.key + ".zst")
+        return self.hass.config.path(STORAGE_DIR, self.key)
+
+    @cached_property
+    def _cache_key(self):
+        """Return the cache key used with _StoreManager.
+
+        For compressed stores the file on disk is named ``key.zst``, which is
+        what ``_StoreManager._files`` contains.  Using the bare ``key`` would
+        always produce a "file does not exist" cache hit, so we append the
+        suffix here to match the real filename.
+        """
+        if self._compress:
+            return self.key + ".zst"
+        return self.key
+
+    @cached_property
+    def _uncompressed_path(self):
+        """Return the plain (uncompressed) config path.
+
+        Used as a fallback when compress=True but only an uncompressed file
+        exists (e.g. the user manually extracted / edited the file), and to
+        clean up the old file after a successful compressed write.
+        """
         return self.hass.config.path(STORAGE_DIR, self.key)
 
     def make_read_only(self) -> None:
@@ -359,66 +415,19 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
             # We make a copy because code might assume it's safe to mutate loaded data
             # and we don't want that to mess with what we're trying to store.
             data = deepcopy(data)
-        elif cache := self._manager.async_fetch(self.key):
+        elif cache := self._manager.async_fetch(self._cache_key):
             exists, data = cache
             if not exists:
                 return None
         else:
             try:
-                data = await self.hass.async_add_executor_job(
-                    json_util.load_json, self.path
-                )
+                data = await self.hass.async_add_executor_job(self._load_data_from_disk)
             except HomeAssistantError as err:
-                if isinstance(err.__cause__, JSONDecodeError):
-                    # If we have a JSONDecodeError, it means the file is corrupt.
-                    # We can't recover from this, so we'll log an error, rename the file and
-                    # return None so that we can start with a clean slate which will
-                    # allow startup to continue so they can restore from a backup.
-                    isotime = dt_util.utcnow().isoformat()
-                    corrupt_postfix = f".corrupt.{isotime}"
-                    corrupt_path = f"{self.path}{corrupt_postfix}"
-                    await self.hass.async_add_executor_job(
-                        os.rename, self.path, corrupt_path
-                    )
-                    storage_key = self.key
-                    _LOGGER.error(
-                        "Unrecoverable error decoding storage %s at %s; "
-                        "This may indicate an unclean shutdown, invalid syntax "
-                        "from manual edits, or disk corruption; "
-                        "The corrupt file has been saved as %s; "
-                        "It is recommended to restore from backup: %s",
-                        storage_key,
-                        self.path,
-                        corrupt_path,
-                        err,
-                    )
-                    from .issue_registry import (  # noqa: PLC0415
-                        IssueSeverity,
-                        async_create_issue,
-                    )
-
-                    issue_domain = HOMEASSISTANT_DOMAIN
-                    if (
-                        domain := (storage_key.partition(".")[0])
-                    ) and domain in self.hass.config.components:
-                        issue_domain = domain
-
-                    async_create_issue(
-                        self.hass,
-                        HOMEASSISTANT_DOMAIN,
-                        f"storage_corruption_{storage_key}_{isotime}",
-                        is_fixable=True,
-                        issue_domain=issue_domain,
-                        translation_key="storage_corruption",
-                        is_persistent=True,
-                        severity=IssueSeverity.CRITICAL,
-                        translation_placeholders={
-                            "storage_key": storage_key,
-                            "original_path": self.path,
-                            "corrupt_path": corrupt_path,
-                            "error": str(err),
-                        },
-                    )
+                if isinstance(err.__cause__, (JSONDecodeError, zstd.ZstdError)):
+                    # If the file is corrupt we log an error, rename it, and
+                    # return None so startup can continue from a clean slate.
+                    # The caller can restore from a backup.
+                    await self._async_handle_corrupt_file(err)
                     return None
                 raise
 
@@ -570,7 +579,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
     async def _async_handle_write_data(self, *_args):
         """Handle writing the config."""
         async with self._write_lock:
-            self._manager.async_invalidate(self.key)
+            self._manager.async_invalidate(self._cache_key)
             self._async_cleanup_delay_listener()
             self._async_cleanup_final_write_listener()
 
@@ -607,6 +616,22 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         mode, json_data = json_helper.prepare_save_json(data, encoder=self._encoder)
         self._write_prepared_data(mode, json_data)
 
+    def _load_data_from_disk(self) -> json_util.JsonValueType:
+        """Load data from disk.
+
+        Called in the executor.  For compressed stores the compressed path is
+        tried first; if it does not exist the plain file is used as a fallback
+        so that a user-edited uncompressed file is transparently picked up.
+
+        Returns ``{}`` (the same sentinel as :func:`json_util.load_json`) when
+        neither file exists.
+        """
+        data = _load_json_file(self.path)
+        if data == {} and self._compress:
+            # .zst not found – fall back to the plain file.
+            data = _load_json_file(self._uncompressed_path)
+        return data
+
     def _write_prepared_data(self, mode: str, json_data: str | bytes) -> None:
         """Write the data."""
         path = self.path
@@ -616,7 +641,62 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         write_method = (
             write_utf8_file_atomic if self._atomic_writes else write_utf8_file
         )
-        write_method(path, json_data, self._private, mode=mode)
+        if self._compress:
+            # Ensure we have bytes before compressing.
+            if isinstance(json_data, str):
+                json_data = json_data.encode("utf-8")
+            compressed = zstd.compress(json_data)
+            write_method(path, compressed, self._private, mode="wb")
+            # Remove the old uncompressed file (migration from plain → compressed).
+            uncompressed = self._uncompressed_path
+            if os.path.isfile(uncompressed):
+                os.unlink(uncompressed)
+        else:
+            write_method(path, json_data, self._private, mode=mode)
+
+    async def _async_handle_corrupt_file(self, err: Exception) -> None:
+        """Rename a corrupt storage file and create a repair issue."""
+        from .issue_registry import IssueSeverity, async_create_issue  # noqa: PLC0415
+
+        isotime = dt_util.utcnow().isoformat()
+        corrupt_postfix = f".corrupt.{isotime}"
+        corrupt_path = f"{self.path}{corrupt_postfix}"
+        await self.hass.async_add_executor_job(os.rename, self.path, corrupt_path)
+        storage_key = self.key
+        _LOGGER.error(
+            "Unrecoverable error decoding storage %s at %s; "
+            "This may indicate an unclean shutdown, invalid syntax "
+            "from manual edits, or disk corruption; "
+            "The corrupt file has been saved as %s; "
+            "It is recommended to restore from backup: %s",
+            storage_key,
+            self.path,
+            corrupt_path,
+            err,
+        )
+
+        issue_domain = HOMEASSISTANT_DOMAIN
+        if (
+            domain := (storage_key.partition(".")[0])
+        ) and domain in self.hass.config.components:
+            issue_domain = domain
+
+        async_create_issue(
+            self.hass,
+            HOMEASSISTANT_DOMAIN,
+            f"storage_corruption_{storage_key}_{isotime}",
+            is_fixable=True,
+            issue_domain=issue_domain,
+            translation_key="storage_corruption",
+            is_persistent=True,
+            severity=IssueSeverity.CRITICAL,
+            translation_placeholders={
+                "storage_key": storage_key,
+                "original_path": self.path,
+                "corrupt_path": corrupt_path,
+                "error": str(err),
+            },
+        )
 
     async def _async_migrate_func(self, old_major_version, old_minor_version, old_data):
         """Migrate to the new version."""
@@ -624,9 +704,15 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
 
     async def async_remove(self) -> None:
         """Remove all data."""
-        self._manager.async_invalidate(self.key)
+        self._manager.async_invalidate(self._cache_key)
         self._async_cleanup_delay_listener()
         self._async_cleanup_final_write_listener()
 
-        with suppress(FileNotFoundError):
-            await self.hass.async_add_executor_job(os.unlink, self.path)
+        def _remove_files() -> None:
+            with suppress(FileNotFoundError):
+                os.unlink(self.path)
+            if self._compress:
+                with suppress(FileNotFoundError):
+                    os.unlink(self._uncompressed_path)
+
+        await self.hass.async_add_executor_job(_remove_files)

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from compression import zstd
 from contextlib import suppress
 from copy import deepcopy
 import inspect
@@ -44,6 +45,34 @@ STORAGE_SEMAPHORE: HassKey[asyncio.Semaphore] = HassKey("storage_semaphore")
 STORAGE_MANAGER: HassKey[_StoreManager] = HassKey("storage_manager")
 
 MANAGER_CLEANUP_DELAY = 60
+
+
+def _load_json_file(path: str | Path) -> json_util.JsonValueType:
+    """Load JSON from a file, transparently decompressing .zst files.
+
+    Returns ``{}`` (the same sentinel as :func:`json_util.load_json`) when
+    the file does not exist.  Raises :class:`HomeAssistantError` wrapping the
+    original exception when the file is corrupt or cannot be read.
+    """
+    if not str(path).endswith(".zst"):
+        return json_util.load_json(path)
+    try:
+        with open(path, "rb") as fh:
+            raw = zstd.decompress(fh.read())
+    except FileNotFoundError:
+        _LOGGER.debug("JSON file not found: %s", path)
+        return {}
+    except zstd.ZstdError as err:
+        _LOGGER.exception("Could not decompress storage file: %s", path)
+        raise HomeAssistantError(f"Error decompressing {path}: {err}") from err
+    except OSError as err:
+        _LOGGER.exception("Storage file reading failed: %s", path)
+        raise HomeAssistantError(f"Error while loading {path}: {err}") from err
+    try:
+        return json_util.json_loads(raw)
+    except json_util.JSON_DECODE_EXCEPTIONS as err:
+        _LOGGER.exception("Could not parse JSON content: %s", path)
+        raise HomeAssistantError(f"Error while loading {path}: {err}") from err
 
 
 async def async_migrator[_T: Mapping[str, Any] | Sequence[Any]](
@@ -212,7 +241,7 @@ class _StoreManager:
             storage_file: Path = storage_path.joinpath(key)
             try:
                 if storage_file.is_file():
-                    data_preload[key] = json_util.load_json(storage_file)
+                    data_preload[key] = _load_json_file(storage_file)
             except Exception as ex:  # noqa: BLE001
                 _LOGGER.debug("Error loading %s: %s", key, ex)
 
@@ -237,6 +266,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         max_readable_version: int | None = None,
         minor_version: int = 1,
         read_only: bool = False,
+        compress: bool = False,
         serialize_in_event_loop: bool = True,
     ) -> None:
         """Initialize storage class.
@@ -280,10 +310,36 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         self._next_write_time = 0.0
         self._manager = get_internal_store_manager(hass)
         self._serialize_in_event_loop = serialize_in_event_loop
+        self._compress = compress
 
     @cached_property
     def path(self):
         """Return the config path."""
+        if self._compress:
+            return self.hass.config.path(STORAGE_DIR, self.key + ".zst")
+        return self.hass.config.path(STORAGE_DIR, self.key)
+
+    @cached_property
+    def _cache_key(self):
+        """Return the cache key used with _StoreManager.
+
+        For compressed stores the file on disk is named ``key.zst``, which is
+        what ``_StoreManager._files`` contains.  Using the bare ``key`` would
+        always produce a "file does not exist" cache hit, so we append the
+        suffix here to match the real filename.
+        """
+        if self._compress:
+            return self.key + ".zst"
+        return self.key
+
+    @cached_property
+    def _uncompressed_path(self):
+        """Return the plain (uncompressed) config path.
+
+        Used as a fallback when compress=True but only an uncompressed file
+        exists (e.g. the user manually extracted / edited the file), and to
+        clean up the old file after a successful compressed write.
+        """
         return self.hass.config.path(STORAGE_DIR, self.key)
 
     def make_read_only(self) -> None:
@@ -357,67 +413,19 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
             # We make a copy because code might assume it's safe to mutate loaded data
             # and we don't want that to mess with what we're trying to store.
             data = deepcopy(data)
-        elif cache := self._manager.async_fetch(self.key):
+        elif cache := self._manager.async_fetch(self._cache_key):
             exists, data = cache
             if not exists:
                 return None
         else:
             try:
-                data = await self.hass.async_add_executor_job(
-                    json_util.load_json, self.path
-                )
+                data = await self.hass.async_add_executor_job(self._load_data_from_disk)
             except HomeAssistantError as err:
-                if isinstance(err.__cause__, JSONDecodeError):
-                    # If we have a JSONDecodeError, it means the file is corrupt.
-                    # We can't recover from this, so we'll log
-                    # an error, rename the file and
-                    # return None so that we can start with a clean slate which will
-                    # allow startup to continue so they can restore from a backup.
-                    isotime = dt_util.utcnow().isoformat()
-                    corrupt_postfix = f".corrupt.{isotime}"
-                    corrupt_path = f"{self.path}{corrupt_postfix}"
-                    await self.hass.async_add_executor_job(
-                        os.rename, self.path, corrupt_path
-                    )
-                    storage_key = self.key
-                    _LOGGER.error(
-                        "Unrecoverable error decoding storage %s at %s; "
-                        "This may indicate an unclean shutdown, invalid syntax "
-                        "from manual edits, or disk corruption; "
-                        "The corrupt file has been saved as %s; "
-                        "It is recommended to restore from backup: %s",
-                        storage_key,
-                        self.path,
-                        corrupt_path,
-                        err,
-                    )
-                    from .issue_registry import (  # noqa: PLC0415
-                        IssueSeverity,
-                        async_create_issue,
-                    )
-
-                    issue_domain = HOMEASSISTANT_DOMAIN
-                    if (
-                        domain := (storage_key.partition(".")[0])
-                    ) and domain in self.hass.config.components:
-                        issue_domain = domain
-
-                    async_create_issue(
-                        self.hass,
-                        HOMEASSISTANT_DOMAIN,
-                        f"storage_corruption_{storage_key}_{isotime}",
-                        is_fixable=True,
-                        issue_domain=issue_domain,
-                        translation_key="storage_corruption",
-                        is_persistent=True,
-                        severity=IssueSeverity.CRITICAL,
-                        translation_placeholders={
-                            "storage_key": storage_key,
-                            "original_path": self.path,
-                            "corrupt_path": corrupt_path,
-                            "error": str(err),
-                        },
-                    )
+                if isinstance(err.__cause__, (JSONDecodeError, zstd.ZstdError)):
+                    # If the file is corrupt we log an error, rename it, and
+                    # return None so startup can continue from a clean slate.
+                    # The caller can restore from a backup.
+                    await self._async_handle_corrupt_file(err)
                     return None
                 raise
 
@@ -569,7 +577,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
     async def _async_handle_write_data(self, *_args):
         """Handle writing the config."""
         async with self._write_lock:
-            self._manager.async_invalidate(self.key)
+            self._manager.async_invalidate(self._cache_key)
             self._async_cleanup_delay_listener()
             self._async_cleanup_final_write_listener()
 
@@ -606,6 +614,22 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         mode, json_data = json_helper.prepare_save_json(data, encoder=self._encoder)
         self._write_prepared_data(mode, json_data)
 
+    def _load_data_from_disk(self) -> json_util.JsonValueType:
+        """Load data from disk.
+
+        Called in the executor.  For compressed stores the compressed path is
+        tried first; if it does not exist the plain file is used as a fallback
+        so that a user-edited uncompressed file is transparently picked up.
+
+        Returns ``{}`` (the same sentinel as :func:`json_util.load_json`) when
+        neither file exists.
+        """
+        data = _load_json_file(self.path)
+        if data == {} and self._compress:
+            # .zst not found - fall back to the plain file.
+            data = _load_json_file(self._uncompressed_path)
+        return data
+
     def _write_prepared_data(self, mode: str, json_data: str | bytes) -> None:
         """Write the data."""
         path = self.path
@@ -615,7 +639,62 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         write_method = (
             write_utf8_file_atomic if self._atomic_writes else write_utf8_file
         )
-        write_method(path, json_data, self._private, mode=mode)
+        if self._compress:
+            # Ensure we have bytes before compressing.
+            if isinstance(json_data, str):
+                json_data = json_data.encode("utf-8")
+            compressed = zstd.compress(json_data)
+            write_method(path, compressed, self._private, mode="wb")
+            # Remove the old uncompressed file (migration from plain → compressed).
+            uncompressed = self._uncompressed_path
+            if os.path.isfile(uncompressed):
+                os.unlink(uncompressed)
+        else:
+            write_method(path, json_data, self._private, mode=mode)
+
+    async def _async_handle_corrupt_file(self, err: Exception) -> None:
+        """Rename a corrupt storage file and create a repair issue."""
+        from .issue_registry import IssueSeverity, async_create_issue  # noqa: PLC0415
+
+        isotime = dt_util.utcnow().isoformat()
+        corrupt_postfix = f".corrupt.{isotime}"
+        corrupt_path = f"{self.path}{corrupt_postfix}"
+        await self.hass.async_add_executor_job(os.rename, self.path, corrupt_path)
+        storage_key = self.key
+        _LOGGER.error(
+            "Unrecoverable error decoding storage %s at %s; "
+            "This may indicate an unclean shutdown, invalid syntax "
+            "from manual edits, or disk corruption; "
+            "The corrupt file has been saved as %s; "
+            "It is recommended to restore from backup: %s",
+            storage_key,
+            self.path,
+            corrupt_path,
+            err,
+        )
+
+        issue_domain = HOMEASSISTANT_DOMAIN
+        if (
+            domain := (storage_key.partition(".")[0])
+        ) and domain in self.hass.config.components:
+            issue_domain = domain
+
+        async_create_issue(
+            self.hass,
+            HOMEASSISTANT_DOMAIN,
+            f"storage_corruption_{storage_key}_{isotime}",
+            is_fixable=True,
+            issue_domain=issue_domain,
+            translation_key="storage_corruption",
+            is_persistent=True,
+            severity=IssueSeverity.CRITICAL,
+            translation_placeholders={
+                "storage_key": storage_key,
+                "original_path": self.path,
+                "corrupt_path": corrupt_path,
+                "error": str(err),
+            },
+        )
 
     async def _async_migrate_func(self, old_major_version, old_minor_version, old_data):
         """Migrate to the new version."""
@@ -623,9 +702,15 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
 
     async def async_remove(self) -> None:
         """Remove all data."""
-        self._manager.async_invalidate(self.key)
+        self._manager.async_invalidate(self._cache_key)
         self._async_cleanup_delay_listener()
         self._async_cleanup_final_write_listener()
 
-        with suppress(FileNotFoundError):
-            await self.hass.async_add_executor_job(os.unlink, self.path)
+        def _remove_files() -> None:
+            with suppress(FileNotFoundError):
+                os.unlink(self.path)
+            if self._compress:
+                with suppress(FileNotFoundError):
+                    os.unlink(self._uncompressed_path)
+
+        await self.hass.async_add_executor_job(_remove_files)

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -46,22 +46,30 @@ STORAGE_MANAGER: HassKey[_StoreManager] = HassKey("storage_manager")
 
 MANAGER_CLEANUP_DELAY = 60
 
+COMPRESSED_SUFFIX = ".zst"
 
-def _load_json_file(path: str | Path) -> json_util.JsonValueType:
+# Distinguishes "no file on disk" from a file whose content is an empty dict.
+_NOT_FOUND = object()
+
+
+def _load_json_file(
+    path: str | Path,
+    default: json_util.JsonValueType = _NOT_FOUND,  # type: ignore[assignment]
+) -> json_util.JsonValueType:
     """Load JSON from a file, transparently decompressing .zst files.
 
-    Returns ``{}`` (the same sentinel as :func:`json_util.load_json`) when
-    the file does not exist.  Raises :class:`HomeAssistantError` wrapping the
-    original exception when the file is corrupt or cannot be read.
+    Returns ``default`` when the file does not exist, mirroring
+    :func:`json_util.load_json`.  Raises :class:`HomeAssistantError` wrapping
+    the original exception when the file is corrupt or cannot be read.
     """
-    if not str(path).endswith(".zst"):
-        return json_util.load_json(path)
+    if Path(path).suffix != COMPRESSED_SUFFIX:
+        return json_util.load_json(path, default=default)
     try:
         with open(path, "rb") as fh:
             raw = zstd.decompress(fh.read())
     except FileNotFoundError:
         _LOGGER.debug("JSON file not found: %s", path)
-        return {}
+        return default
     except zstd.ZstdError as err:
         _LOGGER.exception("Could not decompress storage file: %s", path)
         raise HomeAssistantError(f"Error decompressing {path}: {err}") from err
@@ -230,7 +238,14 @@ class _StoreManager:
     async def async_preload(self, keys: Iterable[str]) -> None:
         """Cache the keys."""
         # If async_initialize has not been called yet, we can't preload
-        if self._files is not None and (existing := self._files.intersection(keys)):
+        if self._files is None:
+            return
+        # Callers pass plain keys; a compressed store is on disk as key + ".zst"
+        # and is cached under that name, so look for both spellings.
+        candidates = {
+            spelling for key in keys for spelling in (key, f"{key}{COMPRESSED_SUFFIX}")
+        }
+        if existing := self._files.intersection(candidates):
             await self._hass.async_add_executor_job(self._preload, existing)
 
     def _preload(self, keys: Iterable[str]) -> None:
@@ -241,7 +256,7 @@ class _StoreManager:
             storage_file: Path = storage_path.joinpath(key)
             try:
                 if storage_file.is_file():
-                    data_preload[key] = _load_json_file(storage_file)
+                    data_preload[key] = _load_json_file(storage_file, default={})
             except Exception as ex:  # noqa: BLE001
                 _LOGGER.debug("Error loading %s: %s", key, ex)
 
@@ -275,6 +290,17 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
             max_readable_version: Maximum major version that can be read. Defaults
             to version. Set higher than version to support forward compatibility,
             allowing reading data written by newer versions (e.g., after downgrade).
+
+            compress: Whether to store the data zstd compressed, under the key
+            with a ".zst" suffix appended. No migration is needed to turn this
+            on or off: an already existing uncompressed file is read as a
+            fallback and removed once the compressed file has been written, so
+            a user can decompress, edit and save a file by hand at any time.
+
+            Compression trades CPU for I/O and disk space. It is paid on every
+            write, while it is only earned back once per load, so it is meant
+            for stores which grow large rather than for ones which are written
+            frequently.
 
             serialize_in_event_loop: Whether to serialize data in the event loop.
             Set to True (default) if data passed to async_save and data produced by
@@ -316,7 +342,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
     def path(self):
         """Return the config path."""
         if self._compress:
-            return self.hass.config.path(STORAGE_DIR, self.key + ".zst")
+            return self.hass.config.path(STORAGE_DIR, self._cache_key)
         return self.hass.config.path(STORAGE_DIR, self.key)
 
     @cached_property
@@ -329,7 +355,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         suffix here to match the real filename.
         """
         if self._compress:
-            return self.key + ".zst"
+            return f"{self.key}{COMPRESSED_SUFFIX}"
         return self.key
 
     @cached_property
@@ -394,6 +420,36 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         async with self.hass.data[STORAGE_SEMAPHORE]:
             return await self._async_load_data()
 
+    @callback
+    def _async_invalidate_cache(self) -> None:
+        """Invalidate every filename this store may be cached under."""
+        self._manager.async_invalidate(self._cache_key)
+        if self._compress:
+            # Writing and removing both drop the uncompressed predecessor.
+            self._manager.async_invalidate(self.key)
+
+    @callback
+    def _async_fetch_cached(
+        self,
+    ) -> tuple[bool, json_util.JsonValueType | None] | None:
+        """Fetch preloaded data, accounting for the uncompressed fallback.
+
+        Returns None when the manager cannot answer and the file has to be
+        read from disk. A compressed store has two candidate filenames, so
+        only report "does not exist" when neither of them is on disk.
+        """
+        primary = self._manager.async_fetch(self._cache_key)
+        if not self._compress:
+            return primary
+        if primary is not None and primary[0]:
+            return primary
+        fallback = self._manager.async_fetch(self.key)
+        if fallback is not None and fallback[0]:
+            return fallback
+        if primary is not None and fallback is not None:
+            return (False, None)
+        return None
+
     async def _async_load_data(self):
         """Load the data."""
         # When load_empty is set, skip loading storage files and use empty
@@ -413,7 +469,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
             # We make a copy because code might assume it's safe to mutate loaded data
             # and we don't want that to mess with what we're trying to store.
             data = deepcopy(data)
-        elif cache := self._manager.async_fetch(self._cache_key):
+        elif cache := self._async_fetch_cached():
             exists, data = cache
             if not exists:
                 return None
@@ -577,7 +633,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
     async def _async_handle_write_data(self, *_args):
         """Handle writing the config."""
         async with self._write_lock:
-            self._manager.async_invalidate(self._cache_key)
+            self._async_invalidate_cache()
             self._async_cleanup_delay_listener()
             self._async_cleanup_final_write_listener()
 
@@ -625,10 +681,9 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         neither file exists.
         """
         data = _load_json_file(self.path)
-        if data == {} and self._compress:
-            # .zst not found - fall back to the plain file.
+        if data is _NOT_FOUND and self._compress:
             data = _load_json_file(self._uncompressed_path)
-        return data
+        return {} if data is _NOT_FOUND else data
 
     def _write_prepared_data(self, mode: str, json_data: str | bytes) -> None:
         """Write the data."""
@@ -658,8 +713,18 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
 
         isotime = dt_util.utcnow().isoformat()
         corrupt_postfix = f".corrupt.{isotime}"
-        corrupt_path = f"{self.path}{corrupt_postfix}"
-        await self.hass.async_add_executor_job(os.rename, self.path, corrupt_path)
+
+        def _rename_corrupt_file() -> tuple[str, str]:
+            # The compressed path is read first, so when it is absent the file
+            # we failed to read is the uncompressed fallback.
+            path = self.path if os.path.isfile(self.path) else self._uncompressed_path
+            corrupt_path = f"{path}{corrupt_postfix}"
+            os.rename(path, corrupt_path)
+            return path, corrupt_path
+
+        path, corrupt_path = await self.hass.async_add_executor_job(
+            _rename_corrupt_file
+        )
         storage_key = self.key
         _LOGGER.error(
             "Unrecoverable error decoding storage %s at %s; "
@@ -668,7 +733,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
             "The corrupt file has been saved as %s; "
             "It is recommended to restore from backup: %s",
             storage_key,
-            self.path,
+            path,
             corrupt_path,
             err,
         )
@@ -690,7 +755,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
             severity=IssueSeverity.CRITICAL,
             translation_placeholders={
                 "storage_key": storage_key,
-                "original_path": self.path,
+                "original_path": path,
                 "corrupt_path": corrupt_path,
                 "error": str(err),
             },
@@ -702,7 +767,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
 
     async def async_remove(self) -> None:
         """Remove all data."""
-        self._manager.async_invalidate(self._cache_key)
+        self._async_invalidate_cache()
         self._async_cleanup_delay_listener()
         self._async_cleanup_final_write_listener()
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -1,6 +1,7 @@
 """Tests for the storage helper."""
 
 import asyncio
+from compression import zstd
 from datetime import timedelta
 import json
 import os
@@ -1382,3 +1383,130 @@ async def test_load_empty_returns_none_and_read_only(
     await store.async_save({"new": "data"})
     assert hass_storage[MOCK_KEY]["data"] == MOCK_DATA
     assert hass_storage[MOCK_KEY]["version"] == 99
+
+
+async def test_compress_save_load_round_trip(tmpdir: py.path.local) -> None:
+    """Test that a compressed store saves a .zst file and loads back correctly."""
+    loop = asyncio.get_running_loop()
+    config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
+
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
+        store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
+        await store.async_save(MOCK_DATA)
+
+        storage_path = Path(config_dir.strpath) / ".storage"
+        zst_file = storage_path / (MOCK_KEY + ".zst")
+        plain_file = storage_path / MOCK_KEY
+
+        assert zst_file.is_file()
+        assert not plain_file.exists()
+
+        raw = zstd.decompress(zst_file.read_bytes())
+        on_disk = json.loads(raw)
+        assert on_disk["data"] == MOCK_DATA
+
+        loaded = await store.async_load()
+        assert loaded == MOCK_DATA
+
+        await hass.async_stop(force=True)
+
+
+async def test_compress_migrates_plain_to_compressed(tmpdir: py.path.local) -> None:
+    """Test that saving with compress=True removes an existing plain file."""
+    loop = asyncio.get_running_loop()
+    config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
+
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
+        plain_store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
+        await plain_store.async_save(MOCK_DATA)
+
+        storage_path = Path(config_dir.strpath) / ".storage"
+        plain_file = storage_path / MOCK_KEY
+        assert plain_file.is_file()
+
+        compressed_store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
+
+        # Before the first compressed write the plain file is still the fallback.
+        loaded = await compressed_store.async_load()
+        assert loaded == MOCK_DATA
+
+        # Saving with compress=True should write .zst and remove the plain file.
+        await compressed_store.async_save(MOCK_DATA2)
+
+        zst_file = storage_path / (MOCK_KEY + ".zst")
+        assert zst_file.is_file()
+        assert not plain_file.exists()
+
+        loaded = await compressed_store.async_load()
+        assert loaded == MOCK_DATA2
+
+        await hass.async_stop(force=True)
+
+
+async def test_compress_corrupt_file(
+    tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a corrupt .zst file is handled gracefully."""
+    loop = asyncio.get_running_loop()
+    config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
+
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
+        store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
+        await store.async_save(MOCK_DATA)
+
+        storage_path = Path(config_dir.strpath) / ".storage"
+        zst_file = storage_path / (MOCK_KEY + ".zst")
+
+        def _corrupt_file() -> None:
+            zst_file.write_bytes(b"this is not valid zstd data")
+
+        await hass.async_add_executor_job(_corrupt_file)
+
+        loaded = await store.async_load()
+        assert loaded is None
+        assert "Unrecoverable error decoding storage" in caplog.text
+
+        files = await hass.async_add_executor_job(os.listdir, storage_path)
+        corrupt_files = [f for f in files if ".corrupt" in f]
+        assert len(corrupt_files) == 1
+
+        await hass.async_stop(force=True)
+
+
+async def test_compress_store_manager_cache(tmpdir: py.path.local) -> None:
+    """Test that compressed stores are cached and served by the store manager."""
+    loop = asyncio.get_running_loop()
+
+    def _setup_mock_storage() -> py.path.local:
+        config_dir = tmpdir.mkdir("temp_config")
+        tmp_storage = config_dir.mkdir(".storage")
+        payload = json.dumps(
+            {
+                "version": MOCK_VERSION,
+                "minor_version": 1,
+                "key": MOCK_KEY,
+                "data": MOCK_DATA,
+            }
+        ).encode()
+        tmp_storage.join(MOCK_KEY + ".zst").write_binary(zstd.compress(payload))
+        return config_dir
+
+    config_dir = await loop.run_in_executor(None, _setup_mock_storage)
+
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
+        store_manager = storage.get_internal_store_manager(hass)
+        await store_manager.async_initialize()
+        await store_manager.async_preload([MOCK_KEY + ".zst"])
+
+        # The cache key for a compressed store is key + ".zst".
+        result = store_manager.async_fetch(MOCK_KEY + ".zst")
+        assert result is not None
+        exists, cached_data = result
+        assert exists is True
+        assert cached_data["data"] == MOCK_DATA  # type: ignore[index]
+
+        store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
+        loaded = await store.async_load()
+        assert loaded == MOCK_DATA
+
+        await hass.async_stop(force=True)

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -1,6 +1,7 @@
 """Tests for the storage helper."""
 
 import asyncio
+from collections.abc import AsyncGenerator
 from compression import zstd
 from datetime import timedelta
 import json
@@ -1385,128 +1386,210 @@ async def test_load_empty_returns_none_and_read_only(
     assert hass_storage[MOCK_KEY]["version"] == 99
 
 
-async def test_compress_save_load_round_trip(tmpdir: py.path.local) -> None:
-    """Test that a compressed store saves a .zst file and loads back correctly."""
+def _storage_file(hass: HomeAssistant, name: str) -> Path:
+    """Return the path of a file in the .storage dir."""
+    return Path(hass.config.config_dir) / storage.STORAGE_DIR / name
+
+
+def _write_store_file(path: Path, data: dict[str, Any], compress: bool) -> None:
+    """Write a store envelope to disk the way a previous run would have."""
+    payload = json.dumps(
+        {
+            "version": MOCK_VERSION,
+            "minor_version": 1,
+            "key": MOCK_KEY,
+            "data": data,
+        }
+    ).encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(zstd.compress(payload) if compress else payload)
+
+
+@pytest.fixture
+async def disk_hass(tmpdir: py.path.local) -> AsyncGenerator[HomeAssistant]:
+    """Yield a Home Assistant instance backed by a real config directory."""
     loop = asyncio.get_running_loop()
     config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
 
     async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
-        store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
-        await store.async_save(MOCK_DATA)
-
-        storage_path = Path(config_dir.strpath) / ".storage"
-        zst_file = storage_path / (MOCK_KEY + ".zst")
-        plain_file = storage_path / MOCK_KEY
-
-        assert zst_file.is_file()
-        assert not plain_file.exists()
-
-        raw = zstd.decompress(zst_file.read_bytes())
-        on_disk = json.loads(raw)
-        assert on_disk["data"] == MOCK_DATA
-
-        loaded = await store.async_load()
-        assert loaded == MOCK_DATA
-
+        yield hass
         await hass.async_stop(force=True)
 
 
-async def test_compress_migrates_plain_to_compressed(tmpdir: py.path.local) -> None:
-    """Test that saving with compress=True removes an existing plain file."""
-    loop = asyncio.get_running_loop()
-    config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
-
-    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
-        plain_store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
-        await plain_store.async_save(MOCK_DATA)
-
-        storage_path = Path(config_dir.strpath) / ".storage"
-        plain_file = storage_path / MOCK_KEY
-        assert plain_file.is_file()
-
-        compressed_store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
-
-        # Before the first compressed write the plain file is still the fallback.
-        loaded = await compressed_store.async_load()
-        assert loaded == MOCK_DATA
-
-        # Saving with compress=True should write .zst and remove the plain file.
-        await compressed_store.async_save(MOCK_DATA2)
-
-        zst_file = storage_path / (MOCK_KEY + ".zst")
-        assert zst_file.is_file()
-        assert not plain_file.exists()
-
-        loaded = await compressed_store.async_load()
-        assert loaded == MOCK_DATA2
-
-        await hass.async_stop(force=True)
-
-
-async def test_compress_corrupt_file(
-    tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
+@pytest.mark.parametrize(
+    ("atomic_writes", "serialize_in_event_loop"),
+    [
+        pytest.param(False, True, id="default"),
+        pytest.param(True, True, id="atomic_writes"),
+        pytest.param(False, False, id="serialize_in_executor"),
+    ],
+)
+async def test_compress_save_load_round_trip(
+    disk_hass: HomeAssistant, atomic_writes: bool, serialize_in_event_loop: bool
 ) -> None:
-    """Test that a corrupt .zst file is handled gracefully."""
-    loop = asyncio.get_running_loop()
-    config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
+    """Test that a compressed store saves a .zst file and loads back correctly."""
+    store = storage.Store(
+        disk_hass,
+        MOCK_VERSION,
+        MOCK_KEY,
+        compress=True,
+        atomic_writes=atomic_writes,
+        serialize_in_event_loop=serialize_in_event_loop,
+    )
+    await store.async_save(MOCK_DATA)
 
-    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
-        store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
-        await store.async_save(MOCK_DATA)
+    zst_file = _storage_file(disk_hass, MOCK_KEY + ".zst")
+    plain_file = _storage_file(disk_hass, MOCK_KEY)
 
-        storage_path = Path(config_dir.strpath) / ".storage"
-        zst_file = storage_path / (MOCK_KEY + ".zst")
+    assert zst_file.is_file()
+    assert not plain_file.exists()
 
-        def _corrupt_file() -> None:
-            zst_file.write_bytes(b"this is not valid zstd data")
+    on_disk = json.loads(zstd.decompress(zst_file.read_bytes()))
+    assert on_disk["data"] == MOCK_DATA
 
-        await hass.async_add_executor_job(_corrupt_file)
-
-        loaded = await store.async_load()
-        assert loaded is None
-        assert "Unrecoverable error decoding storage" in caplog.text
-
-        files = await hass.async_add_executor_job(os.listdir, storage_path)
-        corrupt_files = [f for f in files if ".corrupt" in f]
-        assert len(corrupt_files) == 1
-
-        await hass.async_stop(force=True)
+    assert await store.async_load() == MOCK_DATA
 
 
-async def test_compress_store_manager_cache(tmpdir: py.path.local) -> None:
-    """Test that compressed stores are cached and served by the store manager."""
-    loop = asyncio.get_running_loop()
+async def test_compress_migrates_plain_to_compressed(disk_hass: HomeAssistant) -> None:
+    """Test that saving with compress=True removes an existing plain file."""
+    plain_store = storage.Store(disk_hass, MOCK_VERSION, MOCK_KEY)
+    await plain_store.async_save(MOCK_DATA)
 
-    def _setup_mock_storage() -> py.path.local:
-        config_dir = tmpdir.mkdir("temp_config")
-        tmp_storage = config_dir.mkdir(".storage")
-        payload = json.dumps(
-            {
-                "version": MOCK_VERSION,
-                "minor_version": 1,
-                "key": MOCK_KEY,
-                "data": MOCK_DATA,
-            }
-        ).encode()
-        tmp_storage.join(MOCK_KEY + ".zst").write_binary(zstd.compress(payload))
-        return config_dir
+    plain_file = _storage_file(disk_hass, MOCK_KEY)
+    assert plain_file.is_file()
 
-    config_dir = await loop.run_in_executor(None, _setup_mock_storage)
+    compressed_store = storage.Store(disk_hass, MOCK_VERSION, MOCK_KEY, compress=True)
 
-    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
-        store_manager = storage.get_internal_store_manager(hass)
-        await store_manager.async_initialize()
-        await store_manager.async_preload([MOCK_KEY + ".zst"])
+    # Before the first compressed write the plain file is still the fallback.
+    assert await compressed_store.async_load() == MOCK_DATA
 
-        # The cache key for a compressed store is key + ".zst".
-        result = store_manager.async_fetch(MOCK_KEY + ".zst")
-        assert result is not None
-        exists, cached_data = result
-        assert exists is True
-        assert cached_data["data"] == MOCK_DATA  # type: ignore[index]
+    # Saving with compress=True should write .zst and remove the plain file.
+    await compressed_store.async_save(MOCK_DATA2)
 
-        store = storage.Store(hass, MOCK_VERSION, MOCK_KEY, compress=True)
-        loaded = await store.async_load()
-        assert loaded == MOCK_DATA
+    assert _storage_file(disk_hass, MOCK_KEY + ".zst").is_file()
+    assert not plain_file.exists()
+    assert await compressed_store.async_load() == MOCK_DATA2
 
-        await hass.async_stop(force=True)
+
+async def test_compress_falls_back_with_initialized_manager(
+    disk_hass: HomeAssistant,
+) -> None:
+    """Test the plain fallback is used when the store manager knows the files.
+
+    The manager caches by filename, so it reports the .zst as non-existent.
+    That must not short-circuit the load, because the uncompressed file the
+    store falls back to is still on disk.
+    """
+    await disk_hass.async_add_executor_job(
+        _write_store_file, _storage_file(disk_hass, MOCK_KEY), MOCK_DATA, False
+    )
+    await storage.get_internal_store_manager(disk_hass).async_initialize()
+
+    store = storage.Store(disk_hass, MOCK_VERSION, MOCK_KEY, compress=True)
+    assert await store.async_load() == MOCK_DATA
+
+
+async def test_compress_no_file_at_all(disk_hass: HomeAssistant) -> None:
+    """Test a compressed store with neither file on disk loads as empty."""
+    await storage.get_internal_store_manager(disk_hass).async_initialize()
+
+    store = storage.Store(disk_hass, MOCK_VERSION, MOCK_KEY, compress=True)
+    assert await store.async_load() is None
+
+
+@pytest.mark.parametrize(
+    ("corrupt_name", "absent_name"),
+    [
+        pytest.param(MOCK_KEY + ".zst", MOCK_KEY, id="compressed_file"),
+        pytest.param(MOCK_KEY, MOCK_KEY + ".zst", id="uncompressed_fallback"),
+    ],
+)
+async def test_compress_corrupt_file(
+    disk_hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    corrupt_name: str,
+    absent_name: str,
+) -> None:
+    """Test that the corrupt file is the one renamed, not the compressed path."""
+    corrupt_file = _storage_file(disk_hass, corrupt_name)
+
+    def _write_corrupt() -> None:
+        corrupt_file.parent.mkdir(parents=True, exist_ok=True)
+        corrupt_file.write_bytes(b"this is not valid zstd data")
+
+    await disk_hass.async_add_executor_job(_write_corrupt)
+    assert not _storage_file(disk_hass, absent_name).exists()
+
+    store = storage.Store(disk_hass, MOCK_VERSION, MOCK_KEY, compress=True)
+    assert await store.async_load() is None
+    assert "Unrecoverable error decoding storage" in caplog.text
+    assert not corrupt_file.exists()
+
+    storage_path = corrupt_file.parent
+    files = await disk_hass.async_add_executor_job(os.listdir, storage_path)
+    assert [f for f in files if ".corrupt" in f] == [
+        f for f in files if f.startswith(corrupt_name + ".corrupt")
+    ]
+
+    issue_registry = ir.async_get(disk_hass)
+    issues = [
+        entry
+        for entry in issue_registry.issues.values()
+        if entry.translation_key == "storage_corruption"
+    ]
+    assert len(issues) == 1
+    assert issues[0].translation_placeholders["original_path"] == str(corrupt_file)
+
+
+async def test_compress_store_manager_preload(disk_hass: HomeAssistant) -> None:
+    """Test that a compressed store is preloaded when its plain key is asked for."""
+    await disk_hass.async_add_executor_job(
+        _write_store_file,
+        _storage_file(disk_hass, MOCK_KEY + ".zst"),
+        MOCK_DATA,
+        True,
+    )
+
+    store_manager = storage.get_internal_store_manager(disk_hass)
+    await store_manager.async_initialize()
+    # Callers such as bootstrap only know the plain key.
+    await store_manager.async_preload([MOCK_KEY])
+
+    result = store_manager.async_fetch(MOCK_KEY + ".zst")
+    assert result is not None
+    exists, cached_data = result
+    assert exists is True
+    assert cached_data["data"] == MOCK_DATA  # type: ignore[index]
+
+
+async def test_compress_store_manager_cache(disk_hass: HomeAssistant) -> None:
+    """Test that compressed stores are served from the store manager cache."""
+    await disk_hass.async_add_executor_job(
+        _write_store_file,
+        _storage_file(disk_hass, MOCK_KEY + ".zst"),
+        MOCK_DATA,
+        True,
+    )
+
+    store_manager = storage.get_internal_store_manager(disk_hass)
+    await store_manager.async_initialize()
+    await store_manager.async_preload([MOCK_KEY + ".zst"])
+
+    store = storage.Store(disk_hass, MOCK_VERSION, MOCK_KEY, compress=True)
+    assert await store.async_load() == MOCK_DATA
+
+
+async def test_compress_async_remove(disk_hass: HomeAssistant) -> None:
+    """Test that removing a compressed store removes both files."""
+    zst_file = _storage_file(disk_hass, MOCK_KEY + ".zst")
+    plain_file = _storage_file(disk_hass, MOCK_KEY)
+    await disk_hass.async_add_executor_job(_write_store_file, zst_file, MOCK_DATA, True)
+    await disk_hass.async_add_executor_job(
+        _write_store_file, plain_file, MOCK_DATA, False
+    )
+
+    store = storage.Store(disk_hass, MOCK_VERSION, MOCK_KEY, compress=True)
+    await store.async_remove()
+
+    assert not zst_file.exists()
+    assert not plain_file.exists()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a `compress: bool` flag to the Store `homeassistant.helpers.storage.Store` to compress the resulting file.

- If the flag is set, on the next write the file will be compressed with zstandard (which is in the Python standard `compress` library since 3.14) and saved with `.zst` suffix. 
- The non-compressed version will be deleted after writing a compressed version.
- If the compressed flag is set and the compressed file is not found, it would fall back to look for an uncompressed version. 

So setting the flag doesn't require any migration and users can still (for dev reasons maybe) decompress the file, change things and save it, without needing to do compression again manually.


## Benchmark

Measured on a MacBook M1 Pro with real `.storage` files, phase by phase, median of 25 runs
per measurement. zstd level 3 (the default) unless noted.

### Size

| store | plain | zst | ratio |
|---|---:|---:|---:|
| `core.config_entries` | 13 KB | 4 KB | −68.9 % |
| `core.restore_state` | 34 KB | 5 KB | −85.2 % |
| `core.device_registry` | 63 KB | 6 KB | −91.0 % |
| `core.entity_registry` | 382 KB | 35 KB | −91.0 % |

Store data is highly repetitive, so the ratio improves with size and settles around −91 %
for the registries. Small files do worse because the zstd frame overhead is a larger share.

### Load, phase by phase (warm page cache)

The previous table measured this case only. Warm cache is the *worst* case for compression:
it charges the CPU cost of decompressing while crediting none of the I/O saved.

| store | read | decompress | json parse | plain total | zst total | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `core.config_entries` | 0.037 ms | 0.011 ms | 0.025 ms | 0.064 ms | 0.073 ms | +14 % |
| `core.restore_state` | 0.015 ms | 0.017 ms | 0.061 ms | 0.077 ms | 0.093 ms | +20 % |
| `core.device_registry` | 0.016 ms | 0.018 ms | 0.102 ms | 0.120 ms | 0.136 ms | +14 % |
| `core.entity_registry` | 0.018 ms | 0.134 ms | 0.897 ms | 0.924 ms | 1.049 ms | +13 % |

Splitting the phases shows where the cost sits: **JSON parsing dominates, not zstd.**
Decompressing 382 KB costs 0.13 ms against 0.90 ms to parse it. The relative penalty
therefore *shrinks* as stores grow — at 10 MB it is +0 % and at 50 MB it is −2 %, because by
then the bytes not read start to outweigh the decompression.

### Load on real storage (cold cache, `bytes / throughput + CPU`)

| store | SD card (25 MB/s) | eMMC (150 MB/s) | SATA SSD (500 MB/s) | NVMe (3 GB/s) |
|---|---:|---:|---:|---:|
| `core.restore_state` | −80 % | −61 % | −32 % | +10 % |
| `core.device_registry` | −87 % | −70 % | −42 % | −1 % |
| `core.entity_registry` | −85 % | −63 % | −34 % | +2 % |
| 10 MB store | −92 % | −69 % | −39 % | −6 % |
| 50 MB store | −92 % | −67 % | −37 % | −6 % |

For `core.entity_registry` on an SD card that is 16.2 ms → 2.4 ms.

### Break-even throughput

The storage speed at which the compressed path stops being slower:

```
T = (plain_bytes − zst_bytes) / decompress_time
```

| store | load break-even | save break-even |
|---|---:|---:|
| `core.config_entries` | 890 MB/s | 336 MB/s |
| `core.restore_state` | 1.70 GB/s | 721 MB/s |
| `core.entity_registry` | 2.60 GB/s | 1.02 GB/s |
| 10 MB store | 7.6 GB/s | 3.6 GB/s |

Below those speeds compression is **faster in wall clock time**, not just smaller. Every
device short of warm-cache NVMe sits well below them, so the "+70 % load time" the original
table reported is really "slower only when the file is already in RAM".

### Save, phase by phase

Compression is paid on **every** write while decompression is earned back once per load, so
this is arguably the more important number — and the previous table did not measure it.

| store | serialize | compress | write plain | write zst | plain total | zst total | Δ |
|---|---:|---:|---:|---:|---:|---:|---:|
| `core.restore_state` | 0.020 ms | 0.040 ms | 0.070 ms | 0.078 ms | 0.090 ms | 0.138 ms | +54 % |
| `core.device_registry` | 0.038 ms | 0.041 ms | 0.072 ms | 0.078 ms | 0.109 ms | 0.156 ms | +43 % |
| `core.entity_registry` | 0.239 ms | 0.325 ms | 0.158 ms | 0.062 ms | 0.397 ms | 0.626 ms | +58 % |
| 10 MB store | 8.679 ms | 2.506 ms | 2.511 ms | 0.089 ms | 11.190 ms | 11.274 ms | +1 % |

All of this runs in the executor, so it does not block the event loop. The relative cost
again shrinks with size, because serialization outgrows compression.

### Compression level

| level | `core.entity_registry` ratio | compress | decompress |
|---:|---:|---:|---:|
| 1 | −91.0 % | 0.313 ms | 0.122 ms |
| 3 (default) | −91.0 % | 0.339 ms | 0.134 ms |
| 9 | −92.1 % | 1.690 ms | 0.105 ms |
| 19 | −92.6 % | 113.062 ms | 0.108 ms |

Level 1 reaches the same ratio as level 3 on this data; level 19 costs 333× the compression
time for 1.6 pp. The default (3) is a reasonable choice, and there is no reason to expose a
higher one.

### Peak memory while loading

Within ~7 % of the plain path (the compressed path briefly holds the raw frame, the
decompressed bytes and the parsed object at once), e.g. 6.0 MB → 6.1 MB for
`core.entity_registry`.

---

<details>
<summary>Method</summary>

Payloads are real `.storage` files; the 1/10/50 MB rows are synthetic, built by replicating
the entity registry's own records with varied ids, so their *ratio* is an upper bound — the
real files carry the ratio claim, the synthetic ones show how CPU cost scales. Timings use
`time.perf_counter_ns`, 3 warmup runs discarded, median of 25. Cold-cache figures are
modelled as `bytes / throughput + measured CPU`, not measured on the devices themselves.

</details>

So this could be used for Stores that are known to get quite big (maybe like >10 MB plain), like integration specific logs. It would certainly be more useful on slower storage devices like SD-cards than on modern SSDs.

Related Discord thread: https://discord.com/channels/330944238910963714/1476452709421940796

Let me know what you think 😃!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

