### PR TITLE
Fix inverted cover position for BleBox gate devices

### DIFF
--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -27,6 +27,10 @@ BLEBOX_TO_COVER_DEVICE_CLASSES = {
     "shutter": CoverDeviceClass.SHUTTER,
 }
 
+# Gate devices report position using the same convention as Home Assistant
+# (0 = closed, 100 = open); shutterBox uses the inverted convention.
+GATE_DEVICE_CLASSES = {"gate", "gatebox"}
+
 BLEBOX_TO_HASS_COVER_STATES = {
     None: None,
     # all blebox covers
@@ -62,6 +66,7 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
         """Initialize a BleBox cover feature."""
         super().__init__(feature)
         self._attr_device_class = BLEBOX_TO_COVER_DEVICE_CLASSES[feature.device_class]
+        self._invert_position = feature.device_class not in GATE_DEVICE_CLASSES
         self._attr_supported_features = (
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
         )
@@ -84,8 +89,9 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
         position = self._feature.current
         if position == -1:  # possible for shutterBox
             return None
-
-        return None if position is None else 100 - position
+        if position is None:
+            return None
+        return 100 - position if self._invert_position else position
 
     @property
     def current_cover_tilt_position(self) -> int | None:
@@ -128,7 +134,9 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""
         position = kwargs[ATTR_POSITION]
-        await self._feature.async_set_position(100 - position)
+        await self._feature.async_set_position(
+            100 - position if self._invert_position else position
+        )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -34,6 +34,8 @@ from .conftest import async_setup_entity, mock_feature
 
 ALL_COVER_FIXTURES = ["gatecontroller", "shutterbox", "gatebox"]
 FIXTURES_SUPPORTING_STOP = ["gatecontroller", "shutterbox"]
+INVERTED_POSITION_FIXTURES = ["shutterbox"]
+NON_INVERTED_POSITION_FIXTURES = ["gatecontroller", "gatebox"]
 
 
 @pytest.fixture(name="shutterbox")
@@ -276,9 +278,9 @@ async def test_stop(feature, hass: HomeAssistant) -> None:
     assert hass.states.get(entity_id).state == CoverState.OPEN
 
 
-@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_update(feature, hass: HomeAssistant) -> None:
-    """Test cover updating."""
+@pytest.mark.parametrize("feature", INVERTED_POSITION_FIXTURES, indirect=["feature"])
+async def test_update_inverted(feature, hass: HomeAssistant) -> None:
+    """Test cover updating (shutterBox inverts position)."""
 
     feature_mock, entity_id = feature
 
@@ -296,12 +298,30 @@ async def test_update(feature, hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "feature", ["gatecontroller", "shutterbox"], indirect=["feature"]
+    "feature", NON_INVERTED_POSITION_FIXTURES, indirect=["feature"]
 )
-async def test_set_position(feature, hass: HomeAssistant) -> None:
-    """Test cover position setting."""
+async def test_update_gate(feature, hass: HomeAssistant) -> None:
+    """Test gate cover updating (position reported without inversion)."""
 
     feature_mock, entity_id = feature
+
+    def initial_update():
+        feature_mock.current = 29
+        feature_mock.state = 2  # manually stopped
+
+    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+
+    await async_setup_entity(hass, entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_CURRENT_POSITION] == 29
+    assert state.state == CoverState.OPEN
+
+
+async def test_set_position_shutterbox(shutterbox, hass: HomeAssistant) -> None:
+    """Test cover position setting (shutterBox inverts position)."""
+
+    feature_mock, entity_id = shutterbox
 
     def initial_update():
         feature_mock.state = 3  # closed
@@ -309,7 +329,34 @@ async def test_set_position(feature, hass: HomeAssistant) -> None:
     def set_position(position):
         assert position == 99  # inverted
         feature_mock.state = 1  # opening
-        # feature_mock.current = position
+
+    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.async_set_position = AsyncMock(side_effect=set_position)
+
+    await async_setup_entity(hass, entity_id)
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
+
+    feature_mock.async_update = AsyncMock()
+    await hass.services.async_call(
+        "cover",
+        SERVICE_SET_COVER_POSITION,
+        {"entity_id": entity_id, ATTR_POSITION: 1},
+        blocking=True,
+    )  # almost closed
+    assert hass.states.get(entity_id).state == CoverState.OPENING
+
+
+async def test_set_position_gatecontroller(gatecontroller, hass: HomeAssistant) -> None:
+    """Test gateController position setting (no inversion)."""
+
+    feature_mock, entity_id = gatecontroller
+
+    def initial_update():
+        feature_mock.state = 3  # closed
+
+    def set_position(position):
+        assert position == 1  # not inverted
+        feature_mock.state = 1  # opening
 
     feature_mock.async_update = AsyncMock(side_effect=initial_update)
     feature_mock.async_set_position = AsyncMock(side_effect=set_position)


### PR DESCRIPTION
## Proposed change

Before this fix, BleBox gate owners saw reversed Open/Close buttons in the UI, and any automations reading `current_position` got values inverted from physical reality.

BleBox gate devices (gateController, gateBox, gateBoxPro) report `currentPos` using the same convention as Home Assistant (0 = closed, 100 = open). The cover entity was applying the shutterBox `100 - position` inversion to all devices, causing gate covers to report the position inverted.

As a side effect of the inverted position reporting, the UI presented the wrong action: when the gate was physically **closed** only **Close** was available, and when **open** only **Open** was available.

This change only inverts position for non-gate device classes:
- `current_cover_position` and `async_set_cover_position` now skip the inversion for `gate` and `gatebox` device classes
- shutterBox behavior is unchanged

After the fix:
- Closed gate → `current_position: 0`, **Open** action available
- Open gate → `current_position: 100`, **Close** action available

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Breaking change

Position reporting for BleBox gate devices (gateController, gateBox, gateBoxPro) was inverted: physically closed gates reported `current_position: 100` and open gates reported `0`. After this fix, position reflects reality (closed = 0, open = 100).

Users with automations, scripts, or Lovelace dashboards that compensated for the previous inverted values on `cover.*` entities backed by BleBox gate devices will need to update them (typically by replacing `100 - position` logic with direct `position` use, or swapping comparisons). The same applies to any calls to `cover.set_cover_position` targeting these devices.

ShutterBox behavior is unchanged.

## Additional information

- This PR fixes an issue for the integration: blebox
- Reported on a gateBoxPro device; applies equally to gateController and gateBox.
- Verified on a real gateBoxPro: closed gate now reports `current_position: 0` with the **Open** action available, open gate reports `100` with **Close** available.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. `pytest tests/components/blebox/test_cover.py`
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io