### PR TITLE
Remove name field from ollama config flow

### DIFF
--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import (
     ConfigSubentryFlow,
     SubentryFlowResult,
 )
-from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_NAME, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, llm
 from homeassistant.helpers.selector import (
@@ -298,7 +298,6 @@ class OllamaSubentryFlowHandler(ConfigSubentryFlow):
                 data_schema=vol.Schema(
                     ollama_config_option_schema(
                         self.hass,
-                        self._is_new,
                         self._subentry_type,
                         options,
                         models_to_list,
@@ -308,7 +307,10 @@ class OllamaSubentryFlowHandler(ConfigSubentryFlow):
 
         self._model = user_input[CONF_MODEL]
         if self._is_new:
-            self._name = user_input.pop(CONF_NAME)
+            if self._subentry_type == "ai_task_data":
+                self._name = DEFAULT_AI_TASK_NAME
+            else:
+                self._name = DEFAULT_CONVERSATION_NAME
 
         # Check if model needs to be downloaded
         try:
@@ -407,23 +409,12 @@ def filter_invalid_llm_apis(hass: HomeAssistant, selected_apis: list[str]) -> li
 
 def ollama_config_option_schema(
     hass: HomeAssistant,
-    is_new: bool,
     subentry_type: str,
     options: Mapping[str, Any],
     models_to_list: list[SelectOptionDict],
 ) -> dict:
     """Ollama options schema."""
-    if is_new:
-        if subentry_type == "ai_task_data":
-            default_name = DEFAULT_AI_TASK_NAME
-        else:
-            default_name = DEFAULT_CONVERSATION_NAME
-
-        schema: dict = {
-            vol.Required(CONF_NAME, default=default_name): str,
-        }
-    else:
-        schema = {}
+    schema: dict = {}
 
     selected_llm_apis = filter_invalid_llm_apis(
         hass, options.get(CONF_LLM_HASS_API, [])

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -9,9 +9,13 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import ollama
-from homeassistant.components.ollama.const import DOMAIN
+from homeassistant.components.ollama.const import (
+    DEFAULT_AI_TASK_NAME,
+    DEFAULT_CONVERSATION_NAME,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_NAME, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -136,7 +140,7 @@ async def test_creating_new_conversation_subentry(
     mock_config_entry: MockConfigEntry,
     mock_init_component,
 ) -> None:
-    """Test creating a new conversation subentry includes name field."""
+    """Test creating a new conversation subentry."""
     # Start a new subentry flow
     with patch(
         "ollama.AsyncClient.list",
@@ -150,12 +154,10 @@ async def test_creating_new_conversation_subentry(
         assert new_flow["type"] is FlowResultType.FORM
         assert new_flow["step_id"] == "set_options"
 
-        # Configure the new subentry with name field
         result = await hass.config_entries.subentries.async_configure(
             new_flow["flow_id"],
             {
                 ollama.CONF_MODEL: TEST_MODEL,
-                CONF_NAME: "New Test Conversation",
                 ollama.CONF_PROMPT: "new test prompt",
                 ollama.CONF_MAX_HISTORY: 50,
                 ollama.CONF_NUM_CTX: 16384,
@@ -165,7 +167,7 @@ async def test_creating_new_conversation_subentry(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "New Test Conversation"
+    assert result["title"] == DEFAULT_CONVERSATION_NAME
     assert result["data"] == {
         ollama.CONF_MODEL: TEST_MODEL,
         ollama.CONF_PROMPT: "new test prompt",
@@ -223,7 +225,6 @@ async def test_subentry_need_download(
             new_flow["flow_id"],
             {
                 ollama.CONF_MODEL: "llama3.2:latest",  # not cached
-                CONF_NAME: "New Test Conversation",
                 ollama.CONF_PROMPT: "new test prompt",
                 ollama.CONF_MAX_HISTORY: 50,
                 ollama.CONF_NUM_CTX: 16384,
@@ -242,7 +243,7 @@ async def test_subentry_need_download(
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "New Test Conversation"
+    assert result["title"] == DEFAULT_CONVERSATION_NAME
     assert result["data"] == {
         ollama.CONF_MODEL: "llama3.2:latest",
         ollama.CONF_PROMPT: "new test prompt",
@@ -285,7 +286,6 @@ async def test_subentry_download_error(
             new_flow["flow_id"],
             {
                 ollama.CONF_MODEL: "llama3.2:latest",
-                CONF_NAME: "New Test Conversation",
                 ollama.CONF_PROMPT: "new test prompt",
                 ollama.CONF_MAX_HISTORY: 50,
                 ollama.CONF_NUM_CTX: 16384,
@@ -558,7 +558,6 @@ async def test_subentry_model_check_exception(
             new_flow["flow_id"],
             {
                 ollama.CONF_MODEL: "new_model:latest",
-                CONF_NAME: "Test Conversation",
                 ollama.CONF_PROMPT: "test prompt",
                 ollama.CONF_MAX_HISTORY: 50,
                 ollama.CONF_NUM_CTX: 16384,
@@ -681,7 +680,6 @@ async def test_creating_ai_task_subentry(
         result2 = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
-                "name": "Custom AI Task",
                 ollama.CONF_MODEL: "test_model:latest",
                 ollama.CONF_MAX_HISTORY: 5,
                 ollama.CONF_NUM_CTX: 4096,
@@ -692,7 +690,7 @@ async def test_creating_ai_task_subentry(
         await hass.async_block_till_done()
 
     assert result2.get("type") is FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == "Custom AI Task"
+    assert result2.get("title") == DEFAULT_AI_TASK_NAME
     assert result2.get("data") == {
         ollama.CONF_MODEL: "test_model:latest",
         ollama.CONF_MAX_HISTORY: 5,
@@ -708,7 +706,7 @@ async def test_creating_ai_task_subentry(
     new_subentry_id = list(set(mock_config_entry.subentries) - old_subentries)[0]
     new_subentry = mock_config_entry.subentries[new_subentry_id]
     assert new_subentry.subentry_type == "ai_task_data"
-    assert new_subentry.title == "Custom AI Task"
+    assert new_subentry.title == DEFAULT_AI_TASK_NAME
 
 
 async def test_ai_task_subentry_not_loaded(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->The `ollama` integration includes a `name` field in its config flow subentry
schema when creating new subentries. Config flows should not ask users to
provide a name — the name should be derived from the integration manifest or
set automatically.

This PR removes the `CONF_NAME` field from the `ollama_config_option_schema`
function and derives the subentry title directly from the subentry type using
`DEFAULT_AI_TASK_NAME` or `DEFAULT_CONVERSATION_NAME` constants.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168943
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
