### PR TITLE
Fix jvcprojector entities going unavailable on transient command errors

### DIFF
--- a/homeassistant/components/jvc_projector/coordinator.py
+++ b/homeassistant/components/jvc_projector/coordinator.py
@@ -7,7 +7,12 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any
 
-from jvcprojector import JvcProjector, JvcProjectorTimeoutError, command as cmd
+from jvcprojector import (
+    JvcProjector,
+    JvcProjectorCommandError,
+    JvcProjectorTimeoutError,
+    command as cmd,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -144,7 +149,11 @@ class JvcProjectorDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
         self, command: type[Command], new_state: dict[type[Command], str]
     ) -> str | None:
         """Update state with the current value of a command."""
-        value = await self.device.get(command)
+        try:
+            value = await self.device.get(command)
+        except JvcProjectorCommandError as err:
+            _LOGGER.warning("Command %s failed: %s", command.name, err)
+            return self.state.get(command)
 
         if value != self.state.get(command):
             new_state[command] = value

--- a/homeassistant/components/jvc_projector/coordinator.py
+++ b/homeassistant/components/jvc_projector/coordinator.py
@@ -153,7 +153,12 @@ class JvcProjectorDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
             value = await self.device.get(command)
         except JvcProjectorCommandError as err:
             _LOGGER.warning("Command %s failed: %s", command.name, err)
-            return self.state.get(command)
+            cached = self.state.get(command)
+            if command is cmd.Power and cached is None:
+                raise UpdateFailed(
+                    f"Failed to fetch {command.name} and no cached value is available"
+                ) from err
+            return cached
 
         if value != self.state.get(command):
             new_state[command] = value

--- a/homeassistant/components/jvc_projector/manifest.json
+++ b/homeassistant/components/jvc_projector/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["jvcprojector"],
-  "requirements": ["pyjvcprojector==2.0.5"]
+  "requirements": ["pyjvcprojector==2.0.6"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2222,7 +2222,7 @@ pyitachip2ir==0.0.7
 pyituran==0.1.5
 
 # homeassistant.components.jvc_projector
-pyjvcprojector==2.0.5
+pyjvcprojector==2.0.6
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1905,7 +1905,7 @@ pyisy==3.4.1
 pyituran==0.1.5
 
 # homeassistant.components.jvc_projector
-pyjvcprojector==2.0.5
+pyjvcprojector==2.0.6
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.1.5

--- a/tests/components/jvc_projector/test_coordinator.py
+++ b/tests/components/jvc_projector/test_coordinator.py
@@ -3,7 +3,11 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
-from jvcprojector import JvcProjectorTimeoutError, command as cmd
+from jvcprojector import (
+    JvcProjectorCommandError,
+    JvcProjectorTimeoutError,
+    command as cmd,
+)
 import pytest
 
 from homeassistant.components.jvc_projector.coordinator import (
@@ -11,6 +15,7 @@ from homeassistant.components.jvc_projector.coordinator import (
     INTERVAL_SLOW,
 )
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
@@ -58,3 +63,28 @@ async def test_coordinator_setup_connect_error(
 ) -> None:
     """Test coordinator connect error."""
     assert mock_integration.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    "mock_device",
+    [{"fixture_override": {cmd.Input: JvcProjectorCommandError}}],
+    indirect=True,
+)
+async def test_coordinator_command_error_keeps_other_entities_available(
+    hass: HomeAssistant,
+    mock_device: AsyncMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test a failing command does not take every entity offline."""
+    assert mock_integration.state is ConfigEntryState.LOADED
+
+    coordinator = mock_integration.runtime_data
+    assert coordinator.last_update_success is True
+
+    power = hass.states.get("sensor.jvc_projector_status")
+    assert power is not None
+    assert power.state == "on"
+
+    light_time = hass.states.get("sensor.jvc_projector_light_time")
+    assert light_time is not None
+    assert light_time.state != STATE_UNAVAILABLE

--- a/tests/components/jvc_projector/test_coordinator.py
+++ b/tests/components/jvc_projector/test_coordinator.py
@@ -67,6 +67,20 @@ async def test_coordinator_setup_connect_error(
 
 @pytest.mark.parametrize(
     "mock_device",
+    [{"fixture_override": {cmd.Power: JvcProjectorCommandError}}],
+    indirect=True,
+)
+async def test_coordinator_setup_power_command_error(
+    hass: HomeAssistant,
+    mock_device: AsyncMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test coordinator fails setup when Power command errors with no cached value."""
+    assert mock_integration.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    "mock_device",
     [{"fixture_override": {cmd.Input: JvcProjectorCommandError}}],
     indirect=True,
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump pyjvcprojector dependency to v2.0.6 to fix https://github.com/home-assistant/core/issues/165782. Diff https://github.com/SteveEasley/pyjvcprojector/compare/v2.0.5...v2.0.6.

This PR bumps the dep, and wraps the problem code with the newly created exception.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/165782
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
