### PR TITLE
Added missing translations for login blocked auth errors

### DIFF
--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -148,6 +148,9 @@ from homeassistant.components import websocket_api
 from homeassistant.components.http import KEY_HASS
 from homeassistant.components.http.auth import (
     async_sign_path,
+)
+from homeassistant.components.http.auth_util import (
+    AUTH_ACCESS_ERROR_DESCRIPTIONS,
     async_user_not_allowed_do_auth,
 )
 from homeassistant.components.http.ban import log_invalid_auth
@@ -306,7 +309,9 @@ class TokenView(HomeAssistantView):
             return self.json(
                 {
                     "error": "access_denied",
-                    "error_description": user_access_error,
+                    "error_description": AUTH_ACCESS_ERROR_DESCRIPTIONS.get(
+                        user_access_error, user_access_error
+                    ),
                 },
                 status_code=HTTPStatus.FORBIDDEN,
             )
@@ -377,7 +382,9 @@ class TokenView(HomeAssistantView):
             return self.json(
                 {
                     "error": "access_denied",
-                    "error_description": user_access_error,
+                    "error_description": AUTH_ACCESS_ERROR_DESCRIPTIONS.get(
+                        user_access_error, user_access_error
+                    ),
                 },
                 status_code=HTTPStatus.FORBIDDEN,
             )

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -146,9 +146,7 @@ from homeassistant.auth.models import (
 )
 from homeassistant.components import websocket_api
 from homeassistant.components.http import KEY_HASS
-from homeassistant.components.http.auth import (
-    async_sign_path,
-)
+from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.http.auth_util import (
     AUTH_ACCESS_ERROR_DESCRIPTIONS,
     async_user_not_allowed_do_auth,

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -323,7 +323,9 @@ class LoginFlowBaseView(HomeAssistantView):
             user_access_error := async_user_not_allowed_do_auth(hass, user)
         ):
             return self.json_message(
-                f"Login blocked: {user_access_error}", HTTPStatus.FORBIDDEN
+                f"Login blocked: {user_access_error}",
+                HTTPStatus.FORBIDDEN,
+                message_code="login_blocked",
             )
 
         process_success_login(request)

--- a/homeassistant/components/auth/strings.json
+++ b/homeassistant/components/auth/strings.json
@@ -1,5 +1,8 @@
 {
   "exceptions": {
+    "login_blocked": {
+      "message": "Login blocked: {user_access_error}"
+    },
     "user_not_found": {
       "message": "User not found"
     },

--- a/homeassistant/components/http/auth_util.py
+++ b/homeassistant/components/http/auth_util.py
@@ -17,9 +17,13 @@ from homeassistant.util.network import is_local
 def async_user_not_allowed_do_auth(
     hass: HomeAssistant, user: User, request: Request | None = None
 ) -> str | None:
-    """Validate that user is not allowed to do auth things."""
+    """Validate that user is not allowed to do auth things.
+
+    Returns a translation key from the http component exceptions if the user
+    is not allowed to authenticate, or None if the user is allowed.
+    """
     if not user.is_active:
-        return "User is not active"
+        return "user_not_active"
 
     if not user.local_only:
         return None
@@ -29,17 +33,28 @@ def async_user_not_allowed_do_auth(
         request = current_request.get()
 
     if not request:
-        return "No request available to validate local access"
+        return "no_request_available"
 
     if is_cloud_connection(hass):
-        return "User is local only"
+        return "user_local_only"
 
     try:
         remote_address = ip_address(request.remote)  # type: ignore[arg-type]
     except ValueError:
-        return "Invalid remote IP"
+        return "invalid_remote_ip"
 
     if is_local(remote_address):
         return None
 
-    return "User cannot authenticate remotely"
+    return "user_cannot_authenticate_remotely"
+
+
+# Human-readable descriptions for OAuth2 error_description field.
+# Keys match the translation keys returned by async_user_not_allowed_do_auth.
+AUTH_ACCESS_ERROR_DESCRIPTIONS: dict[str, str] = {
+    "user_not_active": "User is not active",
+    "no_request_available": "No request available to validate local access",
+    "user_local_only": "User is local only",
+    "invalid_remote_ip": "Invalid remote IP",
+    "user_cannot_authenticate_remotely": "User cannot authenticate remotely",
+}

--- a/homeassistant/components/http/auth_util.py
+++ b/homeassistant/components/http/auth_util.py
@@ -49,7 +49,7 @@ def async_user_not_allowed_do_auth(
     return "user_cannot_authenticate_remotely"
 
 
-# Human-readable descriptions for OAuth2 error_description field.
+# Human-readable descriptions for auth access errors.
 # Keys match the translation keys returned by async_user_not_allowed_do_auth.
 AUTH_ACCESS_ERROR_DESCRIPTIONS: dict[str, str] = {
     "user_not_active": "User is not active",

--- a/homeassistant/components/http/strings.json
+++ b/homeassistant/components/http/strings.json
@@ -1,19 +1,19 @@
 {
   "exceptions": {
-    "user_not_active": {
-      "message": "User is not active"
+    "invalid_remote_ip": {
+      "message": "Invalid remote IP"
     },
     "no_request_available": {
       "message": "No request available to validate local access"
     },
+    "user_cannot_authenticate_remotely": {
+      "message": "User cannot authenticate remotely"
+    },
     "user_local_only": {
       "message": "User is local only"
     },
-    "invalid_remote_ip": {
-      "message": "Invalid remote IP"
-    },
-    "user_cannot_authenticate_remotely": {
-      "message": "User cannot authenticate remotely"
+    "user_not_active": {
+      "message": "User is not active"
     }
   },
   "issues": {

--- a/homeassistant/components/http/strings.json
+++ b/homeassistant/components/http/strings.json
@@ -1,4 +1,21 @@
 {
+  "exceptions": {
+    "user_not_active": {
+      "message": "User is not active"
+    },
+    "no_request_available": {
+      "message": "No request available to validate local access"
+    },
+    "user_local_only": {
+      "message": "User is local only"
+    },
+    "invalid_remote_ip": {
+      "message": "Invalid remote IP"
+    },
+    "user_cannot_authenticate_remotely": {
+      "message": "User cannot authenticate remotely"
+    }
+  },
   "issues": {
     "server_host_deprecated_hassio": {
       "description": "The deprecated `server_host` configuration option in the HTTP integration is prone to break the communication between Home Assistant Core and Supervisor, and will be removed.\n\nIf you are using this option to bind Home Assistant to specific network interfaces, please remove it from your configuration. Home Assistant will automatically bind to all available interfaces by default.\n\nIf you have specific networking requirements, consider using firewall rules or other network configuration to control access to Home Assistant.",

--- a/homeassistant/components/websocket_api/auth.py
+++ b/homeassistant/components/websocket_api/auth.py
@@ -9,7 +9,10 @@ from aiohttp.web import Request
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
-from homeassistant.components.http.auth_util import async_user_not_allowed_do_auth
+from homeassistant.components.http.auth_util import (
+    AUTH_ACCESS_ERROR_DESCRIPTIONS,
+    async_user_not_allowed_do_auth,
+)
 from homeassistant.components.http.ban import process_success_login, process_wrong_login
 from homeassistant.components.http.const import KEY_HASS_USER
 from homeassistant.const import __version__
@@ -101,7 +104,13 @@ class AuthPhase:
             if user_access_error := async_user_not_allowed_do_auth(
                 self._hass, refresh_token.user, self._request
             ):
-                await self._send_bytes_text(auth_invalid_message(user_access_error))
+                await self._send_bytes_text(
+                    auth_invalid_message(
+                        AUTH_ACCESS_ERROR_DESCRIPTIONS.get(
+                            user_access_error, user_access_error
+                        )
+                    )
+                )
                 await process_wrong_login(self._request)
                 raise Disconnect
 

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -309,7 +309,7 @@ async def test_login_local_only_user(
 
     with patch(
         "homeassistant.components.auth.login_flow.async_user_not_allowed_do_auth",
-        return_value="User is local only",
+        return_value="user_local_only",
     ) as mock_not_allowed_do_auth:
         resp = await client.post(
             f"/auth/login_flow/{step['flow_id']}",
@@ -322,7 +322,10 @@ async def test_login_local_only_user(
 
     assert resp.status == HTTPStatus.FORBIDDEN
     assert len(mock_not_allowed_do_auth.mock_calls) == 1
-    assert await resp.json() == {"message": "Login blocked: User is local only"}
+    assert await resp.json() == {
+        "message": "Login blocked: user_local_only",
+        "code": "login_blocked",
+    }
 
 
 async def test_login_exist_user_ip_changes(

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -606,10 +606,7 @@ async def test_async_user_not_allowed_do_auth(
     user.local_only = True
 
     # No current request
-    assert (
-        async_user_not_allowed_do_auth(hass, user)
-        == "no_request_available"
-    )
+    assert async_user_not_allowed_do_auth(hass, user) == "no_request_available"
 
     trusted_request = Mock(remote="192.168.1.123")
     untrusted_request = Mock(remote=UNTRUSTED_ADDRESSES[0])

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -600,7 +600,7 @@ async def test_async_user_not_allowed_do_auth(
     user.is_active = False
 
     # User not active
-    assert async_user_not_allowed_do_auth(hass, user) == "User is not active"
+    assert async_user_not_allowed_do_auth(hass, user) == "user_not_active"
 
     user.is_active = True
     user.local_only = True
@@ -608,7 +608,7 @@ async def test_async_user_not_allowed_do_auth(
     # No current request
     assert (
         async_user_not_allowed_do_auth(hass, user)
-        == "No request available to validate local access"
+        == "no_request_available"
     )
 
     trusted_request = Mock(remote="192.168.1.123")
@@ -618,7 +618,7 @@ async def test_async_user_not_allowed_do_auth(
     assert async_user_not_allowed_do_auth(hass, user, trusted_request) is None
     assert (
         async_user_not_allowed_do_auth(hass, user, untrusted_request)
-        == "User cannot authenticate remotely"
+        == "user_cannot_authenticate_remotely"
     )
 
     # Mimic cloud loaded and validate local IP again
@@ -626,7 +626,7 @@ async def test_async_user_not_allowed_do_auth(
     assert async_user_not_allowed_do_auth(hass, user, trusted_request) is None
     assert (
         async_user_not_allowed_do_auth(hass, user, untrusted_request)
-        == "User cannot authenticate remotely"
+        == "user_cannot_authenticate_remotely"
     )
 
     # Is Cloud request and local only, even a local IP will fail
@@ -635,7 +635,7 @@ async def test_async_user_not_allowed_do_auth(
     ):
         assert (
             async_user_not_allowed_do_auth(hass, user, trusted_request)
-            == "User is local only"
+            == "user_local_only"
         )
 
 


### PR DESCRIPTION
Fixes #168983

The strings returned by `async_user_not_allowed_do_auth` (e.g. `"User cannot authenticate remotely"`) and the `"Login blocked: ..."` message in `login_flow.py` were hardcoded English strings with no corresponding entries in `strings.json`, making them untranslatable by Lokalise.

## Breaking change

_None. The OAuth2 `error_description` field continues to return human-readable English strings via the `AUTH_ACCESS_ERROR_DESCRIPTIONS` mapping for backwards compatibility with existing API clients._

## Proposed change

Two areas of the auth flow produced user-visible error messages that were never registered in any `strings.json`, so they could not be picked up by the translation pipeline (Lokalise):

1. **`async_user_not_allowed_do_auth`** in `homeassistant/components/http/auth_util.py` returned raw English strings like `"User cannot authenticate remotely"`, `"User is local only"`, etc.
2. **`login_flow.py`** interpolated one of those strings into `"Login blocked: {user_access_error}"` and returned it directly to the frontend with no `message_code`.

This PR fixes both by:

- Registering all 5 error strings as `exceptions` keys in `homeassistant/components/http/strings.json`
- Registering the `login_blocked` wrapper as an `exceptions` key in `homeassistant/components/auth/strings.json`
- Making `async_user_not_allowed_do_auth` return translation keys (e.g. `"user_cannot_authenticate_remotely"`) instead of raw English strings
- Passing `message_code="login_blocked"` in the `json_message()` call so the frontend can resolve the translated string
- Preserving backwards compatibility for the OAuth2 token endpoint (`/auth/token`) by mapping translation keys back to English strings via `AUTH_ACCESS_ERROR_DESCRIPTIONS` — the `error_description` field in OAuth2 responses is developer-facing and consumed by external clients

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #168983
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
