### PR TITLE
Add distance device class to Ecowitt lightning distance sensors

### DIFF
--- a/homeassistant/components/ecowitt/sensor.py
+++ b/homeassistant/components/ecowitt/sensor.py
@@ -213,11 +213,13 @@ ECOWITT_SENSORS_MAPPING: Final = {
     ),
     EcoWittSensorTypes.LIGHTNING_DISTANCE_KM: SensorEntityDescription(
         key="LIGHTNING_DISTANCE_KM",
+        device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     EcoWittSensorTypes.LIGHTNING_DISTANCE_MILES: SensorEntityDescription(
         key="LIGHTNING_DISTANCE_MILES",
+        device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.MILES,
         state_class=SensorStateClass.MEASUREMENT,
     ),


### PR DESCRIPTION
## Proposed change

Add `device_class=SensorDeviceClass.DISTANCE` to the Ecowitt lightning strike distance sensors (km and miles variants). Without it, the entity cannot be picked in entity-selectors that filter on `device_class: distance`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: caplaz/micro-weather-station#29

Reported downstream in the `micro-weather-station` integration, where the lightning distance entity from the HA-Core Ecowitt integration did not appear in an entity picker filtered on `device_class: distance`. Root cause: the sensor description sets unit + state_class but no device_class, so the selector correctly filters it out. Other lightning-distance integrations (e.g. Ambient PWS, Ecowitt's own \`ha-ecowitt-iot\` HACS integration) already set \`SensorDeviceClass.DISTANCE\` here. Fix is one kwarg per sensor (km / miles), fully backward compatible.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr