### PR TITLE
esphome: register Bluetooth MAC address as device registry connection

### DIFF
--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -1004,6 +1004,10 @@ def _async_setup_device_registry(
     valid_connections = {
         (dr.CONNECTION_NETWORK_MAC, format_mac(device_info.mac_address))
     }
+    if device_info.bluetooth_mac_address:
+        valid_connections.add(
+            (dr.CONNECTION_BLUETOOTH, format_mac(device_info.bluetooth_mac_address))
+        )
     valid_identifiers = {
         (DOMAIN, f"{device_info.mac_address}_{sub_device.device_id}")
         for sub_device in device_info.devices
@@ -1056,10 +1060,17 @@ def _async_setup_device_registry(
         suggested_area = device_info.suggested_area
 
     # Create/update main device
+    connections: set[tuple[str, str]] = {
+        (dr.CONNECTION_NETWORK_MAC, device_info.mac_address)
+    }
+    if device_info.bluetooth_mac_address:
+        connections.add(
+            (dr.CONNECTION_BLUETOOTH, format_mac(device_info.bluetooth_mac_address))
+        )
     device_entry = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         configuration_url=configuration_url,
-        connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)},
+        connections=connections,
         name=entry_data.friendly_name or entry_data.name,
         manufacturer=manufacturer,
         model=model,

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -60,6 +60,7 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
 )
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.setup import async_setup_component
 
@@ -1873,6 +1874,56 @@ async def test_entry_missing_bluetooth_mac_address(
     )
     await hass.async_block_till_done()
     assert entry.data[CONF_BLUETOOTH_MAC_ADDRESS] == "AA:BB:CC:DD:EE:FC"
+
+
+async def test_device_registry_bluetooth_connection_added(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that a Bluetooth MAC address is registered as a device connection."""
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={"bluetooth_mac_address": "AA:BB:CC:DD:EE:FC"},
+    )
+    await hass.async_block_till_done()
+    entry = device.entry
+    dev = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    )
+    assert dev is not None
+    assert (
+        dr.CONNECTION_BLUETOOTH,
+        format_mac("AA:BB:CC:DD:EE:FC"),
+    ) in dev.connections
+    assert any(
+        conn_type == dr.CONNECTION_NETWORK_MAC for conn_type, _ in dev.connections
+    )
+
+
+async def test_device_registry_no_bluetooth_connection_when_absent(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that no Bluetooth connection is added when bluetooth_mac_address is absent."""
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+    )
+    await hass.async_block_till_done()
+    entry = device.entry
+    dev = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    )
+    assert dev is not None
+    assert not any(
+        conn_type == dr.CONNECTION_BLUETOOTH for conn_type, _ in dev.connections
+    )
+    assert any(
+        conn_type == dr.CONNECTION_NETWORK_MAC for conn_type, _ in dev.connections
+    )
 
 
 async def test_device_adds_friendly_name(


### PR DESCRIPTION
## Proposed change

The ESPHome integration already reads `device_info.bluetooth_mac_address` and stores it in the config entry data, but never registers it as a connection in the device registry. This means the ESPHome device and any Bluetooth device that the `bluetooth` integration registered for the same MAC address appear as two separate device entries (with the Bluetooth device having a `via_device` pointer to the ESPHome device).

This change adds `(CONNECTION_BLUETOOTH, format_mac(bluetooth_mac_address))` to the connections set passed to `device_registry.async_get_or_create()` when `bluetooth_mac_address` is present. The device registry will then automatically deduplicate the ESPHome device with the Bluetooth-registered device, collapsing them into a single entry.

`valid_connections` (used by the device-removal loop) is also updated to include the Bluetooth connection.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr