### PR TITLE
Add box state sensors and deferred refresh timers to Duco integration

### DIFF
--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -100,3 +100,17 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
             nodes={node.node_id: node for node in nodes},
             rssi_wifi=lan_info.rssi_wifi,
         )
+
+    async def async_refresh_nodes(self) -> None:
+        """Fetch only node data, reusing the last known rssi_wifi value."""
+        try:
+            nodes = await self.client.async_get_nodes()
+        except DucoConnectionError, DucoError:
+            return
+        if self.data is not None:
+            self.async_set_updated_data(
+                DucoData(
+                    nodes={node.node_id: node for node in nodes},
+                    rssi_wifi=self.data.rssi_wifi,
+                )
+            )

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -150,7 +150,7 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
         async def _deferred_refresh(_now: datetime) -> None:
             await self.coordinator.async_refresh_nodes()
 
-        for delay in (1, 5, 10, 15, 20, 25):
+        for delay in (1, 3, 5, 7, 10):
             self._deferred_refresh_cancellers.append(
                 async_call_later(self.hass, delay, _deferred_refresh)
             )

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 
 from duco.exceptions import DucoError, DucoRateLimitError
@@ -142,7 +143,11 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
         # The Duco firmware applies FlowLvlTgt asynchronously after a state
         # change. Multiple follow-up refreshes ensure the airflow target sensor
         # picks up the updated value before the normal poll interval fires.
-        async def _deferred_refresh(_now: object) -> None:
+        for cancel in self._deferred_refresh_cancellers:
+            cancel()
+        self._deferred_refresh_cancellers.clear()
+
+        async def _deferred_refresh(_now: datetime) -> None:
             await self.coordinator.async_refresh()
 
         for delay in (1, 5, 10, 15, 20, 25):

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -148,7 +148,7 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
         self._deferred_refresh_cancellers.clear()
 
         async def _deferred_refresh(_now: datetime) -> None:
-            await self.coordinator.async_refresh()
+            await self.coordinator.async_refresh_nodes()
 
         for delay in (1, 5, 10, 15, 20, 25):
             self._deferred_refresh_cancellers.append(

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -8,9 +8,10 @@ from duco.exceptions import DucoError, DucoRateLimitError
 from duco.models import Node, NodeType, VentilationState
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util.percentage import percentage_to_ordered_list_item
 
 from .const import DOMAIN
@@ -85,6 +86,7 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
         """Initialize the fan entity."""
         super().__init__(coordinator, node)
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{node.node_id}"
+        self._deferred_refresh_cancellers: list[CALLBACK_TYPE] = []
 
     @property
     def percentage(self) -> int | None:
@@ -136,3 +138,20 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
                 translation_placeholders={"error": repr(err)},
             ) from err
         await self.coordinator.async_refresh()
+
+        # The Duco firmware applies FlowLvlTgt asynchronously after a state
+        # change. Multiple follow-up refreshes ensure the airflow target sensor
+        # picks up the updated value before the normal poll interval fires.
+        async def _deferred_refresh(_now: object) -> None:
+            await self.coordinator.async_refresh()
+
+        for delay in (1, 5, 10, 15, 20, 25):
+            self._deferred_refresh_cancellers.append(
+                async_call_later(self.hass, delay, _deferred_refresh)
+            )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel any pending deferred refreshes when entity is removed."""
+        for cancel in self._deferred_refresh_cancellers:
+            cancel()
+        self._deferred_refresh_cancellers.clear()

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -150,7 +150,7 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
         async def _deferred_refresh(_now: datetime) -> None:
             await self.coordinator.async_refresh_nodes()
 
-        for delay in (1, 3, 5, 7, 10):
+        for delay in (1, 3, 5, 7, 9):
             self._deferred_refresh_cancellers.append(
                 async_call_later(self.hass, delay, _deferred_refresh)
             )

--- a/homeassistant/components/duco/icons.json
+++ b/homeassistant/components/duco/icons.json
@@ -1,11 +1,23 @@
 {
   "entity": {
     "sensor": {
+      "flow_lvl_tgt": {
+        "default": "mdi:gauge"
+      },
       "iaq_co2": {
         "default": "mdi:molecule-co2"
       },
       "iaq_rh": {
         "default": "mdi:water-percent"
+      },
+      "time_state_end": {
+        "default": "mdi:clock-end"
+      },
+      "time_state_remain": {
+        "default": "mdi:timer-sand"
+      },
+      "ventilation_mode": {
+        "default": "mdi:cog"
       },
       "ventilation_state": {
         "default": "mdi:tune-variant"

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 import logging
 
-from duco.models import Node, NodeType, VentilationState
+from duco.models import Node, NodeType, VentilationMode, VentilationState
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -19,6 +20,7 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -37,7 +39,7 @@ PARALLEL_UPDATES = 0
 class DucoSensorEntityDescription(SensorEntityDescription):
     """Duco sensor entity description."""
 
-    value_fn: Callable[[Node], int | float | str | None]
+    value_fn: Callable[[Node], int | float | str | datetime | None]
     node_types: tuple[NodeType, ...]
 
 
@@ -92,6 +94,50 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         value_fn=lambda node: node.sensor.iaq_rh if node.sensor else None,
         node_types=(NodeType.BSRH, NodeType.UCRH),
+    ),
+    DucoSensorEntityDescription(
+        key="flow_lvl_tgt",
+        translation_key="flow_lvl_tgt",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda node: (
+            node.ventilation.flow_lvl_tgt if node.ventilation else None
+        ),
+        node_types=(NodeType.BOX,),
+    ),
+    DucoSensorEntityDescription(
+        key="ventilation_mode",
+        translation_key="ventilation_mode",
+        device_class=SensorDeviceClass.ENUM,
+        options=[VentilationMode.AUTO.lower(), VentilationMode.MANU.lower()],
+        value_fn=lambda node: (
+            node.ventilation.mode.lower()
+            if node.ventilation and node.ventilation.mode != VentilationMode.NONE
+            else None
+        ),
+        node_types=(NodeType.BOX,),
+    ),
+    DucoSensorEntityDescription(
+        key="time_state_remain",
+        translation_key="time_state_remain",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda node: (
+            node.ventilation.time_state_remain if node.ventilation else None
+        ),
+        node_types=(NodeType.BOX,),
+    ),
+    DucoSensorEntityDescription(
+        key="time_state_end",
+        translation_key="time_state_end",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda node: (
+            datetime.fromtimestamp(node.ventilation.time_state_end, tz=UTC)
+            if node.ventilation and node.ventilation.time_state_end != 0
+            else None
+        ),
+        node_types=(NodeType.BOX,),
     ),
 )
 
@@ -190,7 +236,7 @@ class DucoSensorEntity(DucoEntity, SensorEntity):
         )
 
     @property
-    def native_value(self) -> int | float | str | None:
+    def native_value(self) -> int | float | str | datetime | None:
         """Return the sensor value."""
         return self.entity_description.value_fn(self._node)
 

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -66,7 +66,7 @@
         "name": "Ventilation mode",
         "state": {
           "auto": "[%key:common::state::auto%]",
-          "manu": "Manual"
+          "manu": "[%key:common::state::manual%]"
         }
       },
       "ventilation_state": {

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -47,11 +47,27 @@
       }
     },
     "sensor": {
+      "flow_lvl_tgt": {
+        "name": "Airflow target level"
+      },
       "iaq_co2": {
         "name": "CO2 air quality index"
       },
       "iaq_rh": {
         "name": "Humidity air quality index"
+      },
+      "time_state_end": {
+        "name": "Ventilation state end time"
+      },
+      "time_state_remain": {
+        "name": "Ventilation state remaining time"
+      },
+      "ventilation_mode": {
+        "name": "Ventilation mode",
+        "state": {
+          "auto": "[%key:common::state::auto%]",
+          "manu": "Manual"
+        }
       },
       "ventilation_state": {
         "name": "Ventilation state",

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -86,10 +86,10 @@ def mock_nodes() -> list[Node]:
             ),
             ventilation=NodeVentilationInfo(
                 state="AUTO",
-                time_state_remain=0,
-                time_state_end=0,
+                time_state_remain=900,
+                time_state_end=1700001800,
                 mode="AUTO",
-                flow_lvl_tgt=0,
+                flow_lvl_tgt=65,
             ),
             sensor=NodeSensorInfo(
                 co2=None,

--- a/tests/components/duco/snapshots/test_diagnostics.ambr
+++ b/tests/components/duco/snapshots/test_diagnostics.ambr
@@ -47,11 +47,11 @@
           'rh': None,
         }),
         'ventilation': dict({
-          'flow_lvl_tgt': 0,
+          'flow_lvl_tgt': 65,
           'mode': 'AUTO',
           'state': 'AUTO',
-          'time_state_end': 0,
-          'time_state_remain': 0,
+          'time_state_end': 1700001800,
+          'time_state_remain': 900,
         }),
       }),
       '113': dict({

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -217,6 +217,60 @@
     'state': '90',
   })
 # ---
+# name: test_sensor_entities_state[sensor.living_airflow_target_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_airflow_target_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Airflow target level',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Airflow target level',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'flow_lvl_tgt',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_flow_lvl_tgt',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_airflow_target_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living Airflow target level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_airflow_target_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '65',
+  })
+# ---
 # name: test_sensor_entities_state[sensor.living_signal_strength-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -270,6 +324,66 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-60',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'auto',
+        'manu',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_ventilation_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilation mode',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Ventilation mode',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ventilation_mode',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_ventilation_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Living Ventilation mode',
+      'options': list([
+        'auto',
+        'manu',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_ventilation_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
   })
 # ---
 # name: test_sensor_entities_state[sensor.living_ventilation_state-entry]
@@ -360,6 +474,115 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'auto',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_state_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_ventilation_state_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilation state end time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Ventilation state end time',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_state_end',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_end',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_state_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Living Ventilation state end time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_ventilation_state_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-14T22:43:20+00:00',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_state_remaining_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_ventilation_state_remaining_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilation state remaining time',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Ventilation state remaining time',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_state_remain',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_remain',
+    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_state_remaining_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Living Ventilation state remaining time',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_ventilation_state_remaining_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '900',
   })
 # ---
 # name: test_sensor_entities_state[sensor.office_co2_carbon_dioxide-entry]

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -147,8 +147,8 @@ async def test_fan_set_state_triggers_deferred_refresh(
 ) -> None:
     """Test that coordinator refreshes fire after a state change.
 
-    One immediate refresh is followed by 6 deferred refreshes (1, 5, 10, 15,
-    20, 25 s) so the airflow target sensor picks up the updated FlowLvlTgt
+    One immediate refresh is followed by 5 deferred refreshes (1, 3, 5, 7,
+    9 s) so the airflow target sensor picks up the updated FlowLvlTgt
     value regardless of firmware latency.
     """
     mock_duco_client.async_set_ventilation_state = AsyncMock()

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -164,13 +164,13 @@ async def test_fan_set_state_triggers_deferred_refresh(
     # Immediate refresh fires synchronously inside the blocking call.
     assert mock_duco_client.async_get_nodes.call_count == 1
 
-    # Advance time past the last deferred-refresh delay (25 s).
-    freezer.tick(timedelta(seconds=26))
+    # Advance time past the last deferred-refresh delay (10 s).
+    freezer.tick(timedelta(seconds=11))
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    # 1 immediate + 6 deferred refreshes (1, 5, 10, 15, 20, 25 s).
-    assert mock_duco_client.async_get_nodes.call_count == 7
+    # 1 immediate + 5 deferred refreshes (1, 3, 5, 7, 10 s).
+    assert mock_duco_client.async_get_nodes.call_count == 6
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -164,12 +164,12 @@ async def test_fan_set_state_triggers_deferred_refresh(
     # Immediate refresh fires synchronously inside the blocking call.
     assert mock_duco_client.async_get_nodes.call_count == 1
 
-    # Advance time past the last deferred-refresh delay (10 s).
-    freezer.tick(timedelta(seconds=11))
+    # Advance time past the last deferred-refresh delay (9 s).
+    freezer.tick(timedelta(seconds=10))
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    # 1 immediate + 5 deferred refreshes (1, 3, 5, 7, 10 s).
+    # 1 immediate + 5 deferred refreshes (1, 3, 5, 7, 9 s).
     assert mock_duco_client.async_get_nodes.call_count == 6
 
 

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 from unittest.mock import AsyncMock, patch
 
@@ -136,6 +137,40 @@ async def test_fan_set_state_rate_limit_logs_warning(
         )
 
     assert "write rate limit exceeded" in caplog.text
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_set_state_triggers_deferred_refresh(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that coordinator refreshes fire after a state change.
+
+    One immediate refresh is followed by 6 deferred refreshes (1, 5, 10, 15,
+    20, 25 s) so the airflow target sensor picks up the updated FlowLvlTgt
+    value regardless of firmware latency.
+    """
+    mock_duco_client.async_set_ventilation_state = AsyncMock()
+    mock_duco_client.async_get_nodes.reset_mock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: _FAN_ENTITY, ATTR_PERCENTAGE: 100},
+        blocking=True,
+    )
+
+    # Immediate refresh fires synchronously inside the blocking call.
+    assert mock_duco_client.async_get_nodes.call_count == 1
+
+    # Advance time past the last deferred-refresh delay (25 s).
+    freezer.tick(timedelta(seconds=26))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # 1 immediate + 6 deferred refreshes (1, 5, 10, 15, 20, 25 s).
+    assert mock_duco_client.async_get_nodes.call_count == 7
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from duco.exceptions import DucoConnectionError, DucoError
@@ -253,3 +254,66 @@ async def test_unknown_node_type_logs_warning_and_creates_no_entities(
         identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_99")}
     )
     assert device is None
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_time_state_end_zero_returns_unknown(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that time_state_end=0 (permanent state) results in an unknown sensor state."""
+    updated_box_node = Node(
+        node_id=1,
+        general=mock_nodes[0].general,
+        ventilation=NodeVentilationInfo(
+            state="AUTO",
+            time_state_remain=0,
+            time_state_end=0,
+            mode="AUTO",
+            flow_lvl_tgt=65,
+        ),
+        sensor=mock_nodes[0].sensor,
+    )
+    mock_duco_client.async_get_nodes.return_value = [
+        updated_box_node,
+        *mock_nodes[1:],
+    ]
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.living_ventilation_state_end_time")
+    assert state is not None
+    assert state.state == "unknown"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_time_state_end_nonzero_returns_datetime(
+    hass: HomeAssistant,
+) -> None:
+    """Test that a non-zero time_state_end is returned as a UTC datetime."""
+    state = hass.states.get("sensor.living_ventilation_state_end_time")
+    assert state is not None
+    expected = datetime.fromtimestamp(1700001800, tz=UTC).isoformat()
+    assert state.state == expected
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_box_state_sensors_initial_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test that box-level state sensors reflect the initial coordinator data."""
+    state_flow = hass.states.get("sensor.living_airflow_target_level")
+    assert state_flow is not None
+    assert state_flow.state == "65"
+
+    state_mode = hass.states.get("sensor.living_ventilation_mode")
+    assert state_mode is not None
+    assert state_mode.state == "auto"
+
+    state_remain = hass.states.get("sensor.living_ventilation_state_remaining_time")
+    assert state_remain is not None
+    assert state_remain.state == "900"


### PR DESCRIPTION
## Proposed change

Adds four new BOX-level sensor entities to the Duco integration and introduces deferred refresh timers so the fan entity state updates promptly after a write action.

**New sensors (available for the main ventilation box):**

- **Airflow target level** (`flow_lvl_tgt`): the actual airflow target as reported by the Duco box, as a percentage (0-100%). This is the real firmware value and differs from the abstract 33/66/100% speed levels used by the fan entity.
- **Ventilation mode** (`ventilation_mode`): whether ventilation is controlled automatically (`auto`) or manually (`manu`). Uses `SensorDeviceClass.ENUM` with translated states.
- **Ventilation state remaining time** (`time_state_remain`): seconds remaining in the current timed ventilation state. Returns 0 when no timer is active.
- **Ventilation state end time** (`time_state_end`): timestamp at which the current timed state ends. No value when no timer is active.

**Deferred refresh timers:**

After the fan entity writes a speed or preset change to the Duco box, five deferred coordinator refreshes are scheduled at 1, 3, 5, 7, and 9 seconds. This ensures both the fan entity and the airflow target sensor pick up the updated firmware value promptly. Only node data is re-fetched (not lan_info) via `async_refresh_nodes()`, keeping the number of API calls minimal. Timers are cancelled in `async_will_remove_from_hass` to avoid use-after-free errors.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44982
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect_pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
