### PR TITLE
Fix iCloud polling loop dying permanently on transient errors

### DIFF
--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -324,6 +324,8 @@ class IcloudAccount:
             self.setup()
 
         if self.api is None:
+            self._fetch_interval = self._max_interval
+            self._schedule_next_fetch()
             return
 
         try:

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -59,6 +59,12 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+_MSG_PASSWORD_NO_LONGER_WORKING = (
+    "Your password for '%s' is no longer working; Go to the "
+    "Integrations menu and click on Configure on the discovered Apple "
+    "iCloud card to login again"
+)
+
 type IcloudConfigEntry = ConfigEntry[IcloudAccount]
 
 
@@ -114,11 +120,7 @@ class IcloudAccount:
             self.api = None
             # Login failed which means credentials need to be updated.
             _LOGGER.error(
-                (
-                    "Your password for '%s' is no longer working; Go to the "
-                    "Integrations menu and click on Configure on the discovered Apple "
-                    "iCloud card to login again"
-                ),
+                _MSG_PASSWORD_NO_LONGER_WORKING,
                 self._config_entry.data[CONF_USERNAME],
             )
 
@@ -316,11 +318,7 @@ class IcloudAccount:
             self.api.authenticate()
         except PyiCloudFailedLoginException:
             _LOGGER.error(
-                (
-                    "Your password for '%s' is no longer working; Go to the "
-                    "Integrations menu and click on Configure on the discovered Apple "
-                    "iCloud card to login again"
-                ),
+                _MSG_PASSWORD_NO_LONGER_WORKING,
                 self._config_entry.data[CONF_USERNAME],
             )
             self.api = None
@@ -334,11 +332,12 @@ class IcloudAccount:
             self._schedule_next_fetch()
             return
 
-        try:
-            self.api.devices.refresh(locate=True)
-            _LOGGER.debug("Triggered active location refresh (shouldLocate=True)")
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.warning("Could not trigger active location refresh: %s", err)
+        if not self.api.requires_2fa:
+            try:
+                self.api.devices.refresh(locate=True)
+                _LOGGER.debug("Triggered active location refresh (shouldLocate=True)")
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning("Could not trigger active location refresh: %s", err)
         self.update_devices()
 
     def get_devices_with_name(self, name: str) -> list[Any]:

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -61,14 +61,14 @@ _LOGGER = logging.getLogger(__name__)
 
 _MSG_PASSWORD_NO_LONGER_WORKING = (
     "Your password for '%s' is no longer working; go to the "
-    "Integrations menu and click on Configure on the discovered Apple "
+    "Integrations menu and click on Configure on the Apple "
     "iCloud card to log in again"
 )
 
 _MSG_2FA_REQUIRED = (
     "2FA authentication required for '%s'; go to the "
-    "Integrations menu and click on Configure on the iCloud "
-    "card to enter your verification code"
+    "Integrations menu and click on Configure on the Apple "
+    "iCloud card to enter your verification code"
 )
 
 type IcloudConfigEntry = ConfigEntry[IcloudAccount]
@@ -100,6 +100,7 @@ class IcloudAccount:
         self._icloud_dir = icloud_dir
 
         self.api: PyiCloudService | None = None
+        self._setup_credential_failure: bool = False
         self._owner_fullname: str | None = None
         self._family_members_fullname: dict[str, str] = {}
         self._devices: dict[str, IcloudDevice] = {}
@@ -135,6 +136,7 @@ class IcloudAccount:
                     _MSG_PASSWORD_NO_LONGER_WORKING,
                     self._config_entry.data[CONF_USERNAME],
                 )
+                self._setup_credential_failure = True
             self._require_reauth()
             return
 
@@ -331,6 +333,9 @@ class IcloudAccount:
                 self.api = None  # clear any partially-initialized api
 
         if self.api is None:
+            if self._setup_credential_failure:
+                self._setup_credential_failure = False
+                return  # permanent credential failure — don't retry, wait for reauth
             self._fetch_interval = self._max_interval
             self._schedule_next_fetch()
             return

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -60,9 +60,9 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 _MSG_PASSWORD_NO_LONGER_WORKING = (
-    "Your password for '%s' is no longer working; Go to the "
+    "Your password for '%s' is no longer working; go to the "
     "Integrations menu and click on Configure on the discovered Apple "
-    "iCloud card to login again"
+    "iCloud card to log in again"
 )
 
 type IcloudConfigEntry = ConfigEntry[IcloudAccount]

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -314,6 +314,18 @@ class IcloudAccount:
 
         try:
             self.api.authenticate()
+        except PyiCloudFailedLoginException:
+            _LOGGER.error(
+                (
+                    "Your password for '%s' is no longer working; Go to the "
+                    "Integrations menu and click on Configure on the discovered Apple "
+                    "iCloud card to login again"
+                ),
+                self._config_entry.data[CONF_USERNAME],
+            )
+            self.api = None
+            self._require_reauth()
+            return
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning(
                 "Authentication failed in keep_alive, will retry next cycle: %s", err

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -61,13 +61,13 @@ _LOGGER = logging.getLogger(__name__)
 
 _MSG_PASSWORD_NO_LONGER_WORKING = (
     "Your password for '%s' is no longer working; go to the "
-    "Integrations menu and click on Configure on the Apple "
+    "Integrations menu and click Configure on the Apple "
     "iCloud card to log in again"
 )
 
 _MSG_2FA_REQUIRED = (
     "2FA authentication required for '%s'; go to the "
-    "Integrations menu and click on Configure on the Apple "
+    "Integrations menu and click Configure on the Apple "
     "iCloud card to enter your verification code"
 )
 

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -321,7 +321,13 @@ class IcloudAccount:
     def keep_alive(self, now=None) -> None:
         """Keep the API alive."""
         if self.api is None:
-            self.setup()
+            try:
+                self.setup()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Failed to set up iCloud account in keep_alive, will retry: %s",
+                    err,
+                )
 
         if self.api is None:
             self._fetch_interval = self._max_interval

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -161,6 +161,7 @@ class IcloudAccount:
 
         if self.api.requires_2fa:
             self._require_reauth()
+            self._schedule_next_fetch()
             return
 
         api_devices = {}
@@ -311,7 +312,21 @@ class IcloudAccount:
         if self.api is None:
             return
 
-        self.api.authenticate()
+        try:
+            self.api.authenticate()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "Authentication failed in keep_alive, will retry next cycle: %s", err
+            )
+            self._fetch_interval = 2
+            self._schedule_next_fetch()
+            return
+
+        try:
+            self.api.devices._refresh_client(locate=True)
+            _LOGGER.debug("Triggered active location refresh (shouldLocate=True)")
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Could not trigger active location refresh: %s", err)
         self.update_devices()
 
     def get_devices_with_name(self, name: str) -> list[Any]:

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -323,7 +323,7 @@ class IcloudAccount:
             return
 
         try:
-            self.api.devices._refresh_client(locate=True)
+            self.api.devices.refresh(locate=True)
             _LOGGER.debug("Triggered active location refresh (shouldLocate=True)")
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Could not trigger active location refresh: %s", err)

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -65,6 +65,12 @@ _MSG_PASSWORD_NO_LONGER_WORKING = (
     "iCloud card to log in again"
 )
 
+_MSG_2FA_REQUIRED = (
+    "2FA authentication required for '%s'; go to the "
+    "Integrations menu and click on Configure on the iCloud "
+    "card to enter your verification code"
+)
+
 type IcloudConfigEntry = ConfigEntry[IcloudAccount]
 
 
@@ -121,11 +127,7 @@ class IcloudAccount:
             self.api = None
             if requires_2fa:
                 _LOGGER.warning(
-                    (
-                        "2FA authentication required for '%s'; Go to the "
-                        "Integrations menu and click on Configure on the iCloud "
-                        "card to enter your verification code"
-                    ),
+                    _MSG_2FA_REQUIRED,
                     self._config_entry.data[CONF_USERNAME],
                 )
             else:
@@ -172,6 +174,7 @@ class IcloudAccount:
 
         if self.api.requires_2fa:
             self._require_reauth()
+            self._fetch_interval = self._max_interval
             self._schedule_next_fetch()
             return
 
@@ -330,19 +333,18 @@ class IcloudAccount:
             self.api = None
             if requires_2fa:
                 _LOGGER.warning(
-                    (
-                        "2FA authentication required for '%s'; Go to the "
-                        "Integrations menu and click on Configure on the iCloud "
-                        "card to enter your verification code"
-                    ),
+                    _MSG_2FA_REQUIRED,
                     self._config_entry.data[CONF_USERNAME],
                 )
+                self._require_reauth()
+                self._fetch_interval = self._max_interval
+                self._schedule_next_fetch()
             else:
                 _LOGGER.error(
                     _MSG_PASSWORD_NO_LONGER_WORKING,
                     self._config_entry.data[CONF_USERNAME],
                 )
-            self._require_reauth()
+                self._require_reauth()
             return
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning(

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -328,6 +328,7 @@ class IcloudAccount:
                     "Failed to set up iCloud account in keep_alive, will retry: %s",
                     err,
                 )
+                self.api = None  # clear any partially-initialized api
 
         if self.api is None:
             self._fetch_interval = self._max_interval

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -117,13 +117,22 @@ class IcloudAccount:
                 raise PyiCloudFailedLoginException("2FA Required")  # noqa: TRY301
 
         except PyiCloudFailedLoginException:
+            requires_2fa = self.api is not None and self.api.requires_2fa
             self.api = None
-            # Login failed which means credentials need to be updated.
-            _LOGGER.error(
-                _MSG_PASSWORD_NO_LONGER_WORKING,
-                self._config_entry.data[CONF_USERNAME],
-            )
-
+            if requires_2fa:
+                _LOGGER.warning(
+                    (
+                        "2FA authentication required for '%s'; Go to the "
+                        "Integrations menu and click on Configure on the iCloud "
+                        "card to enter your verification code"
+                    ),
+                    self._config_entry.data[CONF_USERNAME],
+                )
+            else:
+                _LOGGER.error(
+                    _MSG_PASSWORD_NO_LONGER_WORKING,
+                    self._config_entry.data[CONF_USERNAME],
+                )
             self._require_reauth()
             return
 

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -317,11 +317,22 @@ class IcloudAccount:
         try:
             self.api.authenticate()
         except PyiCloudFailedLoginException:
-            _LOGGER.error(
-                _MSG_PASSWORD_NO_LONGER_WORKING,
-                self._config_entry.data[CONF_USERNAME],
-            )
+            requires_2fa = self.api is not None and self.api.requires_2fa
             self.api = None
+            if requires_2fa:
+                _LOGGER.warning(
+                    (
+                        "2FA authentication required for '%s'; Go to the "
+                        "Integrations menu and click on Configure on the iCloud "
+                        "card to enter your verification code"
+                    ),
+                    self._config_entry.data[CONF_USERNAME],
+                )
+            else:
+                _LOGGER.error(
+                    _MSG_PASSWORD_NO_LONGER_WORKING,
+                    self._config_entry.data[CONF_USERNAME],
+                )
             self._require_reauth()
             return
         except Exception as err:  # noqa: BLE001

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -278,7 +278,7 @@ async def test_keep_alive_clears_api_and_reschedules_when_setup_raises_after_par
 
     def setup_sets_api_then_raises():
         account.api = MagicMock()
-        raise Exception("Service unavailable")
+        raise ConfigEntryNotReady("Service unavailable")
 
     with (
         patch.object(account, "setup", side_effect=setup_sets_api_then_raises),

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -216,7 +216,7 @@ def _make_account(hass: HomeAssistant, mock_store: Mock) -> IcloudAccount:
     )
 
 
-async def test_keep_alive_reschedules_when_setup_fails(
+async def test_keep_alive_reschedules_when_setup_returns_api_none(
     hass: HomeAssistant,
     mock_store: Mock,
 ) -> None:
@@ -233,6 +233,30 @@ async def test_keep_alive_reschedules_when_setup_fails(
         patch.object(
             account, "setup"
         ),  # setup() leaves api as None (simulates any failure)
+        patch.object(account, "_schedule_next_fetch") as mock_schedule,
+    ):
+        account.keep_alive()
+
+    mock_schedule.assert_called_once()
+    assert account.fetch_interval == MOCK_CONFIG[CONF_MAX_INTERVAL]
+
+
+async def test_keep_alive_reschedules_when_setup_raises(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive reschedules when setup() raises (e.g. transient Apple API outage).
+
+    ConfigEntryNotReady raised by setup() during a keep_alive cycle would propagate
+    uncaught and permanently kill the polling loop. The exception is now caught and
+    the next fetch is still scheduled at max interval.
+    """
+    account = _make_account(hass, mock_store)
+
+    with (
+        patch.object(
+            account, "setup", side_effect=Exception("Apple API unavailable")
+        ),
         patch.object(account, "_schedule_next_fetch") as mock_schedule,
     ):
         account.keep_alive()

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -220,11 +220,10 @@ async def test_keep_alive_reschedules_when_setup_returns_api_none(
     hass: HomeAssistant,
     mock_store: Mock,
 ) -> None:
-    """Test keep_alive reschedules at max interval when setup() returns with api still None.
+    """Test keep_alive reschedules at max interval when setup() returns with api None (2FA path).
 
     Before this fix, keep_alive() would call setup() (because api was None), then return
     early without calling _schedule_next_fetch(), permanently killing the polling loop.
-    This covers the 2FA and bad-password paths in setup() — both leave api as None.
     """
     account = _make_account(hass, mock_store)
     # api starts as None, so keep_alive will call setup()
@@ -232,13 +231,36 @@ async def test_keep_alive_reschedules_when_setup_returns_api_none(
     with (
         patch.object(
             account, "setup"
-        ),  # setup() leaves api as None (simulates any failure)
+        ),  # setup() leaves api as None (simulates 2FA path)
         patch.object(account, "_schedule_next_fetch") as mock_schedule,
     ):
         account.keep_alive()
 
     mock_schedule.assert_called_once()
     assert account.fetch_interval == MOCK_CONFIG[CONF_MAX_INTERVAL]
+
+
+async def test_keep_alive_does_not_reschedule_when_setup_detects_bad_password(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive stops polling when setup() detects a permanent credential failure.
+
+    Rescheduling every max_interval with bad credentials would spam the user with
+    reauth notifications. The _setup_credential_failure flag set by setup() prevents
+    keep_alive from rescheduling in this case.
+    """
+    account = _make_account(hass, mock_store)
+    account._setup_credential_failure = True  # noqa: SLF001
+
+    with (
+        patch.object(account, "setup"),
+        patch.object(account, "_schedule_next_fetch") as mock_schedule,
+    ):
+        account.keep_alive()
+
+    mock_schedule.assert_not_called()
+    assert not account._setup_credential_failure  # noqa: SLF001
 
 
 async def test_keep_alive_reschedules_when_setup_raises(
@@ -254,7 +276,9 @@ async def test_keep_alive_reschedules_when_setup_raises(
     account = _make_account(hass, mock_store)
 
     with (
-        patch.object(account, "setup", side_effect=Exception("Apple API unavailable")),
+        patch.object(
+            account, "setup", side_effect=ConfigEntryNotReady("Apple API unavailable")
+        ),
         patch.object(account, "_schedule_next_fetch") as mock_schedule,
     ):
         account.keep_alive()

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -263,6 +263,34 @@ async def test_keep_alive_reschedules_when_setup_raises(
     assert account.fetch_interval == MOCK_CONFIG[CONF_MAX_INTERVAL]
 
 
+async def test_keep_alive_clears_api_and_reschedules_when_setup_raises_after_partial_init(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive clears api and reschedules when setup() sets api then raises.
+
+    setup() can assign self.api (PyiCloudService) and then raise ConfigEntryNotReady
+    (e.g. PyiCloudServiceUnavailable during device fetch). Without clearing api in the
+    except block, keep_alive would proceed to authenticate() with a partially-initialized
+    api instead of taking the reschedule path.
+    """
+    account = _make_account(hass, mock_store)
+
+    def setup_sets_api_then_raises():
+        account.api = MagicMock()
+        raise Exception("Service unavailable")
+
+    with (
+        patch.object(account, "setup", side_effect=setup_sets_api_then_raises),
+        patch.object(account, "_schedule_next_fetch") as mock_schedule,
+    ):
+        account.keep_alive()
+
+    assert account.api is None
+    mock_schedule.assert_called_once()
+    assert account.fetch_interval == MOCK_CONFIG[CONF_MAX_INTERVAL]
+
+
 async def test_keep_alive_auth_exception_reschedules(
     hass: HomeAssistant,
     mock_store: Mock,

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -280,12 +280,15 @@ async def test_keep_alive_failed_login_2fa_logs_warning_not_error(
 
     with (
         patch.object(account, "_require_reauth") as mock_reauth,
+        patch.object(account, "_schedule_next_fetch") as mock_schedule,
         patch("homeassistant.components.icloud.account._LOGGER") as mock_logger,
     ):
         account.keep_alive()
 
     mock_reauth.assert_called_once()
+    mock_schedule.assert_called_once()
     assert account.api is None
+    assert account.fetch_interval == MOCK_CONFIG[CONF_MAX_INTERVAL]
     mock_logger.warning.assert_called_once()
     mock_logger.error.assert_not_called()
 
@@ -330,3 +333,4 @@ async def test_update_devices_requires_2fa_reschedules(
 
     mock_reauth.assert_called_once()
     mock_schedule.assert_called_once()
+    assert account.fetch_interval == MOCK_CONFIG[CONF_MAX_INTERVAL]

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -220,7 +220,7 @@ async def test_keep_alive_success_sends_locate_before_update(
     ):
         account.keep_alive()
 
-    account.api.devices._refresh_client.assert_called_once_with(locate=True)
+    account.api.devices.refresh.assert_called_once_with(locate=True)
     mock_update.assert_called_once()
 
 

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -168,6 +168,36 @@ async def test_setup_success_with_devices(
     assert account.family_members_fullname["johntravolta"] == "John TRAVOLTA"
 
 
+async def test_setup_requires_2fa_logs_warning_not_error(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test setup logs a warning (not error) when requires_2fa is True.
+
+    PyiCloudFailedLoginException is raised internally for the 2FA path; logging
+    'password no longer working' in that case would mislead the user.
+    """
+    account = _make_account(hass, mock_store)
+
+    service_instance = MagicMock()
+    service_instance.requires_2fa = True
+
+    with (
+        patch(
+            "homeassistant.components.icloud.account.PyiCloudService",
+            return_value=service_instance,
+        ),
+        patch.object(account, "_require_reauth") as mock_reauth,
+        patch("homeassistant.components.icloud.account._LOGGER") as mock_logger,
+    ):
+        account.setup()
+
+    mock_reauth.assert_called_once()
+    assert account.api is None
+    mock_logger.warning.assert_called_once()
+    mock_logger.error.assert_not_called()
+
+
 def _make_account(hass: HomeAssistant, mock_store: Mock) -> IcloudAccount:
     """Build an IcloudAccount with mocked config entry."""
     config_entry = MockConfigEntry(

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -165,3 +165,83 @@ async def test_setup_success_with_devices(
     assert account.owner_fullname == "user name"
     assert "johntravolta" in account.family_members_fullname
     assert account.family_members_fullname["johntravolta"] == "John TRAVOLTA"
+
+
+def _make_account(hass: HomeAssistant, mock_store: Mock) -> IcloudAccount:
+    """Build an IcloudAccount with mocked config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+    return IcloudAccount(
+        hass,
+        MOCK_CONFIG[CONF_USERNAME],
+        MOCK_CONFIG[CONF_PASSWORD],
+        mock_store,
+        MOCK_CONFIG[CONF_WITH_FAMILY],
+        MOCK_CONFIG[CONF_MAX_INTERVAL],
+        MOCK_CONFIG[CONF_GPS_ACCURACY_THRESHOLD],
+        config_entry,
+    )
+
+
+async def test_keep_alive_auth_exception_reschedules(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive reschedules on transient auth error instead of dying permanently.
+
+    Before this fix, any exception from authenticate() propagated out of keep_alive()
+    without scheduling the next call, permanently killing the polling loop.
+    """
+    account = _make_account(hass, mock_store)
+    account.api = MagicMock()
+    account.api.authenticate.side_effect = Exception("Session expired")
+
+    with patch.object(account, "_schedule_next_fetch") as mock_schedule:
+        account.keep_alive()
+
+    mock_schedule.assert_called_once()
+    assert account._fetch_interval == 2
+
+
+async def test_keep_alive_success_sends_locate_before_update(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive sends an active locate push before updating devices."""
+    account = _make_account(hass, mock_store)
+    account.api = MagicMock()
+    account.api.requires_2fa = False
+
+    with (
+        patch.object(account, "update_devices") as mock_update,
+        patch.object(account, "_schedule_next_fetch"),
+    ):
+        account.keep_alive()
+
+    account.api.devices._refresh_client.assert_called_once_with(locate=True)
+    mock_update.assert_called_once()
+
+
+async def test_update_devices_requires_2fa_reschedules(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test update_devices reschedules the next poll even when requires_2fa is True.
+
+    Before this fix, the requires_2fa early return skipped _schedule_next_fetch(),
+    permanently killing the polling loop while waiting for re-authentication.
+    """
+    account = _make_account(hass, mock_store)
+    account.api = MagicMock()
+    account.api.requires_2fa = True
+
+    with (
+        patch.object(account, "_require_reauth") as mock_reauth,
+        patch.object(account, "_schedule_next_fetch") as mock_schedule,
+    ):
+        account.update_devices()
+
+    mock_reauth.assert_called_once()
+    mock_schedule.assert_called_once()

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -216,6 +216,29 @@ def _make_account(hass: HomeAssistant, mock_store: Mock) -> IcloudAccount:
     )
 
 
+async def test_keep_alive_reschedules_when_setup_fails(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive reschedules at max interval when setup() returns with api still None.
+
+    Before this fix, keep_alive() would call setup() (because api was None), then return
+    early without calling _schedule_next_fetch(), permanently killing the polling loop.
+    This covers the 2FA and bad-password paths in setup() — both leave api as None.
+    """
+    account = _make_account(hass, mock_store)
+    # api starts as None, so keep_alive will call setup()
+
+    with (
+        patch.object(account, "setup"),  # setup() leaves api as None (simulates any failure)
+        patch.object(account, "_schedule_next_fetch") as mock_schedule,
+    ):
+        account.keep_alive()
+
+    mock_schedule.assert_called_once()
+    assert account.fetch_interval == MOCK_CONFIG[CONF_MAX_INTERVAL]
+
+
 async def test_keep_alive_auth_exception_reschedules(
     hass: HomeAssistant,
     mock_store: Mock,

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -203,7 +203,7 @@ async def test_keep_alive_auth_exception_reschedules(
         account.keep_alive()
 
     mock_schedule.assert_called_once()
-    assert account._fetch_interval == 2
+    assert account.fetch_interval == 2
 
 
 async def test_keep_alive_failed_login_triggers_reauth(
@@ -217,6 +217,7 @@ async def test_keep_alive_failed_login_triggers_reauth(
     """
     account = _make_account(hass, mock_store)
     account.api = MagicMock()
+    account.api.requires_2fa = False
     account.api.authenticate.side_effect = PyiCloudFailedLoginException("bad password")
 
     with (
@@ -230,6 +231,33 @@ async def test_keep_alive_failed_login_triggers_reauth(
     mock_schedule.assert_not_called()
     assert account.api is None
     mock_logger.error.assert_called_once()
+    mock_logger.warning.assert_not_called()
+
+
+async def test_keep_alive_failed_login_2fa_logs_warning_not_error(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive logs a warning (not error) when the failure is due to 2FA.
+
+    PyiCloudFailedLoginException is also raised for 2FA flows; logging 'password
+    no longer working' in that case would mislead the user.
+    """
+    account = _make_account(hass, mock_store)
+    account.api = MagicMock()
+    account.api.requires_2fa = True
+    account.api.authenticate.side_effect = PyiCloudFailedLoginException("2FA required")
+
+    with (
+        patch.object(account, "_require_reauth") as mock_reauth,
+        patch("homeassistant.components.icloud.account._LOGGER") as mock_logger,
+    ):
+        account.keep_alive()
+
+    mock_reauth.assert_called_once()
+    assert account.api is None
+    mock_logger.warning.assert_called_once()
+    mock_logger.error.assert_not_called()
 
 
 async def test_keep_alive_success_sends_locate_before_update(

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -230,7 +230,9 @@ async def test_keep_alive_reschedules_when_setup_fails(
     # api starts as None, so keep_alive will call setup()
 
     with (
-        patch.object(account, "setup"),  # setup() leaves api as None (simulates any failure)
+        patch.object(
+            account, "setup"
+        ),  # setup() leaves api as None (simulates any failure)
         patch.object(account, "_schedule_next_fetch") as mock_schedule,
     ):
         account.keep_alive()

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, Mock, patch
 
+from pyicloud.exceptions import PyiCloudFailedLoginException
 import pytest
 
 from homeassistant.components.icloud.account import IcloudAccount
@@ -203,6 +204,32 @@ async def test_keep_alive_auth_exception_reschedules(
 
     mock_schedule.assert_called_once()
     assert account._fetch_interval == 2
+
+
+async def test_keep_alive_failed_login_triggers_reauth(
+    hass: HomeAssistant,
+    mock_store: Mock,
+) -> None:
+    """Test keep_alive triggers reauth on PyiCloudFailedLoginException instead of retrying.
+
+    Permanent credential failures (bad password) must not be retried — the integration
+    should stop polling and prompt the user to re-enter credentials via reauth.
+    """
+    account = _make_account(hass, mock_store)
+    account.api = MagicMock()
+    account.api.authenticate.side_effect = PyiCloudFailedLoginException("bad password")
+
+    with (
+        patch.object(account, "_require_reauth") as mock_reauth,
+        patch.object(account, "_schedule_next_fetch") as mock_schedule,
+        patch("homeassistant.components.icloud.account._LOGGER") as mock_logger,
+    ):
+        account.keep_alive()
+
+    mock_reauth.assert_called_once()
+    mock_schedule.assert_not_called()
+    assert account.api is None
+    mock_logger.error.assert_called_once()
 
 
 async def test_keep_alive_success_sends_locate_before_update(

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -251,7 +251,7 @@ async def test_keep_alive_does_not_reschedule_when_setup_detects_bad_password(
     keep_alive from rescheduling in this case.
     """
     account = _make_account(hass, mock_store)
-    account._setup_credential_failure = True  # noqa: SLF001
+    account._setup_credential_failure = True
 
     with (
         patch.object(account, "setup"),
@@ -260,7 +260,7 @@ async def test_keep_alive_does_not_reschedule_when_setup_detects_bad_password(
         account.keep_alive()
 
     mock_schedule.assert_not_called()
-    assert not account._setup_credential_failure  # noqa: SLF001
+    assert not account._setup_credential_failure
 
 
 async def test_keep_alive_reschedules_when_setup_raises(

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -254,9 +254,7 @@ async def test_keep_alive_reschedules_when_setup_raises(
     account = _make_account(hass, mock_store)
 
     with (
-        patch.object(
-            account, "setup", side_effect=Exception("Apple API unavailable")
-        ),
+        patch.object(account, "setup", side_effect=Exception("Apple API unavailable")),
         patch.object(account, "_schedule_next_fetch") as mock_schedule,
     ):
         account.keep_alive()


### PR DESCRIPTION
## Problem

The iCloud polling loop (`keep_alive()`) would die permanently in two scenarios:

**1. Any transient authentication error** — `keep_alive()` called `self.api.authenticate()` with no exception handling. A transient Apple API error or session expiry caused an unhandled exception that propagated out of `keep_alive()` without scheduling the next call. The polling loop then stopped forever, with no log entry to indicate it had died.

**2. 2FA re-authentication required** — `update_devices()` returned early when `self.api.requires_2fa` was `True` without calling `self._schedule_next_fetch()`. This meant the polling loop also stopped permanently while waiting for the user to re-authenticate via the UI.

Both issues were found in production: the polling loop died on April 16 and went undetected until April 23 — seven days of stale device states, during which the integration appeared healthy in the UI.

## Changes

**`keep_alive()`** — wrap `self.api.authenticate()` in a try/except block:
- On `PyiCloudFailedLoginException` (permanent credential failure): log an error, set `api = None`, and call `_require_reauth()` — so the user is directed to re-enter credentials instead of retrying indefinitely.
- On any other exception (transient failure): log a warning, set a short 2-minute retry interval, and reschedule — so the next cycle attempts recovery automatically.
- On success: call `self.api.devices.refresh(locate=True)` to send an active locate push (`shouldLocate: True`) to Apple, which wakes sleeping devices and delivers a fresh GPS fix instead of relying on Apple's cached stale position.

**`update_devices()`** — add `self._schedule_next_fetch()` before the `requires_2fa` early return, so the polling loop continues while the user re-authenticates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional information

- Tested on Home Assistant 2026.4.3 with an Apple account using an app-specific password and Family Sharing enabled.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass with `python -m pytest tests/components/icloud/`

---

Co-authored with Claude Sonnet 4.6