### PR TITLE
Fix Flume sensor units and device classes

### DIFF
--- a/homeassistant/components/flume/sensor.py
+++ b/homeassistant/components/flume/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfVolume
+from homeassistant.const import UnitOfVolume, UnitOfVolumeFlowRate
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -34,7 +34,8 @@ FLUME_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
         key="current_interval",
         translation_key="current_interval",
         suggested_display_precision=2,
-        native_unit_of_measurement=f"{UnitOfVolume.GALLONS}/m",
+        native_unit_of_measurement=UnitOfVolumeFlowRate.GALLONS_PER_MINUTE,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
@@ -65,14 +66,16 @@ FLUME_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
         key="last_60_min",
         translation_key="last_60_min",
         suggested_display_precision=2,
-        native_unit_of_measurement=f"{UnitOfVolume.GALLONS}/h",
+        native_unit_of_measurement=UnitOfVolumeFlowRate.GALLONS_PER_HOUR,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="last_24_hrs",
         translation_key="last_24_hrs",
         suggested_display_precision=2,
-        native_unit_of_measurement=f"{UnitOfVolume.GALLONS}/d",
+        native_unit_of_measurement=UnitOfVolumeFlowRate.GALLONS_PER_DAY,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
@@ -80,6 +83,7 @@ FLUME_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
         translation_key="last_30_days",
         suggested_display_precision=2,
         native_unit_of_measurement=f"{UnitOfVolume.GALLONS}/mo",
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 )

--- a/homeassistant/components/flume/sensor.py
+++ b/homeassistant/components/flume/sensor.py
@@ -83,7 +83,6 @@ FLUME_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
         translation_key="last_30_days",
         suggested_display_precision=2,
         native_unit_of_measurement=f"{UnitOfVolume.GALLONS}/mo",
-        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 )

--- a/tests/components/flume/conftest.py
+++ b/tests/components/flume/conftest.py
@@ -41,6 +41,7 @@ SENSOR_DEVICE = {
     "type": 2,  # Sensor
     "location": {
         "name": "Sensor Location",
+        "tz": "America/New_York",
     },
     "name": "Flume Sensor",
     "connected": True,

--- a/tests/components/flume/snapshots/test_sensor.ambr
+++ b/tests/components/flume/snapshots/test_sensor.ambr
@@ -1,0 +1,413 @@
+# serializer version: 1
+# name: test_sensors[sensor.flume_sensor_sensor_location_24_hours-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flume_sensor_sensor_location_24_hours',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': '24 hours',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLUME_FLOW_RATE: 'volume_flow_rate'>,
+    'original_icon': None,
+    'original_name': '24 hours',
+    'platform': 'flume',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_24_hrs',
+    'unique_id': 'last_24_hrs_1234',
+    'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_DAY: 'gal/d'>,
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_24_hours-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Flume API',
+      'device_class': 'volume_flow_rate',
+      'friendly_name': 'Flume Sensor Sensor Location 24 hours',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_DAY: 'gal/d'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flume_sensor_sensor_location_24_hours',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20.4',
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_30_days-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flume_sensor_sensor_location_30_days',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': '30 days',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': '30 days',
+    'platform': 'flume',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_30_days',
+    'unique_id': 'last_30_days_1234',
+    'unit_of_measurement': 'gal/mo',
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_30_days-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Flume API',
+      'friendly_name': 'Flume Sensor Sensor Location 30 days',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'gal/mo',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flume_sensor_sensor_location_30_days',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '150.8',
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_60_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flume_sensor_sensor_location_60_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': '60 minutes',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLUME_FLOW_RATE: 'volume_flow_rate'>,
+    'original_icon': None,
+    'original_name': '60 minutes',
+    'platform': 'flume',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_60_min',
+    'unique_id': 'last_60_min_1234',
+    'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_HOUR: 'gal/h'>,
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_60_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Flume API',
+      'device_class': 'volume_flow_rate',
+      'friendly_name': 'Flume Sensor Sensor Location 60 minutes',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_HOUR: 'gal/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flume_sensor_sensor_location_60_minutes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.5',
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLUME_FLOW_RATE: 'volume_flow_rate'>,
+    'original_icon': None,
+    'original_name': 'Current',
+    'platform': 'flume',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_interval',
+    'unique_id': 'current_interval_1234',
+    'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_MINUTE: 'gal/min'>,
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Flume API',
+      'device_class': 'volume_flow_rate',
+      'friendly_name': 'Flume Sensor Sensor Location Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_MINUTE: 'gal/min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.23',
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current day',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Current day',
+    'platform': 'flume',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'today',
+    'unique_id': 'today_1234',
+    'unit_of_measurement': <UnitOfVolume.GALLONS: 'gal'>,
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Flume API',
+      'device_class': 'water',
+      'friendly_name': 'Flume Sensor Sensor Location Current day',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfVolume.GALLONS: 'gal'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current_day',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.2',
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current_month-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current_month',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current month',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Current month',
+    'platform': 'flume',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'month_to_date',
+    'unique_id': 'month_to_date_1234',
+    'unit_of_measurement': <UnitOfVolume.GALLONS: 'gal'>,
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current_month-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Flume API',
+      'device_class': 'water',
+      'friendly_name': 'Flume Sensor Sensor Location Current month',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfVolume.GALLONS: 'gal'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current_month',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.1',
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current_week-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current_week',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current week',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Current week',
+    'platform': 'flume',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'week_to_date',
+    'unique_id': 'week_to_date_1234',
+    'unit_of_measurement': <UnitOfVolume.GALLONS: 'gal'>,
+  })
+# ---
+# name: test_sensors[sensor.flume_sensor_sensor_location_current_week-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Flume API',
+      'device_class': 'water',
+      'friendly_name': 'Flume Sensor Sensor Location Current week',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfVolume.GALLONS: 'gal'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.flume_sensor_sensor_location_current_week',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.5',
+  })
+# ---

--- a/tests/components/flume/test_sensor.py
+++ b/tests/components/flume/test_sensor.py
@@ -1,0 +1,130 @@
+"""Test the flume sensor."""
+
+from unittest.mock import patch
+
+import pytest
+from requests_mock.mocker import Mocker
+
+from homeassistant.components.flume.const import DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import Platform, UnitOfVolume, UnitOfVolumeFlowRate
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+from .conftest import DEVICE_LIST, DEVICE_LIST_URL
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def platforms_fixture():
+    """Return the platforms to be loaded for this test."""
+    with patch("homeassistant.components.flume.PLATFORMS", [Platform.SENSOR]):
+        yield
+
+
+@pytest.mark.usefixtures("access_token")
+async def test_sensors(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+
+    # Add TZ to the device list from conftest
+    devices = [dict(device) for device in DEVICE_LIST]
+    for device in devices:
+        if "location" in device:
+            device["location"] = dict(device["location"])
+            device["location"]["tz"] = "America/New_York"
+
+    requests_mock.register_uri(
+        "GET",
+        DEVICE_LIST_URL,
+        status_code=200,
+        json={
+            "data": devices,
+        },
+    )
+
+    # Mock the data returned by PyFlume
+    flume_values = {
+        "current_interval": 1.23,
+        "month_to_date": 100.1,
+        "week_to_date": 50.5,
+        "today": 10.2,
+        "last_60_min": 5.5,
+        "last_24_hrs": 20.4,
+        "last_30_days": 150.8,
+    }
+
+    with patch("homeassistant.components.flume.sensor.FlumeData") as mock_flume_data:
+        instance = mock_flume_data.return_value
+        instance.values = flume_values
+        instance.update_force.return_value = None
+        instance.query_payload = {}
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+
+    # current_interval
+    entry = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "current_interval_1234"
+    )
+    state = hass.states.get(entry)
+    assert state.state == "1.23"
+    assert (
+        state.attributes["unit_of_measurement"]
+        == UnitOfVolumeFlowRate.GALLONS_PER_MINUTE
+    )
+    assert state.attributes["device_class"] == SensorDeviceClass.VOLUME_FLOW_RATE
+
+    # month_to_date
+    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "month_to_date_1234")
+    state = hass.states.get(entry)
+    assert state.state == "100.1"
+    assert state.attributes["unit_of_measurement"] == UnitOfVolume.GALLONS
+    assert state.attributes["device_class"] == SensorDeviceClass.WATER
+
+    # week_to_date
+    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "week_to_date_1234")
+    state = hass.states.get(entry)
+    assert state.state == "50.5"
+    assert state.attributes["unit_of_measurement"] == UnitOfVolume.GALLONS
+    assert state.attributes["device_class"] == SensorDeviceClass.WATER
+
+    # today
+    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "today_1234")
+    state = hass.states.get(entry)
+    assert state.state == "10.2"
+    assert state.attributes["unit_of_measurement"] == UnitOfVolume.GALLONS
+    assert state.attributes["device_class"] == SensorDeviceClass.WATER
+
+    # last_60_min
+    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "last_60_min_1234")
+    state = hass.states.get(entry)
+    assert state.state == "5.5"
+    assert (
+        state.attributes["unit_of_measurement"] == UnitOfVolumeFlowRate.GALLONS_PER_HOUR
+    )
+    assert state.attributes["device_class"] == SensorDeviceClass.VOLUME_FLOW_RATE
+
+    # last_24_hrs
+    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "last_24_hrs_1234")
+    state = hass.states.get(entry)
+    assert state.state == "20.4"
+    assert (
+        state.attributes["unit_of_measurement"] == UnitOfVolumeFlowRate.GALLONS_PER_DAY
+    )
+    assert state.attributes["device_class"] == SensorDeviceClass.VOLUME_FLOW_RATE
+
+    # last_30_days
+    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "last_30_days_1234")
+    state = hass.states.get(entry)
+    assert state.state == "150.8"
+    assert state.attributes["unit_of_measurement"] == "gal/mo"
+    assert "device_class" not in state.attributes

--- a/tests/components/flume/test_sensor.py
+++ b/tests/components/flume/test_sensor.py
@@ -3,18 +3,14 @@
 from unittest.mock import patch
 
 import pytest
-from requests_mock.mocker import Mocker
+from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.flume.const import DOMAIN
-from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import Platform, UnitOfVolume, UnitOfVolumeFlowRate
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-from .conftest import DEVICE_LIST, DEVICE_LIST_URL
-
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture(autouse=True)
@@ -24,32 +20,16 @@ def platforms_fixture():
         yield
 
 
-@pytest.mark.usefixtures("access_token")
+@pytest.mark.usefixtures("access_token", "device_list")
 async def test_sensors(
     hass: HomeAssistant,
-    requests_mock: Mocker,
     config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test sensors."""
     hass.config.units = US_CUSTOMARY_SYSTEM
 
-    # Add TZ to the device list from conftest
-    devices = [dict(device) for device in DEVICE_LIST]
-    for device in devices:
-        if "location" in device:
-            device["location"] = dict(device["location"])
-            device["location"]["tz"] = "America/New_York"
-
-    requests_mock.register_uri(
-        "GET",
-        DEVICE_LIST_URL,
-        status_code=200,
-        json={
-            "data": devices,
-        },
-    )
-
-    # Mock the data returned by PyFlume
     flume_values = {
         "current_interval": 1.23,
         "month_to_date": 100.1,
@@ -61,70 +41,9 @@ async def test_sensors(
     }
 
     with patch("homeassistant.components.flume.sensor.FlumeData") as mock_flume_data:
-        instance = mock_flume_data.return_value
-        instance.values = flume_values
-        instance.update_force.return_value = None
-        instance.query_payload = {}
+        mock_flume_data.return_value.values = flume_values
 
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    entity_registry = er.async_get(hass)
-
-    # current_interval
-    entry = entity_registry.async_get_entity_id(
-        "sensor", DOMAIN, "current_interval_1234"
-    )
-    state = hass.states.get(entry)
-    assert state.state == "1.23"
-    assert (
-        state.attributes["unit_of_measurement"]
-        == UnitOfVolumeFlowRate.GALLONS_PER_MINUTE
-    )
-    assert state.attributes["device_class"] == SensorDeviceClass.VOLUME_FLOW_RATE
-
-    # month_to_date
-    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "month_to_date_1234")
-    state = hass.states.get(entry)
-    assert state.state == "100.1"
-    assert state.attributes["unit_of_measurement"] == UnitOfVolume.GALLONS
-    assert state.attributes["device_class"] == SensorDeviceClass.WATER
-
-    # week_to_date
-    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "week_to_date_1234")
-    state = hass.states.get(entry)
-    assert state.state == "50.5"
-    assert state.attributes["unit_of_measurement"] == UnitOfVolume.GALLONS
-    assert state.attributes["device_class"] == SensorDeviceClass.WATER
-
-    # today
-    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "today_1234")
-    state = hass.states.get(entry)
-    assert state.state == "10.2"
-    assert state.attributes["unit_of_measurement"] == UnitOfVolume.GALLONS
-    assert state.attributes["device_class"] == SensorDeviceClass.WATER
-
-    # last_60_min
-    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "last_60_min_1234")
-    state = hass.states.get(entry)
-    assert state.state == "5.5"
-    assert (
-        state.attributes["unit_of_measurement"] == UnitOfVolumeFlowRate.GALLONS_PER_HOUR
-    )
-    assert state.attributes["device_class"] == SensorDeviceClass.VOLUME_FLOW_RATE
-
-    # last_24_hrs
-    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "last_24_hrs_1234")
-    state = hass.states.get(entry)
-    assert state.state == "20.4"
-    assert (
-        state.attributes["unit_of_measurement"] == UnitOfVolumeFlowRate.GALLONS_PER_DAY
-    )
-    assert state.attributes["device_class"] == SensorDeviceClass.VOLUME_FLOW_RATE
-
-    # last_30_days
-    entry = entity_registry.async_get_entity_id("sensor", DOMAIN, "last_30_days_1234")
-    state = hass.states.get(entry)
-    assert state.state == "150.8"
-    assert state.attributes["unit_of_measurement"] == "gal/mo"
-    assert "device_class" not in state.attributes
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The unit of measurement for the Flume **current interval** sensor has changed from `gal/m` to `gal/min` so it can be used as a standard volume flow rate sensor (for example, in the Energy Dashboard). The `last 60 minutes` and `last 24 hours` sensors now also expose the `volume_flow_rate` device class.

If you have long-term statistics for the **current interval** sensor, Home Assistant will warn you that the unit has changed. To keep your history, open **Developer tools → Statistics**, find the affected sensor, and use **Fix issue** to update the stored unit from `gal/m` to `gal/min`. No action is required for the `last 60 minutes` or `last 24 hours` sensors — their unit strings are unchanged.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the Flume integration sensors to use standardized units and device classes which will enable their use in the water section under the Energy Dashboard. 

Specifically:
- `current_interval`, `last_60_min`, and `last_24_hrs` now use `SensorDeviceClass.VOLUME_FLOW_RATE`.
- `current_interval` uses `UnitOfVolumeFlowRate.GALLONS_PER_MINUTE`.
- `last_60_min` uses `UnitOfVolumeFlowRate.GALLONS_PER_HOUR`.
- `last_24_hrs` uses `UnitOfVolumeFlowRate.GALLONS_PER_DAY`.
- Flow rate sensors previously had manually constructed unit strings (e.g., `gal/m`); these have been replaced with the appropriate constants.
- `last_30_days` cannot be changed to the Volume Flow Rate device class because there is no `per month` unit.
- Added test coverage for the Flume sensor platform in `tests/components/flume/test_sensor.py`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
