### PR TITLE
Bump python-duco-client to 0.3.5

### DIFF
--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "loggers": ["duco"],
   "quality_scale": "platinum",
-  "requirements": ["python-duco-client==0.3.4"],
+  "requirements": ["python-duco-client==0.3.5"],
   "zeroconf": [
     {
       "name": "duco [[][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][]].*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2578,7 +2578,7 @@ python-digitalocean==1.13.2
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.4
+python-duco-client==0.3.5
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2204,7 +2204,7 @@ python-citybikes==0.3.3
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.4
+python-duco-client==0.3.5
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2


### PR DESCRIPTION
## Proposed change

Bump `python-duco-client` from 0.3.4 to 0.3.5.

### What's new in 0.3.5

Add `temp` field to `NodeSensorInfo` — the Duco API returns a temperature reading for all node types (BOX, UCCO2, BSRH, etc.) when authenticated with a valid API key. The field is `float | None` and defaults to `None` when the API does not include a `Temp` key in the `Sensor` object.

Changelog: https://github.com/ronaldvdmeer/python-duco-client/releases/tag/v0.3.5
Diff: https://github.com/ronaldvdmeer/python-duco-client/compare/v0.3.4...v0.3.5

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect_pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
