### PR TITLE
Bump python-duco-client to 0.3.6

### DIFF
--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "loggers": ["duco"],
   "quality_scale": "platinum",
-  "requirements": ["python-duco-client==0.3.4"],
+  "requirements": ["python-duco-client==0.3.6"],
   "zeroconf": [
     {
       "name": "duco [[][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][]].*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2578,7 +2578,7 @@ python-digitalocean==1.13.2
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.4
+python-duco-client==0.3.6
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2204,7 +2204,7 @@ python-citybikes==0.3.3
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.4
+python-duco-client==0.3.6
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/tests/components/duco/snapshots/test_diagnostics.ambr
+++ b/tests/components/duco/snapshots/test_diagnostics.ambr
@@ -45,6 +45,7 @@
           'iaq_co2': None,
           'iaq_rh': None,
           'rh': None,
+          'temp': None,
         }),
         'ventilation': dict({
           'flow_lvl_tgt': 0,
@@ -70,6 +71,7 @@
           'iaq_co2': None,
           'iaq_rh': 85,
           'rh': 42.0,
+          'temp': None,
         }),
         'ventilation': dict({
           'flow_lvl_tgt': None,
@@ -95,6 +97,7 @@
           'iaq_co2': 80,
           'iaq_rh': None,
           'rh': None,
+          'temp': None,
         }),
         'ventilation': dict({
           'flow_lvl_tgt': None,
@@ -120,6 +123,7 @@
           'iaq_co2': None,
           'iaq_rh': 90,
           'rh': 61.0,
+          'temp': None,
         }),
         'ventilation': dict({
           'flow_lvl_tgt': None,


### PR DESCRIPTION
Bump python-duco-client from 0.3.4 to 0.3.6.

- 0.3.5: Add temp field to NodeSensorInfo
- 0.3.6: Add API key authentication (DucoClient handles key generation automatically)

Changelog: https://github.com/ronaldvdmeer/python-duco-client/releases/tag/v0.3.6
Diff: https://github.com/ronaldvdmeer/python-duco-client/compare/v0.3.4...v0.3.6

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The manifest file has all fields filled out correctly. Updated and included derived files by running: python3 -m script.hassfest
- [x] New or updated dependencies have been added to requirements_all.txt. Updated by running python3 -m script.gen_requirements_all
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.
