### PR TITLE
Remove name from config flow of Notifications for Android TV /Fire TV

### DIFF
--- a/homeassistant/components/nfandroidtv/__init__.py
+++ b/homeassistant/components/nfandroidtv/__init__.py
@@ -1,7 +1,7 @@
 """The NFAndroidTV integration."""
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.typing import ConfigType
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass,
             Platform.NOTIFY,
             DOMAIN,
-            dict(entry.data),
+            {CONF_NAME: entry.title, **entry.data},
             hass.data[DATA_HASS_CONFIG],
         )
     )

--- a/homeassistant/components/nfandroidtv/config_flow.py
+++ b/homeassistant/components/nfandroidtv/config_flow.py
@@ -29,7 +29,7 @@ class NFAndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             if not (error := await self._async_try_connect(user_input[CONF_HOST])):
                 return self.async_create_entry(
-                    title=DEFAULT_NAME,
+                    title=f"{DEFAULT_NAME} ({user_input[CONF_HOST]})",
                     data=user_input,
                 )
             errors["base"] = error

--- a/homeassistant/components/nfandroidtv/config_flow.py
+++ b/homeassistant/components/nfandroidtv/config_flow.py
@@ -9,7 +9,7 @@ from notifications_android_tv.notifications import ConnectError, Notifications
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST
 
 from .const import DEFAULT_NAME, DOMAIN
 
@@ -26,24 +26,17 @@ class NFAndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            self._async_abort_entries_match(
-                {CONF_HOST: user_input[CONF_HOST], CONF_NAME: user_input[CONF_NAME]}
-            )
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             if not (error := await self._async_try_connect(user_input[CONF_HOST])):
                 return self.async_create_entry(
-                    title=user_input[CONF_NAME],
+                    title=DEFAULT_NAME,
                     data=user_input,
                 )
             errors["base"] = error
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST): str,
-                    vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
-                }
-            ),
+            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
             errors=errors,
         )
 

--- a/tests/components/nfandroidtv/__init__.py
+++ b/tests/components/nfandroidtv/__init__.py
@@ -2,20 +2,14 @@
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST
 
 HOST = "1.2.3.4"
 NAME = "Android TV / Fire TV"
 
-CONF_DATA = {
-    CONF_HOST: HOST,
-    CONF_NAME: NAME,
-}
+CONF_DATA = {CONF_HOST: HOST}
 
-CONF_CONFIG_FLOW = {
-    CONF_HOST: HOST,
-    CONF_NAME: NAME,
-}
+CONF_CONFIG_FLOW = {CONF_HOST: HOST}
 
 
 async def _create_mocked_tv(raise_exception=False):

--- a/tests/components/nfandroidtv/__init__.py
+++ b/tests/components/nfandroidtv/__init__.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 from homeassistant.const import CONF_HOST
 
 HOST = "1.2.3.4"
-NAME = "Android TV / Fire TV"
+NAME = "Android TV / Fire TV (1.2.3.4)"
 
 CONF_DATA = {CONF_HOST: HOST}
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes name from config flow


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168940
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
