### PR TITLE
Add departure_delay sensor to Israel Rail

### DIFF
--- a/homeassistant/components/israel_rail/coordinator.py
+++ b/homeassistant/components/israel_rail/coordinator.py
@@ -25,6 +25,7 @@ class DataConnection:
     """A connection data class."""
 
     departure: datetime | None
+    departure_delay: int | None
     platform: str
     start: str
     destination: str
@@ -83,6 +84,7 @@ class IsraelRailDataUpdateCoordinator(DataUpdateCoordinator[list[DataConnection]
         return [
             DataConnection(
                 departure=departure_time(train_routes[i]),
+                departure_delay=train_routes[i].trains[0].departure_delay,
                 train_number=train_routes[i].trains[0].data["trainNumber"],
                 platform=train_routes[i].trains[0].platform,
                 trains=len(train_routes[i].trains),

--- a/homeassistant/components/israel_rail/sensor.py
+++ b/homeassistant/components/israel_rail/sensor.py
@@ -12,7 +12,9 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -66,6 +68,15 @@ SENSORS: tuple[IsraelRailSensorEntityDescription, ...] = (
         key="train_number",
         translation_key="train_number",
         value_fn=lambda data_connection: data_connection.train_number,
+    ),
+    IsraelRailSensorEntityDescription(
+        key="departure_delay",
+        translation_key="departure_delay",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        value_fn=lambda data_connection: data_connection.departure_delay,
     ),
 )
 

--- a/homeassistant/components/israel_rail/strings.json
+++ b/homeassistant/components/israel_rail/strings.json
@@ -28,6 +28,9 @@
       "departure2": {
         "name": "Departure +2"
       },
+      "departure_delay": {
+        "name": "Departure delay"
+      },
       "platform": {
         "name": "Platform"
       },

--- a/tests/components/israel_rail/conftest.py
+++ b/tests/components/israel_rail/conftest.py
@@ -71,21 +71,23 @@ def get_train_route(
     dest_platform: str = "2",
     origin_station: str = "3500",
     destination_station: str = "3700",
+    departure_delay: int = 0,
 ) -> TrainRoute:
     """Build a TrainRoute of the israelrail API."""
-    return TrainRoute(
-        [
-            {
-                "orignStation": origin_station,
-                "destinationStation": destination_station,
-                "departureTime": departure_time,
-                "arrivalTime": arrival_time,
-                "originPlatform": origin_platform,
-                "destPlatform": dest_platform,
-                "trainNumber": train_number,
-            }
+    train_data: dict = {
+        "orignStation": origin_station,
+        "destinationStation": destination_station,
+        "departureTime": departure_time,
+        "arrivalTime": arrival_time,
+        "originPlatform": origin_platform,
+        "destPlatform": dest_platform,
+        "trainNumber": train_number,
+    }
+    if departure_delay:
+        train_data["etaDiffTimes"] = [
+            {"stationId": origin_station, "difMin": departure_delay}
         ]
-    )
+    return TrainRoute([train_data])
 
 
 TRAINS = [

--- a/tests/components/israel_rail/conftest.py
+++ b/tests/components/israel_rail/conftest.py
@@ -71,7 +71,7 @@ def get_train_route(
     dest_platform: str = "2",
     origin_station: str = "3500",
     destination_station: str = "3700",
-    departure_delay: int = 0,
+    departure_delay: int | None = None,
 ) -> TrainRoute:
     """Build a TrainRoute of the israelrail API."""
     train_data: dict = {
@@ -83,7 +83,7 @@ def get_train_route(
         "destPlatform": dest_platform,
         "trainNumber": train_number,
     }
-    if departure_delay:
+    if departure_delay is not None:
         train_data["etaDiffTimes"] = [
             {"stationId": origin_station, "difMin": departure_delay}
         ]

--- a/tests/components/israel_rail/snapshots/test_sensor.ambr
+++ b/tests/components/israel_rail/snapshots/test_sensor.ambr
@@ -155,6 +155,65 @@
     'state': '2021-10-10T10:30:10+00:00',
   })
 # ---
+# name: test_valid_config[sensor.mock_title_departure_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_departure_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Departure delay',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Departure delay',
+    'platform': 'israel_rail',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'departure_delay',
+    'unique_id': 'באר יעקב אשקלון_departure_delay',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_valid_config[sensor.mock_title_departure_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Israel rail.',
+      'device_class': 'duration',
+      'friendly_name': 'Mock Title Departure delay',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_departure_delay',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_valid_config[sensor.mock_title_platform-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/israel_rail/test_sensor.py
+++ b/tests/components/israel_rail/test_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import goto_future, init_integration
-from .conftest import TRAINS, get_time
+from .conftest import TRAINS, get_time, get_train_route
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -37,7 +37,7 @@ async def test_update_train(
 ) -> None:
     """Ensure the train data is updated."""
     await init_integration(hass, mock_config_entry)
-    assert len(hass.states.async_entity_ids()) == 6
+    assert len(hass.states.async_entity_ids()) == 7
     departure_sensor = hass.states.get("sensor.mock_title_departure")
     expected_time = get_time(10, 10)
     assert departure_sensor.state == expected_time
@@ -46,7 +46,7 @@ async def test_update_train(
 
     await goto_future(hass, freezer)
 
-    assert len(hass.states.async_entity_ids()) == 6
+    assert len(hass.states.async_entity_ids()) == 7
     departure_sensor = hass.states.get("sensor.mock_title_departure")
     expected_time = get_time(10, 20)
     assert departure_sensor.state == expected_time
@@ -60,10 +60,10 @@ async def test_fail_query(
 ) -> None:
     """Ensure the integration handles query failures."""
     await init_integration(hass, mock_config_entry)
-    assert len(hass.states.async_entity_ids()) == 6
+    assert len(hass.states.async_entity_ids()) == 7
     mock_israelrail.query.side_effect = Exception("error")
     await goto_future(hass, freezer)
-    assert len(hass.states.async_entity_ids()) == 6
+    assert len(hass.states.async_entity_ids()) == 7
     departure_sensor = hass.states.get("sensor.mock_title_departure")
     assert departure_sensor.state == STATE_UNAVAILABLE
 
@@ -76,7 +76,7 @@ async def test_no_departures(
 ) -> None:
     """Test handling when there are no departures available."""
     await init_integration(hass, mock_config_entry)
-    assert len(hass.states.async_entity_ids()) == 6
+    assert len(hass.states.async_entity_ids()) == 7
 
     # Simulate no departures (e.g., after-hours)
     mock_israelrail.query.return_value = []
@@ -84,7 +84,7 @@ async def test_no_departures(
     await goto_future(hass, freezer)
 
     # All sensors should still exist
-    assert len(hass.states.async_entity_ids()) == 6
+    assert len(hass.states.async_entity_ids()) == 7
 
     # Departure sensors should have unknown state (None)
     departure_sensor = hass.states.get("sensor.mock_title_departure")
@@ -106,3 +106,32 @@ async def test_no_departures(
 
     train_number_sensor = hass.states.get("sensor.mock_title_train_number")
     assert train_number_sensor.state == STATE_UNKNOWN
+
+
+async def test_departure_delay(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_israelrail: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Ensure departure_delay is exposed as a sensor."""
+    await init_integration(hass, mock_config_entry)
+
+    departure_delay_sensor = hass.states.get("sensor.mock_title_departure_delay")
+    assert departure_delay_sensor is not None
+    assert departure_delay_sensor.state == "0"
+
+    mock_israelrail.query.return_value = [
+        get_train_route(
+            train_number="1234",
+            departure_time=get_time(10, 10),
+            arrival_time=get_time(10, 30),
+            departure_delay=7,
+        ),
+        *TRAINS[1:],
+    ]
+
+    await goto_future(hass, freezer)
+
+    departure_delay_sensor = hass.states.get("sensor.mock_title_departure_delay")
+    assert departure_delay_sensor.state == "7"

--- a/tests/components/israel_rail/test_sensor.py
+++ b/tests/components/israel_rail/test_sensor.py
@@ -107,6 +107,9 @@ async def test_no_departures(
     train_number_sensor = hass.states.get("sensor.mock_title_train_number")
     assert train_number_sensor.state == STATE_UNKNOWN
 
+    departure_delay_sensor = hass.states.get("sensor.mock_title_departure_delay")
+    assert departure_delay_sensor.state == STATE_UNKNOWN
+
 
 async def test_departure_delay(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expose the departure delay (in minutes) for the next train as a new `departure_delay` sensor.         
   
The upstream `israel-rail-api` library v0.1.5 now extracts a `departure_delay` value from the API's `etaDiffTimes` array on each `TrainRoutePart`. This PR wires that field through to a new sensor:                                                                   
                  
- `DataConnection` gains a `departure_delay: int | None` field, populated from `train_routes[i].trains[0].departure_delay`.
- A new `SensorEntityDescription` exposes it with `SensorDeviceClass.DURATION`, `UnitOfTime.MINUTES`, `SensorStateClass.MEASUREMENT`, and `suggested_display_precision=0` so the UI renders the value as whole minutes.
- Translation string and entity tests (including a snapshot update) added.    

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
 
Library bump diff: https://github.com/sh0oki/israel-rail-api/compare/v0.1.4...v0.1.5

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
