### PR TITLE
Register Hive Hub MAC address as device connection

### DIFF
--- a/homeassistant/components/hive/__init__.py
+++ b/homeassistant/components/hive/__init__.py
@@ -46,14 +46,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: HiveConfigEntry) -> bool
     except HiveReauthRequired as err:
         raise ConfigEntryAuthFailed from err
 
+    hub_data = devices["parent"][0]
+    connections: set[tuple[str, str]] = set()
+    if mac := hub_data.get("macAddress"):
+        connections.add((dr.CONNECTION_NETWORK_MAC, dr.format_mac(mac)))
+
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, devices["parent"][0]["device_id"])},
-        name=devices["parent"][0]["hiveName"],
-        model=devices["parent"][0]["deviceData"]["model"],
-        sw_version=devices["parent"][0]["deviceData"]["version"],
-        manufacturer=devices["parent"][0]["deviceData"]["manufacturer"],
+        identifiers={(DOMAIN, hub_data["device_id"])},
+        connections=connections,
+        name=hub_data["hiveName"],
+        model=hub_data["deviceData"]["model"],
+        sw_version=hub_data["deviceData"]["version"],
+        manufacturer=hub_data["deviceData"]["manufacturer"],
     )
 
     await hass.config_entries.async_forward_entry_setups(

--- a/tests/components/hive/test_init.py
+++ b/tests/components/hive/test_init.py
@@ -37,9 +37,7 @@ def _make_mock_hive(hub_extra: dict) -> MagicMock:
     """Return a mocked Hive instance whose startSession returns a minimal devices dict."""
     hub_data = {**_HUB_BASE, **hub_extra}
     mock_hive = MagicMock()
-    mock_hive.session.startSession = AsyncMock(
-        return_value={"parent": [hub_data]}
-    )
+    mock_hive.session.startSession = AsyncMock(return_value={"parent": [hub_data]})
     return mock_hive
 
 
@@ -63,9 +61,7 @@ async def test_hub_device_registers_mac_connection(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "hive-hub-id")}
-    )
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "hive-hub-id")})
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, "00:1c:2b:1c:2e:68") in device.connections
 
@@ -90,9 +86,7 @@ async def test_hub_device_no_mac_connection_when_absent(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "hive-hub-id")}
-    )
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "hive-hub-id")})
     assert device is not None
     assert not any(
         conn_type == dr.CONNECTION_NETWORK_MAC for conn_type, _ in device.connections

--- a/tests/components/hive/test_init.py
+++ b/tests/components/hive/test_init.py
@@ -1,0 +1,99 @@
+"""Tests for the Hive integration __init__."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.hive.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+_ENTRY_DATA = {
+    CONF_USERNAME: "user@example.com",
+    CONF_PASSWORD: "password",
+    "tokens": {
+        "AuthenticationResult": {
+            "AccessToken": "mock-access-token",
+            "RefreshToken": "mock-refresh-token",
+        },
+        "ChallengeName": "SUCCESS",
+    },
+}
+
+_HUB_BASE = {
+    "device_id": "hive-hub-id",
+    "hiveName": "Hive Hub",
+    "deviceData": {
+        "model": "Hub",
+        "version": "1.2.3",
+        "manufacturer": "Hive",
+        "online": True,
+    },
+}
+
+
+def _make_mock_hive(hub_extra: dict) -> MagicMock:
+    """Return a mocked Hive instance whose startSession returns a minimal devices dict."""
+    hub_data = {**_HUB_BASE, **hub_extra}
+    mock_hive = MagicMock()
+    mock_hive.session.startSession = AsyncMock(
+        return_value={"parent": [hub_data]}
+    )
+    return mock_hive
+
+
+async def test_hub_device_registers_mac_connection(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Hub device entry includes a MAC connection when macAddress is present."""
+    entry = MockConfigEntry(domain=DOMAIN, data=_ENTRY_DATA)
+    entry.add_to_hass(hass)
+
+    mock_hive = _make_mock_hive({"macAddress": "00:1C:2B:1C:2E:68"})
+
+    with (
+        patch(
+            "homeassistant.components.hive.Hive",
+            return_value=mock_hive,
+        ),
+        patch("homeassistant.components.hive.aiohttp_client.async_get_clientsession"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "hive-hub-id")}
+    )
+    assert device is not None
+    assert (dr.CONNECTION_NETWORK_MAC, "00:1c:2b:1c:2e:68") in device.connections
+
+
+async def test_hub_device_no_mac_connection_when_absent(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Hub device entry has no MAC connection when macAddress is absent."""
+    entry = MockConfigEntry(domain=DOMAIN, data=_ENTRY_DATA)
+    entry.add_to_hass(hass)
+
+    mock_hive = _make_mock_hive({})  # no macAddress key
+
+    with (
+        patch(
+            "homeassistant.components.hive.Hive",
+            return_value=mock_hive,
+        ),
+        patch("homeassistant.components.hive.aiohttp_client.async_get_clientsession"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "hive-hub-id")}
+    )
+    assert device is not None
+    assert not any(
+        conn_type == dr.CONNECTION_NETWORK_MAC for conn_type, _ in device.connections
+    )


### PR DESCRIPTION
## Proposed change

The Hive integration creates a device registry entry for the Hive Hub but does not register its MAC address as a connection. This prevents Home Assistant from deduplicating the Hive Hub with device entries created by network integrations (e.g. UniFi) that discover the same physical hardware by MAC address.

The `apyhiveapi` library already exposes the MAC at `devices["parent"][0]["macAddress"]`. This PR passes that value through to `async_get_or_create` via the `connections` argument (using `dr.format_mac` to normalise it), with a graceful fallback when the field is absent.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr