### PR TITLE
fix: the owntracks webhook endpoint at __init__ in __init__.py

### DIFF
--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -2,11 +2,12 @@
 # pylint: disable=hass-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from collections import defaultdict
+import hmac
 import json
 import logging
 import re
 
-from aiohttp import web
+from aiohttp import web, BasicAuth
 import voluptuous as vol
 
 from homeassistant.components import cloud, mqtt, webhook
@@ -164,6 +165,15 @@ async def handle_webhook(
     """
     context = hass.data[DOMAIN]["context"]
     topic_base = re.sub("/#$", "", context.mqtt_topic)
+
+    # Enforce HTTP Basic Auth before processing when secret is a shared string
+    if context.secret and isinstance(context.secret, str):
+        try:
+            basic_auth = BasicAuth.decode(request.headers.get("Authorization", ""))
+        except ValueError:
+            return web.Response(status=401)
+        if not hmac.compare_digest(basic_auth.password, context.secret):
+            return web.Response(status=401)
 
     try:
         message = await request.json()


### PR DESCRIPTION
## Summary
Fix high severity security issue in `homeassistant/components/owntracks/__init__.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `homeassistant/components/owntracks/__init__.py:169` |

**Description**: The OwnTracks webhook endpoint at __init__.py:169 parses incoming JSON location data from mobile devices without confirmed authentication enforcement prior to processing. The Emulated Hue API at hue_api.py:167 and hue_api.py:381 is designed to respond to Alexa and Google Home discovery on the local network and may be accessible to any device on the network without authentication. If authentication is not enforced before JSON parsing and processing, unauthorized parties can inject false location data or manipulate smart home device states.

## Changes
- `homeassistant/components/owntracks/init.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
