### PR TITLE
fix: the remote_calendar/client in client.py

### DIFF
--- a/homeassistant/components/remote_calendar/client.py
+++ b/homeassistant/components/remote_calendar/client.py
@@ -12,6 +12,10 @@ async def get_calendar(
     """Make an HTTP GET request using Home Assistant's async HTTPX client with timeout."""
     auth: Auth | None = None
     if username is not None and password is not None:
+        if not url.lower().startswith("https://"):
+            raise ValueError(
+                "Basic authentication requires HTTPS to protect credentials"
+            )
         auth = BasicAuth(username, password)
 
     return await client.get(


### PR DESCRIPTION
## Summary
Fix high severity security issue in `homeassistant/components/remote_calendar/client.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `homeassistant/components/remote_calendar/client.py:3` |

**Description**: The remote_calendar/client.py and generic/camera.py components use HTTP Basic Authentication to connect to remote calendar servers and IP camera streams respectively. Basic Auth encodes credentials in Base64 without encryption. If the connection uses HTTP rather than HTTPS, credentials are transmitted in cleartext. The generic camera component is particularly at risk because users commonly configure budget IP cameras using HTTP URLs with Basic Auth, which is a widespread real-world configuration.

## Changes
- `homeassistant/components/remote_calendar/client.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
