### PR TITLE
Fetch air-Q device info in coordinator's `_async_setup`

### DIFF
--- a/homeassistant/components/airq/coordinator.py
+++ b/homeassistant/components/airq/coordinator.py
@@ -48,29 +48,25 @@ class AirQCoordinator(DataUpdateCoordinator):
         self.device_info = DeviceInfo(
             manufacturer=MANUFACTURER,
             identifiers={(DOMAIN, self.device_id)},
+            serial_number=self.device_id,
         )
         self.clip_negative = clip_negative
         self.return_average = return_average
 
+    async def _async_setup(self) -> None:
+        """Fetch device info from the device."""
+        info = await self.airq.fetch_device_info()
+        self.device_info.update(
+            DeviceInfo(
+                name=info["name"],
+                model=info["model"],
+                sw_version=info["sw_version"],
+                hw_version=info["hw_version"],
+            )
+        )
+
     async def _async_update_data(self) -> dict:
         """Fetch the data from the device."""
-        if "name" not in self.device_info:
-            _LOGGER.debug(
-                "'name' not found in AirQCoordinator.device_info, fetching from the device"
-            )
-            info = await self.airq.fetch_device_info()
-            self.device_info.update(
-                DeviceInfo(
-                    name=info["name"],
-                    model=info["model"],
-                    sw_version=info["sw_version"],
-                    hw_version=info["hw_version"],
-                )
-            )
-            _LOGGER.debug(
-                "Updated AirQCoordinator.device_info for 'name' %s",
-                self.device_info.get("name"),
-            )
         data: dict = await self.airq.get_latest_data(
             return_average=self.return_average,
             clip_negative_values=self.clip_negative,

--- a/homeassistant/components/airq/diagnostics.py
+++ b/homeassistant/components/airq/diagnostics.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from . import AirQConfigEntry
 
 REDACT_CONFIG = {CONF_PASSWORD, CONF_UNIQUE_ID, CONF_IP_ADDRESS, "title"}
-REDACT_DEVICE_INFO = {"identifiers", "name"}
+REDACT_DEVICE_INFO = {"identifiers", "name", "serial_number"}
 REDACT_COORDINATOR_DATA = {"DeviceID"}
 
 

--- a/tests/components/airq/snapshots/test_diagnostics.ambr
+++ b/tests/components/airq/snapshots/test_diagnostics.ambr
@@ -36,7 +36,7 @@
       'manufacturer': 'CorantGmbH',
       'model': 'model',
       'name': '**REDACTED**',
-      'serial_number': 'id',
+      'serial_number': '**REDACTED**',
       'sw_version': 'sw',
     }),
     'options': dict({

--- a/tests/components/airq/snapshots/test_diagnostics.ambr
+++ b/tests/components/airq/snapshots/test_diagnostics.ambr
@@ -36,6 +36,7 @@
       'manufacturer': 'CorantGmbH',
       'model': 'model',
       'name': '**REDACTED**',
+      'serial_number': 'id',
       'sw_version': 'sw',
     }),
     'options': dict({

--- a/tests/components/airq/test_coordinator.py
+++ b/tests/components/airq/test_coordinator.py
@@ -31,41 +31,21 @@ STATUS_WARMUP = {
 }
 
 
-async def test_logging_in_coordinator_first_update_data(
+async def test_async_setup_populates_device_info(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
     mock_airq: AsyncMock,
 ) -> None:
-    """Test that the first AirQCoordinator._async_update_data call logs necessary setup.
-
-    The fields of AirQCoordinator.device_info that are specific to the device are only
-    populated upon the first call to AirQCoordinator._async_update_data. The one field
-    which is actually necessary is 'name', and its absence is checked and logged,
-    as well as its being set.
-    """
-    caplog.set_level(logging.DEBUG)
+    """Test that AirQCoordinator._async_setup populates device_info from the device."""
     coordinator = AirQCoordinator(hass, MOCKED_ENTRY)
 
-    # check that the name _is_ missing
     assert "name" not in coordinator.device_info
 
-    # First call: fetch missing device info
-    await coordinator._async_update_data()
+    await coordinator._async_setup()
 
-    # check that the missing name is logged...
-    assert (
-        "'name' not found in AirQCoordinator.device_info, fetching from the device"
-        in caplog.text
-    )
-    # ...and fixed
     assert coordinator.device_info.get("name") == TEST_DEVICE_INFO["name"]
-    assert (
-        f"Updated AirQCoordinator.device_info for 'name' {TEST_DEVICE_INFO['name']}"
-        in caplog.text
-    )
-
-    # Also that no warming up sensors is found as none are mocked
-    assert "Following sensors are still warming up" not in caplog.text
+    assert coordinator.device_info.get("model") == TEST_DEVICE_INFO["model"]
+    assert coordinator.device_info.get("sw_version") == TEST_DEVICE_INFO["sw_version"]
+    assert coordinator.device_info.get("hw_version") == TEST_DEVICE_INFO["hw_version"]
 
 
 async def test_logging_in_coordinator_subsequent_update_data(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split out from #166342 per review.

Moves the air-Q device-info fetch (`name`, `model`, `sw_version`, `hw_version`)
from the lazy branch inside `AirQCoordinator._async_update_data` into an explicit
`_async_setup` hook. This runs once during config-entry setup, before the first
update, so `_async_update_data` has a single responsibility (fetch data) and
first-refresh latency no longer includes a separate device-info round-trip.

Also adds `serial_number=device_id` to the initial `DeviceInfo`, so the device
registry shows the serial.

`tests/components/airq/test_coordinator.py::test_async_setup_populates_device_info`
replaces the previous test that asserted log messages from `_async_update_data`
that no longer exist on that code path.

No user-visible behavior change.                                          


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
