### PR TITLE
Introduce AirQEntity base class for airq sensor and number platforms

### DIFF
--- a/homeassistant/components/airq/entity.py
+++ b/homeassistant/components/airq/entity.py
@@ -1,0 +1,19 @@
+"""Base entity for the air-Q integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import AirQCoordinator
+
+
+class AirQEntity(CoordinatorEntity[AirQCoordinator]):
+    """Base class for air-Q entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: AirQCoordinator, key: str) -> None:
+        """Initialize an air-Q entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.device_id}_{key}"

--- a/homeassistant/components/airq/number.py
+++ b/homeassistant/components/airq/number.py
@@ -12,9 +12,10 @@ from homeassistant.components.number import NumberEntity, NumberEntityDescriptio
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import AirQConfigEntry, AirQCoordinator
+from . import AirQConfigEntry
+from .coordinator import AirQCoordinator
+from .entity import AirQEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,10 +53,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AirQLEDBrightness(CoordinatorEntity[AirQCoordinator], NumberEntity):
+class AirQLEDBrightness(AirQEntity, NumberEntity):
     """Representation of the LEDs from a single AirQ."""
 
-    _attr_has_entity_name = True
+    entity_description: AirQBrightnessDescription
 
     def __init__(
         self,
@@ -63,11 +64,8 @@ class AirQLEDBrightness(CoordinatorEntity[AirQCoordinator], NumberEntity):
         description: AirQBrightnessDescription,
     ) -> None:
         """Initialize a single sensor."""
-        super().__init__(coordinator)
-        self.entity_description: AirQBrightnessDescription = description
-
-        self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
 
     @property
     def native_value(self) -> float:

--- a/homeassistant/components/airq/sensor.py
+++ b/homeassistant/components/airq/sensor.py
@@ -24,12 +24,13 @@ from homeassistant.const import (
     UnitOfSoundPressure,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import AirQConfigEntry, AirQCoordinator
+from . import AirQConfigEntry
 from .const import ACTIVITY_BECQUEREL_PER_CUBIC_METER
+from .coordinator import AirQCoordinator
+from .entity import AirQEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -445,10 +446,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AirQSensor(CoordinatorEntity, SensorEntity):
+class AirQSensor(AirQEntity, SensorEntity):
     """Representation of a Sensor."""
 
-    _attr_has_entity_name = True
+    entity_description: AirQEntityDescription
 
     def __init__(
         self,
@@ -456,15 +457,10 @@ class AirQSensor(CoordinatorEntity, SensorEntity):
         description: AirQEntityDescription,
     ) -> None:
         """Initialize a single sensor."""
-        super().__init__(coordinator)
-        self.entity_description: AirQEntityDescription = description
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
 
-        self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
-        self._attr_native_value = description.value(coordinator.data)
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._attr_native_value = self.entity_description.value(self.coordinator.data)
-        self.async_write_ha_state()
+    @property
+    def native_value(self) -> float | int | None:
+        """Return the sensor value."""
+        return self.entity_description.value(self.coordinator.data)

--- a/tests/components/airq/test_sensor.py
+++ b/tests/components/airq/test_sensor.py
@@ -1,0 +1,39 @@
+"""Tests for the air-Q sensor platform."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.components.airq.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_platform
+from .common import TEST_DEVICE_DATA, TEST_DEVICE_INFO
+
+
+async def test_sensor_state_updates_on_coordinator_refresh(
+    hass: HomeAssistant,
+    mock_airq: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that sensor state reflects coordinator.data after a refresh."""
+    await setup_platform(hass, Platform.SENSOR)
+
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{TEST_DEVICE_INFO['id']}_co2"
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == TEST_DEVICE_DATA["co2"]
+
+    new_co2 = TEST_DEVICE_DATA["co2"] + 1
+    mock_airq.get_latest_data.return_value = {"co2": new_co2, "Status": "OK"}
+    coordinator = hass.config_entries.async_entries(DOMAIN)[0].runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == new_co2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split out from #166342 per review.

Introduces a shared `homeassistant/components/airq/entity.py::AirQEntity` base
class and routes both `AirQSensor` and `AirQLEDBrightness` through it. Satisfies
the `common-modules` quality-scale rule and removes duplicated `_attr_device_info`
/ `_attr_unique_id` / `_attr_has_entity_name` boilerplate from each platform.

Also switches `AirQSensor` from the cached-value-plus-`_handle_coordinator_update`
pattern to a `native_value` `@property` that reads fresh from `coordinator.data`
on each access — idiomatic HA CoordinatorEntity usage, fewer attributes to keep
in sync.

No user-visible behavior change. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
