### PR TITLE
Refactor AirQ config flow tests

### DIFF
--- a/tests/components/airq/conftest.py
+++ b/tests/components/airq/conftest.py
@@ -5,7 +5,21 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from .common import TEST_BRIGHTNESS, TEST_DEVICE_DATA, TEST_DEVICE_INFO
+from homeassistant.components.airq.const import DOMAIN
+
+from .common import TEST_BRIGHTNESS, TEST_DEVICE_DATA, TEST_DEVICE_INFO, TEST_USER_DATA
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Create a mock config entry for air-Q."""
+    return MockConfigEntry(
+        data=TEST_USER_DATA,
+        domain=DOMAIN,
+        unique_id=TEST_DEVICE_INFO["id"],
+    )
 
 
 @pytest.fixture

--- a/tests/components/airq/test_config_flow.py
+++ b/tests/components/airq/test_config_flow.py
@@ -40,16 +40,6 @@ DEFAULT_OPTIONS = {
 }
 
 
-@pytest.fixture
-def mock_config_entry() -> MockConfigEntry:
-    """Create a mock config entry for air-Q."""
-    return MockConfigEntry(
-        data=TEST_USER_DATA,
-        domain=DOMAIN,
-        unique_id=TEST_DEVICE_INFO["id"],
-    )
-
-
 async def test_user_flow(
     hass: HomeAssistant,
     mock_airq: AsyncMock,

--- a/tests/components/airq/test_config_flow.py
+++ b/tests/components/airq/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the air-Q config flow."""
 
 from ipaddress import IPv4Address
-import logging
 from unittest.mock import AsyncMock
 
 from aioairq import InvalidAuth
@@ -41,106 +40,119 @@ DEFAULT_OPTIONS = {
 }
 
 
-async def test_form(
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Create a mock config entry for air-Q."""
+    return MockConfigEntry(
+        data=TEST_USER_DATA,
+        domain=DOMAIN,
+        unique_id=TEST_DEVICE_INFO["id"],
+    )
+
+
+async def test_user_flow(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
     mock_airq: AsyncMock,
 ) -> None:
-    """Test we get the form."""
-    caplog.set_level(logging.DEBUG)
+    """Test successful user config flow from start to entry creation."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         TEST_USER_DATA,
     )
     await hass.async_block_till_done()
-    assert f"Creating an entry for {TEST_DEVICE_INFO['name']}" in caplog.text
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == TEST_DEVICE_INFO["name"]
-    assert result2["data"] == TEST_USER_DATA
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_DEVICE_INFO["name"]
+    assert result["data"] == TEST_USER_DATA
+    assert result["result"].unique_id == TEST_DEVICE_INFO["id"]
 
 
-async def test_form_invalid_auth(hass: HomeAssistant, mock_airq: AsyncMock) -> None:
-    """Test we handle invalid auth."""
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (InvalidAuth, "invalid_auth"),
+        (ClientConnectionError, "cannot_connect"),
+    ],
+)
+async def test_user_flow_errors_recover(
+    hass: HomeAssistant,
+    mock_airq: AsyncMock,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Test user flow recovers from errors and completes successfully."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_airq.validate.side_effect = InvalidAuth
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], TEST_USER_DATA | {CONF_PASSWORD: "wrong_password"}
-    )
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_auth"}
-
-
-async def test_form_cannot_connect(hass: HomeAssistant, mock_airq: AsyncMock) -> None:
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    mock_airq.validate.side_effect = ClientConnectionError
-    result2 = await hass.config_entries.flow.async_configure(
+    mock_airq.validate.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], TEST_USER_DATA
     )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}
+
+    # Recover: correct input on retry
+    mock_airq.validate.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], TEST_USER_DATA
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_DEVICE_INFO["name"]
+    assert result["data"] == TEST_USER_DATA
 
 
-async def test_duplicate_error(hass: HomeAssistant, mock_airq: AsyncMock) -> None:
+async def test_duplicate_error(
+    hass: HomeAssistant,
+    mock_airq: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
     """Test that errors are shown when duplicates are added."""
-    MockConfigEntry(
-        data=TEST_USER_DATA,
-        domain=DOMAIN,
-        unique_id=TEST_DEVICE_INFO["id"],
-    ).add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], TEST_USER_DATA
     )
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "already_configured"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 @pytest.mark.parametrize(
     "user_input", [{}, {CONF_RETURN_AVERAGE: False}, {CONF_CLIP_NEGATIVE: False}]
 )
-async def test_options_flow(hass: HomeAssistant, user_input) -> None:
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    user_input: dict,
+) -> None:
     """Test that the options flow works."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, data=TEST_USER_DATA, unique_id=TEST_DEVICE_INFO["id"]
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
-    assert entry.options == {}
+    assert mock_config_entry.options == {}
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input=user_input
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == entry.options == DEFAULT_OPTIONS | user_input
+    assert result["data"] == mock_config_entry.options == DEFAULT_OPTIONS | user_input
 
 
 async def test_zeroconf_discovery(hass: HomeAssistant, mock_airq: AsyncMock) -> None:
@@ -192,25 +204,25 @@ async def test_zeroconf_discovery_errors(
     assert result["step_id"] == "discovery_confirm"
 
     mock_airq.validate.side_effect = side_effect
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_PASSWORD: "wrong_password"},
     )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": expected_error}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}
 
     # Recover: correct password on retry
     mock_airq.validate.side_effect = None
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
         {CONF_PASSWORD: "correct_password"},
     )
     await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "My air-Q"
-    assert result3["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My air-Q"
+    assert result["data"] == {
         CONF_IP_ADDRESS: "192.168.0.123",
         CONF_PASSWORD: "correct_password",
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split out from #166342 per review. Test-only refactor of `tests/components/airq/test_config_flow.py`; no integration code changes.

- `test_form` → `test_user_flow`; the docstring now reflects that the test goes all the way to `CREATE_ENTRY`, not just "getting the form".
- Assert `result["result"].unique_id` on the user-flow `CREATE_ENTRY`. Previously unchecked. 
- Merge `test_form_invalid_auth` and `test_form_cannot_connect` into one parametrized `test_user_flow_errors_recover` that also verifies the flow recovers to `CREATE_ENTRY` after the error.
- Introduce a `mock_config_entry` fixture, reused by the duplicate-entry and options-flow tests.
- Collapse `result{,2,3}` chains to a single reused `result` variable.
- `test_options_flow`: drop a stray user-flow `async_init` that was dead code (its result was overwritten before use), and type-annotate `user_input`.
- Drop `caplog` assertions on internal log messages.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
