### PR TITLE
Slow down Tractive API polling to avoid 429 too many requests

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -112,7 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
     except aiotractive.exceptions.TractiveError as error:
         await client.close()
         raise ConfigEntryNotReady from error
-    except Exception:
+    except ConfigEntryNotReady:
         await client.close()
         raise
 

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -80,6 +80,7 @@ type TractiveConfigEntry = ConfigEntry[TractiveData]
 
 async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> bool:
     """Set up tractive from a config entry."""
+    _LOGGER.warning("Tractive 429 fix v9")
     data = entry.data
 
     client = aiotractive.Tractive(
@@ -102,12 +103,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
 
     tractive = TractiveClient(hass, client, creds["user_id"], entry)
 
+    trackables = []
     try:
-        trackable_objects = await client.trackable_objects()
-        trackables = await asyncio.gather(
-            *(_generate_trackables(client, item) for item in trackable_objects)
-        )
+        for obj in await client.trackable_objects():
+            # To avoid hitting Tractive API rate limits, we add a small delay between requests
+            _LOGGER.debug(
+                "Waiting before fetching details for next trackable to avoid rate limits"
+            )
+            await asyncio.sleep(8)
+            trackables.append(await _generate_trackables(client, obj))
     except aiotractive.exceptions.TractiveError as error:
+        _LOGGER.warning("Error fetching trackable objects: %s", error)
         raise ConfigEntryNotReady from error
 
     # When the pet defined in Tractive has no tracker linked we get None as `trackable`.
@@ -164,12 +170,14 @@ async def _generate_trackables(
     tracker = client.tracker(trackable_data["device_id"])
     trackable_pet = client.trackable_object(trackable_data["_id"])
 
-    tracker_details, hw_info, pos_report, health_overview = await asyncio.gather(
-        tracker.details(),
-        tracker.hw_info(),
-        tracker.pos_report(),
-        trackable_pet.health_overview(),
-    )
+    # Sequential fetching with small delays to prevent HTTP 429 Rate Limits
+    tracker_details = await tracker.details()
+    await asyncio.sleep(1)
+    hw_info = await tracker.hw_info()
+    await asyncio.sleep(1)
+    pos_report = await tracker.pos_report()
+    await asyncio.sleep(1)
+    health_overview = await trackable_pet.health_overview()
 
     if not tracker_details.get("_id"):
         raise ConfigEntryNotReady(

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -80,7 +80,6 @@ type TractiveConfigEntry = ConfigEntry[TractiveData]
 
 async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> bool:
     """Set up tractive from a config entry."""
-    _LOGGER.warning("Tractive 429 fix v10")
     data = entry.data
 
     client = aiotractive.Tractive(
@@ -106,9 +105,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
     trackables = []
     try:
         for obj in await client.trackable_objects():
-            # To avoid hitting Tractive API rate limits,
-            # we add a small delay between requests
-            await asyncio.sleep(4)
+            # To avoid hitting Tractive API rate limits, we add a small
+            # delay between requests to fetch trackable details.
+            await asyncio.sleep(2)
             trackables.append(await _generate_trackables(client, obj))
     except aiotractive.exceptions.TractiveError as error:
         _LOGGER.warning("Error fetching trackable objects: %s", error)

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -110,6 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
             await asyncio.sleep(2)
             trackables.append(await _generate_trackables(client, obj))
     except aiotractive.exceptions.TractiveError as error:
+        await client.close()
         raise ConfigEntryNotReady from error
 
     # When the pet defined in Tractive has no tracker linked we get None as `trackable`.

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -112,6 +112,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
     except aiotractive.exceptions.TractiveError as error:
         await client.close()
         raise ConfigEntryNotReady from error
+    except Exception:
+        await client.close()
+        raise
 
     # When the pet defined in Tractive has no tracker linked we get None as `trackable`.
     # So we have to remove None values from trackables list.

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -80,7 +80,7 @@ type TractiveConfigEntry = ConfigEntry[TractiveData]
 
 async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> bool:
     """Set up tractive from a config entry."""
-    _LOGGER.warning("Tractive 429 fix v9")
+    _LOGGER.warning("Tractive 429 fix v10")
     data = entry.data
 
     client = aiotractive.Tractive(
@@ -106,11 +106,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
     trackables = []
     try:
         for obj in await client.trackable_objects():
-            # To avoid hitting Tractive API rate limits, we add a small delay between requests
-            _LOGGER.debug(
-                "Waiting before fetching details for next trackable to avoid rate limits"
-            )
-            await asyncio.sleep(8)
+            # To avoid hitting Tractive API rate limits,
+            # we add a small delay between requests
+            await asyncio.sleep(4)
             trackables.append(await _generate_trackables(client, obj))
     except aiotractive.exceptions.TractiveError as error:
         _LOGGER.warning("Error fetching trackable objects: %s", error)
@@ -170,13 +168,10 @@ async def _generate_trackables(
     tracker = client.tracker(trackable_data["device_id"])
     trackable_pet = client.trackable_object(trackable_data["_id"])
 
-    # Sequential fetching with small delays to prevent HTTP 429 Rate Limits
+    # Sequential fetching to prevent HTTP 429 Rate Limits
     tracker_details = await tracker.details()
-    await asyncio.sleep(1)
     hw_info = await tracker.hw_info()
-    await asyncio.sleep(1)
     pos_report = await tracker.pos_report()
-    await asyncio.sleep(1)
     health_overview = await trackable_pet.health_overview()
 
     if not tracker_details.get("_id"):

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -110,7 +110,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
             await asyncio.sleep(2)
             trackables.append(await _generate_trackables(client, obj))
     except aiotractive.exceptions.TractiveError as error:
-        _LOGGER.warning("Error fetching trackable objects: %s", error)
         raise ConfigEntryNotReady from error
 
     # When the pet defined in Tractive has no tracker linked we get None as `trackable`.

--- a/tests/components/tractive/conftest.py
+++ b/tests/components/tractive/conftest.py
@@ -89,7 +89,10 @@ def mock_tractive_client() -> Generator[AsyncMock]:
         patch(
             "homeassistant.components.tractive.aiotractive.Tractive", autospec=True
         ) as mock_client,
-        patch("homeassistant.components.tractive.asyncio.sleep"),
+        patch(
+            "homeassistant.components.tractive.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
     ):
         client = mock_client.return_value
         client.authenticate.return_value = {"user_id": "12345"}

--- a/tests/components/tractive/conftest.py
+++ b/tests/components/tractive/conftest.py
@@ -89,6 +89,7 @@ def mock_tractive_client() -> Generator[AsyncMock]:
         patch(
             "homeassistant.components.tractive.aiotractive.Tractive", autospec=True
         ) as mock_client,
+        patch("homeassistant.components.tractive.asyncio.sleep"),
     ):
         client = mock_client.return_value
         client.authenticate.return_value = {"user_id": "12345"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If more than two trackers are configured in a Tractive account, a 429 "too many requests" error often occurs when initializing the integration.
This change slows down requests. Additionally, `aiotractive` has made changes to the retry method, which now waits longer before retrying the request https://github.com/home-assistant/core/pull/169059

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162135
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
