### PR TITLE
Refactor button platform to use indevolt-api 1.4.2

### DIFF
--- a/homeassistant/components/indevolt/button.py
+++ b/homeassistant/components/indevolt/button.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Final
 
+from indevolt_api import IndevoltRealtimeAction
+
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -66,5 +68,4 @@ class IndevoltButtonEntity(IndevoltEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle the button press."""
-
-        await self.coordinator.async_execute_realtime_action([0, 0, 0])
+        await self.coordinator.async_realtime_action(IndevoltRealtimeAction.STOP)

--- a/homeassistant/components/indevolt/const.py
+++ b/homeassistant/components/indevolt/const.py
@@ -16,7 +16,7 @@ ENERGY_MODE_READ_KEY: Final = "7101"
 ENERGY_MODE_WRITE_KEY: Final = "47005"
 PORTABLE_MODE: Final = 0
 
-# API write key and value for real-time control mode
+# Value for real-time control mode
 REALTIME_ACTION_MODE: Final = 4
 
 # API key fields

--- a/homeassistant/components/indevolt/const.py
+++ b/homeassistant/components/indevolt/const.py
@@ -17,7 +17,6 @@ ENERGY_MODE_WRITE_KEY: Final = "47005"
 PORTABLE_MODE: Final = 0
 
 # API write key and value for real-time control mode
-REALTIME_ACTION_KEY: Final = "47015"
 REALTIME_ACTION_MODE: Final = 4
 
 # API key fields

--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -148,18 +148,12 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def async_realtime_action(
         self,
         action_code: IndevoltRealtimeAction,
-        power: int = 0,
-        target_soc: int = 0,
     ) -> None:
         """Switch mode, execute action, and refresh for real-time control."""
         await self.async_switch_energy_mode(REALTIME_ACTION_MODE, refresh=False)
 
         match action_code:
-            case IndevoltRealtimeAction.CHARGE:
-                success = await self.api.charge(power, target_soc)
-            case IndevoltRealtimeAction.DISCHARGE:
-                success = await self.api.discharge(power, target_soc)
-            case _:
+            case IndevoltRealtimeAction.STOP:
                 success = await self.api.stop()
 
         if not success:

--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any, Final
 
 from aiohttp import ClientError
-from indevolt_api import IndevoltAPI, TimeOutException
+from indevolt_api import IndevoltAPI, IndevoltRealtimeAction, TimeOutException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MODEL
@@ -24,7 +24,6 @@ from .const import (
     ENERGY_MODE_READ_KEY,
     ENERGY_MODE_WRITE_KEY,
     PORTABLE_MODE,
-    REALTIME_ACTION_KEY,
     REALTIME_ACTION_MODE,
     SENSOR_KEYS,
 )
@@ -146,19 +145,22 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if refresh:
                 await self.async_request_refresh()
 
-    async def async_execute_realtime_action(self, action: list[int]) -> None:
+    async def async_realtime_action(
+        self,
+        action_code: IndevoltRealtimeAction,
+        power: int = 0,
+        target_soc: int = 0,
+    ) -> None:
         """Switch mode, execute action, and refresh for real-time control."""
-
         await self.async_switch_energy_mode(REALTIME_ACTION_MODE, refresh=False)
 
-        try:
-            success = await self.async_push_data(REALTIME_ACTION_KEY, action)
-
-        except (DeviceTimeoutError, DeviceConnectionError) as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="failed_to_execute_realtime_action",
-            ) from err
+        match action_code:
+            case IndevoltRealtimeAction.CHARGE:
+                success = await self.api.charge(power, target_soc)
+            case IndevoltRealtimeAction.DISCHARGE:
+                success = await self.api.discharge(power, target_soc)
+            case _:
+                success = await self.api.stop()
 
         if not success:
             raise HomeAssistantError(

--- a/tests/components/indevolt/conftest.py
+++ b/tests/components/indevolt/conftest.py
@@ -87,6 +87,9 @@ def mock_indevolt(generation: int) -> Generator[AsyncMock]:
         client = mock_client.return_value
         client.fetch_data.return_value = fixture_data
         client.set_data.return_value = True
+        client.stop.return_value = True
+        client.charge.return_value = True
+        client.discharge.return_value = True
         client.get_config.return_value = {
             "device": {
                 "sn": device_info["sn"],

--- a/tests/components/indevolt/test_button.py
+++ b/tests/components/indevolt/test_button.py
@@ -1,8 +1,7 @@
 """Tests for the Indevolt button platform."""
 
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, patch
 
-from indevolt_api import TimeOutException
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -11,7 +10,6 @@ from homeassistant.components.indevolt.const import (
     ENERGY_MODE_READ_KEY,
     ENERGY_MODE_WRITE_KEY,
     PORTABLE_MODE,
-    REALTIME_ACTION_KEY,
     REALTIME_ACTION_MODE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
@@ -64,14 +62,11 @@ async def test_button_press_standby(
         blocking=True,
     )
 
-    # Verify set_data was called twice with correct parameters
-    assert mock_indevolt.set_data.call_count == 2
-    mock_indevolt.set_data.assert_has_calls(
-        [
-            call(ENERGY_MODE_WRITE_KEY, REALTIME_ACTION_MODE),
-            call(REALTIME_ACTION_KEY, [0, 0, 0]),
-        ]
+    # Verify set_data was called for mode switch and stop() was called
+    mock_indevolt.set_data.assert_called_once_with(
+        ENERGY_MODE_WRITE_KEY, REALTIME_ACTION_MODE
     )
+    mock_indevolt.stop.assert_called_once()
 
 
 @pytest.mark.parametrize("generation", [2], indirect=True)
@@ -98,8 +93,9 @@ async def test_button_press_standby_already_in_realtime_mode(
         blocking=True,
     )
 
-    # Verify set_data was called once with correct parameters
-    mock_indevolt.set_data.assert_called_once_with(REALTIME_ACTION_KEY, [0, 0, 0])
+    # Verify stop() was called and no mode switch was needed
+    mock_indevolt.set_data.assert_not_called()
+    mock_indevolt.stop.assert_called_once()
 
 
 @pytest.mark.parametrize("generation", [2], indirect=True)
@@ -112,8 +108,8 @@ async def test_button_press_standby_timeout_error(
     with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.BUTTON]):
         await setup_integration(hass, mock_config_entry)
 
-    # Simulate an API push failure
-    mock_indevolt.set_data.side_effect = TimeOutException("Timed out")
+    # Simulate stop() returning False (e.g. device rejected the command)
+    mock_indevolt.stop.return_value = False
 
     # Mock call to pause (dis)charging
     with pytest.raises(HomeAssistantError):

--- a/tests/components/indevolt/test_button.py
+++ b/tests/components/indevolt/test_button.py
@@ -99,16 +99,16 @@ async def test_button_press_standby_already_in_realtime_mode(
 
 
 @pytest.mark.parametrize("generation", [2], indirect=True)
-async def test_button_press_standby_timeout_error(
+async def test_button_press_standby_rejected_command(
     hass: HomeAssistant,
     mock_indevolt: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test pressing standby raises HomeAssistantError when the device times out."""
+    """Test pressing standby raises HomeAssistantError when the device rejects the command."""
     with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.BUTTON]):
         await setup_integration(hass, mock_config_entry)
 
-    # Simulate stop() returning False (e.g. device rejected the command)
+    # Simulate stop() returning False (device rejected the command)
     mock_indevolt.stop.return_value = False
 
     # Mock call to pause (dis)charging


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updated the existing integration to utilize the updated Indevolt API library. This prevent having changes to the buttons platform when the PR for actions (#163578) is merged. It is part of a bigger refactoring to move global magic constants into the API library. Changes:
- Leveraged new function to stop() the battery
- Altered exception handling to align on the new approach
- Adjusted test cases accordingly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
