### PR TITLE
Register MAC address connections on Synology DSM hub device

### DIFF
--- a/homeassistant/components/synology_dsm/entity.py
+++ b/homeassistant/components/synology_dsm/entity.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -56,6 +60,9 @@ class SynologyDSMBaseEntity[_CoordinatorT: SynologyDSMUpdateCoordinator[Any]](
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, information.serial)},
+            connections={
+                (CONNECTION_NETWORK_MAC, format_mac(mac)) for mac in network.macs
+            },
             name=network.hostname,
             manufacturer="Synology",
             model=information.model,

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import (
     mock_dsm_external_usb_devices_usb0,
@@ -356,3 +356,17 @@ async def test_no_external_usb(
     """Test Synology DSM without USB."""
     sensor = hass.states.get("sensor.nas_meontheinternet_com_usb_disk_1_device_size")
     assert sensor is None
+
+
+async def test_hub_device_info_mac_connections(
+    hass: HomeAssistant,
+    setup_dsm_with_usb: MagicMock,
+) -> None:
+    """Test that the hub DeviceInfo includes MAC address connections."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    assert device is not None
+    expected_connections = {
+        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(mac)) for mac in MACS
+    }
+    assert device.connections == expected_connections

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -366,8 +366,7 @@ async def test_hub_device_info_mac_connections(
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_device(identifiers={(DOMAIN, SERIAL)})
     assert device is not None
-    expected_connections = {
+    assert device.connections == {
         ("mac", "00:11:32:xx:xx:59"),
         ("mac", "00:11:32:xx:xx:5a"),
     }
-    assert device.connections == expected_connections

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -367,6 +367,7 @@ async def test_hub_device_info_mac_connections(
     device = dev_reg.async_get_device(identifiers={(DOMAIN, SERIAL)})
     assert device is not None
     expected_connections = {
-        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(mac)) for mac in MACS
+        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(MACS[0])),
+        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(MACS[1])),
     }
     assert device.connections == expected_connections

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -367,7 +367,7 @@ async def test_hub_device_info_mac_connections(
     device = dev_reg.async_get_device(identifiers={(DOMAIN, SERIAL)})
     assert device is not None
     expected_connections = {
-        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(MACS[0])),
-        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(MACS[1])),
+        ("mac", "00:11:32:xx:xx:59"),
+        ("mac", "00:11:32:xx:xx:5a"),
     }
     assert device.connections == expected_connections


### PR DESCRIPTION
## Proposed change

`SynologyDSMBaseEntity` was building `DeviceInfo` with only `identifiers={(DOMAIN, serial)}` and no `connections`. The Home Assistant device registry uses MAC address connections to merge device entries across integrations. Without them, integrations such as UniFi that register a `device_tracker` for the same NAS by MAC address would create a separate device entry instead of merging with the Synology hub.

This change adds a `connections` set to the hub's `DeviceInfo`, populated from `network.macs` (the same source already stored in `entry.data[CONF_MAC]` for SSDP compatibility). Each MAC is normalised via `format_mac`. The NAS may have multiple NICs (e.g. DS620slim has two ethernet ports), so all MACs are registered.

`SynologyDSMDeviceEntity` (drives/volumes) is left unchanged — those child devices are identified by `serial_deviceid` and have no independent MAC.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr