### PR TITLE
shelly: fix energy sensor jitter by applying an epsilon threshold

### DIFF
--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -106,6 +106,12 @@ RPC_RECONNECT_INTERVAL = 60
 # Shelly Air - Maximum work hours before lamp replacement
 SHAIR_MAX_WORK_HOURS: Final = 9000
 
+# Tolerance (in native Wh) below which a decrease on a TOTAL_INCREASING energy
+# sensor is treated as floating-point jitter and discarded, so the recorder
+# does not mistake it for a device reset (issue #166816). Drops to exactly 0.0
+# and drops >= this threshold still pass through as genuine resets.
+SH_ENERGY_EPSILON: Final = 0.001
+
 # Map Shelly input events
 INPUTS_EVENTS_DICT: Final = {
     "S": "single",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -42,7 +42,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.typing import StateType
 
-from .const import CONF_SLEEP_PERIOD, ROLE_GENERIC
+from .const import CONF_SLEEP_PERIOD, ROLE_GENERIC, SH_ENERGY_EPSILON
 from .coordinator import ShellyBlockCoordinator, ShellyConfigEntry, ShellyRpcCoordinator
 from .entity import (
     BlockEntityDescription,
@@ -70,6 +70,30 @@ from .utils import (
 )
 
 PARALLEL_UPDATES = 0
+
+
+def _filter_energy_jitter(last_value: StateType, new_value: StateType) -> StateType:
+    """Swallow sub-epsilon decreases on TOTAL_INCREASING energy sensors.
+
+    Shelly firmware occasionally reports an energy counter value that is a
+    few parts-per-million smaller than the previous reading (issue #166816).
+    The recorder interprets any decrease on a ``total_increasing`` sensor as
+    a device reset, which corrupts long-term statistics. This helper returns
+    the previous value when the decrease is strictly less than
+    ``SH_ENERGY_EPSILON`` so the false reset is suppressed. A drop to exactly
+    ``0.0`` and any drop greater than or equal to the epsilon pass through
+    unchanged so genuine resets are preserved.
+    """
+    if (
+        isinstance(last_value, (int, float))
+        and not isinstance(last_value, bool)
+        and isinstance(new_value, (int, float))
+        and not isinstance(new_value, bool)
+        and new_value != 0.0
+        and 0.0 < last_value - new_value < SH_ENERGY_EPSILON
+    ):
+        return last_value
+    return new_value
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -113,12 +137,22 @@ class RpcSensor(ShellyRpcAttributeEntity, SensorEntity):
         if not description.role:
             self.configure_translation_attributes()
 
+        self._prev_energy_value: StateType = None
+
     @property
     def native_value(self) -> StateType:
         """Return value of sensor."""
         attribute_value = self.attribute_value
 
         if not self.option_map:
+            if (
+                self.entity_description.state_class is SensorStateClass.TOTAL_INCREASING
+                and self.entity_description.device_class is SensorDeviceClass.ENERGY
+            ):
+                attribute_value = _filter_energy_jitter(
+                    self._prev_energy_value, attribute_value
+                )
+                self._prev_energy_value = attribute_value
             return attribute_value
 
         if not isinstance(attribute_value, str):
@@ -1812,11 +1846,23 @@ class BlockSensor(ShellyBlockAttributeEntity, SensorEntity):
         """Initialize sensor."""
         super().__init__(coordinator, block, attribute, description)
         self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._prev_energy_value: StateType = None
 
     @property
     def native_value(self) -> StateType:
         """Return value of sensor."""
-        return self.attribute_value
+        attribute_value = self.attribute_value
+
+        if (
+            self.entity_description.state_class is SensorStateClass.TOTAL_INCREASING
+            and self.entity_description.device_class is SensorDeviceClass.ENERGY
+        ):
+            attribute_value = _filter_energy_jitter(
+                self._prev_energy_value, attribute_value
+            )
+            self._prev_energy_value = attribute_value
+
+        return attribute_value
 
 
 class RestSensor(ShellyRestAttributeEntity, SensorEntity):

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1808,6 +1808,63 @@ async def test_rpc_switch_no_energy_returned_sensor(
     assert hass.states.get("sensor.test_name_test_switch_0_energy_consumed") is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_rpc_energy_sensor_jitter_is_filtered(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #166816 - sub-epsilon decreases must not corrupt total_increasing.
+
+    Simulates the sequence 5.0 -> 5.00001 -> 5.0 on a TOTAL_INCREASING
+    energy sensor: the tiny decrease (< SH_ENERGY_EPSILON) must be swallowed,
+    while a genuine reset to 0.0 must still pass through.
+    """
+    entity_id = f"{SENSOR_DOMAIN}.test_name_test_switch_0_energy"
+    status = {
+        "sys": {},
+        "switch:0": {
+            "id": 0,
+            "output": True,
+            "apower": 85.3,
+            "aenergy": {"total": 5.0},
+        },
+    }
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+    await init_integration(hass, 3)
+
+    assert (state := hass.states.get(entity_id))
+    state_initial = state.state
+
+    mutate_rpc_device_status(
+        monkeypatch, mock_rpc_device, "switch:0", "aenergy", {"total": 5.00001}
+    )
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    state_after_increase = state.state
+    assert state_after_increase != state_initial
+
+    mutate_rpc_device_status(
+        monkeypatch, mock_rpc_device, "switch:0", "aenergy", {"total": 5.0}
+    )
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == state_after_increase
+
+    mutate_rpc_device_status(
+        monkeypatch, mock_rpc_device, "switch:0", "aenergy", {"total": 0.0}
+    )
+    mock_rpc_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert float(state.state) == 0.0
+
+
 async def test_rpc_shelly_ev_sensors(
     hass: HomeAssistant,
     mock_rpc_device: Mock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!-- N/A - not a breaking change -->

## Proposed change

Fix floating-point jitter on Shelly energy sensors that use `state_class = total_increasing`. Shelly firmware occasionally reports an energy counter value a few parts-per-million smaller than the previous reading (e.g. `5.00001 → 5.0` Wh). Because Home Assistant's recorder interprets any decrease on a `total_increasing` sensor as a device reset, these microscopic drops create compensation spikes in long-term statistics (see issue #166816).

This PR introduces a small epsilon threshold that swallows strict decreases smaller than `SH_ENERGY_EPSILON` (0.001 in the sensor's native `Wh` unit) while still letting legitimate device resets through:

- New `SH_ENERGY_EPSILON: Final = 0.001` constant in `homeassistant/components/shelly/const.py`.
- New pure helper `_filter_energy_jitter(last_value, new_value)` in `homeassistant/components/shelly/sensor.py`.
- The helper is applied inside `RpcSensor.native_value` (Gen 2+ / RPC) and `BlockSensor.native_value` (Gen 1 / Block), gated by `state_class is SensorStateClass.TOTAL_INCREASING and device_class is SensorDeviceClass.ENERGY`, so every non-energy sensor is a true no-op. Each instance caches its last accepted value in `self._prev_energy_value`.

Behaviour matrix enforced by the helper:

| Transition                   | Action               |
|------------------------------|----------------------|
| Increase                     | Pass through         |
| No change                    | Pass through         |
| Decrease `0 < Δ < 0.001` Wh  | Swallow (jitter)     |
| Decrease `Δ >= 0.001` Wh     | Pass through (reset) |
| Drop to exactly `0.0`        | Pass through (reset) |

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #166816
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
