### PR TITLE
Add button platform to Fumis integration

### DIFF
--- a/homeassistant/components/fumis/__init__.py
+++ b/homeassistant/components/fumis/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import FumisConfigEntry, FumisDataUpdateCoordinator
 
-PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS = [Platform.BUTTON, Platform.CLIMATE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: FumisConfigEntry) -> bool:

--- a/homeassistant/components/fumis/button.py
+++ b/homeassistant/components/fumis/button.py
@@ -1,0 +1,71 @@
+"""Support for Fumis button entities."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from fumis import Fumis
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import FumisConfigEntry, FumisDataUpdateCoordinator
+from .entity import FumisEntity
+from .helpers import fumis_exception_handler
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class FumisButtonEntityDescription(ButtonEntityDescription):
+    """Describes a Fumis button entity."""
+
+    press_fn: Callable[[Fumis], Awaitable[Any]]
+
+
+BUTTONS: tuple[FumisButtonEntityDescription, ...] = (
+    FumisButtonEntityDescription(
+        key="sync_clock",
+        translation_key="sync_clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        press_fn=lambda client: client.set_clock(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FumisConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Fumis button entities based on a config entry."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        FumisButtonEntity(coordinator=coordinator, description=description)
+        for description in BUTTONS
+    )
+
+
+class FumisButtonEntity(FumisEntity, ButtonEntity):
+    """Defines a Fumis button entity."""
+
+    entity_description: FumisButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: FumisDataUpdateCoordinator,
+        description: FumisButtonEntityDescription,
+    ) -> None:
+        """Initialize the Fumis button entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
+
+    @fumis_exception_handler
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.entity_description.press_fn(self.coordinator.client)

--- a/homeassistant/components/fumis/icons.json
+++ b/homeassistant/components/fumis/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "button": {
+      "sync_clock": {
+        "default": "mdi:clock-sync"
+      }
+    },
     "sensor": {
       "combustion_chamber_temperature": {
         "default": "mdi:thermometer-high"

--- a/homeassistant/components/fumis/strings.json
+++ b/homeassistant/components/fumis/strings.json
@@ -53,6 +53,11 @@
     }
   },
   "entity": {
+    "button": {
+      "sync_clock": {
+        "name": "Sync clock"
+      }
+    },
     "sensor": {
       "combustion_chamber_temperature": {
         "name": "Combustion chamber"

--- a/tests/components/fumis/snapshots/test_button.ambr
+++ b/tests/components/fumis/snapshots/test_button.ambr
@@ -1,0 +1,51 @@
+# serializer version: 1
+# name: test_buttons[button][button.clou_duo_sync_clock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.clou_duo_sync_clock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Sync clock',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sync clock',
+    'platform': 'fumis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sync_clock',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_sync_clock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_buttons[button][button.clou_duo_sync_clock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Clou Duo Sync clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.clou_duo_sync_clock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/fumis/test_button.py
+++ b/tests/components/fumis/test_button.py
@@ -1,0 +1,67 @@
+"""Tests for the Fumis button entities."""
+
+from unittest.mock import MagicMock
+
+from fumis import FumisConnectionError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.fumis.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+pytestmark = pytest.mark.parametrize(
+    "init_integration", [Platform.BUTTON], indirect=True
+)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_buttons(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Fumis button entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sync_clock(
+    hass: HomeAssistant,
+    mock_fumis: MagicMock,
+) -> None:
+    """Test pressing the sync clock button."""
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.clou_duo_sync_clock"},
+        blocking=True,
+    )
+
+    mock_fumis.set_clock.assert_called_once()
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sync_clock_error_handling(
+    hass: HomeAssistant,
+    mock_fumis: MagicMock,
+) -> None:
+    """Test error handling for button press."""
+    mock_fumis.set_clock.side_effect = FumisConnectionError
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.clou_duo_sync_clock"},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "communication_error"


### PR DESCRIPTION
## Proposed change

Add a button platform to the Fumis integration with a sync clock button. The Fumis WiRCU module does not synchronize its internal clock from the internet, so this button allows sending the current time from Home Assistant to the stove's controller. This is useful for keeping the stove's weekly timer schedule accurate, especially after daylight saving time changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44999
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr