### PR TITLE
Generalize radio_frequency test fixtures in components conftest

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
     from .conversation import MockAgent
     from .device_tracker.common import MockScanner
     from .light.common import MockLight
+    from .radio_frequency.common import MockRadioFrequencyEntity
     from .sensor.common import MockSensor
     from .switch.common import MockSwitch
 
@@ -202,6 +203,27 @@ def mock_conversation_agent_fixture(hass: HomeAssistant) -> MockAgent:
     )
 
     return mock_conversation_agent_fixture_helper(hass)
+
+
+# Radio frequency test fixtures
+@pytest.fixture(name="init_radio_frequency")
+async def init_radio_frequency_fixture(hass: HomeAssistant) -> None:
+    """Set up the Radio Frequency integration for testing."""
+    from .radio_frequency.common import (  # noqa: PLC0415
+        init_radio_frequency_fixture_helper,
+    )
+
+    await init_radio_frequency_fixture_helper(hass)
+
+
+@pytest.fixture(name="mock_rf_entity")
+async def mock_rf_entity_fixture(
+    hass: HomeAssistant, init_radio_frequency: None
+) -> MockRadioFrequencyEntity:
+    """Return a mock radio frequency entity."""
+    from .radio_frequency.common import mock_rf_entity_fixture_helper  # noqa: PLC0415
+
+    return await mock_rf_entity_fixture_helper(hass)
 
 
 @pytest.fixture(scope="session", autouse=find_spec("haffmpeg") is not None)

--- a/tests/components/honeywell_string_lights/conftest.py
+++ b/tests/components/honeywell_string_lights/conftest.py
@@ -12,11 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
-from tests.components.radio_frequency.conftest import (
-    MockRadioFrequencyEntity,
-    init_integration,  # noqa: F401
-    mock_rf_entity,  # noqa: F401
-)
+from tests.components.radio_frequency.common import MockRadioFrequencyEntity
 
 TRANSMITTER_ENTITY_ID = "radio_frequency.test_rf_transmitter"
 
@@ -24,7 +20,7 @@ TRANSMITTER_ENTITY_ID = "radio_frequency.test_rf_transmitter"
 @pytest.fixture
 def mock_config_entry(
     hass: HomeAssistant,
-    mock_rf_entity: MockRadioFrequencyEntity,  # noqa: F811
+    mock_rf_entity: MockRadioFrequencyEntity,
 ) -> MockConfigEntry:
     """Return a mock config entry for Honeywell String Lights."""
     entity_registry = er.async_get(hass)

--- a/tests/components/honeywell_string_lights/test_config_flow.py
+++ b/tests/components/honeywell_string_lights/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.setup import async_setup_component
 from .conftest import TRANSMITTER_ENTITY_ID
 
 from tests.common import MockConfigEntry
-from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
+from tests.components.radio_frequency.common import MockRadioFrequencyEntity
 
 
 async def test_user_flow(

--- a/tests/components/honeywell_string_lights/test_light.py
+++ b/tests/components/honeywell_string_lights/test_light.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 from homeassistant.core import Context, HomeAssistant, State
 
 from tests.common import MockConfigEntry, mock_restore_cache
-from tests.components.radio_frequency.conftest import MockRadioFrequencyEntity
+from tests.components.radio_frequency.common import MockRadioFrequencyEntity
 
 ENTITY_ID = "light.honeywell_string_lights"
 

--- a/tests/components/radio_frequency/common.py
+++ b/tests/components/radio_frequency/common.py
@@ -1,8 +1,9 @@
-"""Common fixtures for the Radio Frequency tests."""
+"""Common test tools for the Radio Frequency integration."""
+
+from __future__ import annotations
 
 from typing import NamedTuple, override
 
-import pytest
 from rf_protocols import ModulationType, RadioFrequencyCommand
 
 from homeassistant.components.radio_frequency import (
@@ -12,13 +13,6 @@ from homeassistant.components.radio_frequency import (
 from homeassistant.components.radio_frequency.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-
-
-@pytest.fixture
-async def init_integration(hass: HomeAssistant) -> None:
-    """Set up the Radio Frequency integration for testing."""
-    assert await async_setup_component(hass, DOMAIN, {})
-    await hass.async_block_till_done()
 
 
 class MockCommand(NamedTuple):
@@ -81,11 +75,16 @@ class MockRadioFrequencyEntity(RadioFrequencyTransmitterEntity):
         )
 
 
-@pytest.fixture
-async def mock_rf_entity(
-    hass: HomeAssistant, init_integration: None
+async def init_radio_frequency_fixture_helper(hass: HomeAssistant) -> None:
+    """Set up the Radio Frequency integration for testing."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+
+async def mock_rf_entity_fixture_helper(
+    hass: HomeAssistant,
 ) -> MockRadioFrequencyEntity:
-    """Return a mock radio frequency entity."""
+    """Add a mock radio frequency entity to the running integration."""
     entity = MockRadioFrequencyEntity("test_rf_transmitter")
     component = hass.data[DATA_COMPONENT]
     await component.async_add_entities([entity])

--- a/tests/components/radio_frequency/test_init.py
+++ b/tests/components/radio_frequency/test_init.py
@@ -19,7 +19,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from . import ENTITY_ID
-from .conftest import MockRadioFrequencyCommand, MockRadioFrequencyEntity
+from .common import MockRadioFrequencyCommand, MockRadioFrequencyEntity
 
 from tests.common import mock_restore_cache
 
@@ -30,7 +30,7 @@ async def test_get_transmitters_component_not_loaded(hass: HomeAssistant) -> Non
         async_get_transmitters(hass, 433_920_000, ModulationType.OOK)
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("init_radio_frequency")
 async def test_get_transmitters_no_entities(hass: HomeAssistant) -> None:
     """Test getting transmitters raises when none are registered."""
     with pytest.raises(
@@ -110,7 +110,7 @@ async def test_async_send_command_error_does_not_update_state(
     assert state.state == STATE_UNKNOWN
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("init_radio_frequency")
 async def test_async_send_command_entity_not_found(hass: HomeAssistant) -> None:
     """Test async_send_command raises error when entity not found."""
     command = MockRadioFrequencyCommand(frequency=433_920_000)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move MockCommand, MockRadioFrequencyCommand, and MockRadioFrequencyEntity into tests/components/radio_frequency/common.py, and expose init_radio_frequency and mock_rf_entity fixtures from tests/components/conftest.py (following the TTS pattern). This lets other integrations (e.g. honeywell_string_lights) use these fixtures without importing from another integration's conftest.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
