### PR TITLE
Add reconfiguration flow to Notifications for Android TV / Fire TV

### DIFF
--- a/homeassistant/components/nfandroidtv/config_flow.py
+++ b/homeassistant/components/nfandroidtv/config_flow.py
@@ -9,7 +9,7 @@ from notifications_android_tv.notifications import ConnectError, Notifications
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_NAME
 
 from .const import DEFAULT_NAME, DOMAIN
 
@@ -37,6 +37,31 @@ class NFAndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfigure flow for ntfy."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            self._async_abort_entries_match(user_input)
+            if not (error := await self._async_try_connect(user_input[CONF_HOST])):
+                return self.async_update_reload_and_abort(
+                    entry, data_updates=user_input
+                )
+            errors["base"] = error
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+                suggested_values=user_input or entry.data,
+            ),
+            description_placeholders={CONF_NAME: entry.title},
             errors=errors,
         )
 

--- a/homeassistant/components/nfandroidtv/config_flow.py
+++ b/homeassistant/components/nfandroidtv/config_flow.py
@@ -43,7 +43,7 @@ class NFAndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle reconfigure flow for ntfy."""
+        """Handle reconfigure flow for Notification for Android TV / Fire TV."""
         errors: dict[str, str] = {}
         entry = self._get_reconfigure_entry()
 

--- a/homeassistant/components/nfandroidtv/strings.json
+++ b/homeassistant/components/nfandroidtv/strings.json
@@ -1,13 +1,23 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::nfandroidtv::config::step::user::data_description::host%]"
+        },
+        "description": "Reconfigure {name}"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/tests/components/nfandroidtv/conftest.py
+++ b/tests/components/nfandroidtv/conftest.py
@@ -1,0 +1,37 @@
+"""Common fixtures for the Notifications for Android TV / Fire TV tests."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.nfandroidtv.const import DOMAIN
+from homeassistant.const import CONF_HOST
+
+from . import HOST, NAME
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_notifications_android_tv() -> Generator[MagicMock]:
+    """Mock notifications_android_tv."""
+
+    with patch(
+        "homeassistant.components.nfandroidtv.config_flow.Notifications", autospec=True
+    ) as mock_client:
+        client = mock_client.return_value
+        client.cls = mock_client
+
+        yield client
+
+
+@pytest.fixture(name="config_entry")
+def mock_config_entry() -> MockConfigEntry:
+    """Mock Notifications for Android TV / Fire TV configuration entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=NAME,
+        data={CONF_HOST: HOST},
+        entry_id="123456789",
+    )

--- a/tests/components/nfandroidtv/test_config_flow.py
+++ b/tests/components/nfandroidtv/test_config_flow.py
@@ -1,11 +1,13 @@
 """Test NFAndroidTV config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from notifications_android_tv.notifications import ConnectError
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.nfandroidtv.const import DOMAIN
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -97,3 +99,102 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": "unknown"}
+
+
+@pytest.mark.usefixtures("mock_notifications_android_tv")
+async def test_flow_reconfigure(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow."""
+
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "4.3.2.1"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_HOST] == "4.3.2.1"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"), [(ConnectError, "cannot_connect"), (ValueError, "unknown")]
+)
+async def test_flow_reconfigure_errors(
+    hass: HomeAssistant,
+    mock_notifications_android_tv: MagicMock,
+    config_entry: MockConfigEntry,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test reauth flow errors."""
+
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_notifications_android_tv.cls.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "4.3.2.1"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_notifications_android_tv.cls.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "4.3.2.1"},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_HOST] == "4.3.2.1"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.usefixtures("mock_notifications_android_tv")
+async def test_flow_reconfigure_already_configured(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow aborts if already configured."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        title="Android TV / Fire TV (4.3.2.1)",
+        data={CONF_HOST: "4.3.2.1"},
+        entry_id="987654321",
+    ).add_to_hass(hass)
+
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "4.3.2.1"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    assert len(hass.config_entries.async_entries()) == 2

--- a/tests/components/nfandroidtv/test_config_flow.py
+++ b/tests/components/nfandroidtv/test_config_flow.py
@@ -106,7 +106,7 @@ async def test_flow_reconfigure(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
 ) -> None:
-    """Test reauth flow."""
+    """Test reconfigure flow."""
 
     config_entry.add_to_hass(hass)
     result = await config_entry.start_reconfigure_flow(hass)
@@ -137,7 +137,7 @@ async def test_flow_reconfigure_errors(
     exception: Exception,
     error: str,
 ) -> None:
-    """Test reauth flow errors."""
+    """Test reconfigure flow errors."""
 
     config_entry.add_to_hass(hass)
     result = await config_entry.start_reconfigure_flow(hass)
@@ -174,7 +174,7 @@ async def test_flow_reconfigure_already_configured(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
 ) -> None:
-    """Test reauth flow aborts if already configured."""
+    """Test reconfigure flow aborts if already configured."""
     MockConfigEntry(
         domain=DOMAIN,
         title="Android TV / Fire TV (4.3.2.1)",


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reconfiguration flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
