### PR TITLE
Extract common entity base class for RDW

### DIFF
--- a/homeassistant/components/rdw/binary_sensor.py
+++ b/homeassistant/components/rdw/binary_sensor.py
@@ -13,12 +13,10 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
 from .coordinator import RDWConfigEntry, RDWDataUpdateCoordinator
+from .entity import RDWEntity
 
 PARALLEL_UPDATES = 0
 
@@ -51,44 +49,27 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up RDW binary sensors based on a config entry."""
-    coordinator = entry.runtime_data
     async_add_entities(
-        RDWBinarySensorEntity(
-            coordinator=coordinator,
-            description=description,
-        )
+        RDWBinarySensorEntity(entry.runtime_data, description)
         for description in BINARY_SENSORS
-        if description.is_on_fn(coordinator.data) is not None
+        if description.is_on_fn(entry.runtime_data.data) is not None
     )
 
 
-class RDWBinarySensorEntity(
-    CoordinatorEntity[RDWDataUpdateCoordinator], BinarySensorEntity
-):
+class RDWBinarySensorEntity(RDWEntity, BinarySensorEntity):
     """Defines an RDW binary sensor."""
 
     entity_description: RDWBinarySensorEntityDescription
-    _attr_has_entity_name = True
 
     def __init__(
         self,
-        *,
         coordinator: RDWDataUpdateCoordinator,
         description: RDWBinarySensorEntityDescription,
     ) -> None:
         """Initialize RDW binary sensor."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.data.license_plate}_{description.key}"
-
-        self._attr_device_info = DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, coordinator.data.license_plate)},
-            manufacturer=coordinator.data.brand,
-            name=f"{coordinator.data.brand} {coordinator.data.license_plate}",
-            model=coordinator.data.model,
-            configuration_url=f"https://ovi.rdw.nl/default.aspx?kenteken={coordinator.data.license_plate}",
-        )
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/rdw/entity.py
+++ b/homeassistant/components/rdw/entity.py
@@ -1,0 +1,27 @@
+"""Base entity for the RDW integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import RDWDataUpdateCoordinator
+
+
+class RDWEntity(CoordinatorEntity[RDWDataUpdateCoordinator]):
+    """Defines an RDW entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: RDWDataUpdateCoordinator) -> None:
+        """Initialize an RDW entity."""
+        super().__init__(coordinator=coordinator)
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, coordinator.data.license_plate)},
+            manufacturer=coordinator.data.brand,
+            name=f"{coordinator.data.brand} {coordinator.data.license_plate}",
+            model=coordinator.data.model,
+            configuration_url=f"https://ovi.rdw.nl/default.aspx?kenteken={coordinator.data.license_plate}",
+        )

--- a/homeassistant/components/rdw/sensor.py
+++ b/homeassistant/components/rdw/sensor.py
@@ -14,12 +14,10 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_LICENSE_PLATE, DOMAIN
 from .coordinator import RDWConfigEntry, RDWDataUpdateCoordinator
+from .entity import RDWEntity
 
 PARALLEL_UPDATES = 0
 
@@ -53,43 +51,25 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up RDW sensors based on a config entry."""
-    coordinator = entry.runtime_data
     async_add_entities(
-        RDWSensorEntity(
-            coordinator=coordinator,
-            license_plate=entry.data[CONF_LICENSE_PLATE],
-            description=description,
-        )
-        for description in SENSORS
+        RDWSensorEntity(entry.runtime_data, description) for description in SENSORS
     )
 
 
-class RDWSensorEntity(CoordinatorEntity[RDWDataUpdateCoordinator], SensorEntity):
+class RDWSensorEntity(RDWEntity, SensorEntity):
     """Defines an RDW sensor."""
 
     entity_description: RDWSensorEntityDescription
-    _attr_has_entity_name = True
 
     def __init__(
         self,
-        *,
         coordinator: RDWDataUpdateCoordinator,
-        license_plate: str,
         description: RDWSensorEntityDescription,
     ) -> None:
         """Initialize RDW sensor."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{license_plate}_{description.key}"
-
-        self._attr_device_info = DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, f"{license_plate}")},
-            manufacturer=coordinator.data.brand,
-            name=f"{coordinator.data.brand} {coordinator.data.license_plate}",
-            model=coordinator.data.model,
-            configuration_url=f"https://ovi.rdw.nl/default.aspx?kenteken={coordinator.data.license_plate}",
-        )
+        self._attr_unique_id = f"{coordinator.data.license_plate}_{description.key}"
 
     @property
     def native_value(self) -> date | str | float | None:


### PR DESCRIPTION
## Proposed change

Extracts the duplicated `DeviceInfo` construction from `sensor.py` and `binary_sensor.py` into a shared `RDWEntity` base class in a new `entity.py` module.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr