### PR TITLE
Add reconfiguration flow to PVOutput

### DIFF
--- a/homeassistant/components/pvoutput/config_flow.py
+++ b/homeassistant/components/pvoutput/config_flow.py
@@ -114,10 +114,7 @@ class PVOutputFlowHandler(ConfigFlow, domain=DOMAIN):
             },
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_API_KEY,
-                        default=reconfigure_entry.data[CONF_API_KEY],
-                    ): str,
+                    vol.Required(CONF_API_KEY): str,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/pvoutput/config_flow.py
+++ b/homeassistant/components/pvoutput/config_flow.py
@@ -81,6 +81,48 @@ class PVOutputFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of a PVOutput entry."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                await validate_input(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    system_id=reconfigure_entry.data[CONF_SYSTEM_ID],
+                )
+            except PVOutputAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except PVOutputError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={
+                        CONF_API_KEY: user_input[CONF_API_KEY],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            description_placeholders={
+                "account_url": "https://pvoutput.org/account.jsp"
+            },
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_API_KEY,
+                        default=reconfigure_entry.data[CONF_API_KEY],
+                    ): str,
+                }
+            ),
+            errors=errors,
+        )
+
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pvoutput/strings.json
+++ b/homeassistant/components/pvoutput/strings.json
@@ -2,7 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -14,6 +15,12 @@
           "api_key": "[%key:common::config_flow::data::api_key%]"
         },
         "description": "To re-authenticate with PVOutput you'll need to get the API key at {account_url}."
+      },
+      "reconfigure": {
+        "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "description": "Reconfigure your PVOutput integration. You can update your API key at {account_url}."
       },
       "user": {
         "data": {

--- a/tests/components/pvoutput/test_config_flow.py
+++ b/tests/components/pvoutput/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from pvo import PVOutputAuthenticationError, PVOutputConnectionError
+import pytest
 
 from homeassistant.components.pvoutput.const import CONF_SYSTEM_ID, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -242,3 +243,65 @@ async def test_reauth_api_error(
     assert result2.get("type") is FlowResultType.FORM
     assert result2.get("step_id") == "reauth_confirm"
     assert result2.get("errors") == {"base": "cannot_connect"}
+
+
+@pytest.mark.usefixtures("mock_pvoutput")
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguring an existing PVOutput entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_KEY: "new-api-key"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_API_KEY] == "new-api-key"
+    assert mock_config_entry.data[CONF_SYSTEM_ID] == 12345
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (PVOutputAuthenticationError, {"base": "invalid_auth"}),
+        (PVOutputConnectionError, {"base": "cannot_connect"}),
+    ],
+)
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_pvoutput: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
+    expected_error: dict[str, str],
+) -> None:
+    """Test reconfigure flow recovers from errors."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_pvoutput.system.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_KEY: "new-api-key"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == expected_error
+
+    mock_pvoutput.system.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_KEY: "new-api-key"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"


### PR DESCRIPTION
## Proposed change

Adds a reconfiguration flow to the PVOutput integration, allowing users to update their API key without removing and re-adding the integration.

The system ID is fixed (it is the integration's identity) and cannot be changed through reconfigure. The flow validates the new API key against the existing system ID via the PVOutput API before updating.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr