### PR TITLE
Filter unknown values from arcam enum

### DIFF
--- a/homeassistant/components/arcam_fmj/sensor.py
+++ b/homeassistant/components/arcam_fmj/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+import logging
 
 from arcam.fmj import IncomingVideoAspectRatio, IncomingVideoColorspace, IntOrTypeEnum
 from arcam.fmj.state import IncomingAudioConfig, IncomingAudioFormat, State
@@ -18,9 +19,10 @@ from homeassistant.const import EntityCategory, UnitOfFrequency
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import _LOGGER
 from .coordinator import ArcamFmjConfigEntry
 from .entity import ArcamFmjEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _enum_options(value: type[IntOrTypeEnum]) -> list[str]:

--- a/homeassistant/components/arcam_fmj/sensor.py
+++ b/homeassistant/components/arcam_fmj/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from arcam.fmj import IncomingVideoAspectRatio, IncomingVideoColorspace
+from arcam.fmj import IncomingVideoAspectRatio, IncomingVideoColorspace, IntOrTypeEnum
 from arcam.fmj.state import IncomingAudioConfig, IncomingAudioFormat, State
 
 from homeassistant.components.sensor import (
@@ -18,8 +18,26 @@ from homeassistant.const import EntityCategory, UnitOfFrequency
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import _LOGGER
 from .coordinator import ArcamFmjConfigEntry
 from .entity import ArcamFmjEntity
+
+
+def _enum_options(value: type[IntOrTypeEnum]) -> list[str]:
+    return [
+        member.name.lower() for member in value if not member.name.startswith("CODE_")
+    ]
+
+
+def _enum_value(value: IntOrTypeEnum | None) -> str | None:
+    if value is None:
+        return None
+
+    if value.name.startswith("CODE_"):
+        _LOGGER.debug("Undefined enum value %s ignored", value)
+        return None
+
+    return value.name.lower()
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -75,9 +93,9 @@ SENSORS: tuple[ArcamFmjSensorEntityDescription, ...] = (
         translation_key="incoming_video_aspect_ratio",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.ENUM,
-        options=[member.name.lower() for member in IncomingVideoAspectRatio],
+        options=_enum_options(IncomingVideoAspectRatio),
         value_fn=lambda state: (
-            vp.aspect_ratio.name.lower()
+            _enum_value(vp.aspect_ratio)
             if (vp := state.get_incoming_video_parameters()) is not None
             else None
         ),
@@ -87,11 +105,10 @@ SENSORS: tuple[ArcamFmjSensorEntityDescription, ...] = (
         translation_key="incoming_video_colorspace",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.ENUM,
-        options=[member.name.lower() for member in IncomingVideoColorspace],
+        options=_enum_options(IncomingVideoColorspace),
         value_fn=lambda state: (
-            vp.colorspace.name.lower()
+            _enum_value(vp.colorspace)
             if (vp := state.get_incoming_video_parameters()) is not None
-            and vp.colorspace is not None
             else None
         ),
     ),
@@ -100,24 +117,16 @@ SENSORS: tuple[ArcamFmjSensorEntityDescription, ...] = (
         translation_key="incoming_audio_format",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.ENUM,
-        options=[member.name.lower() for member in IncomingAudioFormat],
-        value_fn=lambda state: (
-            result.name.lower()
-            if (result := state.get_incoming_audio_format()[0]) is not None
-            else None
-        ),
+        options=_enum_options(IncomingAudioFormat),
+        value_fn=lambda state: _enum_value(state.get_incoming_audio_format()[0]),
     ),
     ArcamFmjSensorEntityDescription(
         key="incoming_audio_config",
         translation_key="incoming_audio_config",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.ENUM,
-        options=[member.name.lower() for member in IncomingAudioConfig],
-        value_fn=lambda state: (
-            result.name.lower()
-            if (result := state.get_incoming_audio_format()[1]) is not None
-            else None
-        ),
+        options=_enum_options(IncomingAudioConfig),
+        value_fn=lambda state: _enum_value(state.get_incoming_audio_format()[1]),
     ),
     ArcamFmjSensorEntityDescription(
         key="incoming_audio_sample_rate",

--- a/tests/components/arcam_fmj/test_sensor.py
+++ b/tests/components/arcam_fmj/test_sensor.py
@@ -100,7 +100,15 @@ async def test_sensor_enum_unknown(
     state_1: State,
     client: Mock,
 ) -> None:
-    """Test audio parameter sensors with actual data."""
+    """Test parameter sensors with unknown data."""
+    video_params = Mock()
+    video_params.horizontal_resolution = 0
+    video_params.vertical_resolution = 0
+    video_params.refresh_rate = 0
+    video_params.aspect_ratio = IncomingVideoAspectRatio.from_int(0x99)
+    video_params.colorspace = IncomingVideoColorspace.from_int(0x99)
+
+    state_1.get_incoming_video_parameters.return_value = video_params
     state_1.get_incoming_audio_format.return_value = (
         None,
         IncomingAudioConfig.from_int(0x99),
@@ -109,11 +117,12 @@ async def test_sensor_enum_unknown(
     client.notify_data_updated()
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("sensor.arcam_fmj_127_0_0_1_incoming_audio_format").state
-        == "unknown"
-    )
-    assert (
-        hass.states.get("sensor.arcam_fmj_127_0_0_1_incoming_audio_configuration").state
-        == "unknown"
-    )
+    def _get(key: str) -> str:
+        state = hass.states.get(f"sensor.arcam_fmj_127_0_0_1_{key}")
+        assert state
+        return state.state
+
+    assert _get("incoming_audio_format") == "unknown"
+    assert _get("incoming_audio_configuration") == "unknown"
+    assert _get("incoming_video_aspect_ratio") == "unknown"
+    assert _get("incoming_video_colorspace") == "unknown"

--- a/tests/components/arcam_fmj/test_sensor.py
+++ b/tests/components/arcam_fmj/test_sensor.py
@@ -92,3 +92,28 @@ async def test_sensor_audio_parameters(
         hass.states.get("sensor.arcam_fmj_127_0_0_1_incoming_audio_sample_rate").state
         == "48000"
     )
+
+
+@pytest.mark.usefixtures("player_setup")
+async def test_sensor_enum_unknown(
+    hass: HomeAssistant,
+    state_1: State,
+    client: Mock,
+) -> None:
+    """Test audio parameter sensors with actual data."""
+    state_1.get_incoming_audio_format.return_value = (
+        None,
+        IncomingAudioConfig.from_int(0x99),
+    )
+
+    client.notify_data_updated()
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.arcam_fmj_127_0_0_1_incoming_audio_format").state
+        == "unknown"
+    )
+    assert (
+        hass.states.get("sensor.arcam_fmj_127_0_0_1_incoming_audio_configuration").state
+        == "unknown"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Protect for auto extended enum values in arcam_fmj for unknown values received from
device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169109
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
