### PR TITLE
Modernize RDW config flow tests

### DIFF
--- a/tests/components/rdw/conftest.py
+++ b/tests/components/rdw/conftest.py
@@ -33,29 +33,16 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_rdw_config_flow() -> Generator[MagicMock]:
+def mock_rdw() -> Generator[MagicMock]:
     """Return a mocked RDW client."""
-    with patch(
-        "homeassistant.components.rdw.config_flow.RDW", autospec=True
-    ) as rdw_mock:
+    with (
+        patch(
+            "homeassistant.components.rdw.coordinator.RDW", autospec=True
+        ) as rdw_mock,
+        patch("homeassistant.components.rdw.config_flow.RDW", new=rdw_mock),
+    ):
         rdw = rdw_mock.return_value
         rdw.vehicle.return_value = Vehicle.from_json(load_fixture("rdw/11ZKZ3.json"))
-        yield rdw
-
-
-@pytest.fixture
-def mock_rdw(request: pytest.FixtureRequest) -> Generator[MagicMock]:
-    """Return a mocked WLED client."""
-    fixture: str = "rdw/11ZKZ3.json"
-    if hasattr(request, "param") and request.param:
-        fixture = request.param
-
-    vehicle = Vehicle.from_json(load_fixture(fixture))
-    with patch(
-        "homeassistant.components.rdw.coordinator.RDW", autospec=True
-    ) as rdw_mock:
-        rdw = rdw_mock.return_value
-        rdw.vehicle.return_value = vehicle
         yield rdw
 
 

--- a/tests/components/rdw/test_config_flow.py
+++ b/tests/components/rdw/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from vehicle.exceptions import RDWConnectionError, RDWUnknownLicensePlateError
 
 from homeassistant.components.rdw.const import CONF_LICENSE_PLATE, DOMAIN
@@ -9,81 +10,85 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
 
-async def test_full_user_flow(
-    hass: HomeAssistant, mock_rdw_config_flow: MagicMock, mock_setup_entry: MagicMock
-) -> None:
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+@pytest.mark.usefixtures("mock_rdw")
+async def test_full_user_flow(hass: HomeAssistant) -> None:
     """Test the full user configuration flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
 
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "user"
-
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_LICENSE_PLATE: "11-ZKZ-3",
-        },
+        user_input={CONF_LICENSE_PLATE: "11-ZKZ-3"},
     )
 
-    assert result2.get("type") is FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == "11-ZKZ-3"
-    assert result2.get("data") == {CONF_LICENSE_PLATE: "11ZKZ3"}
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "11-ZKZ-3"
+    assert result["data"] == {CONF_LICENSE_PLATE: "11ZKZ3"}
+    assert result["result"].unique_id == "11ZKZ3"
 
 
-async def test_full_flow_with_authentication_error(
-    hass: HomeAssistant, mock_rdw_config_flow: MagicMock, mock_setup_entry: MagicMock
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (RDWUnknownLicensePlateError, {"base": "unknown_license_plate"}),
+        (RDWConnectionError, {"base": "cannot_connect"}),
+    ],
+)
+async def test_user_flow_errors(
+    hass: HomeAssistant,
+    mock_rdw: MagicMock,
+    side_effect: type[Exception],
+    expected_error: dict[str, str],
 ) -> None:
-    """Test the full user configuration flow with incorrect license plate.
+    """Test the user flow with errors and recovery."""
+    mock_rdw.vehicle.side_effect = side_effect
 
-    This tests tests a full config flow, with a case the user enters an invalid
-    license plate, but recover by entering the correct one.
-    """
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "user"
-
-    mock_rdw_config_flow.vehicle.side_effect = RDWUnknownLicensePlateError
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_LICENSE_PLATE: "0001TJ",
-        },
+        user_input={CONF_LICENSE_PLATE: "0001TJ"},
     )
 
-    assert result2.get("type") is FlowResultType.FORM
-    assert result2.get("step_id") == "user"
-    assert result2.get("errors") == {"base": "unknown_license_plate"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == expected_error
 
-    mock_rdw_config_flow.vehicle.side_effect = None
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
-        user_input={
-            CONF_LICENSE_PLATE: "11-ZKZ-3",
-        },
+    mock_rdw.vehicle.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_LICENSE_PLATE: "11-ZKZ-3"},
     )
 
-    assert result3.get("type") is FlowResultType.CREATE_ENTRY
-    assert result3.get("title") == "11-ZKZ-3"
-    assert result3.get("data") == {CONF_LICENSE_PLATE: "11ZKZ3"}
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_connection_error(
-    hass: HomeAssistant, mock_rdw_config_flow: MagicMock
+@pytest.mark.usefixtures("mock_rdw")
+async def test_user_flow_already_configured(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test API connection error."""
-    mock_rdw_config_flow.vehicle.side_effect = RDWConnectionError
+    """Test the user flow when the vehicle is already configured."""
+    mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_LICENSE_PLATE: "0001TJ"},
+        DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("errors") == {"base": "cannot_connect"}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_LICENSE_PLATE: "11-ZKZ-3"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
## Proposed change

Modernizes the RDW config flow tests to follow current HA patterns (as used in e.g. the Fumis integration):

- Merges the separate `mock_rdw_config_flow` and `mock_rdw` conftest fixtures into a single `mock_rdw` fixture that patches both `coordinator.RDW` and `config_flow.RDW`.
- Uses `pytestmark = pytest.mark.usefixtures("mock_setup_entry")` instead of passing the fixture per-test.
- Parametrizes error tests with a recovery path (error → fix → success) instead of separate non-recovering test functions.
- Adds a missing `test_user_flow_already_configured` test.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr