### PR TITLE
Fix StatesManager oldest_ts wedge after recorder session recovery

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -1279,7 +1279,7 @@ class Recorder(threading.Thread):
         """Rollback the event session and reopen it after a failure."""
         self._close_event_session()
         self._open_event_session()
-        with session_scope(session=self.get_session()) as session:
+        with session_scope(session=self.get_session(), read_only=True) as session:
             self.states_manager.load_from_db(session)
 
     def _open_event_session(self) -> None:

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -1279,6 +1279,8 @@ class Recorder(threading.Thread):
         """Rollback the event session and reopen it after a failure."""
         self._close_event_session()
         self._open_event_session()
+        with session_scope(session=self.get_session()) as session:
+            self.states_manager.load_from_db(session)
 
     def _open_event_session(self) -> None:
         """Open the event session."""

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -476,6 +476,53 @@ async def test_saving_state_with_sqlalchemy_exception(
     assert "SQLAlchemyError error processing task" not in caplog.text
 
 
+async def test_states_manager_oldest_ts_restored_after_sqlalchemy_recovery(
+    hass: HomeAssistant,
+    setup_recorder: None,
+) -> None:
+    """Test oldest_ts is restored from the DB after _reopen_event_session().
+
+    Regression test for a wedge where _reopen_event_session() (triggered by a
+    SQLAlchemyError on the recorder thread) calls _close_event_session() which
+    resets the StatesManager cache, but does not reseed oldest_ts from the DB.
+    The next add_pending() then seeds oldest_ts from that state's last_updated_ts
+    (≈ "now" at recovery), not from the actual DB minimum, causing
+    has_states_before(t) and /api/history/period to falsely report "no data"
+    for any window ending before recovery.
+    """
+    instance = get_instance(hass)
+    entity_id = "test.recorder_recovery"
+
+    hass.states.async_set(entity_id, "first", {"attr": 1})
+    await async_wait_recording_done(hass)
+
+    oldest_ts_before_recovery = instance.states_manager.oldest_ts
+    assert oldest_ts_before_recovery is not None
+
+    def _throw_if_state_in_session(*args: Any, **kwargs: Any) -> None:
+        for obj in instance.event_session:
+            if isinstance(obj, States):
+                raise SQLAlchemyError(
+                    "insert the state", "fake params", "forced to fail"
+                )
+
+    with (
+        patch("time.sleep"),
+        patch.object(
+            instance.event_session,
+            "flush",
+            side_effect=_throw_if_state_in_session,
+        ),
+    ):
+        hass.states.async_set(entity_id, "fail", {"attr": 2})
+        await async_wait_recording_done(hass)
+
+    hass.states.async_set(entity_id, "after_recovery", {"attr": 3})
+    await async_wait_recording_done(hass)
+
+    assert instance.states_manager.oldest_ts == oldest_ts_before_recovery
+
+
 async def test_force_shutdown_with_queue_of_writes_that_generate_exceptions(
     hass: HomeAssistant,
     async_setup_recorder_instance: RecorderInstanceGenerator,


### PR DESCRIPTION
## Proposed change

When the recorder thread catches a `SQLAlchemyError` (or `DatabaseError` that isn't SQLite corruption) while processing an event or task, it calls `_reopen_event_session()` to recover. That path calls `states_manager.reset()`, which sets `_oldest_ts = None`. The new session is opened without a follow-up `load_from_db()`, so `_oldest_ts` stays `None` until the next `add_pending()` call — which seeds it from `state.last_updated_ts` of that pending state (≈ "now"), not from the actual DB minimum.

Once wedged, `homeassistant.components.history.helpers.has_states_before(hass, t)` returns `False` for any `t < wedged_ts`. The history HTTP view treats that as "no states in the database up until end_time" and returns `[]` without consulting the DB ([history/__init__.py L109](https://github.com/home-assistant/core/blob/dev/homeassistant/components/history/__init__.py#L109)).

The wedge persists until the next purge cycle (`purge.py` calls `states_manager.load_from_db()`) — by default ~24h — or until process restart.

### Code path

1. `MySQLdb.OperationalError "Lost connection to server during query"` (or any other `SQLAlchemyError` from the recorder thread)
2. Caught in `_process_one_task_or_event_or_recover` (`recorder/core.py`, `except exc.DatabaseError` / `except SQLAlchemyError`)
3. `_handle_database_error` only handles SQLite corruption (`malformed`/`not a database`); returns `False` for everything else
4. Falls through to `_reopen_event_session()`
5. `_close_event_session()` calls `states_manager.reset()` → `_oldest_ts = None`
6. `_open_event_session()` opens a new SQLAlchemy session — does not call `load_from_db()`
7. Next `_process_one_event()` → `add_pending(entity_id, state)`:
   ```python
   self._pending[entity_id] = state
   if self._oldest_ts is None:
       self._oldest_ts = state.last_updated_ts  # wedge: ~"now"
   ```
8. Subsequent `add_pending()` calls take the `is not None` branch and never update — wedge persists.

### Fix

Have `_reopen_event_session()` re-seed `_oldest_ts` from the DB after the new session opens, mirroring what `_setup_run()` already does:

```python
def _reopen_event_session(self) -> None:
    """Rollback the event session and reopen it after a failure."""
    self._close_event_session()
    self._open_event_session()
    with session_scope(session=self.get_session()) as session:
        self.states_manager.load_from_db(session)
```

Alternative considered: re-seed inside `add_pending` when `_oldest_ts is None`. Rejected — that path also fires on a fresh install with empty `states`, where the current "seed from the first pending state" behavior is correct (the first state IS the oldest). The bug is specifically that the recovery path conflates "we forgot due to reset" with "no data in DB". Fixing it at the recovery site preserves the semantics of `add_pending` for the empty-DB case.

### Regression test

Added `test_states_manager_oldest_ts_restored_after_sqlalchemy_recovery` in `tests/components/recorder/test_init.py`, mirroring the existing `test_saving_state_with_sqlalchemy_exception` pattern: forces a `SQLAlchemyError` on `event_session.flush()`, lets the recorder recover, and asserts `oldest_ts` after recovery equals the pre-recovery value (the DB minimum), not the post-recovery state's timestamp.

Verified failing on `dev` without the fix: `assert 1777100075.323314 == 1777100075.317269` (wedged at the post-recovery state's ts, ~6ms after the DB minimum). Passes with the fix.

### Field incident

Observed on Home Assistant Core + MariaDB recorder (`purge_keep_days: 15`). Logs:

```
ERROR (Recorder) [recorder.util] Error executing query:
  (MySQLdb.OperationalError) (2013, 'Lost connection to server during query')
ERROR (Recorder) [recorder.core] Unhandled database error while processing task ...
  sqlalchemy.exc.PendingRollbackError: Can't reconnect until invalid transaction
  is rolled back. Please rollback() fully before proceeding
```

After recovery, every `GET /api/history/period?filter_entity_id=…&end_time=<any ts before the recovery>` returned `[]`, even though `SELECT MIN(last_updated_ts) FROM states` confirmed the true minimum was 15 days earlier and the DB rows were intact. Cleared by HA Core restart (which triggers `_setup_run()` → `states_manager.load_from_db()`).

### Severity

Lower than initial impression — purge auto-heals via `load_from_db()` at the next purge cycle (default ~24h), so worst case is one day of broken `/api/history/period` for windows ending before the wedge timestamp. But the failure mode is silent (no error in logs after the initial connection failure; queries just return `[]`), and the user-visible symptom is the energy dashboard, history graphs, and statistics queries all showing empty data for that window. Took non-trivial debugging to trace.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
