### PR TITLE
Detect .start entry point files in hassfest check

### DIFF
--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -729,7 +729,7 @@ def check_dependency_files(
             if not (top := file.parts[0].lower()).endswith((".dist-info", ".py")):
                 top_level.add(top)
             if (name := str(file).lower()) in FORBIDDEN_FILE_NAMES or (
-                name.endswith(".pth") and len(file.parts) == 1
+                name.endswith((".pth", ".start")) and len(file.parts) == 1
             ):
                 file_names.add(str(file))
         results = _PackageFilesCheckResult(

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -276,6 +276,7 @@ def test_check_dependency_file_names(integration: Integration) -> None:
         PackagePath("py.typed"),
         PackagePath("my_package.py"),
         PackagePath("some_script.Pth"),
+        PackagePath("entry_point.start"),
         PackagePath("my_package-1.0.0.dist-info/METADATA"),
     ]
     with (
@@ -289,20 +290,25 @@ def test_check_dependency_file_names(integration: Integration) -> None:
         assert _packages_checked_files_cache[pkg]["file_names"] == {
             "py.typed",
             "some_script.Pth",
+            "entry_point.start",
         }
-        assert len(integration.errors) == 2
+        assert len(integration.errors) == 3
         assert f"Package {pkg} has a forbidden file 'py.typed' in {package}" in [
             x.error for x in integration.errors
         ]
         assert f"Package {pkg} has a forbidden file 'some_script.Pth' in {package}" in [
             x.error for x in integration.errors
         ]
+        assert (
+            f"Package {pkg} has a forbidden file 'entry_point.start' in {package}"
+            in [x.error for x in integration.errors]
+        )
         integration.errors.clear()
 
         # Repeated call should use cache
         assert check_dependency_files(integration, package, pkg, ()) is False
         assert mock_files.call_count == 1
-        assert len(integration.errors) == 2
+        assert len(integration.errors) == 3
         integration.errors.clear()
 
     # All good


### PR DESCRIPTION
## Proposed change
Followup to https://github.com/home-assistant/core/pull/166411

In response to the `.pth` file attack vector, [PEP 829](https://peps.python.org/pep-0829/) was created which adds some new constraints on the `.pth` file but also introduces a new `.start` file for entry points. The PEP was [accepted yesterday](https://discuss.python.org/t/pep-829-structured-startup-configuration-files/106789/112) and will be implemented in time for Python 3.15.

Hassfest should flag these files as well, so they can be verified manually.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
