### PR TITLE
Add Powerwall 3 support to powerwall integration

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -39,6 +39,7 @@ from .coordinator import (
     PowerwallRuntimeData,
     PowerwallUpdateCoordinator,
 )
+from .helpers import is_api_404
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
@@ -282,11 +283,6 @@ async def _login_and_fetch_base_info(
     return await _call_base_info(power_wall, host, fallback_din)
 
 
-def _is_404_api_error(err: ApiError) -> bool:
-    """Return True if an ApiError represents an HTTP 404 from the gateway."""
-    return "returned error 404" in str(err)
-
-
 async def _call_base_info(
     power_wall: Powerwall, host: str, fallback_din: str | None = None
 ) -> PowerwallBaseInfo:
@@ -303,7 +299,7 @@ async def _call_base_info(
     try:
         gateway_din = await power_wall.get_gateway_din()
     except ApiError as err:
-        if not _is_404_api_error(err):
+        if not is_api_404(err):
             raise
         # No DIN available — fall back to the caller-supplied identifier
         # (typically the MAC saved as the config-entry unique_id) so the device

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -73,6 +73,7 @@ class PowerwallDataManager:
         self.power_wall = power_wall
         self.cookie_jar = cookie_jar
         self.entry = entry
+        self.restricted = runtime_data["base_info"].restricted
 
     @property
     def api_changed(self) -> int:
@@ -102,7 +103,9 @@ class PowerwallDataManager:
             try:
                 if attempt == 1:
                     await self._recreate_powerwall_login()
-                data = await _fetch_powerwall_data(self.power_wall)
+                data = await _fetch_powerwall_data(
+                    self.power_wall, restricted=self.restricted
+                )
             except (TimeoutError, PowerwallUnreachableError) as err:
                 raise UpdateFailed("Unable to fetch data from powerwall") from err
             except MissingAttributeError as err:
@@ -171,7 +174,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerwallConfigEntry) ->
         for tries in range(2):
             try:
                 base_info = await _login_and_fetch_base_info(
-                    power_wall, ip_address, password, use_auth_cookie
+                    power_wall,
+                    ip_address,
+                    password,
+                    use_auth_cookie,
+                    fallback_din=entry.unique_id,
                 )
 
                 # Cancel closing power_wall on success
@@ -239,6 +246,8 @@ async def async_migrate_entity_unique_ids(
     hass: HomeAssistant, entry: PowerwallConfigEntry, base_info: PowerwallBaseInfo
 ) -> None:
     """Migrate old entity unique ids to use gateway_din."""
+    if not base_info.serial_numbers:
+        return
     old_base_unique_id = "_".join(base_info.serial_numbers)
     new_base_unique_id = base_info.gateway_din
 
@@ -260,24 +269,60 @@ async def async_migrate_entity_unique_ids(
 
 
 async def _login_and_fetch_base_info(
-    power_wall: Powerwall, host: str, password: str | None, use_auth_cookie: bool
+    power_wall: Powerwall,
+    host: str,
+    password: str | None,
+    use_auth_cookie: bool,
+    fallback_din: str | None = None,
 ) -> PowerwallBaseInfo:
     """Login to the powerwall and fetch the base info."""
     # Login step is skipped if password is None or if we are using the auth cookie
     if not (password is None or use_auth_cookie):
         await power_wall.login(password)
-    return await _call_base_info(power_wall, host)
+    return await _call_base_info(power_wall, host, fallback_din)
 
 
-async def _call_base_info(power_wall: Powerwall, host: str) -> PowerwallBaseInfo:
+def _is_404_api_error(err: ApiError) -> bool:
+    """Return True if an ApiError represents an HTTP 404 from the gateway."""
+    return "returned error 404" in str(err)
+
+
+async def _call_base_info(
+    power_wall: Powerwall, host: str, fallback_din: str | None = None
+) -> PowerwallBaseInfo:
     """Return PowerwallBaseInfo for the device."""
     # We await each call individually since the powerwall
     # supports http keep-alive and we want to reuse the connection
     # as its faster than establishing a new connection when
     # run concurrently.
-    gateway_din = await power_wall.get_gateway_din()
-    site_info = await power_wall.get_site_info()
+    url = f"https://{host}"
+    # Probe via get_gateway_din (hits /api/powerwalls) to detect the restricted
+    # PW3-style surface. PW3 (and recent firmware revisions) return HTTP 404 on
+    # /api/powerwalls and most other legacy endpoints; only meters/aggregates,
+    # system_status/soe, and system_status/grid_status are guaranteed to work.
+    try:
+        gateway_din = await power_wall.get_gateway_din()
+    except ApiError as err:
+        if not _is_404_api_error(err):
+            raise
+        # No DIN available — fall back to the caller-supplied identifier
+        # (typically the MAC saved as the config-entry unique_id) so the device
+        # identifier is stable across restarts.
+        identifier = fallback_din or host
+        return PowerwallBaseInfo(
+            gateway_din=identifier,
+            site_name=f"Powerwall {host}",
+            site_info=None,
+            status=None,
+            device_type=None,
+            serial_numbers=[],
+            url=url,
+            batteries={},
+            restricted=True,
+        )
+
     status = await power_wall.get_status()
+    site_info = await power_wall.get_site_info()
     device_type = await power_wall.get_device_type()
     serial_numbers = await power_wall.get_serial_numbers()
     batteries = await power_wall.get_batteries()
@@ -285,11 +330,12 @@ async def _call_base_info(power_wall: Powerwall, host: str) -> PowerwallBaseInfo
     # for backwards compatibility.
     return PowerwallBaseInfo(
         gateway_din=gateway_din,
+        site_name=site_info.site_name,
         site_info=site_info,
         status=status,
         device_type=device_type,
         serial_numbers=sorted(serial_numbers),
-        url=f"https://{host}",
+        url=url,
         batteries={battery.serial_number: battery for battery in batteries},
     )
 
@@ -302,18 +348,30 @@ async def get_backup_reserve_percentage(power_wall: Powerwall) -> float | None:
         return None
 
 
-async def _fetch_powerwall_data(power_wall: Powerwall) -> PowerwallData:
+async def _fetch_powerwall_data(
+    power_wall: Powerwall, restricted: bool = False
+) -> PowerwallData:
     """Process and update powerwall data."""
     # We await each call individually since the powerwall
     # supports http keep-alive and we want to reuse the connection
     # as its faster than establishing a new connection when
     # run concurrently.
-    backup_reserve = await get_backup_reserve_percentage(power_wall)
     charge = await power_wall.get_charge()
-    site_master = await power_wall.get_sitemaster()
     meters = await power_wall.get_meters()
     grid_services_active = await power_wall.is_grid_services_active()
     grid_status = await power_wall.get_grid_status()
+    if restricted:
+        return PowerwallData(
+            charge=charge,
+            site_master=None,
+            meters=meters,
+            grid_services_active=grid_services_active,
+            grid_status=grid_status,
+            backup_reserve=None,
+            batteries={},
+        )
+    backup_reserve = await get_backup_reserve_percentage(power_wall)
+    site_master = await power_wall.get_sitemaster()
     batteries = await power_wall.get_batteries()
     return PowerwallData(
         charge=charge,

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -72,6 +72,7 @@ class PowerwallDataManager:
         self.power_wall = power_wall
         self.cookie_jar = cookie_jar
         self.entry = entry
+        self.restricted = runtime_data["base_info"].restricted
 
     @property
     def api_changed(self) -> int:
@@ -101,7 +102,9 @@ class PowerwallDataManager:
             try:
                 if attempt == 1:
                     await self._recreate_powerwall_login()
-                data = await _fetch_powerwall_data(self.power_wall)
+                data = await _fetch_powerwall_data(
+                    self.power_wall, restricted=self.restricted
+                )
             except (TimeoutError, PowerwallUnreachableError) as err:
                 raise UpdateFailed("Unable to fetch data from powerwall") from err
             except MissingAttributeError as err:
@@ -170,7 +173,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerwallConfigEntry) ->
         for tries in range(2):
             try:
                 base_info = await _login_and_fetch_base_info(
-                    power_wall, ip_address, password, use_auth_cookie
+                    power_wall,
+                    ip_address,
+                    password,
+                    use_auth_cookie,
+                    fallback_din=entry.unique_id,
                 )
 
                 # Cancel closing power_wall on success
@@ -239,6 +246,8 @@ async def async_migrate_entity_unique_ids(
     hass: HomeAssistant, entry: PowerwallConfigEntry, base_info: PowerwallBaseInfo
 ) -> None:
     """Migrate old entity unique ids to use gateway_din."""
+    if not base_info.serial_numbers:
+        return
     old_base_unique_id = "_".join(base_info.serial_numbers)
     new_base_unique_id = base_info.gateway_din
 
@@ -260,24 +269,60 @@ async def async_migrate_entity_unique_ids(
 
 
 async def _login_and_fetch_base_info(
-    power_wall: Powerwall, host: str, password: str | None, use_auth_cookie: bool
+    power_wall: Powerwall,
+    host: str,
+    password: str | None,
+    use_auth_cookie: bool,
+    fallback_din: str | None = None,
 ) -> PowerwallBaseInfo:
     """Login to the powerwall and fetch the base info."""
     # Login step is skipped if password is None or if we are using the auth cookie
     if not (password is None or use_auth_cookie):
         await power_wall.login(password)
-    return await _call_base_info(power_wall, host)
+    return await _call_base_info(power_wall, host, fallback_din)
 
 
-async def _call_base_info(power_wall: Powerwall, host: str) -> PowerwallBaseInfo:
+def _is_404_api_error(err: ApiError) -> bool:
+    """Return True if an ApiError represents an HTTP 404 from the gateway."""
+    return "returned error 404" in str(err)
+
+
+async def _call_base_info(
+    power_wall: Powerwall, host: str, fallback_din: str | None = None
+) -> PowerwallBaseInfo:
     """Return PowerwallBaseInfo for the device."""
     # We await each call individually since the powerwall
     # supports http keep-alive and we want to reuse the connection
     # as its faster than establishing a new connection when
     # run concurrently.
-    gateway_din = await power_wall.get_gateway_din()
-    site_info = await power_wall.get_site_info()
+    url = f"https://{host}"
+    # Probe via get_gateway_din (hits /api/powerwalls) to detect the restricted
+    # PW3-style surface. PW3 (and recent firmware revisions) return HTTP 404 on
+    # /api/powerwalls and most other legacy endpoints; only meters/aggregates,
+    # system_status/soe, and system_status/grid_status are guaranteed to work.
+    try:
+        gateway_din = await power_wall.get_gateway_din()
+    except ApiError as err:
+        if not _is_404_api_error(err):
+            raise
+        # No DIN available — fall back to the caller-supplied identifier
+        # (typically the MAC saved as the config-entry unique_id) so the device
+        # identifier is stable across restarts.
+        identifier = fallback_din or host
+        return PowerwallBaseInfo(
+            gateway_din=identifier,
+            site_name=f"Powerwall {host}",
+            site_info=None,
+            status=None,
+            device_type=None,
+            serial_numbers=[],
+            url=url,
+            batteries={},
+            restricted=True,
+        )
+
     status = await power_wall.get_status()
+    site_info = await power_wall.get_site_info()
     device_type = await power_wall.get_device_type()
     serial_numbers = await power_wall.get_serial_numbers()
     batteries = await power_wall.get_batteries()
@@ -285,11 +330,12 @@ async def _call_base_info(power_wall: Powerwall, host: str) -> PowerwallBaseInfo
     # for backwards compatibility.
     return PowerwallBaseInfo(
         gateway_din=gateway_din,
+        site_name=site_info.site_name,
         site_info=site_info,
         status=status,
         device_type=device_type,
         serial_numbers=sorted(serial_numbers),
-        url=f"https://{host}",
+        url=url,
         batteries={battery.serial_number: battery for battery in batteries},
     )
 
@@ -310,19 +356,32 @@ async def get_operation_mode(power_wall: Powerwall) -> OperationMode | None:
         return None
 
 
-async def _fetch_powerwall_data(power_wall: Powerwall) -> PowerwallData:
+async def _fetch_powerwall_data(
+    power_wall: Powerwall, restricted: bool = False
+) -> PowerwallData:
     """Process and update powerwall data."""
     # We await each call individually since the powerwall
     # supports http keep-alive and we want to reuse the connection
     # as its faster than establishing a new connection when
     # run concurrently.
-    backup_reserve = await get_backup_reserve_percentage(power_wall)
-    operation_mode = await get_operation_mode(power_wall)
     charge = await power_wall.get_charge()
-    site_master = await power_wall.get_sitemaster()
     meters = await power_wall.get_meters()
     grid_services_active = await power_wall.is_grid_services_active()
     grid_status = await power_wall.get_grid_status()
+    if restricted:
+        return PowerwallData(
+            charge=charge,
+            site_master=None,
+            meters=meters,
+            grid_services_active=grid_services_active,
+            grid_status=grid_status,
+            backup_reserve=None,
+            operation_mode=None,
+            batteries={},
+        )
+    backup_reserve = await get_backup_reserve_percentage(power_wall)
+    operation_mode = await get_operation_mode(power_wall)
+    site_master = await power_wall.get_sitemaster()
     batteries = await power_wall.get_batteries()
     return PowerwallData(
         charge=charge,

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -38,6 +38,7 @@ from .coordinator import (
     PowerwallRuntimeData,
     PowerwallUpdateCoordinator,
 )
+from .helpers import is_api_404
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
@@ -282,11 +283,6 @@ async def _login_and_fetch_base_info(
     return await _call_base_info(power_wall, host, fallback_din)
 
 
-def _is_404_api_error(err: ApiError) -> bool:
-    """Return True if an ApiError represents an HTTP 404 from the gateway."""
-    return "returned error 404" in str(err)
-
-
 async def _call_base_info(
     power_wall: Powerwall, host: str, fallback_din: str | None = None
 ) -> PowerwallBaseInfo:
@@ -303,7 +299,7 @@ async def _call_base_info(
     try:
         gateway_din = await power_wall.get_gateway_din()
     except ApiError as err:
-        if not _is_404_api_error(err):
+        if not is_api_404(err):
             raise
         # No DIN available — fall back to the caller-supplied identifier
         # (typically the MAC saved as the config-entry unique_id) so the device

--- a/homeassistant/components/powerwall/binary_sensor.py
+++ b/homeassistant/components/powerwall/binary_sensor.py
@@ -27,17 +27,24 @@ async def async_setup_entry(
 ) -> None:
     """Set up the powerwall sensors."""
     powerwall_data = entry.runtime_data
+    base_info = powerwall_data["base_info"]
+    if base_info.restricted:
+        # Running and Connected sensors require /api/sitemaster which 404s on PW3.
+        sensor_classes: tuple[type[PowerWallEntity], ...] = (
+            PowerWallGridServicesActiveSensor,
+            PowerWallGridStatusSensor,
+            PowerWallChargingStatusSensor,
+        )
+    else:
+        sensor_classes = (
+            PowerWallRunningSensor,
+            PowerWallGridServicesActiveSensor,
+            PowerWallGridStatusSensor,
+            PowerWallConnectedSensor,
+            PowerWallChargingStatusSensor,
+        )
     async_add_entities(
-        [
-            sensor_class(powerwall_data)
-            for sensor_class in (
-                PowerWallRunningSensor,
-                PowerWallGridServicesActiveSensor,
-                PowerWallGridStatusSensor,
-                PowerWallConnectedSensor,
-                PowerWallChargingStatusSensor,
-            )
-        ]
+        [sensor_class(powerwall_data) for sensor_class in sensor_classes]
     )
 
 
@@ -55,7 +62,10 @@ class PowerWallRunningSensor(PowerWallEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Get the powerwall running state."""
-        return self.data.site_master.is_running
+        site_master = self.data.site_master
+        if TYPE_CHECKING:
+            assert site_master is not None
+        return site_master.is_running
 
 
 class PowerWallConnectedSensor(PowerWallEntity, BinarySensorEntity):
@@ -72,7 +82,10 @@ class PowerWallConnectedSensor(PowerWallEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Get the powerwall connected to tesla state."""
-        return self.data.site_master.is_connected_to_tesla
+        site_master = self.data.site_master
+        if TYPE_CHECKING:
+            assert site_master is not None
+        return site_master.is_connected_to_tesla
 
 
 class PowerWallGridServicesActiveSensor(PowerWallEntity, BinarySensorEntity):

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Mapping
+import hashlib
 import logging
 from typing import Any
 
 from aiohttp import CookieJar
 from tesla_powerwall import (
     AccessDeniedError,
+    ApiError,
     MissingAttributeError,
     Powerwall,
     PowerwallUnreachableError,
-    SiteInfoResponse,
 )
 import voluptuous as vol
 
@@ -28,7 +28,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
-from homeassistant.util.network import is_ip_address
 
 from . import async_last_update_was_successful
 from .const import CONFIG_ENTRY_COOKIE, DOMAIN
@@ -44,14 +43,29 @@ ENTRY_FAILURE_STATES = {
 
 async def _login_and_fetch_site_info(
     power_wall: Powerwall, password: str
-) -> tuple[SiteInfoResponse, str]:
-    """Login to the powerwall and fetch the base info."""
+) -> tuple[str | None, str | None]:
+    """Login to the powerwall and return (title, gateway_din).
+
+    On the restricted PW3-style surface, ``/api/powerwalls`` and
+    ``/api/site_info`` return 404. Both ``None`` results signal that the caller
+    should synthesize a title and unique id from the host.
+    """
     if password is not None:
         await power_wall.login(password)
 
-    return await asyncio.gather(
-        power_wall.get_site_info(), power_wall.get_gateway_din()
-    )
+    try:
+        gateway_din = await power_wall.get_gateway_din()
+    except ApiError as err:
+        if "returned error 404" not in str(err):
+            raise
+        return None, None
+    try:
+        site_info = await power_wall.get_site_info()
+    except ApiError as err:
+        if "returned error 404" not in str(err):
+            raise
+        return f"Powerwall {gateway_din[-5:]}", gateway_din
+    return site_info.site_name, gateway_din
 
 
 async def _powerwall_is_reachable(ip_address: str, password: str) -> bool:
@@ -78,16 +92,26 @@ async def validate_input(hass: HomeAssistant, data: dict[str, str]) -> dict[str,
         password = data[CONF_PASSWORD]
 
         try:
-            site_info, gateway_din = await _login_and_fetch_site_info(
-                power_wall, password
-            )
+            title, gateway_din = await _login_and_fetch_site_info(power_wall, password)
         except MissingAttributeError as err:
             # Only log the exception without the traceback
             _LOGGER.error(str(err))
             raise WrongVersion from err
 
+        ip_address = data[CONF_IP_ADDRESS]
+        if gateway_din is None:
+            # PW3-style restricted gateway — no DIN exposed via HTTP. Fall back
+            # to a hash of the password (gateway serial-derived) for a stable
+            # unique id that survives IP changes. DHCP discovery (which carries
+            # the real DIN as the hostname) can later upgrade the entry.
+            unique_id = hashlib.sha256(password.encode()).hexdigest()
+            return {
+                "title": f"Powerwall {ip_address}",
+                "unique_id": unique_id,
+            }
+        assert title is not None
         # Return info that you want to store in the config entry.
-        return {"title": site_info.site_name, "unique_id": gateway_din.upper()}
+        return {"title": title, "unique_id": gateway_din.upper()}
 
 
 class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -125,7 +149,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(gateway_din)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.data[CONF_IP_ADDRESS] == discovery_info.ip:
-                if entry.unique_id is not None and is_ip_address(entry.unique_id):
+                if entry.unique_id is not None and entry.unique_id != gateway_din:
                     if self.hass.config_entries.async_update_entry(
                         entry, unique_id=gateway_din
                     ):
@@ -167,14 +191,16 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             info = await validate_input(self.hass, user_input)
         except (PowerwallUnreachableError, TimeoutError) as ex:
+            _LOGGER.debug("Cannot connect to powerwall", exc_info=ex)
             errors[CONF_IP_ADDRESS] = "cannot_connect"
-            description_placeholders = {"error": str(ex)}
+            description_placeholders = {"error": str(ex) or type(ex).__name__}
         except WrongVersion as ex:
             errors["base"] = "wrong_version"
-            description_placeholders = {"error": str(ex)}
+            description_placeholders = {"error": str(ex) or type(ex).__name__}
         except AccessDeniedError as ex:
+            _LOGGER.debug("Access denied to powerwall", exc_info=ex)
             errors[CONF_PASSWORD] = "invalid_auth"
-            description_placeholders = {"error": str(ex)}
+            description_placeholders = {"error": str(ex) or type(ex).__name__}
         except Exception as ex:
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -28,9 +28,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.util.network import is_ip_address
 
 from . import async_last_update_was_successful
 from .const import CONFIG_ENTRY_COOKIE, DOMAIN
+from .helpers import is_api_404
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,16 +58,29 @@ async def _login_and_fetch_site_info(
     try:
         gateway_din = await power_wall.get_gateway_din()
     except ApiError as err:
-        if "returned error 404" not in str(err):
+        if not is_api_404(err):
             raise
         return None, None
     try:
         site_info = await power_wall.get_site_info()
     except ApiError as err:
-        if "returned error 404" not in str(err):
+        if not is_api_404(err):
             raise
         return f"Powerwall {gateway_din[-5:]}", gateway_din
     return site_info.site_name, gateway_din
+
+
+def _is_synthetic_unique_id(unique_id: str) -> bool:
+    """Return True if the unique_id was synthesized by us.
+
+    Real Powerwall DINs are short alphanumeric strings; the synthetic forms we
+    produce are dotted IPs (legacy) or 64-character hex digests (restricted
+    PW3 gateways). Anything else is treated as a real DIN and must not be
+    silently overwritten by DHCP discovery.
+    """
+    if is_ip_address(unique_id):
+        return True
+    return len(unique_id) == 64 and all(c in "0123456789abcdef" for c in unique_id)
 
 
 async def _powerwall_is_reachable(ip_address: str, password: str) -> bool:
@@ -149,7 +164,11 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(gateway_din)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.data[CONF_IP_ADDRESS] == discovery_info.ip:
-                if entry.unique_id is not None and entry.unique_id != gateway_din:
+                if (
+                    entry.unique_id is not None
+                    and entry.unique_id != gateway_din
+                    and _is_synthetic_unique_id(entry.unique_id)
+                ):
                     if self.hass.config_entries.async_update_entry(
                         entry, unique_id=gateway_din
                     ):

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -71,19 +71,6 @@ async def _login_and_fetch_site_info(
     return site_info.site_name, gateway_din
 
 
-def _is_synthetic_unique_id(unique_id: str) -> bool:
-    """Return True if the unique_id was synthesized by us.
-
-    Real Powerwall DINs are short alphanumeric strings; the synthetic forms we
-    produce are dotted IPs (legacy) or 64-character hex digests (restricted
-    PW3 gateways). Anything else is treated as a real DIN and must not be
-    silently overwritten by DHCP discovery.
-    """
-    if is_ip_address(unique_id):
-        return True
-    return len(unique_id) == 64 and all(c in "0123456789abcdef" for c in unique_id)
-
-
 async def _powerwall_is_reachable(ip_address: str, password: str) -> bool:
     """Check if the powerwall is reachable."""
     try:
@@ -165,11 +152,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(gateway_din)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.data[CONF_IP_ADDRESS] == discovery_info.ip:
-                if (
-                    entry.unique_id is not None
-                    and entry.unique_id != gateway_din
-                    and _is_synthetic_unique_id(entry.unique_id)
-                ):
+                if entry.unique_id is not None and is_ip_address(entry.unique_id):
                     if self.hass.config_entries.async_update_entry(
                         entry, unique_id=gateway_din
                     ):

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Tesla Powerwall integration."""
 
 from collections.abc import Mapping
-import hashlib
 import logging
 from typing import Any
 
@@ -75,7 +74,9 @@ async def _powerwall_is_reachable(ip_address: str, password: str) -> bool:
     return True
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, str]) -> dict[str, str]:
+async def validate_input(
+    hass: HomeAssistant, data: dict[str, str]
+) -> dict[str, str | None]:
     """Validate the user input allows us to connect.
 
     Data has the keys from schema with values provided by the user.
@@ -95,14 +96,13 @@ async def validate_input(hass: HomeAssistant, data: dict[str, str]) -> dict[str,
 
         ip_address = data[CONF_IP_ADDRESS]
         if gateway_din is None:
-            # PW3-style restricted gateway — no DIN exposed via HTTP. Fall back
-            # to a hash of the password (gateway serial-derived) for a stable
-            # unique id that survives IP changes. DHCP discovery (which carries
-            # the real DIN as the hostname) can later upgrade the entry.
-            unique_id = hashlib.sha256(password.encode()).hexdigest()
+            # PW3-style restricted gateway — no DIN exposed via HTTP. We have no
+            # stable hardware identifier to use as a unique id, so leave it unset
+            # and rely on IP-based dedup. DHCP discovery (which carries the real
+            # DIN as the hostname) can later assign a unique id to the entry.
             return {
                 "title": f"Powerwall {ip_address}",
-                "unique_id": unique_id,
+                "unique_id": None,
             }
         assert title is not None
         # Return info that you want to store in the config entry.
@@ -178,7 +178,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _async_try_connect(
         self, user_input: dict[str, Any]
-    ) -> tuple[dict[str, Any] | None, dict[str, str] | None, dict[str, str]]:
+    ) -> tuple[dict[str, str] | None, dict[str, str | None] | None, dict[str, str]]:
         """Try to connect to the powerwall."""
         info = None
         errors: dict[str, str] = {}
@@ -244,6 +244,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             if not errors:
                 assert info is not None
+                assert info["title"] is not None
                 if info["unique_id"]:
                     await self.async_set_unique_id(
                         info["unique_id"], raise_on_progress=False

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -1,8 +1,5 @@
 """Config flow for Tesla Powerwall integration."""
 
-from __future__ import annotations
-
-import asyncio
 from collections.abc import Mapping
 import hashlib
 import logging
@@ -49,9 +46,9 @@ async def _login_and_fetch_site_info(
 ) -> tuple[str | None, str | None]:
     """Login to the powerwall and return (title, gateway_din).
 
-    On the restricted PW3-style surface, ``/api/powerwalls`` and
-    ``/api/site_info`` return 404. Both ``None`` results signal that the caller
-    should synthesize a title and unique id from the host.
+    On the restricted PW3-style surface, ``/api/powerwalls`` returns 404. Both
+    ``None`` results signal that the caller should synthesize a title and unique
+    id from the host.
     """
     if password is not None:
         await power_wall.login(password)
@@ -62,12 +59,7 @@ async def _login_and_fetch_site_info(
         if not is_api_404(err):
             raise
         return None, None
-    try:
-        site_info = await power_wall.get_site_info()
-    except ApiError as err:
-        if not is_api_404(err):
-            raise
-        return f"Powerwall {gateway_din[-5:]}", gateway_din
+    site_info = await power_wall.get_site_info()
     return site_info.site_name, gateway_din
 
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -29,9 +29,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.util.network import is_ip_address
 
 from . import async_last_update_was_successful
 from .const import CONFIG_ENTRY_COOKIE, DOMAIN
+from .helpers import is_api_404
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,16 +59,29 @@ async def _login_and_fetch_site_info(
     try:
         gateway_din = await power_wall.get_gateway_din()
     except ApiError as err:
-        if "returned error 404" not in str(err):
+        if not is_api_404(err):
             raise
         return None, None
     try:
         site_info = await power_wall.get_site_info()
     except ApiError as err:
-        if "returned error 404" not in str(err):
+        if not is_api_404(err):
             raise
         return f"Powerwall {gateway_din[-5:]}", gateway_din
     return site_info.site_name, gateway_din
+
+
+def _is_synthetic_unique_id(unique_id: str) -> bool:
+    """Return True if the unique_id was synthesized by us.
+
+    Real Powerwall DINs are short alphanumeric strings; the synthetic forms we
+    produce are dotted IPs (legacy) or 64-character hex digests (restricted
+    PW3 gateways). Anything else is treated as a real DIN and must not be
+    silently overwritten by DHCP discovery.
+    """
+    if is_ip_address(unique_id):
+        return True
+    return len(unique_id) == 64 and all(c in "0123456789abcdef" for c in unique_id)
 
 
 async def _powerwall_is_reachable(ip_address: str, password: str) -> bool:
@@ -150,7 +165,11 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(gateway_din)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.data[CONF_IP_ADDRESS] == discovery_info.ip:
-                if entry.unique_id is not None and entry.unique_id != gateway_din:
+                if (
+                    entry.unique_id is not None
+                    and entry.unique_id != gateway_din
+                    and _is_synthetic_unique_id(entry.unique_id)
+                ):
                     if self.hass.config_entries.async_update_entry(
                         entry, unique_id=gateway_din
                     ):

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -1,17 +1,20 @@
 """Config flow for Tesla Powerwall integration."""
 
+from __future__ import annotations
+
 import asyncio
 from collections.abc import Mapping
+import hashlib
 import logging
 from typing import Any
 
 from aiohttp import CookieJar
 from tesla_powerwall import (
     AccessDeniedError,
+    ApiError,
     MissingAttributeError,
     Powerwall,
     PowerwallUnreachableError,
-    SiteInfoResponse,
 )
 import voluptuous as vol
 
@@ -26,7 +29,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
-from homeassistant.util.network import is_ip_address
 
 from . import async_last_update_was_successful
 from .const import CONFIG_ENTRY_COOKIE, DOMAIN
@@ -42,14 +44,29 @@ ENTRY_FAILURE_STATES = {
 
 async def _login_and_fetch_site_info(
     power_wall: Powerwall, password: str
-) -> tuple[SiteInfoResponse, str]:
-    """Login to the powerwall and fetch the base info."""
+) -> tuple[str | None, str | None]:
+    """Login to the powerwall and return (title, gateway_din).
+
+    On the restricted PW3-style surface, ``/api/powerwalls`` and
+    ``/api/site_info`` return 404. Both ``None`` results signal that the caller
+    should synthesize a title and unique id from the host.
+    """
     if password is not None:
         await power_wall.login(password)
 
-    return await asyncio.gather(
-        power_wall.get_site_info(), power_wall.get_gateway_din()
-    )
+    try:
+        gateway_din = await power_wall.get_gateway_din()
+    except ApiError as err:
+        if "returned error 404" not in str(err):
+            raise
+        return None, None
+    try:
+        site_info = await power_wall.get_site_info()
+    except ApiError as err:
+        if "returned error 404" not in str(err):
+            raise
+        return f"Powerwall {gateway_din[-5:]}", gateway_din
+    return site_info.site_name, gateway_din
 
 
 async def _powerwall_is_reachable(ip_address: str, password: str) -> bool:
@@ -76,16 +93,26 @@ async def validate_input(hass: HomeAssistant, data: dict[str, str]) -> dict[str,
         password = data[CONF_PASSWORD]
 
         try:
-            site_info, gateway_din = await _login_and_fetch_site_info(
-                power_wall, password
-            )
+            title, gateway_din = await _login_and_fetch_site_info(power_wall, password)
         except MissingAttributeError as err:
             # Only log the exception without the traceback
             _LOGGER.error(str(err))
             raise WrongVersion from err
 
+        ip_address = data[CONF_IP_ADDRESS]
+        if gateway_din is None:
+            # PW3-style restricted gateway — no DIN exposed via HTTP. Fall back
+            # to a hash of the password (gateway serial-derived) for a stable
+            # unique id that survives IP changes. DHCP discovery (which carries
+            # the real DIN as the hostname) can later upgrade the entry.
+            unique_id = hashlib.sha256(password.encode()).hexdigest()
+            return {
+                "title": f"Powerwall {ip_address}",
+                "unique_id": unique_id,
+            }
+        assert title is not None
         # Return info that you want to store in the config entry.
-        return {"title": site_info.site_name, "unique_id": gateway_din.upper()}
+        return {"title": title, "unique_id": gateway_din.upper()}
 
 
 class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -123,7 +150,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(gateway_din)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.data[CONF_IP_ADDRESS] == discovery_info.ip:
-                if entry.unique_id is not None and is_ip_address(entry.unique_id):
+                if entry.unique_id is not None and entry.unique_id != gateway_din:
                     if self.hass.config_entries.async_update_entry(
                         entry, unique_id=gateway_din
                     ):
@@ -165,14 +192,16 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             info = await validate_input(self.hass, user_input)
         except (PowerwallUnreachableError, TimeoutError) as ex:
+            _LOGGER.debug("Cannot connect to powerwall", exc_info=ex)
             errors[CONF_IP_ADDRESS] = "cannot_connect"
-            description_placeholders = {"error": str(ex)}
+            description_placeholders = {"error": str(ex) or type(ex).__name__}
         except WrongVersion as ex:
             errors["base"] = "wrong_version"
-            description_placeholders = {"error": str(ex)}
+            description_placeholders = {"error": str(ex) or type(ex).__name__}
         except AccessDeniedError as ex:
+            _LOGGER.debug("Access denied to powerwall", exc_info=ex)
             errors[CONF_PASSWORD] = "invalid_auth"
-            description_placeholders = {"error": str(ex)}
+            description_placeholders = {"error": str(ex) or type(ex).__name__}
         except Exception as ex:
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -157,6 +157,16 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
                     ):
                         self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="already_configured")
+        # A restricted PW3-style gateway is stored without a unique id because no
+        # DIN is exposed over HTTP. We never stored its DIN, so we cannot match a
+        # discovery against it (e.g. after its IP changed). If such an entry
+        # exists we abort rather than risk setting up a duplicate of a powerwall
+        # that is already configured.
+        if any(
+            entry.unique_id is None
+            for entry in self._async_current_entries(include_ignore=False)
+        ):
+            return self.async_abort(reason="already_configured")
         # Still need to abort for ignored entries
         self._abort_if_unique_id_configured()
         self.context["title_placeholders"] = {

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -119,6 +119,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the powerwall flow."""
         self.ip_address: str | None = None
         self.title: str | None = None
+        self.password: str | None = None
 
     async def _async_powerwall_is_offline(self, entry: ConfigEntry) -> bool:
         """Check if the power wall is offline.
@@ -185,6 +186,13 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="cannot_connect")
         assert info is not None
         self.title = info["title"]
+        self.password = gateway_din[-5:]
+        if info["unique_id"] is None:
+            # Restricted gateway reached via DHCP. The hostname we stored as the
+            # flow unique id is not a real DIN (e.g. PW3 advertises a TeslaPW_*
+            # name unrelated to the DIN), so drop it and store the entry without
+            # a unique id, consistent with the manual restricted path.
+            await self.async_set_unique_id(None)
         return await self.async_step_confirm_discovery()
 
     async def _async_try_connect(
@@ -220,13 +228,13 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         """Confirm a discovered powerwall."""
         assert self.ip_address is not None
         assert self.title is not None
-        assert self.unique_id is not None
+        assert self.password is not None
         if user_input is not None:
             return self.async_create_entry(
                 title=self.title,
                 data={
                     CONF_IP_ADDRESS: self.ip_address,
-                    CONF_PASSWORD: self.unique_id[-5:],
+                    CONF_PASSWORD: self.password,
                 },
             )
 
@@ -263,6 +271,11 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._abort_if_unique_id_configured(
                         updates={CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS]}
                     )
+                else:
+                    # Restricted gateway: a DHCP discovery may have pre-set the
+                    # flow unique id from the hostname, which is not a real DIN.
+                    # Clear it so the entry is stored without a unique id.
+                    await self.async_set_unique_id(None)
                 self._async_abort_entries_match({CONF_IP_ADDRESS: self.ip_address})
                 return self.async_create_entry(title=info["title"], data=user_input)
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -98,8 +98,9 @@ async def validate_input(
         if gateway_din is None:
             # PW3-style restricted gateway — no DIN exposed via HTTP. We have no
             # stable hardware identifier to use as a unique id, so leave it unset
-            # and rely on IP-based dedup. DHCP discovery (which carries the real
-            # DIN as the hostname) can later assign a unique id to the entry.
+            # and rely on IP-based dedup. Because the entry has no unique id, DHCP
+            # discovery cannot match it and instead aborts (see async_step_dhcp)
+            # to avoid setting up a duplicate.
             return {
                 "title": f"Powerwall {ip_address}",
                 "unique_id": None,

--- a/homeassistant/components/powerwall/coordinator.py
+++ b/homeassistant/components/powerwall/coordinator.py
@@ -37,12 +37,14 @@ class PowerwallBaseInfo:
     """Base information for the powerwall integration."""
 
     gateway_din: str
-    site_info: SiteInfoResponse
-    status: PowerwallStatusResponse
-    device_type: DeviceType
+    site_name: str
+    site_info: SiteInfoResponse | None
+    status: PowerwallStatusResponse | None
+    device_type: DeviceType | None
     serial_numbers: list[str]
     url: str
     batteries: dict[str, BatteryResponse]
+    restricted: bool = False
 
 
 @dataclass
@@ -50,7 +52,7 @@ class PowerwallData:
     """Point in time data for the powerwall integration."""
 
     charge: float
-    site_master: SiteMasterResponse
+    site_master: SiteMasterResponse | None
     meters: MetersAggregatesResponse
     grid_services_active: bool
     grid_status: GridStatus

--- a/homeassistant/components/powerwall/coordinator.py
+++ b/homeassistant/components/powerwall/coordinator.py
@@ -36,12 +36,14 @@ class PowerwallBaseInfo:
     """Base information for the powerwall integration."""
 
     gateway_din: str
-    site_info: SiteInfoResponse
-    status: PowerwallStatusResponse
-    device_type: DeviceType
+    site_name: str
+    site_info: SiteInfoResponse | None
+    status: PowerwallStatusResponse | None
+    device_type: DeviceType | None
     serial_numbers: list[str]
     url: str
     batteries: dict[str, BatteryResponse]
+    restricted: bool = False
 
 
 @dataclass
@@ -49,7 +51,7 @@ class PowerwallData:
     """Point in time data for the powerwall integration."""
 
     charge: float
-    site_master: SiteMasterResponse
+    site_master: SiteMasterResponse | None
     meters: MetersAggregatesResponse
     grid_services_active: bool
     grid_status: GridStatus

--- a/homeassistant/components/powerwall/entity.py
+++ b/homeassistant/components/powerwall/entity.py
@@ -32,7 +32,7 @@ class PowerWallEntity(CoordinatorEntity[PowerwallUpdateCoordinator]):
         model = (
             f"{MODEL} ({base_info.device_type.name})"
             if base_info.device_type is not None
-            else "Powerwall 3"
+            else None
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.base_unique_id)},

--- a/homeassistant/components/powerwall/entity.py
+++ b/homeassistant/components/powerwall/entity.py
@@ -29,12 +29,17 @@ class PowerWallEntity(CoordinatorEntity[PowerwallUpdateCoordinator]):
         super().__init__(coordinator)
         self.power_wall = powerwall_data[POWERWALL_API]
         self.base_unique_id = base_info.gateway_din
+        model = (
+            f"{MODEL} ({base_info.device_type.name})"
+            if base_info.device_type is not None
+            else "Powerwall 3"
+        )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.base_unique_id)},
             manufacturer=MANUFACTURER,
-            model=f"{MODEL} ({base_info.device_type.name})",
-            name=base_info.site_info.site_name,
-            sw_version=base_info.status.version,
+            model=model,
+            name=base_info.site_name,
+            sw_version=base_info.status.version if base_info.status else None,
             configuration_url=base_info.url,
         )
 
@@ -65,8 +70,8 @@ class BatteryEntity(CoordinatorEntity[PowerwallUpdateCoordinator]):
             identifiers={(DOMAIN, self.base_unique_id)},
             manufacturer=MANUFACTURER,
             model=f"{MODEL} ({battery.part_number})",
-            name=f"{base_info.site_info.site_name} {battery.serial_number}",
-            sw_version=base_info.status.version,
+            name=f"{base_info.site_name} {battery.serial_number}",
+            sw_version=base_info.status.version if base_info.status else None,
             configuration_url=base_info.url,
             via_device=(DOMAIN, base_info.gateway_din),
         )

--- a/homeassistant/components/powerwall/entity.py
+++ b/homeassistant/components/powerwall/entity.py
@@ -32,7 +32,7 @@ class PowerWallEntity(CoordinatorEntity[PowerwallUpdateCoordinator]):
         model = (
             f"{MODEL} ({base_info.device_type.name})"
             if base_info.device_type is not None
-            else None
+            else MODEL
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.base_unique_id)},

--- a/homeassistant/components/powerwall/helpers.py
+++ b/homeassistant/components/powerwall/helpers.py
@@ -1,0 +1,17 @@
+"""Helpers for the powerwall integration."""
+
+from __future__ import annotations
+
+from tesla_powerwall import ApiError
+
+# tesla_powerwall 0.5.2 raises ApiError with a fixed message of the form
+# "Powerwall api error: The url <url> returned error 404". The library does
+# not expose the underlying HTTP status code, so we match the exact phrase
+# produced at tesla_powerwall/api.py:_handle_error. Once upstream exposes a
+# status_code attribute on ApiError this becomes a one-line attribute check.
+_API_404_MARKER = "returned error 404"
+
+
+def is_api_404(err: ApiError) -> bool:
+    """Return True if an ApiError represents an HTTP 404 from the gateway."""
+    return _API_404_MARKER in str(err)

--- a/homeassistant/components/powerwall/helpers.py
+++ b/homeassistant/components/powerwall/helpers.py
@@ -1,7 +1,5 @@
 """Helpers for the powerwall integration."""
 
-from __future__ import annotations
-
 from tesla_powerwall import ApiError
 
 # tesla_powerwall 0.5.2 raises ApiError with a fixed message of the form

--- a/homeassistant/components/powerwall/helpers.py
+++ b/homeassistant/components/powerwall/helpers.py
@@ -2,11 +2,12 @@
 
 from tesla_powerwall import ApiError
 
-# tesla_powerwall 0.5.2 raises ApiError with a fixed message of the form
-# "Powerwall api error: The url <url> returned error 404". The library does
-# not expose the underlying HTTP status code, so we match the exact phrase
-# produced at tesla_powerwall/api.py:_handle_error. Once upstream exposes a
-# status_code attribute on ApiError this becomes a one-line attribute check.
+# tesla_powerwall 0.5.2 raises ApiError with a message that embeds the HTTP
+# status but not a structured status code, e.g. "... returned error 404". The
+# exact prefix varies by call site (the request method and url are interpolated
+# in), but the "returned error <status>" suffix is stable, so we match that
+# phrase. Once upstream exposes a status_code attribute on ApiError this becomes
+# a one-line attribute check.
 _API_404_MARKER = "returned error 404"
 
 

--- a/homeassistant/components/powerwall/manifest.json
+++ b/homeassistant/components/powerwall/manifest.json
@@ -9,6 +9,9 @@
     },
     {
       "hostname": "1232100-*"
+    },
+    {
+      "hostname": "teslapw_*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/powerwall",

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -217,6 +217,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the powerwall sensors."""
     powerwall_data = entry.runtime_data
+    base_info = powerwall_data["base_info"]
     coordinator = powerwall_data[POWERWALL_COORDINATOR]
     assert coordinator is not None
     data = coordinator.data
@@ -224,7 +225,7 @@ async def async_setup_entry(
         PowerWallChargeSensor(powerwall_data),
     ]
 
-    if data.backup_reserve is not None:
+    if not base_info.restricted and data.backup_reserve is not None:
         entities.append(PowerWallBackupReserveSensor(powerwall_data))
 
     for meter in data.meters.meters:
@@ -235,11 +236,12 @@ async def async_setup_entry(
             for description in POWERWALL_INSTANT_SENSORS
         )
 
-    for battery in data.batteries.values():
-        entities.extend(
-            PowerWallBatterySensor(powerwall_data, battery, description)
-            for description in BATTERY_INSTANT_SENSORS
-        )
+    if not base_info.restricted:
+        for battery in data.batteries.values():
+            entities.extend(
+                PowerWallBatterySensor(powerwall_data, battery, description)
+                for description in BATTERY_INSTANT_SENSORS
+            )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -221,6 +221,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the powerwall sensors."""
     powerwall_data = entry.runtime_data
+    base_info = powerwall_data["base_info"]
     coordinator = powerwall_data[POWERWALL_COORDINATOR]
     assert coordinator is not None
     data = coordinator.data
@@ -228,7 +229,7 @@ async def async_setup_entry(
         PowerWallChargeSensor(powerwall_data),
     ]
 
-    if data.backup_reserve is not None:
+    if not base_info.restricted and data.backup_reserve is not None:
         entities.append(PowerWallBackupReserveSensor(powerwall_data))
 
     if data.operation_mode is not None:
@@ -242,11 +243,12 @@ async def async_setup_entry(
             for description in POWERWALL_INSTANT_SENSORS
         )
 
-    for battery in data.batteries.values():
-        entities.extend(
-            PowerWallBatterySensor(powerwall_data, battery, description)
-            for description in BATTERY_INSTANT_SENSORS
-        )
+    if not base_info.restricted:
+        for battery in data.batteries.values():
+            entities.extend(
+                PowerWallBatterySensor(powerwall_data, battery, description)
+                for description in BATTERY_INSTANT_SENSORS
+            )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/powerwall/switch.py
+++ b/homeassistant/components/powerwall/switch.py
@@ -25,6 +25,10 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Powerwall switch platform from Powerwall resources."""
+    # Off-grid switch requires writing to /api/operation, which 404s on the
+    # restricted PW3-style surface. Skip when no writes are available.
+    if entry.runtime_data["base_info"].restricted:
+        return
     async_add_entities([PowerwallOffGridEnabledEntity(entry.runtime_data)])
 
 

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -629,6 +629,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "hostname": "1232100-*",
     },
     {
+        "domain": "powerwall",
+        "hostname": "teslapw_*",
+    },
+    {
         "domain": "prusalink",
         "macaddress": "109C70*",
     },

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -649,6 +649,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "hostname": "1232100-*",
     },
     {
+        "domain": "powerwall",
+        "hostname": "teslapw_*",
+    },
+    {
         "domain": "prusalink",
         "macaddress": "109C70*",
     },

--- a/tests/components/powerwall/mocks.py
+++ b/tests/components/powerwall/mocks.py
@@ -6,6 +6,7 @@ import os
 from unittest.mock import MagicMock
 
 from tesla_powerwall import (
+    ApiError,
     BatteryResponse,
     DeviceType,
     GridStatus,
@@ -99,6 +100,35 @@ async def _mock_powerwall_site_name(hass: HomeAssistant, site_name: str) -> Magi
     site_info_resp.site_name = site_name
     powerwall_mock.get_site_info.return_value = site_info_resp
     powerwall_mock.get_gateway_din.return_value = MOCK_GATEWAY_DIN
+
+    return powerwall_mock
+
+
+async def _mock_powerwall_restricted(hass: HomeAssistant) -> MagicMock:
+    """Mock a PW3-style restricted gateway.
+
+    Only the three guaranteed endpoints work; everything else raises a 404
+    ``ApiError``.
+    """
+    meters = await _async_load_json_fixture(hass, "meters.json")
+
+    powerwall_mock = MagicMock(Powerwall)
+    powerwall_mock.__aenter__.return_value = powerwall_mock
+    powerwall_mock.get_charge.return_value = 47.34587394586
+    powerwall_mock.get_meters.return_value = MetersAggregatesResponse.from_dict(meters)
+    powerwall_mock.is_grid_services_active.return_value = True
+    powerwall_mock.get_grid_status.return_value = GridStatus.CONNECTED
+
+    not_found = ApiError("GET request to /api/status returned error 404")
+    powerwall_mock.get_gateway_din.side_effect = not_found
+    powerwall_mock.get_status.side_effect = not_found
+    powerwall_mock.get_site_info.side_effect = not_found
+    powerwall_mock.get_device_type.side_effect = not_found
+    powerwall_mock.get_serial_numbers.side_effect = not_found
+    powerwall_mock.get_batteries.side_effect = not_found
+    powerwall_mock.get_sitemaster.side_effect = not_found
+    powerwall_mock.get_backup_reserve_percentage.side_effect = not_found
+    powerwall_mock.set_island_mode.side_effect = not_found
 
     return powerwall_mock
 

--- a/tests/components/powerwall/mocks.py
+++ b/tests/components/powerwall/mocks.py
@@ -6,6 +6,7 @@ import os
 from unittest.mock import MagicMock
 
 from tesla_powerwall import (
+    ApiError,
     BatteryResponse,
     DeviceType,
     GridStatus,
@@ -103,6 +104,35 @@ async def _mock_powerwall_site_name(hass: HomeAssistant, site_name: str) -> Magi
     site_info_resp.site_name = site_name
     powerwall_mock.get_site_info.return_value = site_info_resp
     powerwall_mock.get_gateway_din.return_value = MOCK_GATEWAY_DIN
+
+    return powerwall_mock
+
+
+async def _mock_powerwall_restricted(hass: HomeAssistant) -> MagicMock:
+    """Mock a PW3-style restricted gateway.
+
+    Only the three guaranteed endpoints work; everything else raises a 404
+    ``ApiError``.
+    """
+    meters = await _async_load_json_fixture(hass, "meters.json")
+
+    powerwall_mock = MagicMock(Powerwall)
+    powerwall_mock.__aenter__.return_value = powerwall_mock
+    powerwall_mock.get_charge.return_value = 47.34587394586
+    powerwall_mock.get_meters.return_value = MetersAggregatesResponse.from_dict(meters)
+    powerwall_mock.is_grid_services_active.return_value = True
+    powerwall_mock.get_grid_status.return_value = GridStatus.CONNECTED
+
+    not_found = ApiError("GET request to /api/status returned error 404")
+    powerwall_mock.get_gateway_din.side_effect = not_found
+    powerwall_mock.get_status.side_effect = not_found
+    powerwall_mock.get_site_info.side_effect = not_found
+    powerwall_mock.get_device_type.side_effect = not_found
+    powerwall_mock.get_serial_numbers.side_effect = not_found
+    powerwall_mock.get_batteries.side_effect = not_found
+    powerwall_mock.get_sitemaster.side_effect = not_found
+    powerwall_mock.get_backup_reserve_percentage.side_effect = not_found
+    powerwall_mock.set_island_mode.side_effect = not_found
 
     return powerwall_mock
 

--- a/tests/components/powerwall/test_binary_sensor.py
+++ b/tests/components/powerwall/test_binary_sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.powerwall.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
-from .mocks import _mock_powerwall_with_fixtures
+from .mocks import _mock_powerwall_restricted, _mock_powerwall_with_fixtures
 
 from tests.common import MockConfigEntry
 
@@ -102,3 +102,36 @@ async def test_sensors_with_empty_meters(hass: HomeAssistant) -> None:
 
     state = hass.states.get("binary_sensor.mysite_charging")
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_pw3_restricted_entities(hass: HomeAssistant) -> None:
+    """Restricted PW3 surface should only expose the three meter-driven binary sensors."""
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4"},
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("binary_sensor.powerwall_1_2_3_4_grid_services_active")
+        is not None
+    )
+    assert hass.states.get("binary_sensor.powerwall_1_2_3_4_grid_status") is not None
+    assert hass.states.get("binary_sensor.powerwall_1_2_3_4_charging") is not None
+    # Running and Connected sensors require sitemaster which 404s on PW3.
+    assert hass.states.get("binary_sensor.powerwall_1_2_3_4_status") is None
+    assert hass.states.get("binary_sensor.powerwall_1_2_3_4_connected_to_tesla") is None

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Powerwall config flow."""
 
 from datetime import timedelta
+import hashlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from homeassistant.util import dt as dt_util
 
 from .mocks import (
     MOCK_GATEWAY_DIN,
+    _mock_powerwall_restricted,
     _mock_powerwall_side_effect,
     _mock_powerwall_site_name,
     _mock_powerwall_with_fixtures,
@@ -107,6 +109,40 @@ async def test_invalid_auth(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {CONF_PASSWORD: "invalid_auth"}
+
+
+async def test_form_pw3_restricted(hass: HomeAssistant) -> None:
+    """Test config flow succeeds for a PW3-style restricted gateway."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+        await hass.async_block_till_done()
+
+    expected_unique_id = hashlib.sha256(
+        VALID_CONFIG[CONF_PASSWORD].encode()
+    ).hexdigest()
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == f"Powerwall {VALID_CONFIG[CONF_IP_ADDRESS]}"
+    assert result2["data"] == VALID_CONFIG
+    assert result2["result"].unique_id == expected_unique_id
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_form_unknown_exception(hass: HomeAssistant) -> None:

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from tesla_powerwall import (
     AccessDeniedError,
+    ApiError,
     MissingAttributeError,
     PowerwallUnreachableError,
 )
@@ -143,6 +144,62 @@ async def test_form_pw3_restricted(hass: HomeAssistant) -> None:
     assert result2["data"] == VALID_CONFIG
     assert result2["result"].unique_id == expected_unique_id
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_pw3_site_info_404(hass: HomeAssistant) -> None:
+    """Gateway DIN succeeds but site_info 404s — title falls back to DIN suffix."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_powerwall = await _mock_powerwall_site_name(hass, "MySite")
+    mock_powerwall.get_site_info.side_effect = ApiError(
+        "GET request to /api/site_info returned error 404"
+    )
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == f"Powerwall {MOCK_GATEWAY_DIN[-5:]}"
+    assert result2["result"].unique_id == MOCK_GATEWAY_DIN.upper()
+
+
+async def test_form_non_404_api_error_propagates(hass: HomeAssistant) -> None:
+    """Non-404 ApiError from get_gateway_din must surface as unknown."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_powerwall = await _mock_powerwall_site_name(hass, "MySite")
+    mock_powerwall.get_gateway_din.side_effect = ApiError(
+        "GET request to /api/gateway returned error 500"
+    )
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "unknown"}
 
 
 async def test_form_unknown_exception(hass: HomeAssistant) -> None:

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -14,6 +14,7 @@ from tesla_powerwall import (
 
 from homeassistant import config_entries
 from homeassistant.components.powerwall.const import DOMAIN
+from homeassistant.components.powerwall.helpers import is_api_404
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
@@ -733,3 +734,87 @@ async def test_discovered_wifi_does_not_update_ip_online_but_access_denied(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_IP_ADDRESS] == "1.2.3.4"
+
+
+def test_is_api_404() -> None:
+    """The 404 helper matches the upstream message format and nothing else."""
+    not_found = ApiError("The url https://1.2.3.4/api/powerwalls returned error 404")
+    server_error = ApiError(
+        "API returned status code '500: Internal Server Error' with body: boom"
+    )
+    assert is_api_404(not_found) is True
+    assert is_api_404(server_error) is False
+
+
+async def test_dhcp_discovery_upgrades_hash_unique_id(hass: HomeAssistant) -> None:
+    """A SHA-256 hash unique_id (PW3 restricted) is upgraded to a real DIN."""
+    hash_unique_id = hashlib.sha256(b"00GGX").hexdigest()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=hash_unique_id,
+    )
+    entry.add_to_hass(hass)
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DhcpServiceInfo(
+                ip="1.2.3.4",
+                macaddress="aabbcceeddff",
+                hostname=MOCK_GATEWAY_DIN.lower(),
+            ),
+        )
+        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.unique_id == MOCK_GATEWAY_DIN
+
+
+async def test_dhcp_discovery_does_not_overwrite_real_din(
+    hass: HomeAssistant,
+) -> None:
+    """DHCP must not stomp an existing real-DIN unique_id with a different DIN."""
+    existing_din = "111-0----2-000000000AAA"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=existing_din,
+    )
+    entry.add_to_hass(hass)
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DhcpServiceInfo(
+                ip="1.2.3.4",
+                macaddress="aabbcceeddff",
+                hostname=MOCK_GATEWAY_DIN.lower(),
+            ),
+        )
+        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.unique_id == existing_din

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -746,42 +746,6 @@ def test_is_api_404() -> None:
     assert is_api_404(server_error) is False
 
 
-async def test_dhcp_discovery_upgrades_hash_unique_id(hass: HomeAssistant) -> None:
-    """A SHA-256 hash unique_id (PW3 restricted) is upgraded to a real DIN."""
-    hash_unique_id = hashlib.sha256(b"00GGX").hexdigest()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=VALID_CONFIG,
-        unique_id=hash_unique_id,
-    )
-    entry.add_to_hass(hass)
-    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
-
-    with (
-        patch(
-            "homeassistant.components.powerwall.config_flow.Powerwall",
-            return_value=mock_powerwall,
-        ),
-        patch(
-            "homeassistant.components.powerwall.async_setup_entry",
-            return_value=True,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_DHCP},
-            data=DhcpServiceInfo(
-                ip="1.2.3.4",
-                macaddress="aabbcceeddff",
-                hostname=MOCK_GATEWAY_DIN.lower(),
-            ),
-        )
-        await hass.async_block_till_done()
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    assert entry.unique_id == MOCK_GATEWAY_DIN
-
-
 async def test_dhcp_discovery_does_not_overwrite_real_din(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -147,38 +147,6 @@ async def test_form_pw3_restricted(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_pw3_site_info_404(hass: HomeAssistant) -> None:
-    """Gateway DIN succeeds but site_info 404s — title falls back to DIN suffix."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    mock_powerwall = await _mock_powerwall_site_name(hass, "MySite")
-    mock_powerwall.get_site_info.side_effect = ApiError(
-        "GET request to /api/site_info returned error 404"
-    )
-
-    with (
-        patch(
-            "homeassistant.components.powerwall.config_flow.Powerwall",
-            return_value=mock_powerwall,
-        ),
-        patch(
-            "homeassistant.components.powerwall.async_setup_entry",
-            return_value=True,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            VALID_CONFIG,
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == f"Powerwall {MOCK_GATEWAY_DIN[-5:]}"
-    assert result2["result"].unique_id == MOCK_GATEWAY_DIN.upper()
-
-
 async def test_form_non_404_api_error_propagates(hass: HomeAssistant) -> None:
     """Non-404 ApiError from get_gateway_din must surface as unknown."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the Powerwall config flow."""
 
 from datetime import timedelta
-import hashlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -137,13 +136,12 @@ async def test_form_pw3_restricted(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    expected_unique_id = hashlib.sha256(
-        VALID_CONFIG[CONF_PASSWORD].encode()
-    ).hexdigest()
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == f"Powerwall {VALID_CONFIG[CONF_IP_ADDRESS]}"
     assert result2["data"] == VALID_CONFIG
-    assert result2["result"].unique_id == expected_unique_id
+    # Restricted gateways expose no stable hardware id, so we set no unique id
+    # rather than deriving one from the credential.
+    assert result2["result"].unique_id is None
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -369,6 +369,51 @@ async def test_dhcp_discovery_restricted_clears_unique_id(hass: HomeAssistant) -
     assert result2["result"].unique_id is None
 
 
+async def test_dhcp_discovery_auto_configure_restricted(hass: HomeAssistant) -> None:
+    """Test DHCP auto-configure of a restricted gateway stores no unique id.
+
+    When the default password is accepted but the gateway is restricted (no DIN
+    over HTTP), the discovery hostname must not be persisted as the unique id.
+    """
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DhcpServiceInfo(
+                ip="1.1.1.1",
+                macaddress="aabbcceeddff",
+                hostname="00GGX",
+            ),
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] is None
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {"ip_address": "1.1.1.1", "password": "00GGX"}
+    assert result2["result"].unique_id is None
+
+
 async def test_dhcp_discovery_auto_configure(hass: HomeAssistant) -> None:
     """Test we can process the discovery from dhcp and auto configure."""
     mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -386,6 +386,34 @@ async def test_dhcp_discovery_cannot_connect(hass: HomeAssistant) -> None:
     assert result["reason"] == "cannot_connect"
 
 
+async def test_dhcp_discovery_aborts_with_restricted_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test discovery aborts when a restricted gateway (no unique id) is set up.
+
+    The restricted gateway is stored without a unique id, so we cannot tell
+    whether a discovery belongs to it. We abort rather than risk a duplicate.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4", CONF_PASSWORD: "00GGX"},
+        unique_id=None,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            ip="1.1.1.1",
+            macaddress="aabbcceeddff",
+            hostname=MOCK_GATEWAY_DIN.lower(),
+        ),
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 async def test_form_reauth(hass: HomeAssistant) -> None:
     """Test reauthenticate."""
 

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -321,6 +321,54 @@ async def test_dhcp_discovery_manual_configure(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_dhcp_discovery_restricted_clears_unique_id(hass: HomeAssistant) -> None:
+    """Test DHCP discovery of a restricted PW3 stores no unique id.
+
+    A PW3 advertises a ``TeslaPW_*`` hostname that is not the DIN, so the
+    default password fails and we fall back to the user form. Once the user
+    provides a password the gateway is detected as restricted (no DIN over
+    HTTP), and the entry must be stored without a unique id rather than pinning
+    to the discovery hostname.
+    """
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall.login",
+        side_effect=AccessDeniedError("xyz"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DhcpServiceInfo(
+                ip="1.1.1.1",
+                macaddress="aabbcceeddff",
+                hostname="TeslaPW_BLGZUP",
+            ),
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == VALID_CONFIG
+    assert result2["result"].unique_id is None
+
+
 async def test_dhcp_discovery_auto_configure(hass: HomeAssistant) -> None:
     """Test we can process the discovery from dhcp and auto configure."""
     mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")

--- a/tests/components/powerwall/test_init.py
+++ b/tests/components/powerwall/test_init.py
@@ -17,7 +17,11 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
-from .mocks import MOCK_GATEWAY_DIN, _mock_powerwall_with_fixtures
+from .mocks import (
+    MOCK_GATEWAY_DIN,
+    _mock_powerwall_restricted,
+    _mock_powerwall_with_fixtures,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -305,3 +309,48 @@ async def test_init_retries_with_password(hass: HomeAssistant) -> None:
 
         mock_powerwall.login.assert_called_with("somepassword")
         assert mock_powerwall.get_gateway_din.call_count == 2
+
+
+async def test_setup_pw3_restricted(hass: HomeAssistant) -> None:
+    """Test setup completes for a PW3-style restricted gateway."""
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_IP_ADDRESS: "1.2.3.4",
+            CONF_PASSWORD: "00FFA",
+        },
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    base_info = config_entry.runtime_data["base_info"]
+    assert base_info.restricted is True
+    assert base_info.site_name == "Powerwall 1.2.3.4"
+    assert base_info.gateway_din == "aa:bb:cc:dd:ee:ff"
+    assert base_info.site_info is None
+    assert base_info.status is None
+    assert base_info.serial_numbers == []
+    assert base_info.batteries == {}
+
+    coordinator = config_entry.runtime_data["coordinator"]
+    assert coordinator is not None
+    assert coordinator.data.site_master is None
+    assert coordinator.data.batteries == {}
+    assert coordinator.data.backup_reserve is None
+    # Restricted devices must not call the dead endpoints during updates.
+    mock_powerwall.get_sitemaster.assert_not_called()
+    mock_powerwall.get_backup_reserve_percentage.assert_not_called()

--- a/tests/components/powerwall/test_init.py
+++ b/tests/components/powerwall/test_init.py
@@ -5,7 +5,7 @@ from http.cookies import Morsel
 from unittest.mock import MagicMock, patch
 
 from aiohttp import CookieJar
-from tesla_powerwall import AccessDeniedError, LoginResponse
+from tesla_powerwall import AccessDeniedError, ApiError, LoginResponse
 
 from homeassistant.components.powerwall.const import (
     AUTH_COOKIE_KEY,
@@ -354,3 +354,25 @@ async def test_setup_pw3_restricted(hass: HomeAssistant) -> None:
     # Restricted devices must not call the dead endpoints during updates.
     mock_powerwall.get_sitemaster.assert_not_called()
     mock_powerwall.get_backup_reserve_percentage.assert_not_called()
+
+
+async def test_setup_non_404_api_error_propagates(hass: HomeAssistant) -> None:
+    """Non-404 ApiError from get_gateway_din should surface as ConfigEntryNotReady."""
+    mock_powerwall = await _mock_powerwall_with_fixtures(hass)
+    mock_powerwall.get_gateway_din.side_effect = ApiError(
+        "GET request to /api/gateway returned error 500"
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4", CONF_PASSWORD: "somepassword"},
+        unique_id=MOCK_GATEWAY_DIN,
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+    ):
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/powerwall/test_init.py
+++ b/tests/components/powerwall/test_init.py
@@ -17,7 +17,11 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
-from .mocks import MOCK_GATEWAY_DIN, _mock_powerwall_with_fixtures
+from .mocks import (
+    MOCK_GATEWAY_DIN,
+    _mock_powerwall_restricted,
+    _mock_powerwall_with_fixtures,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -306,3 +310,48 @@ async def test_init_retries_with_password(hass: HomeAssistant) -> None:
 
         mock_powerwall.login.assert_called_with("somepassword")
         assert mock_powerwall.get_gateway_din.call_count == 2
+
+
+async def test_setup_pw3_restricted(hass: HomeAssistant) -> None:
+    """Test setup completes for a PW3-style restricted gateway."""
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_IP_ADDRESS: "1.2.3.4",
+            CONF_PASSWORD: "00FFA",
+        },
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    base_info = config_entry.runtime_data["base_info"]
+    assert base_info.restricted is True
+    assert base_info.site_name == "Powerwall 1.2.3.4"
+    assert base_info.gateway_din == "aa:bb:cc:dd:ee:ff"
+    assert base_info.site_info is None
+    assert base_info.status is None
+    assert base_info.serial_numbers == []
+    assert base_info.batteries == {}
+
+    coordinator = config_entry.runtime_data["coordinator"]
+    assert coordinator is not None
+    assert coordinator.data.site_master is None
+    assert coordinator.data.batteries == {}
+    assert coordinator.data.backup_reserve is None
+    # Restricted devices must not call the dead endpoints during updates.
+    mock_powerwall.get_sitemaster.assert_not_called()
+    mock_powerwall.get_backup_reserve_percentage.assert_not_called()

--- a/tests/components/powerwall/test_init.py
+++ b/tests/components/powerwall/test_init.py
@@ -5,7 +5,7 @@ from http.cookies import Morsel
 from unittest.mock import MagicMock, patch
 
 from aiohttp import CookieJar
-from tesla_powerwall import AccessDeniedError, LoginResponse
+from tesla_powerwall import AccessDeniedError, ApiError, LoginResponse
 
 from homeassistant.components.powerwall.const import (
     AUTH_COOKIE_KEY,
@@ -355,3 +355,25 @@ async def test_setup_pw3_restricted(hass: HomeAssistant) -> None:
     # Restricted devices must not call the dead endpoints during updates.
     mock_powerwall.get_sitemaster.assert_not_called()
     mock_powerwall.get_backup_reserve_percentage.assert_not_called()
+
+
+async def test_setup_non_404_api_error_propagates(hass: HomeAssistant) -> None:
+    """Non-404 ApiError from get_gateway_din should surface as ConfigEntryNotReady."""
+    mock_powerwall = await _mock_powerwall_with_fixtures(hass)
+    mock_powerwall.get_gateway_din.side_effect = ApiError(
+        "GET request to /api/gateway returned error 500"
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4", CONF_PASSWORD: "somepassword"},
+        unique_id=MOCK_GATEWAY_DIN,
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+    ):
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -21,7 +21,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from .mocks import MOCK_GATEWAY_DIN, _mock_powerwall_with_fixtures
+from .mocks import (
+    MOCK_GATEWAY_DIN,
+    _mock_powerwall_restricted,
+    _mock_powerwall_with_fixtures,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -305,3 +309,46 @@ async def test_unique_id_migrate(
 
     state = hass.states.get("sensor.mysite_load_power")
     assert state.state == "1.971"
+
+
+async def test_pw3_restricted_entities(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Restricted PW3 surface should only expose meter-driven sensors and charge."""
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4"},
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    reg_device = device_registry.async_get_device(
+        identifiers={("powerwall", "aa:bb:cc:dd:ee:ff")},
+    )
+    assert reg_device.model == "Powerwall 3"
+    assert reg_device.sw_version is None
+    assert reg_device.manufacturer == "Tesla"
+    assert reg_device.name == "Powerwall 1.2.3.4"
+
+    assert hass.states.get("sensor.powerwall_1_2_3_4_charge") is not None
+    assert hass.states.get("sensor.powerwall_1_2_3_4_load_power") is not None
+    assert hass.states.get("sensor.powerwall_1_2_3_4_battery_power") is not None
+    # Backup reserve and per-battery sensors must not be created.
+    assert hass.states.get("sensor.powerwall_1_2_3_4_backup_reserve") is None
+    assert (
+        hass.states.get("sensor.powerwall_1_2_3_4_tg0123456789ab_battery_capacity")
+        is None
+    )

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -338,7 +338,7 @@ async def test_pw3_restricted_entities(
     reg_device = device_registry.async_get_device(
         identifiers={("powerwall", "aa:bb:cc:dd:ee:ff")},
     )
-    assert reg_device.model == "Powerwall 3"
+    assert reg_device.model is None
     assert reg_device.sw_version is None
     assert reg_device.manufacturer == "Tesla"
     assert reg_device.name == "Powerwall 1.2.3.4"

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -371,7 +371,7 @@ async def test_pw3_restricted_entities(
     reg_device = device_registry.async_get_device(
         identifiers={("powerwall", "aa:bb:cc:dd:ee:ff")},
     )
-    assert reg_device.model == "Powerwall 3"
+    assert reg_device.model is None
     assert reg_device.sw_version is None
     assert reg_device.manufacturer == "Tesla"
     assert reg_device.name == "Powerwall 1.2.3.4"

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -21,7 +21,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from .mocks import MOCK_GATEWAY_DIN, _mock_powerwall_with_fixtures
+from .mocks import (
+    MOCK_GATEWAY_DIN,
+    _mock_powerwall_restricted,
+    _mock_powerwall_with_fixtures,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -338,3 +342,46 @@ async def test_unique_id_migrate(
 
     state = hass.states.get("sensor.mysite_load_power")
     assert state.state == "1.971"
+
+
+async def test_pw3_restricted_entities(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Restricted PW3 surface should only expose meter-driven sensors and charge."""
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4"},
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    reg_device = device_registry.async_get_device(
+        identifiers={("powerwall", "aa:bb:cc:dd:ee:ff")},
+    )
+    assert reg_device.model == "Powerwall 3"
+    assert reg_device.sw_version is None
+    assert reg_device.manufacturer == "Tesla"
+    assert reg_device.name == "Powerwall 1.2.3.4"
+
+    assert hass.states.get("sensor.powerwall_1_2_3_4_charge") is not None
+    assert hass.states.get("sensor.powerwall_1_2_3_4_load_power") is not None
+    assert hass.states.get("sensor.powerwall_1_2_3_4_battery_power") is not None
+    # Backup reserve and per-battery sensors must not be created.
+    assert hass.states.get("sensor.powerwall_1_2_3_4_backup_reserve") is None
+    assert (
+        hass.states.get("sensor.powerwall_1_2_3_4_tg0123456789ab_battery_capacity")
+        is None
+    )

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -371,7 +371,7 @@ async def test_pw3_restricted_entities(
     reg_device = device_registry.async_get_device(
         identifiers={("powerwall", "aa:bb:cc:dd:ee:ff")},
     )
-    assert reg_device.model is None
+    assert reg_device.model == "PowerWall 2"
     assert reg_device.sw_version is None
     assert reg_device.manufacturer == "Tesla"
     assert reg_device.name == "Powerwall 1.2.3.4"

--- a/tests/components/powerwall/test_switch.py
+++ b/tests/components/powerwall/test_switch.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .mocks import _mock_powerwall_with_fixtures
+from .mocks import _mock_powerwall_restricted, _mock_powerwall_with_fixtures
 
 from tests.common import MockConfigEntry
 
@@ -103,3 +103,25 @@ async def test_exception_on_powerwall_error(
             {ATTR_ENTITY_ID: ENTITY_ID},
             blocking=True,
         )
+
+
+async def test_pw3_no_switch(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Switch platform must not create entities for restricted PW3 surface."""
+    mock_powerwall = await _mock_powerwall_restricted(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4"},
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("switch.powerwall_1_2_3_4_off_grid_operation") is None
+    assert "switch.powerwall_1_2_3_4_off_grid_operation" not in entity_registry.entities


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for Powerwall 3 (and other recent Tesla gateway firmware revisions) which expose a much more restricted local HTTP surface than Powerwall 2.

On these gateways, the following endpoints all return HTTP 404:
- `/api/powerwalls` (gateway DIN, per-battery info)
- `/api/site_info`
- `/api/sitemaster`
- `/api/operation` (off-grid switch writes)
- Per-battery status endpoints

Only `/api/meters/aggregates`, `/api/system_status/soe`, and `/api/system_status/grid_status` are guaranteed to be available.

Changes:
- Probe `get_gateway_din` during setup; on a 404 mark the entry as `restricted` and synthesize a stable identifier from the password hash (password cannot be changed).
- Skip calls and entities that depend on unavailable endpoints when restricted: off-grid switch, backup reserve sensor, per-battery sensors, and the Running/Connected binary sensors.
- Add a `teslapw_*` DHCP discovery match (the hostname pattern broadcast by PW3 gateways).
- During config flow, when `/api/powerwalls` returns 404, fall back to a SHA-256 hash of the password as a stable unique id.
- Make the affected `PowerwallBaseInfo` and `PowerwallData` fields optional, add a `site_name` field, and adjust entities to handle the missing data.
- Extend the test suite with restricted-surface fixtures and coverage for config flow, init, sensors, binary sensors, and switches.

### Unique ID handling

To keep this PR scoped, DHCP discovery only upgrades the pre-existing legacy IP-address unique IDs to a real DIN — it does not touch the SHA-256 hash IDs synthesized for restricted PW3 gateways. This avoids introducing a migration path in this PR. A future PR may revisit upgrading hash-based unique IDs to real DINs once the restricted gateway behaviour is more broadly validated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45029
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
