### PR TITLE
Remove `name` from AccuWeather config flow

### DIFF
--- a/homeassistant/components/accuweather/config_flow.py
+++ b/homeassistant/components/accuweather/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from asyncio import timeout
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError
 from aiohttp import ClientError
@@ -12,7 +12,7 @@ from aiohttp.client_exceptions import ClientConnectorError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -55,8 +55,11 @@ class AccuWeatherFlowHandler(ConfigFlow, domain=DOMAIN):
                 )
                 self._abort_if_unique_id_configured()
 
+                if TYPE_CHECKING:
+                    assert accuweather.location_name is not None
+
                 return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
+                    title=accuweather.location_name, data=user_input
                 )
 
         return self.async_show_form(
@@ -70,9 +73,6 @@ class AccuWeatherFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_LONGITUDE, default=self.hass.config.longitude
                     ): cv.longitude,
-                    vol.Optional(
-                        CONF_NAME, default=self.hass.config.location_name
-                    ): str,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/accuweather/coordinator.py
+++ b/homeassistant/components/accuweather/coordinator.py
@@ -64,7 +64,7 @@ class AccuWeatherObservationDataUpdateCoordinator(
         """Initialize."""
         self.accuweather = accuweather
         self.location_key = accuweather.location_key
-        name = config_entry.data[CONF_NAME]
+        name = config_entry.data.get(CONF_NAME) or config_entry.title
 
         if TYPE_CHECKING:
             assert self.location_key is not None
@@ -122,7 +122,7 @@ class AccuWeatherForecastDataUpdateCoordinator(
         self.accuweather = accuweather
         self.location_key = accuweather.location_key
         self._fetch_method = fetch_method
-        name = config_entry.data[CONF_NAME]
+        name = config_entry.data.get(CONF_NAME) or config_entry.title
 
         if TYPE_CHECKING:
             assert self.location_key is not None

--- a/tests/components/accuweather/__init__.py
+++ b/tests/components/accuweather/__init__.py
@@ -16,7 +16,6 @@ async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
             "api_key": "32-character-string-1234567890qw",
             "latitude": 55.55,
             "longitude": 122.12,
-            "name": "Home",
         },
     )
 

--- a/tests/components/accuweather/conftest.py
+++ b/tests/components/accuweather/conftest.py
@@ -33,6 +33,7 @@ def mock_accuweather_client() -> Generator[AsyncMock]:
         client.async_get_daily_forecast.return_value = daily_forecast
         client.async_get_hourly_forecast.return_value = hourly_forecast
         client.location_key = "0123456"
+        client.location_name = "Test location"
         client.requests_remaining = 10
 
         yield client

--- a/tests/components/accuweather/snapshots/test_diagnostics.ambr
+++ b/tests/components/accuweather/snapshots/test_diagnostics.ambr
@@ -5,7 +5,6 @@
       'api_key': '**REDACTED**',
       'latitude': '**REDACTED**',
       'longitude': '**REDACTED**',
-      'name': 'Home',
     }),
     'observation_data': dict({
       'ApparentTemperature': dict({

--- a/tests/components/accuweather/test_config_flow.py
+++ b/tests/components/accuweather/test_config_flow.py
@@ -7,7 +7,7 @@ import pytest
 
 from homeassistant.components.accuweather.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -16,7 +16,6 @@ from . import init_integration
 from tests.common import MockConfigEntry
 
 VALID_CONFIG = {
-    CONF_NAME: "abcd",
     CONF_API_KEY: "32-character-string-1234567890qw",
     CONF_LATITUDE: 55.55,
     CONF_LONGITUDE: 122.12,
@@ -115,8 +114,7 @@ async def test_create_entry(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "abcd"
-    assert result["data"][CONF_NAME] == "abcd"
+    assert result["title"] == "Test location"
     assert result["data"][CONF_LATITUDE] == 55.55
     assert result["data"][CONF_LONGITUDE] == 122.12
     assert result["data"][CONF_API_KEY] == "32-character-string-1234567890qw"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes `name` field from AccuWeather config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168913
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
