### PR TITLE
Preserve sub-meter GPS accuracy in mobile_app webhooks

### DIFF
--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -414,7 +414,7 @@ async def webhook_render_template(
             {
                 vol.Optional(ATTR_LOCATION_NAME): cv.string,
                 vol.Optional(ATTR_GPS): cv.gps,
-                vol.Optional(ATTR_GPS_ACCURACY): cv.positive_int,
+                vol.Optional(ATTR_GPS_ACCURACY): cv.positive_float,
                 vol.Optional(ATTR_BATTERY): cv.positive_int,
                 vol.Optional(ATTR_SPEED): cv.positive_int,
                 vol.Optional(ATTR_ALTITUDE): vol.Coerce(float),

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -738,6 +738,34 @@ async def test_webhook_update_location_with_gps_without_accuracy(
     assert state.state == STATE_UNKNOWN
 
 
+async def test_webhook_update_location_preserves_float_gps_accuracy(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+    webhook_client: TestClient,
+) -> None:
+    """Test that sub-meter ``gps_accuracy`` is not floored to an integer.
+
+    Android's fused location provider reports accuracy as a float in metres.
+    The zone-containment predicate (``zone_dist - zone_radius < accuracy``)
+    can flip its result over a sub-metre difference at zone boundaries —
+    so flooring 6.938 to 6 has been observed to drop inner-zone transitions
+    in nested same-centre zones, with no automatic retry.
+    """
+    resp = await webhook_client.post(
+        f"/api/webhook/{create_registrations[1]['webhook_id']}",
+        json={
+            "type": "update_location",
+            "data": {"gps": [1, 2], "gps_accuracy": 6.938},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state is not None
+    assert state.attributes["gps_accuracy"] == 6.938
+
+
 async def test_webhook_update_location_with_location_name(
     hass: HomeAssistant,
     create_registrations: tuple[dict[str, Any], dict[str, Any]],


### PR DESCRIPTION
## Proposed change

The `update_location` webhook validates `gps_accuracy` with `cv.positive_int`, which floors the float metres reported by the Companion app to integers. The Android Companion app's fused-provider accuracy is a float (e.g. `6.938`), and this is the *last* numeric input to the zone-containment predicate in `homeassistant/components/zone/__init__.py`:

```python
not (zone_dist - zone_radius < radius)   # skip if outside; radius == gps_accuracy
```

So even sub-metre rounding can flip the result at zone boundaries. Latitude and longitude are already kept as floats — only accuracy is silently truncated.

### Real-world reproducer

Two concentric zones at the same centre, inner `r=50 m`, outer `r=200 m`. A Companion-app fix arrives at `zone_dist≈56.8 m` with `accuracy=6.938`:

|                   | predicate                  | result                |
|-------------------|----------------------------|-----------------------|
| with float `6.938`| `56.8 − 50 = 6.8 < 6.938`  | inner zone (correct)  |
| with floored `6`  | `56.8 − 50 = 6.8 < 6`      | only outer zone (bug) |

Captured from a live install (Pixel 9 / Companion `2026.3.x`):

```
20:15:32.59  EVENT  android.zone_entered  zone=zone.home   acc=6.938
20:15:32.62  STATE  device_tracker.pixel_9 = 'Home (for gate opening)'   acc=6
```

The Companion app fired `android.zone_entered` for the inner zone correctly, but the simultaneous `update_location` webhook (which is what drives `device_tracker` state) had its accuracy floored at the validator and `async_in_zones` resolved against the outer zone. The two HA-internal data paths silently disagreed by 0.14 m.

### Why this matters

There is no automatic retry. Once `device_tracker` state is "wrong but plausible", the next location update typically only arrives when Android wakes the app from doze — observed gap in this case: **4 h 36 min**. So a sub-metre rounding error caused multi-hour state staleness, and any automation watching `device_tracker.<phone>` going to `home` failed to trigger.

### Fix

Use `cv.positive_float` to keep the input precision intact. This matches how `latitude`/`longitude` are already handled. `cv.positive_float` accepts ints unchanged, so no existing client breaks.

The other `cv.positive_int` fields on this handler (`battery`, `speed`, `course`, `vertical_accuracy`) are intentionally left as-is — they are not on the zone-selection path. `vertical_accuracy` could merit the same change later for symmetry, but I've kept this PR scoped to the demonstrated bug.

### Notes for reviewers

- The strict `<` in `async_in_zones` vs. Android's geofence threshold semantics is a separate, deeper question; it isn't addressed here.
- A second class of inconsistency exists where the webhook payload's `location_name` may name a different zone than `android.zone_entered` reports. That requires a Companion-app-side investigation and is out of scope for this PR.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.