### PR TITLE
Use defaults for device class UPTIME in Shelly

### DIFF
--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -467,7 +467,6 @@ REST_SENSORS: Final = {
     ),
     "uptime": RestSensorDescription(
         key="uptime",
-        translation_key="last_restart",
         value=lambda status, _: utcnow() - timedelta(seconds=status["uptime"]),
         device_class=SensorDeviceClass.UPTIME,
         entity_registry_enabled_default=False,
@@ -1243,7 +1242,6 @@ RPC_SENSORS: Final = {
     "uptime": RpcSensorDescription(
         key="sys",
         sub_key="uptime",
-        translation_key="last_restart",
         device_class=SensorDeviceClass.UPTIME,
         value=lambda status, _: utcnow() - timedelta(seconds=status),
         entity_registry_enabled_default=False,

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -424,9 +424,6 @@
       "lamp_life": {
         "name": "Lamp life"
       },
-      "last_restart": {
-        "name": "Last restart"
-      },
       "left_slot_level": {
         "name": "Left slot level"
       },

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -443,57 +443,6 @@
     'state': 'living_room',
   })
 # ---
-# name: test_device[cury_gen4][sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_device[cury_gen4][sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-05-26T12:31:05+00:00',
-  })
-# ---
 # name: test_device[cury_gen4][sensor.test_name_left_slot_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -755,6 +704,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-49',
+  })
+# ---
+# name: test_device[cury_gen4][sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_device[cury_gen4][sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-05-26T12:31:05+00:00',
   })
 # ---
 # name: test_device[cury_gen4][switch.test_name_away_mode-entry]
@@ -1354,57 +1354,6 @@
     'state': 'off',
   })
 # ---
-# name: test_device[duo_bulb_gen3][sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_device[duo_bulb_gen3][sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-05-24T02:30:09+00:00',
-  })
-# ---
 # name: test_device[duo_bulb_gen3][sensor.test_name_living_room_lamp_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -1577,6 +1526,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-50',
+  })
+# ---
+# name: test_device[duo_bulb_gen3][sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_device[duo_bulb_gen3][sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-05-24T02:30:09+00:00',
   })
 # ---
 # name: test_device[duo_bulb_gen3][update.test_name_beta_firmware-entry]
@@ -3563,57 +3563,6 @@
     'state': '231.2',
   })
 # ---
-# name: test_device[power_strip_gen4][sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_device[power_strip_gen4][sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-04-02T18:10:04+00:00',
-  })
-# ---
 # name: test_device[power_strip_gen4][sensor.test_name_output_0_current-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -4499,6 +4448,57 @@
     'state': '-68',
   })
 # ---
+# name: test_device[power_strip_gen4][sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_device[power_strip_gen4][sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-04-02T18:10:04+00:00',
+  })
+# ---
 # name: test_device[power_strip_gen4][switch.switch_1_name-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -5143,57 +5143,6 @@
     'state': 'twilight',
   })
 # ---
-# name: test_device[presence_gen4][sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_device[presence_gen4][sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-05-26T15:55:14+00:00',
-  })
-# ---
 # name: test_device[presence_gen4][sensor.test_name_my_zone_detected_objects-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -5409,6 +5358,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-60',
+  })
+# ---
+# name: test_device[presence_gen4][sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_device[presence_gen4][sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-05-26T15:55:14+00:00',
   })
 # ---
 # name: test_device[presence_gen4][update.test_name_beta_firmware-entry]
@@ -6305,57 +6305,6 @@
     'state': 'twilight',
   })
 # ---
-# name: test_device[wall_display_xl][sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_device[wall_display_xl][sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-05-15T21:33:41+00:00',
-  })
-# ---
 # name: test_device[wall_display_xl][sensor.test_name_signal_strength-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -6467,6 +6416,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-275.149993896484',
+  })
+# ---
+# name: test_device[wall_display_xl][sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_device[wall_display_xl][sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-05-15T21:33:41+00:00',
   })
 # ---
 # name: test_device[wall_display_xl][switch.test_name-entry]
@@ -7334,57 +7334,6 @@
     'state': '50.0',
   })
 # ---
-# name: test_shelly_2pm_gen3_cover[sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_shelly_2pm_gen3_cover[sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-05-26T15:57:39+00:00',
-  })
-# ---
 # name: test_shelly_2pm_gen3_cover[sensor.test_name_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -7554,6 +7503,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '36.4',
+  })
+# ---
+# name: test_shelly_2pm_gen3_cover[sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_shelly_2pm_gen3_cover[sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-05-26T15:57:39+00:00',
   })
 # ---
 # name: test_shelly_2pm_gen3_cover[sensor.test_name_voltage-entry]
@@ -8401,57 +8401,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
-  })
-# ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-05-26T16:02:17+00:00',
   })
 # ---
 # name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_output_0_current-entry]
@@ -9455,6 +9404,57 @@
     'state': '-52',
   })
 # ---
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_shelly_2pm_gen3_no_relay_names[sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-05-26T16:02:17+00:00',
+  })
+# ---
 # name: test_shelly_2pm_gen3_no_relay_names[switch.test_name_output_0-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -10070,57 +10070,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
-  })
-# ---
-# name: test_shelly_pro_3em[sensor.test_name_last_restart-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Last restart',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
-    'original_icon': None,
-    'original_name': 'Last restart',
-    'platform': 'shelly',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_restart',
-    'unique_id': '123456789ABC-sys-uptime',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_shelly_pro_3em[sensor.test_name_last_restart-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'uptime',
-      'friendly_name': 'Test name Last restart',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_name_last_restart',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-05-20T20:42:37+00:00',
   })
 # ---
 # name: test_shelly_pro_3em[sensor.test_name_neutral_current-entry]
@@ -11748,6 +11697,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '46.3',
+  })
+# ---
+# name: test_shelly_pro_3em[sensor.test_name_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_name_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-sys-uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_shelly_pro_3em[sensor.test_name_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'uptime',
+      'friendly_name': 'Test name Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-05-20T20:42:37+00:00',
   })
 # ---
 # name: test_shelly_pro_3em[update.test_name_beta_firmware-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Sensor for device uptime now uses new sensor class UPTIME:
- old   entity id: `sensor.device_name_last_restart`
- new entity id: `sensor.device_name_uptime`

Please review your automations accordly.
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use defaults for device class UPTIME in Shelly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
