### PR TITLE
Update knx-frontend to 2026.4.25.155016: Add notes to UI expose

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "xknx==3.15.0",
     "xknxproject==3.8.2",
-    "knx-frontend==2026.4.22.141111"
+    "knx-frontend==2026.4.25.155016"
   ],
   "single_config_entry": true
 }

--- a/homeassistant/components/knx/storage/config_store.py
+++ b/homeassistant/components/knx/storage/config_store.py
@@ -14,7 +14,7 @@ from homeassistant.util.ulid import ulid_now
 from ..const import DOMAIN, KNX_MODULE_KEY
 from . import migration
 from .const import CONF_DATA
-from .expose_controller import KNXExposeStoreModel, KNXExposeStoreOptionModel
+from .expose_controller import KNXExposeStoreConfigModel, KNXExposeStoreModel
 from .time_server import KNXTimeServerStoreModel
 
 _LOGGER = logging.getLogger(__name__)
@@ -201,20 +201,26 @@ class KNXConfigStore:
     def get_expose_groups(self) -> dict[str, list[str]]:
         """Return KNX entity state exposes and their group addresses."""
         return {
-            entity_id: [option["ga"]["write"] for option in config]
+            entity_id: [option["ga"]["write"] for option in config["options"]]
             for entity_id, config in self.data["expose"].items()
         }
 
-    def get_expose_config(self, entity_id: str) -> list[KNXExposeStoreOptionModel]:
-        """Return KNX entity state expose configuration for an entity."""
-        return self.data["expose"].get(entity_id, [])
+    def get_expose_config(self, entity_id: str) -> KNXExposeStoreConfigModel:
+        """Return KNX entity state expose configuration and notes for an entity."""
+        return self.data["expose"].get(entity_id, KNXExposeStoreConfigModel(options=[]))
 
     async def update_expose(
-        self, entity_id: str, expose_config: list[KNXExposeStoreOptionModel]
+        self, entity_id: str, expose_config: KNXExposeStoreConfigModel
     ) -> None:
-        """Update KNX expose configuration for an entity."""
+        """Update KNX expose configuration for an entity.
+
+        Args:
+            entity_id: The entity ID to configure.
+            expose_config: Expose configuration with options and optional notes.
+        """
         knx_module = self.hass.data[KNX_MODULE_KEY]
         expose_controller = knx_module.ui_expose_controller
+
         expose_controller.update_entity_expose(
             self.hass, knx_module.xknx, entity_id, expose_config
         )

--- a/homeassistant/components/knx/storage/expose_controller.py
+++ b/homeassistant/components/knx/storage/expose_controller.py
@@ -7,7 +7,6 @@ from xknx import XKNX
 from xknx.dpt import DPTBase
 from xknx.telegram.address import parse_device_group_address
 
-from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     config_validation as cv,
@@ -18,10 +17,6 @@ from homeassistant.helpers import (
 from ..expose import KnxExposeEntity, KnxExposeOptions
 from .entity_store_validation import validate_config_store_data
 from .knx_selector import GASelector
-
-type KNXExposeStoreModel = dict[
-    str, list[KNXExposeStoreOptionModel]  # entity_id: configuration
-]
 
 
 class KNXExposeStoreOptionModel(TypedDict):
@@ -36,11 +31,21 @@ class KNXExposeStoreOptionModel(TypedDict):
     value_template: NotRequired[str]
 
 
+class KNXExposeStoreConfigModel(TypedDict):
+    """Represent stored KNX expose configuration with metadata."""
+
+    options: list[KNXExposeStoreOptionModel]
+    notes: NotRequired[str]
+
+
+type KNXExposeStoreModel = dict[str, KNXExposeStoreConfigModel]  # dict[entity_id: conf]
+
+
 class KNXExposeDataModel(TypedDict):
     """Represent a loaded KNX expose config for validation."""
 
     entity_id: str
-    options: list[KNXExposeStoreOptionModel]
+    data: KNXExposeStoreConfigModel
 
 
 def validate_expose_template_no_coerce(value: str) -> str:
@@ -72,8 +77,13 @@ EXPOSE_OPTION_SCHEMA = vol.Schema(
 
 EXPOSE_CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(),
-        vol.Required("options"): [EXPOSE_OPTION_SCHEMA],
+        vol.Required("entity_id"): selector.EntitySelector(),
+        vol.Required("data"): vol.Schema(
+            {
+                vol.Required("options"): [EXPOSE_OPTION_SCHEMA],
+                vol.Optional("notes"): str,
+            }
+        ),
     },
     extra=vol.REMOVE_EXTRA,
 )
@@ -135,13 +145,13 @@ class ExposeController:
         hass: HomeAssistant,
         xknx: XKNX,
         entity_id: str,
-        expose_config: list[KNXExposeStoreOptionModel],
+        expose_config: KNXExposeStoreConfigModel,
     ) -> None:
         """Update entity expose configuration for an entity."""
         self.remove_entity_expose(entity_id)
 
         expose_options = [
-            _store_to_expose_option(hass, config) for config in expose_config
+            _store_to_expose_option(hass, config) for config in expose_config["options"]
         ]
         expose = KnxExposeEntity(hass, xknx, entity_id, expose_options)
         self._entity_exposes[entity_id] = expose

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -978,6 +978,10 @@
         "ga": {
           "label": "[%key:component::knx::config_panel::common::group_address%]"
         },
+        "notes": {
+          "label": "Notes",
+          "placeholder": "Add your notes here..."
+        },
         "periodic_send": {
           "description": "Time interval to automatically resend the current value to the KNX bus, even if it hasn’t changed.",
           "label": "Periodic send interval"

--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -644,7 +644,7 @@ def ws_get_expose_config(
     {
         vol.Required("type"): "knx/update_expose",
         vol.Required("entity_id"): str,
-        vol.Required("options"): list,  # validation done in handler
+        vol.Required("data"): dict,  # validation done in handler
     }
 )
 @websocket_api.async_response
@@ -663,7 +663,7 @@ async def ws_update_expose(
         return
     try:
         await knx.config_store.update_expose(
-            validated_data["entity_id"], validated_data["options"]
+            validated_data["entity_id"], validated_data["data"]
         )
     except ConfigStoreException as err:
         connection.send_error(
@@ -706,7 +706,7 @@ async def ws_delete_expose(
     {
         vol.Required("type"): "knx/validate_expose",
         vol.Required("entity_id"): str,
-        vol.Required("options"): list,  # validation done in handler
+        vol.Required("data"): dict,  # validation done in handler
     }
 )
 @callback

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1402,7 +1402,7 @@ kiwiki-client==0.1.1
 knocki==0.4.2
 
 # homeassistant.components.knx
-knx-frontend==2026.4.22.141111
+knx-frontend==2026.4.25.155016
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1242,7 +1242,7 @@ kiosker-python-api==1.2.9
 knocki==0.4.2
 
 # homeassistant.components.knx
-knx-frontend==2026.4.22.141111
+knx-frontend==2026.4.25.155016
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/tests/components/knx/fixtures/config_store_expose.json
+++ b/tests/components/knx/fixtures/config_store_expose.json
@@ -1,0 +1,31 @@
+{
+  "version": 2,
+  "minor_version": 4,
+  "key": "knx/config_store.json",
+  "data": {
+    "entities": {},
+    "expose": {
+      "cover.test": {
+        "options": [
+          {
+            "ga": {
+              "write": "1/1/1",
+              "dpt": "1.001"
+            }
+          },
+          {
+            "ga": {
+              "write": "2/2/2",
+              "dpt": "5.001"
+            },
+            "attribute": "current_position",
+            "value_template": "{{ 100 - value }}",
+            "cooldown": 5.0
+          }
+        ],
+        "notes": "Invert cover position for KNX uses 0: open"
+      }
+    },
+    "time_server": {}
+  }
+}

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -1,4 +1,44 @@
 # serializer version: 1
+# name: test_knx_get_expose_config
+  dict({
+    'id': 1,
+    'result': dict({
+      'notes': 'Invert cover position for KNX uses 0: open',
+      'options': list([
+        dict({
+          'ga': dict({
+            'dpt': '1.001',
+            'write': '1/1/1',
+          }),
+        }),
+        dict({
+          'attribute': 'current_position',
+          'cooldown': 5.0,
+          'ga': dict({
+            'dpt': '5.001',
+            'write': '2/2/2',
+          }),
+          'value_template': '{{ 100 - value }}',
+        }),
+      ]),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
+# name: test_knx_get_expose_groups
+  dict({
+    'id': 1,
+    'result': dict({
+      'cover.test': list([
+        '1/1/1',
+        '2/2/2',
+      ]),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
 # name: test_knx_get_schema[binary_sensor]
   dict({
     'id': 1,

--- a/tests/components/knx/test_config_store.py
+++ b/tests/components/knx/test_config_store.py
@@ -468,13 +468,13 @@ async def test_update_expose_error(
         {
             "type": "knx/update_expose",
             "entity_id": "switch.test",
-            "options": [{"ga": {"dpt": "1.001"}}],
+            "data": {"options": [{"ga": {"dpt": "1.001"}}]},
         }
     )
     res = await client.receive_json()
     assert res["success"], res
     assert res["result"]["success"] is False
-    assert res["result"]["errors"][0]["path"] == ["options", "0", "ga", "write"]
+    assert res["result"]["errors"][0]["path"] == ["data", "options", "0", "ga", "write"]
     assert res["result"]["errors"][0]["error_message"] == "required key not provided"
 
 
@@ -491,7 +491,7 @@ async def test_validate_expose(
         {
             "type": "knx/validate_expose",
             "entity_id": "switch.test",
-            "options": [{"ga": {"write": "1/2/3", "dpt": "1.001"}}],
+            "data": {"options": [{"ga": {"write": "1/2/3", "dpt": "1.001"}}]},
         }
     )
     res = await client.receive_json()
@@ -502,13 +502,13 @@ async def test_validate_expose(
         {
             "type": "knx/validate_expose",
             "entity_id": "switch.test",
-            "options": [{"ga": {"write": "1/2/3", "dpt": "invalid"}}],
+            "data": {"options": [{"ga": {"write": "1/2/3", "dpt": "invalid"}}]},
         }
     )
     res = await client.receive_json()
     assert res["success"], res
     assert res["result"]["success"] is False
-    assert res["result"]["errors"][0]["path"] == ["options", "0", "ga", "dpt"]
+    assert res["result"]["errors"][0]["path"] == ["data", "options", "0", "ga", "dpt"]
 
 
 async def test_delete_expose(
@@ -523,13 +523,13 @@ async def test_delete_expose(
     await knx.setup_integration()
     client = await hass_ws_client(hass)
 
-    expose_options = [{"ga": {"write": "2/2/2", "dpt": "1.001"}}]
+    expose_options = {"options": [{"ga": {"write": "2/2/2", "dpt": "1.001"}}]}
 
     await client.send_json_auto_id(
         {
             "type": "knx/update_expose",
             "entity_id": ENTITY_ID,
-            "options": expose_options,
+            "data": expose_options,
         }
     )
     res = await client.receive_json()

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -401,7 +401,16 @@ async def test_ui_expose_create_and_update(
         {
             "type": "knx/update_expose",
             "entity_id": ENTITY_ID,
-            "options": [{"ga": {"write": GROUP_ADDRESS_1, "dpt": "1.001"}}],
+            "data": {
+                "options": [
+                    {
+                        "ga": {
+                            "write": GROUP_ADDRESS_1,
+                            "dpt": "1.001",
+                        }
+                    }
+                ],
+            },
         }
     )
     res = await ws_client.receive_json()
@@ -418,13 +427,15 @@ async def test_ui_expose_create_and_update(
         {
             "type": "knx/update_expose",
             "entity_id": ENTITY_ID,
-            "options": [
-                {"ga": {"write": GROUP_ADDRESS_1, "dpt": "1.001"}},
-                {
-                    "ga": {"write": GROUP_ADDRESS_2, "dpt": "5.001"},
-                    "attribute": "brightness",
-                },
-            ],
+            "data": {
+                "options": [
+                    {"ga": {"write": GROUP_ADDRESS_1, "dpt": "1.001"}},
+                    {
+                        "ga": {"write": GROUP_ADDRESS_2, "dpt": "5.001"},
+                        "attribute": "brightness",
+                    },
+                ],
+            },
         }
     )
     res = await ws_client.receive_json()
@@ -455,17 +466,19 @@ async def test_ui_expose_with_options(
         {
             "type": "knx/update_expose",
             "entity_id": ENTITY_ID,
-            "options": [
-                {
-                    "ga": {"write": GROUP_ADDRESS_1, "dpt": "5.010"},
-                    "attribute": "brightness",
-                    "cooldown": 2.5,
-                    "default": 0,
-                    "periodic_send": 60.0,
-                    "respond_to_read": False,
-                    "value_template": "{{ 50 if value >= 50 else 1 }}",
-                }
-            ],
+            "data": {
+                "options": [
+                    {
+                        "ga": {"write": GROUP_ADDRESS_1, "dpt": "5.010"},
+                        "attribute": "brightness",
+                        "cooldown": 2.5,
+                        "default": 0,
+                        "periodic_send": 60.0,
+                        "respond_to_read": False,
+                        "value_template": "{{ 50 if value >= 50 else 1 }}",
+                    }
+                ],
+            },
         }
     )
     res = await ws_client.receive_json()

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -435,6 +435,7 @@ async def test_ui_expose_create_and_update(
                         "attribute": "brightness",
                     },
                 ],
+                "notes": "This is a note",
             },
         }
     )

--- a/tests/components/knx/test_websocket.py
+++ b/tests/components/knx/test_websocket.py
@@ -442,6 +442,43 @@ async def test_knx_get_schema(
     assert res == snapshot
 
 
+async def test_knx_get_expose_groups(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test knx/get_expose_groups command returning proper expose groups data."""
+    await knx.setup_integration(
+        config_store_fixture="config_store_expose.json",
+    )
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "knx/get_expose_groups"})
+    res = await client.receive_json()
+    assert res == snapshot
+
+
+async def test_knx_get_expose_config(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test knx/get_expose_config command returning proper expose config data."""
+    await knx.setup_integration(
+        config_store_fixture="config_store_expose.json",
+    )
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "knx/get_expose_config",
+            "entity_id": "cover.test",
+        }
+    )
+    res = await client.receive_json()
+    assert res == snapshot
+
+
 @pytest.mark.parametrize(
     "endpoint",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This is a breaking change for the knx-frontend. Therefore the feature is bundled with the supporting dependency update here. Since that's not yet in production, but will be included in 2025.5, there is no migration added.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/XKNX/knx-frontend/releases/tag/2026.4.25.155016

https://github.com/XKNX/knx-frontend/compare/2026.4.22.141111...2026.4.25.155016

This changes the schema for the expose UI feature to be more flexible - and adds a new key "notes".  The dependency (frontend) changes are used to support the new schema and the "notes" feature. 



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
