### PR TITLE
Add navigation destination text entity to Tessie integration

### DIFF
--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -49,6 +49,7 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TEXT,
     Platform.UPDATE,
 ]
 

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -50,6 +50,7 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TEXT,
     Platform.UPDATE,
 ]
 

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -291,6 +291,11 @@
       "vehicle_state_valet_mode": {
         "default": "mdi:bow-tie"
       }
+    },
+    "text": {
+      "navigation_destination": {
+        "default": "mdi:map-marker"
+      }
     }
   }
 }

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -612,6 +612,11 @@
         "name": "Valet mode"
       }
     },
+    "text": {
+      "navigation_destination": {
+        "name": "Navigation destination"
+      }
+    },
     "update": {
       "update": {
         "name": "[%key:component::update::title%]"

--- a/homeassistant/components/tessie/text.py
+++ b/homeassistant/components/tessie/text.py
@@ -1,0 +1,41 @@
+"""Text platform for Tessie integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import TessieConfigEntry
+from .entity import TessieEntity
+from .models import TessieVehicleData
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Tessie Text platform from a config entry."""
+    async_add_entities(
+        TessieNavigationTextEntity(vehicle) for vehicle in entry.runtime_data.vehicles
+    )
+
+
+class TessieNavigationTextEntity(TessieEntity, TextEntity):
+    """Text entity to send a navigation destination to the vehicle."""
+
+    _attr_mode = TextMode.TEXT
+    _attr_native_max = 255
+    _attr_native_min = 1
+    _attr_native_value: str | None = None
+
+    def __init__(self, vehicle: TessieVehicleData) -> None:
+        """Initialize the navigation text entity."""
+        super().__init__(vehicle, "navigation_destination")
+
+    async def async_set_value(self, value: str) -> None:
+        """Send a navigation destination to the vehicle."""
+        await self.run(self.api.navigation_request(value))

--- a/homeassistant/components/tessie/text.py
+++ b/homeassistant/components/tessie/text.py
@@ -1,0 +1,42 @@
+"""Text platform for Tessie integration."""
+
+from typing import override
+
+from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import TessieConfigEntry
+from .entity import TessieEntity
+from .models import TessieVehicleData
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Tessie Text platform from a config entry."""
+    async_add_entities(
+        TessieNavigationTextEntity(vehicle) for vehicle in entry.runtime_data.vehicles
+    )
+
+
+class TessieNavigationTextEntity(TessieEntity, TextEntity):
+    """Text entity to send a navigation destination to the vehicle."""
+
+    _attr_mode = TextMode.TEXT
+    _attr_native_max = 255
+    _attr_native_min = 1
+    _attr_native_value: str | None = None
+
+    def __init__(self, vehicle: TessieVehicleData) -> None:
+        """Initialize the navigation text entity."""
+        super().__init__(vehicle, "navigation_destination")
+
+    @override
+    async def async_set_value(self, value: str) -> None:
+        """Send a navigation destination to the vehicle."""
+        await self.run(self.api.navigation_request(value))

--- a/tests/components/tessie/snapshots/test_text.ambr
+++ b/tests/components/tessie/snapshots/test_text.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_text_entities[text.test_navigation_destination-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 255,
+      'min': 1,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': None,
+    'entity_id': 'text.test_navigation_destination',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Navigation destination',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Navigation destination',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'navigation_destination',
+    'unique_id': 'VINVINVIN-navigation_destination',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_text_entities[text.test_navigation_destination-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Navigation destination',
+      'max': 255,
+      'min': 1,
+      'mode': <TextMode.TEXT: 'text'>,
+      'pattern': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.test_navigation_destination',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/tessie/snapshots/test_text.ambr
+++ b/tests/components/tessie/snapshots/test_text.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_text_entities[text.test_navigation_destination-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
+      <TextEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
+      <TextEntityCapabilityAttribute.PATTERN: 'pattern'>: None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': None,
+    'entity_id': 'text.test_navigation_destination',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Navigation destination',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Navigation destination',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'navigation_destination',
+    'unique_id': 'VINVINVIN-navigation_destination',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_text_entities[text.test_navigation_destination-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Navigation destination',
+      <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
+      <TextEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
+      <TextEntityCapabilityAttribute.PATTERN: 'pattern'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.test_navigation_destination',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/tessie/test_text.py
+++ b/tests/components/tessie/test_text.py
@@ -1,0 +1,68 @@
+"""Test the Tessie text platform."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.text import DOMAIN as TEXT_DOMAIN, SERVICE_SET_VALUE
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from .common import ERROR_UNKNOWN, assert_entities, setup_platform
+
+NAVIGATION_ENTITY_ID = "text.test_navigation_destination"
+
+
+async def test_text_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that the navigation text entity is set up correctly."""
+    entry = await setup_platform(hass, [Platform.TEXT])
+    assert_entities(hass, entry.entry_id, entity_registry, snapshot)
+
+
+async def test_set_navigation_destination(hass: HomeAssistant) -> None:
+    """Test sending a navigation destination to the vehicle."""
+    await setup_platform(hass, [Platform.TEXT])
+
+    with patch(
+        "tesla_fleet_api.tessie.Vehicle.navigation_request",
+    ) as mock_nav:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: NAVIGATION_ENTITY_ID,
+                "value": "1 Infinite Loop, Cupertino, CA",
+            },
+            blocking=True,
+        )
+        mock_nav.assert_called_once_with("1 Infinite Loop, Cupertino, CA")
+
+
+async def test_set_navigation_destination_error(hass: HomeAssistant) -> None:
+    """Test that a transport error is translated to HomeAssistantError."""
+    await setup_platform(hass, [Platform.TEXT])
+
+    with (
+        patch(
+            "tesla_fleet_api.tessie.Vehicle.navigation_request",
+            side_effect=ERROR_UNKNOWN,
+        ) as mock_nav,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: NAVIGATION_ENTITY_ID, "value": "Times Square, New York"},
+            blocking=True,
+        )
+
+    mock_nav.assert_called_once()
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"

--- a/tests/components/tessie/test_text.py
+++ b/tests/components/tessie/test_text.py
@@ -1,0 +1,75 @@
+"""Test the Tessie text platform."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.text import (
+    ATTR_VALUE,
+    DOMAIN as TEXT_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from .common import ERROR_UNKNOWN, assert_entities, setup_platform
+
+NAVIGATION_ENTITY_ID = "text.test_navigation_destination"
+
+
+async def test_text_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that the navigation text entity is set up correctly."""
+    entry = await setup_platform(hass, [Platform.TEXT])
+    assert_entities(hass, entry.entry_id, entity_registry, snapshot)
+
+
+async def test_set_navigation_destination(hass: HomeAssistant) -> None:
+    """Test sending a navigation destination to the vehicle."""
+    await setup_platform(hass, [Platform.TEXT])
+
+    with patch(
+        "tesla_fleet_api.tessie.Vehicle.navigation_request",
+    ) as mock_nav:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: NAVIGATION_ENTITY_ID,
+                ATTR_VALUE: "1 Infinite Loop, Cupertino, CA",
+            },
+            blocking=True,
+        )
+        mock_nav.assert_called_once_with("1 Infinite Loop, Cupertino, CA")
+
+
+async def test_set_navigation_destination_error(hass: HomeAssistant) -> None:
+    """Test that a transport error is translated to HomeAssistantError."""
+    await setup_platform(hass, [Platform.TEXT])
+
+    with (
+        patch(
+            "tesla_fleet_api.tessie.Vehicle.navigation_request",
+            side_effect=ERROR_UNKNOWN,
+        ) as mock_nav,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: NAVIGATION_ENTITY_ID,
+                ATTR_VALUE: "Times Square, New York",
+            },
+            blocking=True,
+        )
+
+    mock_nav.assert_called_once()
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Adds a text entity (navigation_destination) to the Tessie integration, allowing users to send a navigation destination string to their vehicle from Home Assistant.

The entity calls tesla_fleet_api.tessie.Vehicle.navigation_request(value) which POSTs to the vehicle's /command/navigation_request endpoint. It is intentionally write-only (state is always None) with a minimum length of 1.

Changes:
- text.py - new platform with TessieNavigationTextEntity
- __init__.py - add Platform.TEXT to PLATFORMS (alphabetical order)
- strings.json - add 	ext.navigation_destination translation key
- icons.json - add mdi:map-marker icon for the entity
- tests/components/tessie/test_text.py - entity setup, happy-path command, and error translation tests

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- Tested against tesla-fleet-api==1.4.5 (no dependency bump required)
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45007

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/) has all fields filled out correctly.
- [x] New or updated dependencies have been added to \
equirements_all.txt\ *(no new deps)*

