### PR TITLE
Add alarm control panel platform to UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -158,6 +158,13 @@ async def _async_setup_entry(
     await async_migrate_data(hass, entry, data_service.api, bootstrap)
     data_service.async_setup()
 
+    # Prime the public bootstrap. The devices websocket subscription was already
+    # registered in async_setup() per library docs (subscribe first, then prime).
+    try:
+        await data_service.api.update_public()
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Public API bootstrap update failed", exc_info=True)
+
     # Load PTZ patrol data before loading platforms
     await data_service.async_load_ptz_patrols()
 

--- a/homeassistant/components/unifiprotect/alarm_control_panel.py
+++ b/homeassistant/components/unifiprotect/alarm_control_panel.py
@@ -15,8 +15,10 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .data import ProtectData, ProtectDeviceType, UFPConfigEntry
 from .entity import ProtectNVREntity
+from .utils import async_ufp_instance_command
 
 PARALLEL_UPDATES = 0
 
@@ -93,22 +95,24 @@ class ProtectNVRAlarmControlPanel(ProtectNVREntity, AlarmControlPanelEntity):
         super()._async_update_device_from_protect(device)
         self._refresh_alarm_state()
 
+    @async_ufp_instance_command
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         try:
             await self.data.api.disable_arm_alarm_public()
         except GlobalAlarmManagerError as err:
             raise HomeAssistantError(
-                translation_domain="unifiprotect",
+                translation_domain=DOMAIN,
                 translation_key="global_alarm_manager",
             ) from err
 
+    @async_ufp_instance_command
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command (arms with the currently selected profile)."""
         try:
             await self.data.api.enable_arm_alarm_public()
         except GlobalAlarmManagerError as err:
             raise HomeAssistantError(
-                translation_domain="unifiprotect",
+                translation_domain=DOMAIN,
                 translation_key="global_alarm_manager",
             ) from err

--- a/homeassistant/components/unifiprotect/alarm_control_panel.py
+++ b/homeassistant/components/unifiprotect/alarm_control_panel.py
@@ -1,0 +1,114 @@
+"""Support for UniFi Protect NVR alarm control panel."""
+
+from __future__ import annotations
+
+from uiprotect.data import NVR, NvrArmModeStatus
+from uiprotect.exceptions import GlobalAlarmManagerError
+
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntity,
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .data import ProtectData, ProtectDeviceType, UFPConfigEntry
+from .entity import ProtectNVREntity
+
+PARALLEL_UPDATES = 0
+
+_UIPROTECT_TO_HA: dict[NvrArmModeStatus, AlarmControlPanelState] = {
+    NvrArmModeStatus.DISABLED: AlarmControlPanelState.DISARMED,
+    NvrArmModeStatus.ARMING: AlarmControlPanelState.ARMING,
+    NvrArmModeStatus.ARMED: AlarmControlPanelState.ARMED_AWAY,
+    NvrArmModeStatus.BREACH: AlarmControlPanelState.TRIGGERED,
+    NvrArmModeStatus.UNKNOWN: AlarmControlPanelState.DISARMED,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: UFPConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up alarm control panel for UniFi Protect NVR."""
+    data = entry.runtime_data
+    api = data.api
+
+    # No public Integration API available (e.g. older NVR firmware that does
+    # not expose the Alarm Manager endpoint, or no API key configured).
+    # Skip entity creation entirely; we cannot represent the alarm state.
+    if not api.has_public_bootstrap:
+        return
+
+    # ``arm_mode`` is ``None`` on NVR firmware that predates the Alarm Manager
+    # public API. Skip entity creation so the user does not see a permanently
+    # unavailable entity.
+    if api.public_bootstrap.arm_mode is None:
+        return
+
+    nvr = api.bootstrap.nvr
+    async_add_entities([ProtectNVRAlarmControlPanel(data, device=nvr)])
+
+
+class ProtectNVRAlarmControlPanel(ProtectNVREntity, AlarmControlPanelEntity):
+    """UniFi Protect NVR Alarm Control Panel."""
+
+    _attr_code_arm_required = False
+    _attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
+    _attr_translation_key = "nvr_alarm"
+    _state_attrs = ("_attr_available", "_attr_alarm_state")
+
+    def __init__(self, data: ProtectData, device: NVR) -> None:
+        """Initialize the alarm control panel."""
+        super().__init__(data, device, EntityDescription(key="alarm"))
+        self._refresh_alarm_state()
+
+    @callback
+    def _refresh_alarm_state(self) -> None:
+        """Update _attr_alarm_state from the public bootstrap cache."""
+        api = self.data.api
+        arm_mode = api.public_bootstrap.arm_mode if api.has_public_bootstrap else None
+        if arm_mode is None:
+            # No alarm data available — force unavailable regardless of the
+            # private WebSocket state managed by the base class.
+            self._attr_available = False
+            self._attr_alarm_state = None
+            return
+        # Do NOT set _attr_available = True here.  Availability when alarm data
+        # is present is determined exclusively by the base class via
+        # last_update_success (private WebSocket health). Only force it to
+        # False as an additional condition when alarm data is missing.
+        # Fall back to DISARMED for unknown future status values rather than
+        # rendering the entity as ``unknown``.
+        self._attr_alarm_state = _UIPROTECT_TO_HA.get(
+            arm_mode.status, AlarmControlPanelState.DISARMED
+        )
+
+    @callback
+    def _async_update_device_from_protect(self, device: ProtectDeviceType) -> None:
+        super()._async_update_device_from_protect(device)
+        self._refresh_alarm_state()
+
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send disarm command."""
+        try:
+            await self.data.api.disable_arm_alarm_public()
+        except GlobalAlarmManagerError as err:
+            raise HomeAssistantError(
+                translation_domain="unifiprotect",
+                translation_key="global_alarm_manager",
+            ) from err
+
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Send arm away command (arms with the currently selected profile)."""
+        try:
+            await self.data.api.enable_arm_alarm_public()
+        except GlobalAlarmManagerError as err:
+            raise HomeAssistantError(
+                translation_domain="unifiprotect",
+                translation_key="global_alarm_manager",
+            ) from err

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -52,6 +52,9 @@ DEVICES_THAT_ADOPT = {
 DEVICES_WITH_ENTITIES = DEVICES_THAT_ADOPT | {ModelType.NVR}
 DEVICES_FOR_SUBSCRIBE = DEVICES_WITH_ENTITIES | {ModelType.EVENT}
 
+# Public API devices WebSocket: NVR (for arm_mode updates).
+DEVICES_WS_SUBSCRIBED_MODELS = {ModelType.NVR}
+
 MIN_REQUIRED_PROTECT_V = Version("6.0.0")
 OUTDATED_LOG_MESSAGE = (
     "You are running v%s of UniFi Protect. Minimum required version is v%s. Please"
@@ -61,6 +64,7 @@ OUTDATED_LOG_MESSAGE = (
 TYPE_EMPTY_VALUE = ""
 
 PLATFORMS = [
+    Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CAMERA,

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -164,7 +164,26 @@ class ProtectData:
             async_track_time_interval(
                 self._hass, self._async_poll, self._update_interval
             ),
+            # Subscribe to the public devices websocket unconditionally so that
+            # it is active before update_public() primes the cache.
+            # Per library docs: subscribe first, then call update_public().
+            api.subscribe_devices_websocket(
+                self._async_process_public_devices_ws_message
+            ),
         ]
+
+    @callback
+    def _async_process_public_devices_ws_message(
+        self, message: WSSubscriptionMessage
+    ) -> None:
+        """Process a message from the public devices websocket.
+
+        The API client pre-filters messages to ModelType.NVR via
+        DEVICES_WS_SUBSCRIBED_MODELS, so every message here is an NVR update.
+        The library has already merged the arm_mode into the PublicNVR cache;
+        signal the private NVR so alarm entities pick up the new state.
+        """
+        self._async_signal_device_update(self.api.bootstrap.nvr)
 
     @callback
     def _async_websocket_state_changed(self, state: WebsocketState) -> None:

--- a/homeassistant/components/unifiprotect/icons.json
+++ b/homeassistant/components/unifiprotect/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "alarm_control_panel": {
+      "nvr_alarm": {
+        "default": "mdi:shield-home"
+      }
+    },
     "binary_sensor": {
       "alarm_sound_detection": {
         "default": "mdi:alarm-bell"

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -90,6 +90,11 @@
     }
   },
   "entity": {
+    "alarm_control_panel": {
+      "nvr_alarm": {
+        "name": "Alarm Manager"
+      }
+    },
     "binary_sensor": {
       "alarm_sound_detection": {
         "name": "Alarm sound detection"
@@ -667,6 +672,9 @@
     },
     "device_not_found": {
       "message": "No device found for device id: {device_id}"
+    },
+    "global_alarm_manager": {
+      "message": "The alarm manager on this UniFi Protect NVR is set to Global mode and cannot be controlled locally."
     },
     "no_users_found": {
       "message": "No users found, please check Protect permissions"

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_ALL_UPDATES,
     CONF_OVERRIDE_CHOST,
     DEVICES_FOR_SUBSCRIBE,
+    DEVICES_WS_SUBSCRIBED_MODELS,
     DOMAIN,
     ModelType,
 )
@@ -126,6 +127,7 @@ def async_create_api_client(
         session=session,
         public_api_session=public_api_session,
         subscribed_models=DEVICES_FOR_SUBSCRIBE,
+        devices_ws_subscribed_models=DEVICES_WS_SUBSCRIBED_MODELS,
         override_connection_host=entry.options.get(CONF_OVERRIDE_CHOST, False),
         ignore_stats=not entry.options.get(CONF_ALL_UPDATES, False),
         ignore_unadopted=False,

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -187,6 +187,9 @@ def mock_entry(
 
         ufp_client.subscribe_websocket = subscribe
         ufp_client.subscribe_websocket_state = subscribe_websocket_state
+        ufp_client.subscribe_devices_websocket = Mock(return_value=Mock())
+        ufp_client.update_public = AsyncMock()
+        ufp_client.has_public_bootstrap = False
         yield ufp
 
 

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -185,9 +185,15 @@ def mock_entry(
             ufp.ws_state_subscription = ws_state_subscription
             return Mock()
 
+        def subscribe_devices_websocket(
+            ws_callback: Callable[[WSSubscriptionMessage], None],
+        ) -> Any:
+            ufp.devices_ws_subscription = ws_callback
+            return Mock()
+
         ufp_client.subscribe_websocket = subscribe
         ufp_client.subscribe_websocket_state = subscribe_websocket_state
-        ufp_client.subscribe_devices_websocket = Mock(return_value=Mock())
+        ufp_client.subscribe_devices_websocket = subscribe_devices_websocket
         ufp_client.update_public = AsyncMock()
         ufp_client.has_public_bootstrap = False
         yield ufp

--- a/tests/components/unifiprotect/test_alarm_control_panel.py
+++ b/tests/components/unifiprotect/test_alarm_control_panel.py
@@ -221,7 +221,7 @@ async def test_alarm_panel_state_update_via_ws(
     ufp: MockUFPFixture,
     nvr: NVR,
 ) -> None:
-    """Test that WS device update triggers state refresh."""
+    """Test that public devices WS update triggers state refresh."""
     arm_mode = _make_arm_mode(NvrArmModeStatus.DISABLED)
     pb = _make_public_bootstrap(arm_mode)
     ufp.api.has_public_bootstrap = True
@@ -233,7 +233,7 @@ async def test_alarm_panel_state_update_via_ws(
     assert state is not None
     assert state.state == AlarmControlPanelState.DISARMED
 
-    # Simulate arm state change via websocket
+    # Simulate arm state change via the public devices websocket
     armed_arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
     pb.arm_mode = armed_arm_mode
 
@@ -241,7 +241,8 @@ async def test_alarm_panel_state_update_via_ws(
     mock_msg.changed_data = {}
     mock_msg.old_obj = nvr
     mock_msg.new_obj = nvr
-    ufp.ws_msg(mock_msg)
+    assert ufp.devices_ws_subscription is not None
+    ufp.devices_ws_subscription(mock_msg)
     await hass.async_block_till_done()
 
     state = hass.states.get(ALARM_ENTITY_ID)

--- a/tests/components/unifiprotect/test_alarm_control_panel.py
+++ b/tests/components/unifiprotect/test_alarm_control_panel.py
@@ -1,0 +1,312 @@
+"""Test the UniFi Protect alarm control panel platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from uiprotect.data import NVR, NvrArmMode, NvrArmModeStatus, PublicBootstrap
+from uiprotect.exceptions import GlobalAlarmManagerError
+from uiprotect.websocket import WebsocketState
+
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_DOMAIN,
+    AlarmControlPanelState,
+)
+from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_ENTITY_ID,
+    SERVICE_ALARM_ARM_AWAY,
+    SERVICE_ALARM_DISARM,
+    STATE_UNAVAILABLE,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from .utils import MockUFPFixture, assert_entity_counts, init_entry
+
+ALARM_ENTITY_ID = "alarm_control_panel.unifiprotect_alarm_manager"
+
+
+def _make_arm_mode(status: NvrArmModeStatus) -> Mock:
+    """Create a NvrArmMode object for testing."""
+    arm_mode = Mock(spec=NvrArmMode)
+    arm_mode.status = status
+    return arm_mode
+
+
+def _make_public_bootstrap(arm_mode: Mock | None) -> Mock:
+    """Create a PublicBootstrap with the given arm_mode."""
+    pb = Mock(spec=PublicBootstrap)
+    pb.arm_mode = arm_mode
+    pb.arm_profiles = {}
+    return pb
+
+
+async def test_alarm_panel_not_created_without_public_bootstrap(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Alarm panel entity is NOT created when has_public_bootstrap is False."""
+    ufp.api.has_public_bootstrap = False
+
+    await init_entry(hass, ufp, [])
+    assert_entity_counts(hass, Platform.ALARM_CONTROL_PANEL, 0, 0)
+
+
+async def test_alarm_panel_created_with_public_bootstrap(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    ufp: MockUFPFixture,
+    nvr: NVR,
+) -> None:
+    """Alarm panel entity IS created when has_public_bootstrap is True."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.DISABLED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+    await init_entry(hass, ufp, [])
+    assert_entity_counts(hass, Platform.ALARM_CONTROL_PANEL, 1, 1)
+
+    entity = entity_registry.async_get(ALARM_ENTITY_ID)
+    assert entity is not None
+    assert entity.unique_id == f"{nvr.mac}_alarm"
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.DISARMED
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+
+
+@pytest.mark.parametrize(
+    ("nvr_status", "expected_state"),
+    [
+        (NvrArmModeStatus.DISABLED, AlarmControlPanelState.DISARMED),
+        (NvrArmModeStatus.UNKNOWN, AlarmControlPanelState.DISARMED),
+        (NvrArmModeStatus.ARMING, AlarmControlPanelState.ARMING),
+        (NvrArmModeStatus.ARMED, AlarmControlPanelState.ARMED_AWAY),
+        (NvrArmModeStatus.BREACH, AlarmControlPanelState.TRIGGERED),
+    ],
+)
+async def test_alarm_panel_state_mapping(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    nvr_status: NvrArmModeStatus,
+    expected_state: AlarmControlPanelState,
+) -> None:
+    """Test that NvrArmModeStatus maps to correct AlarmControlPanelState."""
+    arm_mode = _make_arm_mode(nvr_status)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+    await init_entry(hass, ufp, [])
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == expected_state
+
+
+async def test_alarm_panel_not_created_without_arm_mode(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Alarm panel entity is NOT created on old firmware (arm_mode is None)."""
+    pb = _make_public_bootstrap(arm_mode=None)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+    await init_entry(hass, ufp, [])
+    assert_entity_counts(hass, Platform.ALARM_CONTROL_PANEL, 0, 0)
+
+
+async def test_alarm_panel_disarm(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Test that disarm service calls disable_arm_alarm_public."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+    ufp.api.disable_arm_alarm_public = AsyncMock()
+
+    await init_entry(hass, ufp, [])
+
+    await hass.services.async_call(
+        ALARM_DOMAIN,
+        SERVICE_ALARM_DISARM,
+        {ATTR_ENTITY_ID: ALARM_ENTITY_ID},
+        blocking=True,
+    )
+
+    ufp.api.disable_arm_alarm_public.assert_called_once()
+
+
+async def test_alarm_panel_arm_away(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Test that arm_away service calls enable_arm_alarm_public."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.DISABLED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+    ufp.api.enable_arm_alarm_public = AsyncMock()
+
+    await init_entry(hass, ufp, [])
+
+    await hass.services.async_call(
+        ALARM_DOMAIN,
+        SERVICE_ALARM_ARM_AWAY,
+        {ATTR_ENTITY_ID: ALARM_ENTITY_ID},
+        blocking=True,
+    )
+
+    ufp.api.enable_arm_alarm_public.assert_called_once()
+
+
+async def test_alarm_panel_disarm_global_manager_error(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Test that GlobalAlarmManagerError on disarm raises HomeAssistantError."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+    ufp.api.disable_arm_alarm_public = AsyncMock(side_effect=GlobalAlarmManagerError())
+
+    await init_entry(hass, ufp, [])
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            ALARM_DOMAIN,
+            SERVICE_ALARM_DISARM,
+            {ATTR_ENTITY_ID: ALARM_ENTITY_ID},
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "global_alarm_manager"
+
+
+async def test_alarm_panel_arm_away_global_manager_error(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Test that GlobalAlarmManagerError on arm raises HomeAssistantError."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.DISABLED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+    ufp.api.enable_arm_alarm_public = AsyncMock(side_effect=GlobalAlarmManagerError())
+
+    await init_entry(hass, ufp, [])
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            ALARM_DOMAIN,
+            SERVICE_ALARM_ARM_AWAY,
+            {ATTR_ENTITY_ID: ALARM_ENTITY_ID},
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "global_alarm_manager"
+
+
+async def test_alarm_panel_state_update_via_ws(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    nvr: NVR,
+) -> None:
+    """Test that WS device update triggers state refresh."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.DISABLED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+    await init_entry(hass, ufp, [])
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.DISARMED
+
+    # Simulate arm state change via websocket
+    armed_arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
+    pb.arm_mode = armed_arm_mode
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.old_obj = nvr
+    mock_msg.new_obj = nvr
+    ufp.ws_msg(mock_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.ARMED_AWAY
+
+
+async def test_alarm_panel_unavailable_when_arm_mode_disappears(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    nvr: NVR,
+) -> None:
+    """Entity becomes unavailable when arm_mode disappears after a WS update."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+    await init_entry(hass, ufp, [])
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.ARMED_AWAY
+
+    # Simulate firmware downgrade / global mode switch: arm_mode becomes None
+    pb.arm_mode = None
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.old_obj = nvr
+    mock_msg.new_obj = nvr
+    ufp.ws_msg(mock_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_alarm_panel_unavailable_on_ws_disconnect(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Entity becomes unavailable when the private WebSocket disconnects."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+    await init_entry(hass, ufp, [])
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.ARMED_AWAY
+
+    ufp.ws_state_subscription(WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    ufp.ws_state_subscription(WebsocketState.CONNECTED)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.ARMED_AWAY

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -38,6 +38,7 @@ class MockUFPFixture:
     api: ProtectApiClient
     ws_subscription: Callable[[WSSubscriptionMessage], None] | None = None
     ws_state_subscription: Callable[[WebsocketState], None] | None = None
+    devices_ws_subscription: Callable[[WSSubscriptionMessage], None] | None = None
 
     def ws_msg(self, msg: WSSubscriptionMessage) -> None:
         """Emit WS message for testing."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Adds an `alarm_control_panel` entity to the UniFi Protect integration, backed by the **Public Integration API** introduced in `uiprotect` 10.4.0. The entity represents the **NVR Alarm Manager** and supports arming (away mode) and disarming.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45018
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
