### PR TITLE
Modernize arwn integration to config-entry architecture

### DIFF
--- a/homeassistant/components/arwn/__init__.py
+++ b/homeassistant/components/arwn/__init__.py
@@ -1,1 +1,34 @@
 """The arwn component."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components import mqtt
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .sensor import ArwnSensor
+
+_LOGGER = logging.getLogger(__name__)
+
+type ArwnConfigEntry = ConfigEntry[dict[str, ArwnSensor]]
+
+PLATFORMS = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ArwnConfigEntry) -> bool:
+    """Set up ARWN from a config entry."""
+    if not await mqtt.async_wait_for_mqtt_client(hass):
+        _LOGGER.error("MQTT integration is not available")
+        return False
+
+    entry.runtime_data = {}
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ArwnConfigEntry) -> bool:
+    """Unload ARWN config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/arwn/config_flow.py
+++ b/homeassistant/components/arwn/config_flow.py
@@ -1,0 +1,25 @@
+"""Config flow for the ARWN integration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
+
+from .const import DOMAIN
+
+
+async def _async_has_devices(_: HomeAssistant) -> bool:
+    """MQTT is set as dependency, so that should be sufficient."""
+    return True
+
+
+class ArwnFlowHandler(DiscoveryFlowHandler[Awaitable[bool]], domain=DOMAIN):
+    """Handle ARWN config flow. The MQTT step is inherited from the parent class."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Set up the config flow."""
+        super().__init__(DOMAIN, "Ambient Radio Weather Network", _async_has_devices)

--- a/homeassistant/components/arwn/const.py
+++ b/homeassistant/components/arwn/const.py
@@ -1,0 +1,3 @@
+"""Constants for the ARWN integration."""
+
+DOMAIN = "arwn"

--- a/homeassistant/components/arwn/manifest.json
+++ b/homeassistant/components/arwn/manifest.json
@@ -2,8 +2,11 @@
   "domain": "arwn",
   "name": "Ambient Radio Weather Network",
   "codeowners": [],
+  "config_flow": true,
   "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/arwn",
-  "iot_class": "local_polling",
+  "integration_type": "hub",
+  "iot_class": "local_push",
+  "mqtt": ["arwn/#"],
   "quality_scale": "legacy"
 }

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import mqtt
 from homeassistant.components.sensor import (
@@ -13,16 +13,14 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import DEGREE, UnitOfPrecipitationDepth, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import slugify
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.json import json_loads_object
+
+if TYPE_CHECKING:
+    from . import ArwnConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "arwn"
-
-DATA_ARWN = "arwn"
 TOPIC = "arwn/#"
 
 
@@ -32,9 +30,13 @@ def discover_sensors(topic: str, payload: dict[str, Any]) -> list[ArwnSensor] | 
     Async friendly.
     """
     parts = topic.split("/")
+    if len(parts) < 2:
+        return None
     unit = payload.get("units", "")
     domain = parts[1]
     if domain == "temperature":
+        if len(parts) < 3:
+            return None
         name = parts[2]
         if unit == "F":
             unit = UnitOfTemperature.FAHRENHEIT
@@ -46,6 +48,8 @@ def discover_sensors(topic: str, payload: dict[str, Any]) -> list[ArwnSensor] | 
             )
         ]
     if domain == "moisture":
+        if len(parts) < 3:
+            return None
         name = f"{parts[2]} Moisture"
         return [ArwnSensor(topic, name, "moisture", unit, "mdi:water-percent")]
     if domain == "rain":
@@ -108,26 +112,16 @@ def discover_sensors(topic: str, payload: dict[str, Any]) -> list[ArwnSensor] | 
     return None
 
 
-def _slug(name: str) -> str:
-    return f"sensor.arwn_{slugify(name)}"
-
-
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: ArwnConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the ARWN platform."""
-
-    # Make sure MQTT integration is enabled and the client is available
-    if not await mqtt.async_wait_for_mqtt_client(hass):
-        _LOGGER.error("MQTT integration is not available")
-        return
+    """Set up the ARWN sensor platform."""
 
     @callback
     def async_sensor_event_received(msg: mqtt.ReceiveMessage) -> None:
-        """Process events as sensors.
+        """Process MQTT events as sensors.
 
         When a new event on our topic (arwn/#) is received we map it
         into a known kind of sensor based on topic name. If we've
@@ -139,35 +133,44 @@ async def async_setup_platform(
         This lets us dynamically incorporate sensors without any
         configuration on our side.
         """
-        event = json_loads_object(msg.payload)
+        try:
+            event = json_loads_object(msg.payload)
+        except ValueError:
+            _LOGGER.warning(
+                "Invalid JSON in MQTT message on %s: %s", msg.topic, msg.payload
+            )
+            return
+
         sensors = discover_sensors(msg.topic, event)
         if not sensors:
             return
 
-        if (store := hass.data.get(DATA_ARWN)) is None:
-            store = hass.data[DATA_ARWN] = {}
+        store = entry.runtime_data
 
         if "timestamp" in event:
             del event["timestamp"]
 
         for sensor in sensors:
-            if sensor.name not in store:
-                sensor.hass = hass
-                sensor.set_event(event)
-                store[sensor.name] = sensor
+            if (unique_id := sensor.unique_id) is None:
+                continue
+            if unique_id not in store:
+                store[unique_id] = sensor
+                sensor.set_initial_event(event)
                 _LOGGER.debug(
                     "Registering sensor %(name)s => %(event)s",
                     {"name": sensor.name, "event": event},
                 )
-                async_add_entities((sensor,), True)
+                async_add_entities((sensor,), False)
             else:
                 _LOGGER.debug(
                     "Recording sensor %(name)s => %(event)s",
                     {"name": sensor.name, "event": event},
                 )
-                store[sensor.name].set_event(event)
+                store[unique_id].set_event(event)
 
-    await mqtt.async_subscribe(hass, TOPIC, async_sensor_event_received, 0)
+    entry.async_on_unload(
+        await mqtt.async_subscribe(hass, TOPIC, async_sensor_event_received, 0)
+    )
 
 
 class ArwnSensor(SensorEntity):
@@ -186,7 +189,6 @@ class ArwnSensor(SensorEntity):
         state_class: SensorStateClass | None = None,
     ) -> None:
         """Initialize the sensor."""
-        self.entity_id = _slug(name)
         self._attr_name = name
         # This mqtt topic for the sensor which is its uid
         self._attr_unique_id = topic
@@ -196,10 +198,15 @@ class ArwnSensor(SensorEntity):
         self._attr_device_class = device_class
         self._attr_state_class = state_class
 
+    def set_initial_event(self, event: dict[str, Any]) -> None:
+        """Set the initial state before the entity is registered."""
+        ev: dict[str, Any] = dict(event)
+        self._attr_extra_state_attributes = ev
+        self._attr_native_value = ev.get(self._state_key)
+
     def set_event(self, event: dict[str, Any]) -> None:
         """Update the sensor with the most recent event."""
-        ev: dict[str, Any] = {}
-        ev.update(event)
+        ev: dict[str, Any] = dict(event)
         self._attr_extra_state_attributes = ev
         self._attr_native_value = ev.get(self._state_key)
         self.async_write_ha_state()

--- a/homeassistant/components/arwn/strings.json
+++ b/homeassistant/components/arwn/strings.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
+    "step": {
+      "confirm": {
+        "description": "Set up the Ambient Radio Weather Network integration. Make sure your ARWN weather station is publishing to the MQTT broker."
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -74,6 +74,7 @@ FLOWS = {
         "aranet",
         "arcam_fmj",
         "arve",
+        "arwn",
         "aseko_pool_live",
         "asuswrt",
         "atag",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -569,8 +569,8 @@
     "arwn": {
       "name": "Ambient Radio Weather Network",
       "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "local_polling"
+      "config_flow": true,
+      "iot_class": "local_push"
     },
     "aseko_pool_live": {
       "name": "Aseko Pool Live",

--- a/homeassistant/generated/mqtt.py
+++ b/homeassistant/generated/mqtt.py
@@ -4,6 +4,9 @@ To update, run python3 -m script.hassfest
 """
 
 MQTT = {
+    "arwn": [
+        "arwn/#",
+    ],
     "drop_connect": [
         "drop_connect/discovery/#",
     ],

--- a/tests/components/arwn/__init__.py
+++ b/tests/components/arwn/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the arwn integration."""

--- a/tests/components/arwn/test_config_flow.py
+++ b/tests/components/arwn/test_config_flow.py
@@ -1,0 +1,69 @@
+"""Tests for the arwn config flow."""
+
+from homeassistant import config_entries
+from homeassistant.components.arwn.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
+
+from tests.typing import MqttMockHAClient
+
+
+async def test_user_step(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+) -> None:
+    """Test the user step shows confirm form then creates entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    config_result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert config_result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_result["title"] == "Ambient Radio Weather Network"
+
+
+async def test_mqtt_step(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+) -> None:
+    """Test that MQTT discovery triggers a confirm form."""
+    discovery_info = MqttServiceInfo(
+        topic="arwn/temperature/outside",
+        payload='{"temp": 72.5, "units": "F"}',
+        qos=0,
+        retain=False,
+        subscribed_topic="arwn/#",
+        timestamp=0.0,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_MQTT},
+        data=discovery_info,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+
+async def test_single_instance_allowed(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+) -> None:
+    """Test that a second setup attempt is aborted."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
+
+    duplicate = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert duplicate["type"] is FlowResultType.ABORT
+    assert duplicate["reason"] == "single_instance_allowed"

--- a/tests/components/arwn/test_sensor.py
+++ b/tests/components/arwn/test_sensor.py
@@ -188,9 +188,7 @@ async def test_barometer_sensor_discovery(
     await hass.async_block_till_done()
 
     entity_registry = er.async_get(hass)
-    entity_id = entity_registry.async_get_entity_id(
-        "sensor", DOMAIN, "arwn/barometer"
-    )
+    entity_id = entity_registry.async_get_entity_id("sensor", DOMAIN, "arwn/barometer")
     assert entity_id is not None
     assert hass.states.get(entity_id).state not in ("unknown", "unavailable")
 

--- a/tests/components/arwn/test_sensor.py
+++ b/tests/components/arwn/test_sensor.py
@@ -72,6 +72,7 @@ async def test_temperature_sensor_state_update(
     entity_id = entity_registry.async_get_entity_id(
         "sensor", DOMAIN, "arwn/temperature/BackYard"
     )
+    assert entity_id is not None
     state_after_first = hass.states.get(entity_id).state
     assert state_after_first not in ("unknown", "unavailable")
 
@@ -242,7 +243,7 @@ async def test_unknown_domain_ignored(
     assert len(entries) == 0
 
 
-async def test_entry_unload_removes_sensors(
+async def test_entry_unload_makes_sensors_unavailable(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
     config_entry: MockConfigEntry,

--- a/tests/components/arwn/test_sensor.py
+++ b/tests/components/arwn/test_sensor.py
@@ -1,0 +1,274 @@
+"""Tests for arwn sensor platform."""
+
+import pytest
+
+from homeassistant.components.arwn.const import DOMAIN
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, async_fire_mqtt_message
+from tests.typing import MqttMockHAClient
+
+
+@pytest.fixture
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a mock config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Ambient Radio Weather Network",
+        entry_id="TEST_ENTRY_ID",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_temperature_sensor_discovery(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test temperature sensor is created on first MQTT message."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/temperature/BackYard",
+        '{"temp": 72.5, "units": "F"}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "arwn/temperature/BackYard"
+    )
+    assert entity is not None
+
+    state = hass.states.get(entity)
+    assert state is not None
+    assert state.state not in ("unknown", "unavailable")
+    assert state.attributes["unit_of_measurement"] in (
+        UnitOfTemperature.FAHRENHEIT,
+        UnitOfTemperature.CELSIUS,
+    )
+
+
+async def test_temperature_sensor_state_update(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that a second MQTT message updates state, not adds a new entity."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass, "arwn/temperature/BackYard", '{"temp": 72.5, "units": "F"}'
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "arwn/temperature/BackYard"
+    )
+    state_after_first = hass.states.get(entity_id).state
+    assert state_after_first not in ("unknown", "unavailable")
+
+    async_fire_mqtt_message(
+        hass, "arwn/temperature/BackYard", '{"temp": 75.0, "units": "F"}'
+    )
+    await hass.async_block_till_done()
+
+    state_after_second = hass.states.get(entity_id).state
+    assert state_after_second not in ("unknown", "unavailable")
+    assert state_after_second != state_after_first
+
+    # Only one entity should exist for this config entry
+    entries = [
+        e
+        for e in entity_registry.entities.values()
+        if e.config_entry_id == config_entry.entry_id
+    ]
+    assert len(entries) == 1
+
+
+async def test_wind_sensor_discovery(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test wind message creates speed, gust, and direction sensors."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/wind",
+        '{"speed": 12.3, "gust": 18.0, "direction": 270, "units": "mph"}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    unique_ids = {
+        e.unique_id
+        for e in entity_registry.entities.values()
+        if e.config_entry_id == config_entry.entry_id
+    }
+    assert "arwn/wind/speed" in unique_ids
+    assert "arwn/wind/gust" in unique_ids
+    assert "arwn/wind/dir" in unique_ids
+
+
+async def test_rain_sensor_discovery(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test rain message creates total and rate sensors."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/rain",
+        '{"total": 1.2, "rate": 0.1, "units": "in"}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    unique_ids = {
+        e.unique_id
+        for e in entity_registry.entities.values()
+        if e.config_entry_id == config_entry.entry_id
+    }
+    assert "arwn/rain/total" in unique_ids
+    assert "arwn/rain/rate" in unique_ids
+
+
+async def test_rain_today_sensor_discovery(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test arwn/rain/today creates since_midnight sensor."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/rain/today",
+        '{"since_midnight": 0.5, "units": "in"}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    unique_ids = {
+        e.unique_id
+        for e in entity_registry.entities.values()
+        if e.config_entry_id == config_entry.entry_id
+    }
+    assert "arwn/rain/today" in unique_ids
+
+
+async def test_barometer_sensor_discovery(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test barometer sensor is created."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/barometer",
+        '{"pressure": 1013.25, "units": "mb"}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "arwn/barometer"
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id).state not in ("unknown", "unavailable")
+
+
+async def test_moisture_sensor_discovery(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test moisture sensor is created."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/moisture/FrontLawn",
+        '{"moisture": 45.2, "units": "%"}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "arwn/moisture/FrontLawn"
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id).state not in ("unknown", "unavailable")
+
+
+async def test_unknown_domain_ignored(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that messages on unknown sub-topics create no entities."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/unknown_sensor",
+        '{"value": 1.0}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entries = [
+        e
+        for e in entity_registry.entities.values()
+        if e.config_entry_id == config_entry.entry_id
+    ]
+    assert len(entries) == 0
+
+
+async def test_entry_unload_removes_sensors(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that unloading the config entry marks all sensors unavailable."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "arwn/temperature/BackYard",
+        '{"temp": 72.5, "units": "F"}',
+    )
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "arwn/temperature/BackYard"
+    )
+    assert entity_id is not None
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unavailable"


### PR DESCRIPTION
 Migrates the arwn integration from the legacy async_setup_platform / hass.data pattern to the modern config-entry architecture:                                     
   
  - Add config_flow.py using DiscoveryFlowHandler — supports both manual setup and MQTT auto-discovery via arwn/#                                                     
  - Add const.py with DOMAIN                                                                                                                                        
  - Add strings.json with confirm step and single-instance abort copy                                                                                                 
  - Update manifest.json: config_flow: true, integration_type: hub, iot_class: local_push (was local_polling), mqtt: ["arwn/#"]                                       
  - Replace async_setup_platform with async_setup_entry in sensor.py; sensor store moves from hass.data[DATA_ARWN] to entry.runtime_data                              
  - Register MQTT unsubscribe via entry.async_on_unload so the subscription is properly cleaned up on unload                                                          
  - Add set_initial_event to populate entity state before registration (avoids initial unknown state)                                                                 
  - Add missing length guards in discover_sensors for malformed topics                                                                                                
  - Add try/except ValueError around JSON parsing with a warning log                                                                                                  
  - Remove _slug / self.entity_id assignment (legacy YAML pattern, no longer needed with config entries)                                                              
  - Update generated files: config_flows.py, integrations.json, mqtt.py                                            

## Breaking change

none. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
