### PR TITLE
Bump python-duco-client to 0.3.8

### DIFF
--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "loggers": ["duco"],
   "quality_scale": "platinum",
-  "requirements": ["python-duco-client==0.3.6"],
+  "requirements": ["python-duco-client==0.3.8"],
   "zeroconf": [
     {
       "name": "duco [[][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][]].*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2578,7 +2578,7 @@ python-digitalocean==1.13.2
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.6
+python-duco-client==0.3.8
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2204,7 +2204,7 @@ python-citybikes==0.3.3
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.3.6
+python-duco-client==0.3.8
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2


### PR DESCRIPTION
## Proposed change

Bumps `python-duco-client` from `0.3.6` to `0.3.8`.

Notable changes in `0.3.7`:
- Bundles the Duco device CA certificate chain so HTTPS connections are verified without requiring `verify_ssl=False` in callers.
- Adds a `build_ssl_context()` helper in `duco._ssl`.
- `DucoClient` automatically uses the SSL context for HTTPS connections.

Notable changes in `0.3.8`:
- `DucoClient` now defaults to `scheme="https"`, removing the need for callers to pass it explicitly.

A follow-up PR will remove the `verify_ssl=False` workaround and the explicit `scheme="https"` from the integration.

Changelog: https://github.com/ronaldvdmeer/python-duco-client/releases/tag/v0.3.8
Diff: https://github.com/ronaldvdmeer/python-duco-client/compare/v0.3.6...v0.3.8

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR was triggered by a dependency upgrade.
- This PR relates to: https://github.com/home-assistant/core/pull/169021

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [translation requirements](https://developers.home-assistant.io/docs/internationalization/core)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
