### PR TITLE
Deprecate use of config entry listener with reloading methods in config entries

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3097,9 +3097,10 @@ class ConfigFlow(ConfigEntryBaseFlow):
             should_reload = True
             if entry.update_listeners:
                 report_usage(
-                    "has an update listener and will reload twice",
+                    "has an update listener and should use it for scheduling a reload",
                     core_behavior=ReportBehavior.LOG,
                     breaks_in_ha_version="2026.11.0",
+                    integration_domain=self.handler,
                 )
         elif (
             self.source in DISCOVERY_SOURCES
@@ -3502,9 +3503,10 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if reload_even_if_entry_is_unchanged or result:
             if entry.update_listeners:
                 report_usage(
-                    "has an update listener and will reload twice",
+                    "has an update listener and should use it for scheduling a reload",
                     core_behavior=ReportBehavior.LOG,
                     breaks_in_ha_version="2026.11.0",
+                    integration_domain=self.handler,
                 )
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         if reason is UNDEFINED:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3500,11 +3500,12 @@ class ConfigFlow(ConfigEntryBaseFlow):
             options=options,
         )
         if reload_even_if_entry_is_unchanged or result:
-            report_usage(
-                "has an update listener and will reload twice",
-                core_behavior=ReportBehavior.LOG,
-                breaks_in_ha_version="2026.11.0",
-            )
+            if entry.update_listeners:
+                report_usage(
+                    "has an update listener and will reload twice",
+                    core_behavior=ReportBehavior.LOG,
+                    breaks_in_ha_version="2026.11.0",
+                )
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         if reason is UNDEFINED:
             reason = "reauth_successful"

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3095,6 +3095,12 @@ class ConfigFlow(ConfigEntryBaseFlow):
             # Existing config entry present, and the
             # entry data just changed
             should_reload = True
+            if entry.update_listeners:
+                report_usage(
+                    "has an update listener and will reload twice",
+                    core_behavior=ReportBehavior.LOG,
+                    breaks_in_ha_version="2026.11.0",
+                )
         elif (
             self.source in DISCOVERY_SOURCES
             and entry.state is ConfigEntryState.SETUP_RETRY
@@ -3494,6 +3500,11 @@ class ConfigFlow(ConfigEntryBaseFlow):
             options=options,
         )
         if reload_even_if_entry_is_unchanged or result:
+            report_usage(
+                "has an update listener and will reload twice",
+                core_behavior=ReportBehavior.LOG,
+                breaks_in_ha_version="2026.11.0",
+            )
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         if reason is UNDEFINED:
             reason = "reauth_successful"

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3099,7 +3099,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
                 report_usage(
                     "has an update listener and should use it for scheduling a reload",
                     core_behavior=ReportBehavior.LOG,
-                    breaks_in_ha_version="2026.11.0",
+                    breaks_in_ha_version="2026.12.0",
                     integration_domain=self.handler,
                 )
         elif (
@@ -3505,7 +3505,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
                 report_usage(
                     "has an update listener and should use it for scheduling a reload",
                     core_behavior=ReportBehavior.LOG,
-                    breaks_in_ha_version="2026.11.0",
+                    breaks_in_ha_version="2026.12.0",
                     integration_domain=self.handler,
                 )
             self.hass.config_entries.async_schedule_reload(entry.entry_id)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7074,13 +7074,19 @@ async def test_update_entry_and_reload_with_listener_logs(
         " for scheduling a reload. This will stop working in Home Assistant 2026.11.0"
     )
 
-    with mock_config_flow("comp", MockFlowHandler):
+    with (
+        mock_config_flow("comp", MockFlowHandler),
+        patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
+    ):
         await entry.start_reauth_flow(hass)
 
     assert message in caplog.text
     caplog.clear()
 
-    with mock_config_flow("comp", MockFlowHandler):
+    with (
+        mock_config_flow("comp", MockFlowHandler),
+        patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
+    ):
         await entry.start_reconfigure_flow(hass)
 
     assert message in caplog.text

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7071,7 +7071,7 @@ async def test_update_entry_and_reload_with_listener_logs(
 
     message = (
         "Detected that integration 'comp' has an update listener and should use it"
-        " for scheduling a reload. This will stop working in Home Assistant 2026.11.0"
+        " for scheduling a reload. This will stop working in Home Assistant 2026.12.0"
     )
 
     with (

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7067,7 +7067,7 @@ async def test_update_entry_and_reload_with_listener_logs(
 
         async def async_step_reconfigure(self, data):
             """Mock Reconfigure."""
-            return self.async_update_reload_and_abort(entry, data={"vendor": "data2"})
+            return self.async_update_reload_and_abort(entry, data={"vendor": "data3"})
 
     message = (
         "Detected that integration 'comp' has an update listener and should use it"
@@ -7079,6 +7079,7 @@ async def test_update_entry_and_reload_with_listener_logs(
         patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
     ):
         await entry.start_reauth_flow(hass)
+    await hass.async_block_till_done()
 
     assert message in caplog.text
     caplog.clear()
@@ -7088,6 +7089,7 @@ async def test_update_entry_and_reload_with_listener_logs(
         patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
     ):
         await entry.start_reconfigure_flow(hass)
+    await hass.async_block_till_done()
 
     assert message in caplog.text
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7032,6 +7032,60 @@ async def test_update_entry_and_reload(
     assert len(comp.async_unload_entry.mock_calls) == calls_entry_load_unload[1]
 
 
+async def test_update_entry_and_reload_with_listener_logs(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test updating an entry and reloading with a config entry listener logs deprecation."""
+    entry = MockConfigEntry(
+        domain="comp",
+        unique_id="1234",
+        title="Test",
+        data={"vendor": "data"},
+        options={"vendor": "options"},
+    )
+    entry.add_to_hass(hass)
+    entry.add_update_listener(AsyncMock())
+
+    comp = MockModule(
+        "comp",
+        async_setup_entry=AsyncMock(return_value=True),
+        async_unload_entry=AsyncMock(return_value=True),
+    )
+    mock_integration(hass, comp)
+    mock_platform(hass, "comp.config_flow", None)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    class MockFlowHandler(config_entries.ConfigFlow):
+        """Define a mock flow handler."""
+
+        VERSION = 1
+
+        async def async_step_reauth(self, data):
+            """Mock Reauth."""
+            self._abort_if_unique_id_configured(updates={"vendor": "data2"})
+
+        async def async_step_reconfigure(self, data):
+            """Mock Reconfigure."""
+            return self.async_update_reload_and_abort(entry, data={"vendor": "data2"})
+
+    message = (
+        "Detected code that has an update listener and will reload twice."
+        " This will stop working in Home Assistant 2026.11.0, please report this issue"
+    )
+
+    with mock_config_flow("comp", MockFlowHandler):
+        await entry.start_reauth_flow(hass)
+
+    assert message in caplog.text
+    caplog.clear()
+
+    with mock_config_flow("comp", MockFlowHandler):
+        await entry.start_reconfigure_flow(hass)
+
+    assert message in caplog.text
+
+
 @pytest.mark.parametrize(
     ("source", "reason"),
     [

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7070,8 +7070,8 @@ async def test_update_entry_and_reload_with_listener_logs(
             return self.async_update_reload_and_abort(entry, data={"vendor": "data2"})
 
     message = (
-        "Detected code that has an update listener and will reload twice."
-        " This will stop working in Home Assistant 2026.11.0, please report this issue"
+        "Detected that integration 'comp' has an update listener and should use it"
+        " for scheduling a reload. This will stop working in Home Assistant 2026.11.0"
     )
 
     with mock_config_flow("comp", MockFlowHandler):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
When using a config entry listener in combination with `async_update_reload_and_abort` or `_abort_if_unique_id_configured` there might be a double reload of the integration, or at least a race in between.

This is now deprecated and will be changed raise error in 2026.12

(only `unifi` still has this from core integrations, which has a PR open to fix it)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3082
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 