### PR TITLE
Restrict homematic.set_install_mode service to admins

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -26,7 +26,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.async_ import run_callback_threadsafe
 
 from .const import (
     ATTR_ADDRESS,
@@ -381,12 +383,15 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         homematic.setInstallMode(interface, t=time, mode=mode, address=address)
 
-    hass.services.register(
+    run_callback_threadsafe(
+        hass.loop,
+        async_register_admin_service,
+        hass,
         DOMAIN,
         SERVICE_SET_INSTALL_MODE,
         _service_handle_install_mode,
-        schema=SCHEMA_SERVICE_SET_INSTALL_MODE,
-    )
+        SCHEMA_SERVICE_SET_INSTALL_MODE,
+    ).result()
 
     def _service_put_paramset(service: ServiceCall) -> None:
         """Service to call the putParamset method on a HomeMatic connection."""

--- a/tests/components/homematic/test_init.py
+++ b/tests/components/homematic/test_init.py
@@ -1,0 +1,62 @@
+"""Tests for the Homematic integration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.homematic.const import (
+    ATTR_INTERFACE,
+    DATA_HOMEMATIC,
+    SERVICE_SET_INSTALL_MODE,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import Unauthorized
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockUser
+
+DOMAIN = "homematic"
+BASE_CONFIG = {DOMAIN: {"hosts": {"ccu2": {"host": "127.0.0.1"}}}}
+
+
+@pytest.fixture
+async def setup_homematic(hass: HomeAssistant) -> None:
+    """Set up the homematic component."""
+    with patch(
+        "homeassistant.components.homematic.HMConnection",
+        return_value=MagicMock(),
+    ):
+        await async_setup_component(hass, DOMAIN, BASE_CONFIG)
+        await hass.async_block_till_done()
+
+
+async def test_set_install_mode_admin_allowed(
+    hass: HomeAssistant,
+    setup_homematic: None,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that admin users can call set_install_mode."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_INSTALL_MODE,
+        {ATTR_INTERFACE: "ccu2"},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+    hass.data[DATA_HOMEMATIC].setInstallMode.assert_called_once()
+
+
+async def test_set_install_mode_non_admin_rejected(
+    hass: HomeAssistant,
+    setup_homematic: None,
+    hass_read_only_user: MockUser,
+) -> None:
+    """Test that non-admin users cannot call set_install_mode."""
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_INSTALL_MODE,
+            {ATTR_INTERFACE: "ccu2"},
+            blocking=True,
+            context=Context(user_id=hass_read_only_user.id),
+        )

--- a/tests/components/homematic/test_init.py
+++ b/tests/components/homematic/test_init.py
@@ -43,7 +43,9 @@ async def test_set_install_mode_admin_allowed(
         blocking=True,
         context=Context(user_id=hass_admin_user.id),
     )
-    hass.data[DATA_HOMEMATIC].setInstallMode.assert_called_once()
+    hass.data[DATA_HOMEMATIC].setInstallMode.assert_called_once_with(
+        "ccu2", t=60, mode=1, address=None
+    )
 
 
 async def test_set_install_mode_non_admin_rejected(


### PR DESCRIPTION
## Proposed change

Switch the `homematic.set_install_mode` service from a bare `hass.services.register` to `async_register_admin_service`, so only admin users can put the HomeMatic radio interface into pairing/install mode.

Pairing mode is bus management rather than raw device I/O — same shape as ZHA `permit` (admin-gated) and Z-Wave `add_node` (admin-gated). Aligning this service with that precedent.

When adding a new admin in the UI, we mention: "The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators." This PR is part of that audit.

The integration's `setup` is sync, so `async_register_admin_service` is dispatched via `run_callback_threadsafe`, mirroring how `hass.services.register` itself bridges into the event loop.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr