### PR TITLE
Restrict Insteon link management services to admins

### DIFF
--- a/homeassistant/components/insteon/services.py
+++ b/homeassistant/components/insteon/services.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
     dispatcher_send,
 )
+from homeassistant.helpers.service import async_register_admin_service
 
 from .const import (
     CONF_CAT,
@@ -231,11 +232,19 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
         )
         await async_srv_save_devices()
 
-    hass.services.async_register(
-        DOMAIN, SRV_ADD_ALL_LINK, async_srv_add_all_link, schema=ADD_ALL_LINK_SCHEMA
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SRV_ADD_ALL_LINK,
+        async_srv_add_all_link,
+        schema=ADD_ALL_LINK_SCHEMA,
     )
-    hass.services.async_register(
-        DOMAIN, SRV_DEL_ALL_LINK, async_srv_del_all_link, schema=DEL_ALL_LINK_SCHEMA
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SRV_DEL_ALL_LINK,
+        async_srv_del_all_link,
+        schema=DEL_ALL_LINK_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN, SRV_LOAD_ALDB, async_srv_load_aldb, schema=LOAD_ALDB_SCHEMA
@@ -269,7 +278,8 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
         DOMAIN, SRV_SCENE_OFF, async_srv_scene_off, schema=TRIGGER_SCENE_SCHEMA
     )
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SRV_ADD_DEFAULT_LINKS,
         async_add_default_links,


### PR DESCRIPTION
## Proposed change

Convert three Insteon services to admin-only registrations using `async_register_admin_service`:

- `insteon.add_all_link` — puts the modem into All-Link (linking) mode.
- `insteon.del_all_link` — puts the modem into unlinking mode.
- `insteon.add_default_links` — writes default link records to a device's persistent All-Link Database.

These services manage Insteon network linking and write persistent device configuration, so they should require admin privileges.

When adding a new admin in the UI, we mention:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr