### PR TITLE
Require admin for deCONZ services

### DIFF
--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .const import CONF_BRIDGE_ID, DOMAIN, LOGGER
@@ -98,7 +99,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
             await async_remove_orphaned_entries_service(hub)
 
     for service in SUPPORTED_SERVICES:
-        hass.services.async_register(
+        async_register_admin_service(
+            hass,
             DOMAIN,
             service,
             async_call_deconz_service,


### PR DESCRIPTION
## Proposed change

Register the three deCONZ services (`configure`, `device_refresh`, `remove_orphaned_entries`) via `async_register_admin_service` instead of `hass.services.async_register`, matching the pattern ZHA uses for its analogous bridge-management services.

The motivating case is `deconz.configure`: its schema accepts `field: cv.matches_regex(\"/.*\")` and the handler forwards an arbitrary PUT to the deCONZ bridge with an arbitrary body, so before this change a non-admin user could hit `/config/whitelist/*` (creating API keys) or `/config` (bridge admin config). The other two services are also bridge-level management operations (registry mutation / state refresh), so they get the same treatment.

When adding a new admin via the UI we tell users:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

Service calls without a `user_id` (automations, internal contexts) still pass through `_async_admin_handler` unchanged, so existing automations are unaffected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr