### PR TITLE
Require admin for management WebSocket commands

### DIFF
--- a/homeassistant/components/application_credentials/__init__.py
+++ b/homeassistant/components/application_credentials/__init__.py
@@ -341,6 +341,7 @@ async def handle_integration_list(
         vol.Required("config_entry_id"): str,
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 async def handle_config_entry(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]

--- a/homeassistant/components/assist_satellite/websocket_api.py
+++ b/homeassistant/components/assist_satellite/websocket_api.py
@@ -165,6 +165,7 @@ async def websocket_set_wake_words(
         vol.Required("entity_id"): cv.entity_domain(DOMAIN),
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_test_connection(
     hass: HomeAssistant,

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -1276,6 +1276,7 @@ async def _async_process_if(
 
 
 @websocket_api.websocket_command({"type": "automation/config", "entity_id": str})
+@websocket_api.require_admin
 def websocket_config(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -926,6 +926,7 @@ async def websocket_get_prefs(
         vol.Optional(PREF_ORIENTATION): vol.Coerce(Orientation),
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_update_prefs(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]

--- a/homeassistant/components/logger/websocket_api.py
+++ b/homeassistant/components/logger/websocket_api.py
@@ -67,6 +67,7 @@ def handle_integration_log_info(
         vol.Required("persistence"): vol.Coerce(LogPersistance),
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 async def handle_integration_log_level(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
@@ -99,6 +100,7 @@ async def handle_integration_log_level(
         vol.Required("persistence"): vol.Coerce(LogPersistance),
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 async def handle_module_log_level(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -238,6 +238,25 @@ async def test_websocket_list_empty(ws_client: ClientFixture) -> None:
     assert await client.cmd_result("list") == []
 
 
+async def test_websocket_config_entry_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test config_entry websocket command requires admin."""
+    ws_client = await hass_ws_client(hass, hass_read_only_access_token)
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "application_credentials/config_entry",
+            "config_entry_id": "some_id",
+        }
+    )
+    resp = await ws_client.receive_json()
+    assert not resp["success"]
+    assert resp["error"]["code"] == "unauthorized"
+
+
 async def test_websocket_create(ws_client: ClientFixture) -> None:
     """Test websocket create command."""
     client = await ws_client()

--- a/tests/components/assist_satellite/test_websocket_api.py
+++ b/tests/components/assist_satellite/test_websocket_api.py
@@ -423,6 +423,33 @@ async def test_set_wake_words_bad_id(
     }
 
 
+async def test_connection_test_require_admin(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test connection test requires admin access."""
+    ws_client = await hass_ws_client(hass, hass_read_only_access_token)
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "assist_satellite/test_connection",
+            "entity_id": ENTITY_ID,
+        }
+    )
+
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"] == {
+        "code": "unauthorized",
+        "message": "Unauthorized",
+    }
+
+
 async def test_connection_test(
     hass: HomeAssistant,
     init_components: ConfigEntry,

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -3591,6 +3591,34 @@ async def test_websocket_config(
     assert msg["error"]["code"] == "not_found"
 
 
+async def test_websocket_config_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test config command requires admin."""
+    config = {
+        "alias": "hello",
+        "triggers": {"trigger": "event", "event_type": "test_event"},
+        "actions": {"action": "test.automation", "data": 100},
+    }
+    assert await async_setup_component(
+        hass, automation.DOMAIN, {automation.DOMAIN: config}
+    )
+    client = await hass_ws_client(hass, hass_read_only_access_token)
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "automation/config",
+            "entity_id": "automation.hello",
+        }
+    )
+
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "unauthorized"
+
+
 async def test_automation_turns_off_other_automation(hass: HomeAssistant) -> None:
     """Test an automation that turns off another automation."""
     hass.set_state(CoreState.not_running)

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -389,6 +389,27 @@ async def test_websocket_get_prefs(
 
 
 @pytest.mark.usefixtures("mock_camera")
+async def test_websocket_update_prefs_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test updating camera preferences requires admin."""
+    client = await hass_ws_client(hass, hass_read_only_access_token)
+    await client.send_json(
+        {
+            "id": 7,
+            "type": "camera/update_prefs",
+            "entity_id": "camera.demo_camera",
+            "preload_stream": True,
+        }
+    )
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "unauthorized"
+
+
+@pytest.mark.usefixtures("mock_camera")
 async def test_websocket_update_preload_prefs(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:

--- a/tests/components/logger/test_websocket_api.py
+++ b/tests/components/logger/test_websocket_api.py
@@ -364,3 +364,51 @@ async def test_module_log_level_override(
     assert hass.data[DATA_LOGGER].overrides == {
         "homeassistant.components.websocket_api": logging.NOTSET
     }
+
+
+async def test_integration_log_level_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test setting integration log level requires admin."""
+    assert await async_setup_component(hass, "logger", {})
+
+    websocket_client = await hass_ws_client(hass, hass_read_only_access_token)
+    await websocket_client.send_json(
+        {
+            "id": 7,
+            "type": "logger/integration_log_level",
+            "integration": "websocket_api",
+            "level": "DEBUG",
+            "persistence": "none",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "unauthorized"
+
+
+async def test_module_log_level_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test setting module log level requires admin."""
+    assert await async_setup_component(hass, "logger", {})
+
+    websocket_client = await hass_ws_client(hass, hass_read_only_access_token)
+    await websocket_client.send_json(
+        {
+            "id": 7,
+            "type": "logger/log_level",
+            "module": "homeassistant.components.websocket_api",
+            "level": "DEBUG",
+            "persistence": "none",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "unauthorized"


### PR DESCRIPTION
## Breaking change

## Proposed change

Add `@websocket_api.require_admin` to several WebSocket commands that read sensitive configuration or mutate persistent/management state. Each was previously callable by any authenticated user (including non-admins), while their sibling commands in the same files were already admin-gated — making this an asymmetry rather than a designed difference.

When adding a new non-admin user, the UI states:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

Commands gated:

- `automation/config` ([homeassistant/components/automation/__init__.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/__init__.py)) — returns `raw_config` (templates, webhook IDs, action payloads). The HTTP equivalent in `config/view.py` is already admin-gated.
- `camera/update_prefs` ([homeassistant/components/camera/__init__.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/camera/__init__.py)) — mutates entity-registry options (orientation) and Store (`preload_stream`).
- `logger/integration_log_level` and `logger/log_level` ([homeassistant/components/logger/websocket_api.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/logger/websocket_api.py)) — persist log-level changes to a Store; `module` is unconstrained `str` so non-admins could target e.g. `homeassistant.components.auth`.
- `assist_satellite/test_connection` ([homeassistant/components/assist_satellite/websocket_api.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/assist_satellite/websocket_api.py)) — triggers a physical audible announcement on the device. Sibling `intercept_wake_word` and `set_wake_words` are already admin-gated.
- `application_credentials/config_entry` ([homeassistant/components/application_credentials/__init__.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/application_credentials/__init__.py)) — discloses the OAuth `client_id` (encoded as `application_credentials_id`). Sibling CRUD commands are already admin-gated.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr