### PR TITLE
Remove name from workday

### DIFF
--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -71,3 +71,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> 
     """Unload Workday config entry."""
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> bool:
+    """Migrate old config entry."""
+
+    # This means the user has downgraded from a future version
+    if entry.version > 1:
+        return False
+
+    if entry.version == 1 and entry.minor_version == 1:
+        # By keeping name in the data, it's enough to bump the minor version
+        hass.config_entries.async_update_entry(
+            entry,
+            minor_version=2,
+        )
+
+    return True

--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -69,3 +69,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> 
     """Unload Workday config entry."""
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> bool:
+    """Migrate old config entry."""
+
+    # This means the user has downgraded from a future version
+    if entry.version > 1:
+        return False
+
+    if entry.version == 1 and entry.minor_version == 1:
+        # By keeping name in the data, it's enough to bump the minor version
+        hass.config_entries.async_update_entry(
+            entry,
+            minor_version=2,
+        )
+
+    return True

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -9,7 +9,6 @@ from holidays import HolidayBase
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import (
@@ -33,7 +32,6 @@ async def async_setup_entry(
     """Set up the Workday sensor."""
     days_offset: int = int(entry.options[CONF_OFFSET])
     excludes: list[str] = entry.options[CONF_EXCLUDES]
-    sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
     obj_holidays = entry.runtime_data
 
@@ -53,7 +51,7 @@ async def async_setup_entry(
                 workdays,
                 excludes,
                 days_offset,
-                sensor_name,
+                entry.title,
                 entry.entry_id,
             )
         ],

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -7,7 +7,6 @@ from holidays import HolidayBase
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import (
@@ -31,7 +30,6 @@ async def async_setup_entry(
     """Set up the Workday sensor."""
     days_offset: int = int(entry.options[CONF_OFFSET])
     excludes: list[str] = entry.options[CONF_EXCLUDES]
-    sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
     obj_holidays = entry.runtime_data
 
@@ -51,7 +49,7 @@ async def async_setup_entry(
                 workdays,
                 excludes,
                 days_offset,
-                sensor_name,
+                entry.title,
                 entry.entry_id,
             )
         ],

--- a/homeassistant/components/workday/calendar.py
+++ b/homeassistant/components/workday/calendar.py
@@ -7,7 +7,6 @@ from datetime import date, datetime, timedelta
 from holidays import HolidayBase
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -25,7 +24,6 @@ async def async_setup_entry(
     """Set up the Holiday Calendar config entry."""
     days_offset: int = int(entry.options[CONF_OFFSET])
     excludes: list[str] = entry.options[CONF_EXCLUDES]
-    sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
     obj_holidays = entry.runtime_data
 
@@ -36,7 +34,7 @@ async def async_setup_entry(
                 workdays,
                 excludes,
                 days_offset,
-                sensor_name,
+                entry.title,
                 entry.entry_id,
             )
         ],

--- a/homeassistant/components/workday/calendar.py
+++ b/homeassistant/components/workday/calendar.py
@@ -5,7 +5,6 @@ from datetime import date, datetime, timedelta
 from holidays import HolidayBase
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -23,7 +22,6 @@ async def async_setup_entry(
     """Set up the Holiday Calendar config entry."""
     days_offset: int = int(entry.options[CONF_OFFSET])
     excludes: list[str] = entry.options[CONF_EXCLUDES]
-    sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
     obj_holidays = entry.runtime_data
 
@@ -34,7 +32,7 @@ async def async_setup_entry(
                 workdays,
                 excludes,
                 days_offset,
-                sensor_name,
+                entry.title,
                 entry.entry_id,
             )
         ],

--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlowWithReload,
 )
-from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE, CONF_NAME
+from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
@@ -30,7 +30,6 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
-    TextSelector,
 )
 from homeassistant.util import dt as dt_util
 
@@ -215,6 +214,7 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Workday integration."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     data: dict[str, Any] = {}
 
@@ -243,7 +243,6 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
                     vol.Optional(CONF_COUNTRY): CountrySelector(
                         CountrySelectorConfig(
                             countries=list(supported_countries),
@@ -292,8 +291,14 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
             LOGGER.debug("Errors have occurred %s", errors)
             if not errors:
                 LOGGER.debug("No duplicate, no errors, creating entry")
+
+                name = DEFAULT_NAME
+                if (country := combined_input.get(CONF_COUNTRY)) is not None:
+                    name += f" {country}"
+                if (province := combined_input.get(CONF_PROVINCE)) is not None:
+                    name += f" {province}"
                 return self.async_create_entry(
-                    title=combined_input[CONF_NAME],
+                    title=name,
                     data={},
                     options=combined_input,
                 )
@@ -309,7 +314,6 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=new_schema,
             errors=errors,
             description_placeholders={
-                "name": self.data[CONF_NAME],
                 "country": self.data.get(CONF_COUNTRY, "-"),
             },
         )
@@ -376,7 +380,7 @@ class WorkdayOptionsFlowHandler(OptionsFlowWithReload):
             data_schema=new_schema,
             errors=errors,
             description_placeholders={
-                "name": options[CONF_NAME],
+                "name": self.config_entry.title,
                 "country": options.get(CONF_COUNTRY, "-"),
             },
         )

--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlowWithReload,
 )
-from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE, CONF_NAME
+from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
@@ -28,7 +28,6 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
-    TextSelector,
 )
 from homeassistant.util import dt as dt_util
 
@@ -213,6 +212,7 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Workday integration."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     data: dict[str, Any] = {}
 
@@ -241,9 +241,6 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    # Name field is no longer allowed in config flow schemas
-                    # pylint: disable-next=home-assistant-config-flow-name-field
-                    vol.Required(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
                     vol.Optional(CONF_COUNTRY): CountrySelector(
                         CountrySelectorConfig(
                             countries=list(supported_countries),
@@ -292,8 +289,14 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
             LOGGER.debug("Errors have occurred %s", errors)
             if not errors:
                 LOGGER.debug("No duplicate, no errors, creating entry")
+
+                name = DEFAULT_NAME
+                if (country := combined_input.get(CONF_COUNTRY)) is not None:
+                    name += f" {country}"
+                if (province := combined_input.get(CONF_PROVINCE)) is not None:
+                    name += f" {province}"
                 return self.async_create_entry(
-                    title=combined_input[CONF_NAME],
+                    title=name,
                     data={},
                     options=combined_input,
                 )
@@ -309,7 +312,6 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=new_schema,
             errors=errors,
             description_placeholders={
-                "name": self.data[CONF_NAME],
                 "country": self.data.get(CONF_COUNTRY, "-"),
             },
         )
@@ -376,7 +378,7 @@ class WorkdayOptionsFlowHandler(OptionsFlowWithReload):
             data_schema=new_schema,
             errors=errors,
             description_placeholders={
-                "name": options[CONF_NAME],
+                "name": self.config_entry.title,
                 "country": options.get(CONF_COUNTRY, "-"),
             },
         )

--- a/homeassistant/components/workday/strings.json
+++ b/homeassistant/components/workday/strings.json
@@ -176,7 +176,7 @@
           "remove_holidays": "[%key:component::workday::config::step::options::data_description::remove_holidays%]",
           "workdays": "[%key:component::workday::config::step::options::data_description::workdays%]"
         },
-        "description": "Change additional options for country {country}"
+        "description": "Change additional options for {name} configured for country {country}"
       }
     }
   },

--- a/homeassistant/components/workday/strings.json
+++ b/homeassistant/components/workday/strings.json
@@ -31,7 +31,7 @@
           "remove_holidays": "Remove holidays as YYYY-MM-DD, as range using `,` as separator or by using partial of name",
           "workdays": "Select which weekdays to include as possible workdays."
         },
-        "description": "Set additional options for {name} configured for country {country}"
+        "description": "Set additional options for country {country}"
       },
       "user": {
         "data": {
@@ -176,7 +176,7 @@
           "remove_holidays": "[%key:component::workday::config::step::options::data_description::remove_holidays%]",
           "workdays": "[%key:component::workday::config::step::options::data_description::workdays%]"
         },
-        "description": "Change additional options for {name} configured for country {country}"
+        "description": "Change additional options for country {country}"
       }
     }
   },

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -25,7 +25,7 @@ async def init_integration(
     entry_id: str = "1",
     source: str = SOURCE_USER,
 ) -> MockConfigEntry:
-    """Set up the Scrape integration in Home Assistant."""
+    """Set up the Workday integration in Home Assistant."""
 
     name = DEFAULT_NAME
     if config.get("country"):

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -27,12 +27,20 @@ async def init_integration(
 ) -> MockConfigEntry:
     """Set up the Scrape integration in Home Assistant."""
 
+    name = DEFAULT_NAME
+    if config.get("country"):
+        name += f" {config['country']}"
+    if config.get("province"):
+        name += f" {config['province']}"
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         source=source,
         data={},
         options=config,
         entry_id=entry_id,
+        title=name,
+        minor_version=2,
     )
 
     config_entry.add_to_hass(hass)
@@ -44,7 +52,6 @@ async def init_integration(
 
 
 TEST_CONFIG_NO_COUNTRY = {
-    "name": DEFAULT_NAME,
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
     "workdays": DEFAULT_WORKDAYS,
@@ -52,7 +59,6 @@ TEST_CONFIG_NO_COUNTRY = {
     "remove_holidays": [],
 }
 TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
-    "name": DEFAULT_NAME,
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
     "workdays": DEFAULT_WORKDAYS,
@@ -60,7 +66,6 @@ TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
     "remove_holidays": [],
 }
 TEST_CONFIG_WITH_PROVINCE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -71,7 +76,6 @@ TEST_CONFIG_WITH_PROVINCE = {
     "language": "de",
 }
 TEST_CONFIG_NO_LANGUAGE_CONFIGURED = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -81,7 +85,6 @@ TEST_CONFIG_NO_LANGUAGE_CONFIGURED = {
     "remove_holidays": [],
 }
 TEST_CONFIG_INCORRECT_COUNTRY = {
-    "name": DEFAULT_NAME,
     "country": "ZZ",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -91,7 +94,6 @@ TEST_CONFIG_INCORRECT_COUNTRY = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_PROVINCE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "ZZ",
     "excludes": DEFAULT_EXCLUDES,
@@ -102,7 +104,6 @@ TEST_CONFIG_INCORRECT_PROVINCE = {
     "language": "de",
 }
 TEST_CONFIG_NO_PROVINCE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -112,7 +113,6 @@ TEST_CONFIG_NO_PROVINCE = {
     "language": "de",
 }
 TEST_CONFIG_WITH_STATE = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "province": "CA",
     "excludes": DEFAULT_EXCLUDES,
@@ -123,7 +123,6 @@ TEST_CONFIG_WITH_STATE = {
     "language": "en_US",
 }
 TEST_CONFIG_NO_STATE = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -133,7 +132,6 @@ TEST_CONFIG_NO_STATE = {
     "language": "en_US",
 }
 TEST_CONFIG_INCLUDE_HOLIDAY = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": ["sat", "sun"],
@@ -144,7 +142,6 @@ TEST_CONFIG_INCLUDE_HOLIDAY = {
     "language": "de",
 }
 TEST_CONFIG_EXAMPLE_1 = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": ["sat", "sun"],
     "days_offset": DEFAULT_OFFSET,
@@ -154,7 +151,6 @@ TEST_CONFIG_EXAMPLE_1 = {
     "language": "en_US",
 }
 TEST_CONFIG_EXAMPLE_2 = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -165,7 +161,6 @@ TEST_CONFIG_EXAMPLE_2 = {
     "language": "de",
 }
 TEST_CONFIG_REMOVE_HOLIDAY = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -175,7 +170,6 @@ TEST_CONFIG_REMOVE_HOLIDAY = {
     "language": "en_US",
 }
 TEST_CONFIG_REMOVE_NAMED = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -185,7 +179,6 @@ TEST_CONFIG_REMOVE_NAMED = {
     "language": "en_US",
 }
 TEST_CONFIG_REMOVE_DATE = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -195,7 +188,6 @@ TEST_CONFIG_REMOVE_DATE = {
     "language": "en_US",
 }
 TEST_CONFIG_TOMORROW = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": 1,
@@ -205,7 +197,6 @@ TEST_CONFIG_TOMORROW = {
     "language": "de",
 }
 TEST_CONFIG_DAY_AFTER_TOMORROW = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": 2,
@@ -215,7 +206,6 @@ TEST_CONFIG_DAY_AFTER_TOMORROW = {
     "language": "de",
 }
 TEST_CONFIG_YESTERDAY = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": -1,
@@ -225,7 +215,6 @@ TEST_CONFIG_YESTERDAY = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_ADD_REMOVE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -236,7 +225,6 @@ TEST_CONFIG_INCORRECT_ADD_REMOVE = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_ADD_DATE_RANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -247,7 +235,6 @@ TEST_CONFIG_INCORRECT_ADD_DATE_RANGE = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -258,7 +245,6 @@ TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_ADD_DATE_RANGE_LEN = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -269,7 +255,6 @@ TEST_CONFIG_INCORRECT_ADD_DATE_RANGE_LEN = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE_LEN = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -280,7 +265,6 @@ TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE_LEN = {
     "language": "de",
 }
 TEST_CONFIG_ADD_REMOVE_DATE_RANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -291,7 +275,6 @@ TEST_CONFIG_ADD_REMOVE_DATE_RANGE = {
     "language": "de",
 }
 TEST_LANGUAGE_CHANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -302,7 +285,6 @@ TEST_LANGUAGE_CHANGE = {
     "language": "en",
 }
 TEST_LANGUAGE_NO_CHANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -313,7 +295,6 @@ TEST_LANGUAGE_NO_CHANGE = {
     "language": "de",
 }
 TEST_NO_OPTIONAL_CATEGORY = {
-    "name": DEFAULT_NAME,
     "country": "CH",
     "province": "FR",
     "excludes": DEFAULT_EXCLUDES,
@@ -324,7 +305,6 @@ TEST_NO_OPTIONAL_CATEGORY = {
     "language": "de",
 }
 TEST_OPTIONAL_CATEGORY = {
-    "name": DEFAULT_NAME,
     "country": "CH",
     "province": "FR",
     "excludes": DEFAULT_EXCLUDES,

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -62,7 +62,7 @@ TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
     "workdays": DEFAULT_WORKDAYS,
-    "add_holidays": ["2020-02-24"],
+    "add_holidays": ["2020-02-24", "2022-04-15"],
     "remove_holidays": [],
 }
 TEST_CONFIG_WITH_PROVINCE = {

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -25,12 +25,20 @@ async def init_integration(
 ) -> MockConfigEntry:
     """Set up the Scrape integration in Home Assistant."""
 
+    name = DEFAULT_NAME
+    if config.get("country"):
+        name += f" {config['country']}"
+    if config.get("province"):
+        name += f" {config['province']}"
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         source=source,
         data={},
         options=config,
         entry_id=entry_id,
+        title=name,
+        minor_version=2,
     )
 
     config_entry.add_to_hass(hass)
@@ -42,7 +50,6 @@ async def init_integration(
 
 
 TEST_CONFIG_NO_COUNTRY = {
-    "name": DEFAULT_NAME,
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
     "workdays": DEFAULT_WORKDAYS,
@@ -50,7 +57,6 @@ TEST_CONFIG_NO_COUNTRY = {
     "remove_holidays": [],
 }
 TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
-    "name": DEFAULT_NAME,
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
     "workdays": DEFAULT_WORKDAYS,
@@ -58,7 +64,6 @@ TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
     "remove_holidays": [],
 }
 TEST_CONFIG_WITH_PROVINCE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -69,7 +74,6 @@ TEST_CONFIG_WITH_PROVINCE = {
     "language": "de",
 }
 TEST_CONFIG_NO_LANGUAGE_CONFIGURED = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -79,7 +83,6 @@ TEST_CONFIG_NO_LANGUAGE_CONFIGURED = {
     "remove_holidays": [],
 }
 TEST_CONFIG_INCORRECT_COUNTRY = {
-    "name": DEFAULT_NAME,
     "country": "ZZ",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -89,7 +92,6 @@ TEST_CONFIG_INCORRECT_COUNTRY = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_PROVINCE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "ZZ",
     "excludes": DEFAULT_EXCLUDES,
@@ -100,7 +102,6 @@ TEST_CONFIG_INCORRECT_PROVINCE = {
     "language": "de",
 }
 TEST_CONFIG_NO_PROVINCE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -110,7 +111,6 @@ TEST_CONFIG_NO_PROVINCE = {
     "language": "de",
 }
 TEST_CONFIG_WITH_STATE = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "province": "CA",
     "excludes": DEFAULT_EXCLUDES,
@@ -121,7 +121,6 @@ TEST_CONFIG_WITH_STATE = {
     "language": "en_US",
 }
 TEST_CONFIG_NO_STATE = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -131,7 +130,6 @@ TEST_CONFIG_NO_STATE = {
     "language": "en_US",
 }
 TEST_CONFIG_INCLUDE_HOLIDAY = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": ["sat", "sun"],
@@ -142,7 +140,6 @@ TEST_CONFIG_INCLUDE_HOLIDAY = {
     "language": "de",
 }
 TEST_CONFIG_EXAMPLE_1 = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": ["sat", "sun"],
     "days_offset": DEFAULT_OFFSET,
@@ -152,7 +149,6 @@ TEST_CONFIG_EXAMPLE_1 = {
     "language": "en_US",
 }
 TEST_CONFIG_EXAMPLE_2 = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -163,7 +159,6 @@ TEST_CONFIG_EXAMPLE_2 = {
     "language": "de",
 }
 TEST_CONFIG_REMOVE_HOLIDAY = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -173,7 +168,6 @@ TEST_CONFIG_REMOVE_HOLIDAY = {
     "language": "en_US",
 }
 TEST_CONFIG_REMOVE_NAMED = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -183,7 +177,6 @@ TEST_CONFIG_REMOVE_NAMED = {
     "language": "en_US",
 }
 TEST_CONFIG_REMOVE_DATE = {
-    "name": DEFAULT_NAME,
     "country": "US",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
@@ -193,7 +186,6 @@ TEST_CONFIG_REMOVE_DATE = {
     "language": "en_US",
 }
 TEST_CONFIG_TOMORROW = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": 1,
@@ -203,7 +195,6 @@ TEST_CONFIG_TOMORROW = {
     "language": "de",
 }
 TEST_CONFIG_DAY_AFTER_TOMORROW = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": 2,
@@ -213,7 +204,6 @@ TEST_CONFIG_DAY_AFTER_TOMORROW = {
     "language": "de",
 }
 TEST_CONFIG_YESTERDAY = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": -1,
@@ -223,7 +213,6 @@ TEST_CONFIG_YESTERDAY = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_ADD_REMOVE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -234,7 +223,6 @@ TEST_CONFIG_INCORRECT_ADD_REMOVE = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_ADD_DATE_RANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -245,7 +233,6 @@ TEST_CONFIG_INCORRECT_ADD_DATE_RANGE = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -256,7 +243,6 @@ TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_ADD_DATE_RANGE_LEN = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -267,7 +253,6 @@ TEST_CONFIG_INCORRECT_ADD_DATE_RANGE_LEN = {
     "language": "de",
 }
 TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE_LEN = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -278,7 +263,6 @@ TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE_LEN = {
     "language": "de",
 }
 TEST_CONFIG_ADD_REMOVE_DATE_RANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -289,7 +273,6 @@ TEST_CONFIG_ADD_REMOVE_DATE_RANGE = {
     "language": "de",
 }
 TEST_LANGUAGE_CHANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -300,7 +283,6 @@ TEST_LANGUAGE_CHANGE = {
     "language": "en",
 }
 TEST_LANGUAGE_NO_CHANGE = {
-    "name": DEFAULT_NAME,
     "country": "DE",
     "province": "BW",
     "excludes": DEFAULT_EXCLUDES,
@@ -311,7 +293,6 @@ TEST_LANGUAGE_NO_CHANGE = {
     "language": "de",
 }
 TEST_NO_OPTIONAL_CATEGORY = {
-    "name": DEFAULT_NAME,
     "country": "CH",
     "province": "FR",
     "excludes": DEFAULT_EXCLUDES,
@@ -322,7 +303,6 @@ TEST_NO_OPTIONAL_CATEGORY = {
     "language": "de",
 }
 TEST_OPTIONAL_CATEGORY = {
-    "name": DEFAULT_NAME,
     "country": "CH",
     "province": "FR",
     "excludes": DEFAULT_EXCLUDES,

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -23,7 +23,7 @@ async def init_integration(
     entry_id: str = "1",
     source: str = SOURCE_USER,
 ) -> MockConfigEntry:
-    """Set up the Scrape integration in Home Assistant."""
+    """Set up the Workday integration in Home Assistant."""
 
     name = DEFAULT_NAME
     if config.get("country"):

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -60,7 +60,7 @@ TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
     "excludes": DEFAULT_EXCLUDES,
     "days_offset": DEFAULT_OFFSET,
     "workdays": DEFAULT_WORKDAYS,
-    "add_holidays": ["2020-02-24"],
+    "add_holidays": ["2020-02-24", "2022-04-15"],
     "remove_holidays": [],
 }
 TEST_CONFIG_WITH_PROVINCE = {

--- a/tests/components/workday/snapshots/test_binary_sensor.ambr
+++ b/tests/components/workday/snapshots/test_binary_sensor.ambr
@@ -25,7 +25,7 @@
       'translation_placeholders': dict({
         'country': 'DE',
         'remove_holidays': '2024-08-15',
-        'title': 'Mock Title',
+        'title': 'Workday Sensor DE BW',
       }),
     }),
     tuple(
@@ -52,7 +52,7 @@
       'translation_placeholders': dict({
         'country': 'DE',
         'remove_holidays': '2025-08-15',
-        'title': 'Mock Title',
+        'title': 'Workday Sensor DE BW',
       }),
     }),
   })

--- a/tests/components/workday/snapshots/test_diagnostics.ambr
+++ b/tests/components/workday/snapshots/test_diagnostics.ambr
@@ -9,7 +9,7 @@
       }),
       'domain': 'workday',
       'entry_id': '1',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
         'add_holidays': list([
           '2022-12-01',
@@ -23,7 +23,6 @@
           'holiday',
         ]),
         'language': 'de',
-        'name': 'Workday Sensor',
         'province': 'BW',
         'remove_holidays': list([
           '2022-12-04',
@@ -42,7 +41,7 @@
       'source': 'user',
       'subentries': list([
       ]),
-      'title': 'Mock Title',
+      'title': 'Workday Sensor DE BW',
       'unique_id': None,
       'version': 1,
     }),

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -35,6 +35,7 @@ from . import (
     TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE,
     TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE_LEN,
     TEST_CONFIG_NO_COUNTRY,
+    TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY,
     TEST_CONFIG_NO_LANGUAGE_CONFIGURED,
     TEST_CONFIG_NO_PROVINCE,
     TEST_CONFIG_NO_STATE,
@@ -68,6 +69,7 @@ from tests.common import async_fire_time_changed
         (TEST_CONFIG_DAY_AFTER_TOMORROW, "off", "off"),
         (TEST_CONFIG_YESTERDAY, "on", "off"),  # Friday was good Friday
         (TEST_CONFIG_NO_LANGUAGE_CONFIGURED, "off", "off"),
+        (TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY, "off", "off"),
     ],
 )
 async def test_setup(

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.components.workday.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 from homeassistant.util.dt import UTC
 
 from . import (
@@ -35,7 +35,6 @@ from . import (
     TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE,
     TEST_CONFIG_INCORRECT_REMOVE_DATE_RANGE_LEN,
     TEST_CONFIG_NO_COUNTRY,
-    TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY,
     TEST_CONFIG_NO_LANGUAGE_CONFIGURED,
     TEST_CONFIG_NO_PROVINCE,
     TEST_CONFIG_NO_STATE,
@@ -84,11 +83,18 @@ async def test_setup(
     freezer.move_to(datetime(2022, 4, 15, 0, tzinfo=timezone(timedelta(hours=1))))
     await init_integration(hass, config)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    name = "Workday Sensor"
+    if config.get("country"):
+        name += f" {config['country']}"
+    if config.get("province"):
+        name += f" {config['province']}"
+    slug_name = slugify(name)
+
+    state = hass.states.get(f"binary_sensor.{slug_name}")
     assert state is not None
     assert state.state == expected_state
     assert state.attributes == {
-        "friendly_name": "Workday Sensor",
+        "friendly_name": name,
         "workdays": config["workdays"],
         "excludes": config["excludes"],
         "days_offset": config["days_offset"],
@@ -97,7 +103,7 @@ async def test_setup(
     freezer.tick(timedelta(days=1))  # Saturday
     async_fire_time_changed(hass)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get(f"binary_sensor.{slug_name}")
     assert state is not None
     assert state.state == expected_state_weekend
 
@@ -129,28 +135,20 @@ async def test_setup_with_working_holiday(
     freezer.move_to(datetime(2017, 1, 6, 12, tzinfo=UTC))  # Friday
     await init_integration(hass, TEST_CONFIG_INCLUDE_HOLIDAY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state is not None
     assert state.state == "on"
 
 
-@pytest.mark.parametrize(
-    "config",
-    [
-        TEST_CONFIG_EXAMPLE_2,
-        TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY,
-    ],
-)
 async def test_setup_add_holiday(
     hass: HomeAssistant,
-    config: dict[str, Any],
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test setup from various configs."""
     freezer.move_to(datetime(2020, 2, 24, 12, tzinfo=UTC))  # Monday
     await init_integration(hass, TEST_CONFIG_EXAMPLE_2)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state is not None
     assert state.state == "off"
 
@@ -217,7 +215,7 @@ async def test_setup_remove_holiday(
     freezer.move_to(datetime(2020, 12, 25, 12, tzinfo=UTC))  # Friday
     await init_integration(hass, TEST_CONFIG_REMOVE_HOLIDAY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state is not None
     assert state.state == "on"
 
@@ -230,7 +228,7 @@ async def test_setup_remove_holiday_named(
     freezer.move_to(datetime(2020, 12, 25, 12, tzinfo=UTC))  # Friday
     await init_integration(hass, TEST_CONFIG_REMOVE_NAMED)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state is not None
     assert state.state == "on"
 
@@ -243,7 +241,7 @@ async def test_setup_day_after_tomorrow(
     freezer.move_to(datetime(2022, 5, 27, 12, tzinfo=UTC))  # Friday
     await init_integration(hass, TEST_CONFIG_DAY_AFTER_TOMORROW)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de")
     assert state is not None
     assert state.state == "off"
 
@@ -342,7 +340,7 @@ async def test_setup_date_range(
     )  # Boxing Day should be working day
     await init_integration(hass, TEST_CONFIG_ADD_REMOVE_DATE_RANGE)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state.state == "on"
 
 
@@ -355,43 +353,43 @@ async def test_check_date_service(
     freezer.move_to(datetime(2017, 1, 6, 12, tzinfo=UTC))  # Friday
     await init_integration(hass, TEST_CONFIG_WITH_PROVINCE)
 
-    hass.states.get("binary_sensor.workday_sensor")
+    hass.states.get("binary_sensor.workday_sensor_de_bw")
 
     response = await hass.services.async_call(
         DOMAIN,
         SERVICE_CHECK_DATE,
         {
-            "entity_id": "binary_sensor.workday_sensor",
+            "entity_id": "binary_sensor.workday_sensor_de_bw",
             "check_date": date(2022, 12, 25),  # Christmas Day
         },
         blocking=True,
         return_response=True,
     )
-    assert response == {"binary_sensor.workday_sensor": {"workday": False}}
+    assert response == {"binary_sensor.workday_sensor_de_bw": {"workday": False}}
 
     response = await hass.services.async_call(
         DOMAIN,
         SERVICE_CHECK_DATE,
         {
-            "entity_id": "binary_sensor.workday_sensor",
+            "entity_id": "binary_sensor.workday_sensor_de_bw",
             "check_date": date(2022, 12, 23),  # Normal Friday
         },
         blocking=True,
         return_response=True,
     )
-    assert response == {"binary_sensor.workday_sensor": {"workday": True}}
+    assert response == {"binary_sensor.workday_sensor_de_bw": {"workday": True}}
 
     response = await hass.services.async_call(
         DOMAIN,
         SERVICE_CHECK_DATE,
         {
-            "entity_id": "binary_sensor.workday_sensor",
+            "entity_id": "binary_sensor.workday_sensor_de_bw",
             "check_date": date(2022, 12, 17),  # Saturday (no workday)
         },
         blocking=True,
         return_response=True,
     )
-    assert response == {"binary_sensor.workday_sensor": {"workday": False}}
+    assert response == {"binary_sensor.workday_sensor_de_bw": {"workday": False}}
 
 
 async def test_language_difference_english_language(
@@ -427,7 +425,7 @@ async def test_optional_category(
     freezer.move_to(datetime(2024, 1, 2, 12, tzinfo=UTC))  # Tuesday
     await init_integration(hass, config)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_ch_fr")
     assert state is not None
     assert state.state == end_state
 

--- a/tests/components/workday/test_calendar.py
+++ b/tests/components/workday/test_calendar.py
@@ -42,7 +42,7 @@ async def test_holiday_calendar_entity(
         CALENDAR_DOMAIN,
         SERVICE_GET_EVENTS,
         {
-            ATTR_ENTITY_ID: "calendar.workday_sensor_calendar",
+            ATTR_ENTITY_ID: "calendar.workday_sensor_de_bw_calendar",
             EVENT_START_DATETIME: dt_util.now(),
             EVENT_END_DATETIME: dt_util.now() + timedelta(days=10, hours=1),
         },
@@ -52,15 +52,15 @@ async def test_holiday_calendar_entity(
     assert {
         ATTR_END: "2023-01-02",
         ATTR_START: "2023-01-01",
-        EVENT_SUMMARY: "Workday Sensor",
-    } not in response["calendar.workday_sensor_calendar"]["events"]
+        EVENT_SUMMARY: "Workday Sensor DE BW",
+    } not in response["calendar.workday_sensor_de_bw_calendar"]["events"]
     assert {
         ATTR_END: "2023-01-04",
         ATTR_START: "2023-01-03",
-        EVENT_SUMMARY: "Workday Sensor",
-    } in response["calendar.workday_sensor_calendar"]["events"]
+        EVENT_SUMMARY: "Workday Sensor DE BW",
+    } in response["calendar.workday_sensor_de_bw_calendar"]["events"]
 
-    state = hass.states.get("calendar.workday_sensor_calendar")
+    state = hass.states.get("calendar.workday_sensor_de_bw_calendar")
     assert state is not None
     assert state.state == "off"
 
@@ -71,11 +71,11 @@ async def test_holiday_calendar_entity(
     await hass.async_block_till_done()
 
     # Binary sensor added to ensure same state for both entities
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state is not None
     assert state.state == "on"
 
-    state = hass.states.get("calendar.workday_sensor_calendar")
+    state = hass.states.get("calendar.workday_sensor_de_bw_calendar")
     assert state is not None
     assert state.state == "on"
 
@@ -83,10 +83,10 @@ async def test_holiday_calendar_entity(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state is not None
     assert state.state == "off"
 
-    state = hass.states.get("calendar.workday_sensor_calendar")
+    state = hass.states.get("calendar.workday_sensor_de_bw_calendar")
     assert state is not None
     assert state.state == "off"

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -22,7 +22,7 @@ from homeassistant.components.workday.const import (
     DEFAULT_WORKDAYS,
     DOMAIN,
 )
-from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE, CONF_NAME
+from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.util.dt import UTC
@@ -42,7 +42,6 @@ async def test_form(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -61,9 +60,8 @@ async def test_form(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -86,7 +84,6 @@ async def test_form_province_no_alias(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "US",
         },
     )
@@ -104,9 +101,8 @@ async def test_form_province_no_alias(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor US"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "US",
         "excludes": ["sat", "sun", "holiday"],
         "language": "en_US",
@@ -128,9 +124,7 @@ async def test_form_no_country(hass: HomeAssistant) -> None:
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            CONF_NAME: "Workday Sensor",
-        },
+        {},
     )
     await hass.async_block_till_done()
     result3 = await hass.config_entries.flow.async_configure(
@@ -148,7 +142,6 @@ async def test_form_no_country(hass: HomeAssistant) -> None:
     assert result3["type"] is FlowResultType.CREATE_ENTRY
     assert result3["title"] == "Workday Sensor"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
@@ -169,7 +162,6 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "SE",
         },
     )
@@ -187,9 +179,8 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor SE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "SE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -207,7 +198,6 @@ async def test_options_form(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -235,7 +225,6 @@ async def test_options_form(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -259,7 +248,6 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -307,9 +295,8 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -327,7 +314,6 @@ async def test_options_form_incorrect_dates(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -385,7 +371,6 @@ async def test_options_form_incorrect_dates(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -404,7 +389,6 @@ async def test_options_form_abort_duplicate(hass: HomeAssistant) -> None:
     await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "CH",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -419,7 +403,6 @@ async def test_options_form_abort_duplicate(hass: HomeAssistant) -> None:
     entry2 = await init_integration(
         hass,
         {
-            "name": "Workday Sensor2",
             "country": "CH",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -463,7 +446,6 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -511,9 +493,8 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -531,7 +512,6 @@ async def test_options_form_incorrect_date_ranges(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -589,7 +569,6 @@ async def test_options_form_incorrect_date_ranges(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -622,7 +601,6 @@ async def test_language(
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -641,9 +619,8 @@ async def test_language(
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -653,7 +630,7 @@ async def test_language(
         "language": language,
     }
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de")
     assert state is not None
     assert state.state == "on"
 
@@ -669,7 +646,6 @@ async def test_form_with_categories(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "CH",
         },
     )
@@ -689,9 +665,8 @@ async def test_form_with_categories(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor CH"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "CH",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -714,7 +689,6 @@ async def test_form_with_categories_can_remove_day(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "CH",
         },
     )
@@ -735,9 +709,8 @@ async def test_form_with_categories_can_remove_day(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor CH FR"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "CH",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -756,7 +729,6 @@ async def test_options_form_removes_subdiv(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -784,7 +756,6 @@ async def test_options_form_removes_subdiv(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.components.workday.const import (
     DEFAULT_WORKDAYS,
     DOMAIN,
 )
-from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE, CONF_NAME
+from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.util.dt import UTC
@@ -40,7 +40,6 @@ async def test_form(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -59,9 +58,8 @@ async def test_form(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -84,7 +82,6 @@ async def test_form_province_no_alias(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "US",
         },
     )
@@ -102,9 +99,8 @@ async def test_form_province_no_alias(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor US"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "US",
         "excludes": ["sat", "sun", "holiday"],
         "language": "en_US",
@@ -126,9 +122,7 @@ async def test_form_no_country(hass: HomeAssistant) -> None:
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            CONF_NAME: "Workday Sensor",
-        },
+        {},
     )
     await hass.async_block_till_done()
     result3 = await hass.config_entries.flow.async_configure(
@@ -146,7 +140,6 @@ async def test_form_no_country(hass: HomeAssistant) -> None:
     assert result3["type"] is FlowResultType.CREATE_ENTRY
     assert result3["title"] == "Workday Sensor"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
@@ -167,7 +160,6 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "SE",
         },
     )
@@ -185,9 +177,8 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor SE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "SE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -205,7 +196,6 @@ async def test_options_form(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -233,7 +223,6 @@ async def test_options_form(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -257,7 +246,6 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -305,9 +293,8 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -325,7 +312,6 @@ async def test_options_form_incorrect_dates(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -383,7 +369,6 @@ async def test_options_form_incorrect_dates(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -402,7 +387,6 @@ async def test_options_form_abort_duplicate(hass: HomeAssistant) -> None:
     await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "CH",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -417,7 +401,6 @@ async def test_options_form_abort_duplicate(hass: HomeAssistant) -> None:
     entry2 = await init_integration(
         hass,
         {
-            "name": "Workday Sensor2",
             "country": "CH",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -461,7 +444,6 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -509,9 +491,8 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -529,7 +510,6 @@ async def test_options_form_incorrect_date_ranges(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -587,7 +567,6 @@ async def test_options_form_incorrect_date_ranges(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -620,7 +599,6 @@ async def test_language(
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "DE",
         },
     )
@@ -639,9 +617,8 @@ async def test_language(
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor DE"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -651,7 +628,7 @@ async def test_language(
         "language": language,
     }
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de")
     assert state is not None
     assert state.state == "on"
 
@@ -667,7 +644,6 @@ async def test_form_with_categories(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "CH",
         },
     )
@@ -687,9 +663,8 @@ async def test_form_with_categories(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor CH"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "CH",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -712,7 +687,6 @@ async def test_form_with_categories_can_remove_day(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: "Workday Sensor",
             CONF_COUNTRY: "CH",
         },
     )
@@ -733,9 +707,8 @@ async def test_form_with_categories_can_remove_day(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Workday Sensor"
+    assert result3["title"] == "Workday Sensor CH FR"
     assert result3["options"] == {
-        "name": "Workday Sensor",
         "country": "CH",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,
@@ -754,7 +727,6 @@ async def test_options_form_removes_subdiv(hass: HomeAssistant) -> None:
     entry = await init_integration(
         hass,
         {
-            "name": "Workday Sensor",
             "country": "DE",
             "excludes": ["sat", "sun", "holiday"],
             "days_offset": 0,
@@ -782,7 +754,6 @@ async def test_options_form_removes_subdiv(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
-        "name": "Workday Sensor",
         "country": "DE",
         "excludes": ["sat", "sun", "holiday"],
         "days_offset": 0,

--- a/tests/components/workday/test_init.py
+++ b/tests/components/workday/test_init.py
@@ -7,24 +7,31 @@ from datetime import datetime
 from freezegun.api import FrozenDateTimeFactory
 from holidays.utils import country_holidays
 
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.workday.const import (
+    DEFAULT_OFFSET,
+    DEFAULT_WORKDAYS,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import UTC
 
 from . import TEST_CONFIG_EXAMPLE_1, TEST_CONFIG_WITH_PROVINCE, init_integration
+
+from tests.common import MockConfigEntry
 
 
 async def test_load_unload_entry(hass: HomeAssistant) -> None:
     """Test load and unload entry."""
     entry = await init_integration(hass, TEST_CONFIG_EXAMPLE_1)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert not state
 
 
@@ -38,7 +45,7 @@ async def test_update_options(
     entry = await init_integration(hass, TEST_CONFIG_WITH_PROVINCE)
     assert entry.state is ConfigEntryState.LOADED
     assert entry.update_listeners is not None
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state.state == "on"
 
     new_options = TEST_CONFIG_WITH_PROVINCE.copy()
@@ -50,7 +57,7 @@ async def test_update_options(
 
     entry_check = hass.config_entries.async_get_entry("1")
     assert entry_check.state is ConfigEntryState.LOADED
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state.state == "off"
 
 
@@ -63,3 +70,36 @@ async def test_workday_subdiv_aliases() -> None:
     )
     subdiv_aliases = country.get_subdivision_aliases()
     assert subdiv_aliases["6AE"] == ["Alsace"]
+
+
+async def test_migrate_to_1_1(hass: HomeAssistant) -> None:
+    """Test migrates to version 1.1."""
+    config = {
+        "name": "Test sensor",
+        "country": "US",
+        "excludes": ["sat", "sun"],
+        "days_offset": DEFAULT_OFFSET,
+        "workdays": DEFAULT_WORKDAYS,
+        "add_holidays": [],
+        "remove_holidays": [],
+        "language": "en_US",
+    }
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={},
+        options=config,
+        entry_id="1",
+        title="Test sensor",
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_sensor")
+    assert state
+
+    assert config_entry.minor_version == 2
+    assert config_entry.options == config

--- a/tests/components/workday/test_init.py
+++ b/tests/components/workday/test_init.py
@@ -72,8 +72,8 @@ async def test_workday_subdiv_aliases() -> None:
     assert subdiv_aliases["6AE"] == ["Alsace"]
 
 
-async def test_migrate_to_1_1(hass: HomeAssistant) -> None:
-    """Test migrates to version 1.1."""
+async def test_migrate_minor_version_1_to_2(hass: HomeAssistant) -> None:
+    """Test migrates to version 1.2."""
     config = {
         "name": "Test sensor",
         "country": "US",
@@ -101,5 +101,6 @@ async def test_migrate_to_1_1(hass: HomeAssistant) -> None:
     state = hass.states.get("binary_sensor.test_sensor")
     assert state
 
+    assert config_entry.version == 1
     assert config_entry.minor_version == 2
     assert config_entry.options == config

--- a/tests/components/workday/test_init.py
+++ b/tests/components/workday/test_init.py
@@ -70,8 +70,8 @@ async def test_workday_subdiv_aliases() -> None:
     assert subdiv_aliases["6AE"] == ["Alsace"]
 
 
-async def test_migrate_to_1_1(hass: HomeAssistant) -> None:
-    """Test migrates to version 1.1."""
+async def test_migrate_minor_version_1_to_2(hass: HomeAssistant) -> None:
+    """Test migrates to version 1.2."""
     config = {
         "name": "Test sensor",
         "country": "US",
@@ -99,5 +99,6 @@ async def test_migrate_to_1_1(hass: HomeAssistant) -> None:
     state = hass.states.get("binary_sensor.test_sensor")
     assert state
 
+    assert config_entry.version == 1
     assert config_entry.minor_version == 2
     assert config_entry.options == config

--- a/tests/components/workday/test_init.py
+++ b/tests/components/workday/test_init.py
@@ -5,24 +5,31 @@ from datetime import datetime
 from freezegun.api import FrozenDateTimeFactory
 from holidays.utils import country_holidays
 
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.workday.const import (
+    DEFAULT_OFFSET,
+    DEFAULT_WORKDAYS,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import UTC
 
 from . import TEST_CONFIG_EXAMPLE_1, TEST_CONFIG_WITH_PROVINCE, init_integration
+
+from tests.common import MockConfigEntry
 
 
 async def test_load_unload_entry(hass: HomeAssistant) -> None:
     """Test load and unload entry."""
     entry = await init_integration(hass, TEST_CONFIG_EXAMPLE_1)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert not state
 
 
@@ -36,7 +43,7 @@ async def test_update_options(
     entry = await init_integration(hass, TEST_CONFIG_WITH_PROVINCE)
     assert entry.state is ConfigEntryState.LOADED
     assert entry.update_listeners is not None
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state.state == "on"
 
     new_options = TEST_CONFIG_WITH_PROVINCE.copy()
@@ -48,7 +55,7 @@ async def test_update_options(
 
     entry_check = hass.config_entries.async_get_entry("1")
     assert entry_check.state is ConfigEntryState.LOADED
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_bw")
     assert state.state == "off"
 
 
@@ -61,3 +68,36 @@ async def test_workday_subdiv_aliases() -> None:
     )
     subdiv_aliases = country.get_subdivision_aliases()
     assert subdiv_aliases["6AE"] == ["Alsace"]
+
+
+async def test_migrate_to_1_1(hass: HomeAssistant) -> None:
+    """Test migrates to version 1.1."""
+    config = {
+        "name": "Test sensor",
+        "country": "US",
+        "excludes": ["sat", "sun"],
+        "days_offset": DEFAULT_OFFSET,
+        "workdays": DEFAULT_WORKDAYS,
+        "add_holidays": [],
+        "remove_holidays": [],
+        "language": "en_US",
+    }
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={},
+        options=config,
+        entry_id="1",
+        title="Test sensor",
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_sensor")
+    assert state
+
+    assert config_entry.minor_version == 2
+    assert config_entry.options == config

--- a/tests/components/workday/test_repairs.py
+++ b/tests/components/workday/test_repairs.py
@@ -32,7 +32,7 @@ async def test_bad_country(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_COUNTRY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -62,7 +62,7 @@ async def test_bad_country(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -85,7 +85,7 @@ async def test_bad_country_none(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_COUNTRY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -115,7 +115,7 @@ async def test_bad_country_none(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -138,7 +138,7 @@ async def test_bad_country_no_province(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_COUNTRY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -166,7 +166,7 @@ async def test_bad_country_no_province(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -189,7 +189,7 @@ async def test_bad_province(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_PROVINCE)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -220,7 +220,7 @@ async def test_bad_province(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -243,7 +243,7 @@ async def test_bad_province_none(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_PROVINCE)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -274,7 +274,7 @@ async def test_bad_province_none(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -298,7 +298,7 @@ async def test_bad_named_holiday(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_REMOVE_NAMED)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     issues = issue_registry.issues.keys()
@@ -347,7 +347,7 @@ async def test_bad_named_holiday(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -371,7 +371,7 @@ async def test_bad_date_holiday(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_REMOVE_DATE)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     issues = issue_registry.issues.keys()
@@ -410,7 +410,7 @@ async def test_bad_date_holiday(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})

--- a/tests/components/workday/test_repairs.py
+++ b/tests/components/workday/test_repairs.py
@@ -30,7 +30,7 @@ async def test_bad_country(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_COUNTRY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -60,7 +60,7 @@ async def test_bad_country(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -83,7 +83,7 @@ async def test_bad_country_none(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_COUNTRY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -113,7 +113,7 @@ async def test_bad_country_none(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -136,7 +136,7 @@ async def test_bad_country_no_province(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_COUNTRY)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -164,7 +164,7 @@ async def test_bad_country_no_province(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -187,7 +187,7 @@ async def test_bad_province(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_PROVINCE)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -218,7 +218,7 @@ async def test_bad_province(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -241,7 +241,7 @@ async def test_bad_province_none(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_INCORRECT_PROVINCE)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert not state
 
     ws_client = await hass_ws_client(hass)
@@ -272,7 +272,7 @@ async def test_bad_province_none(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_de_zz")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -296,7 +296,7 @@ async def test_bad_named_holiday(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_REMOVE_NAMED)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     issues = issue_registry.issues.keys()
@@ -345,7 +345,7 @@ async def test_bad_named_holiday(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
@@ -369,7 +369,7 @@ async def test_bad_date_holiday(
     assert await async_setup_component(hass, "repairs", {})
     entry = await init_integration(hass, TEST_CONFIG_REMOVE_DATE)
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     issues = issue_registry.issues.keys()
@@ -408,7 +408,7 @@ async def test_bad_date_holiday(
     assert data["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.workday_sensor")
+    state = hass.states.get("binary_sensor.workday_sensor_us")
     assert state
 
     await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Remove `name` from config entry flow in `workday` as pointed out in https://github.com/home-assistant/core/issues/168967

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #168967
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 