### PR TITLE
Remove unique id in dnsip

### DIFF
--- a/homeassistant/components/dnsip/__init__.py
+++ b/homeassistant/components/dnsip/__init__.py
@@ -30,12 +30,10 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         return False
 
     if config_entry.version < 2 and config_entry.minor_version < 2:
-        version = config_entry.version
-        minor_version = config_entry.minor_version
         _LOGGER.debug(
             "Migrating configuration from version %s.%s",
-            version,
-            minor_version,
+            config_entry.version,
+            config_entry.minor_version,
         )
 
         new_options = {**config_entry.options}
@@ -46,10 +44,19 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry, options=new_options, minor_version=2
         )
 
+        _LOGGER.debug("Migration to configuration version %s.%s successful", 1, 2)
+
+    if config_entry.version < 2 and config_entry.minor_version < 3:
         _LOGGER.debug(
-            "Migration to configuration version %s.%s successful",
-            1,
-            2,
+            "Migrating configuration from version %s.%s",
+            config_entry.version,
+            config_entry.minor_version,
         )
+
+        hass.config_entries.async_update_entry(
+            config_entry, unique_id=None, minor_version=3
+        )
+
+        _LOGGER.debug("Migration to configuration version %s.%s successful", 1, 3)
 
     return True

--- a/homeassistant/components/dnsip/config_flow.py
+++ b/homeassistant/components/dnsip/config_flow.py
@@ -93,7 +93,7 @@ class DnsIPConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for dnsip integration."""
 
     VERSION = 1
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     @staticmethod
     @callback
@@ -133,10 +133,7 @@ class DnsIPConfigFlow(ConfigFlow, domain=DOMAIN):
             ):
                 errors["base"] = "invalid_hostname"
             else:
-                # Uses hostname as unique ID, which is no longer allowed
-                # pylint: disable-next=hass-unique-id-ip-based
-                await self.async_set_unique_id(hostname)
-                self._abort_if_unique_id_configured()
+                self._async_abort_entries_match({CONF_HOSTNAME: hostname})
 
                 return self.async_create_entry(
                     title=name,

--- a/tests/components/dnsip/test_init.py
+++ b/tests/components/dnsip/test_init.py
@@ -91,9 +91,49 @@ async def test_port_migration(
         await hass.async_block_till_done()
 
     assert entry.version == 1
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert entry.options[CONF_PORT] == DEFAULT_PORT
     assert entry.options[CONF_PORT_IPV6] == DEFAULT_PORT
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_remove_unique_id_migration(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration of the config entry removing the unique_id."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={
+            CONF_HOSTNAME: "home-assistant.io",
+            CONF_NAME: "home-assistant.io",
+            CONF_IPV4: True,
+            CONF_IPV6: True,
+        },
+        options={
+            CONF_RESOLVER: "208.67.222.222",
+            CONF_RESOLVER_IPV6: "2620:119:53::53",
+            CONF_PORT: DEFAULT_PORT,
+            CONF_PORT_IPV6: DEFAULT_PORT,
+        },
+        entry_id="1",
+        unique_id="home-assistant.io",
+        version=1,
+        minor_version=2,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.dnsip.sensor.aiodns.DNSResolver",
+        return_value=RetrieveDNS(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.version == 1
+    assert entry.minor_version == 3
+    assert entry.unique_id is None
     assert entry.state is ConfigEntryState.LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Remove unique id and use `_async_abort_entries_match`instead in `dnsip` as spotted in https://github.com/home-assistant/core/pull/168822

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 