### PR TITLE
Remove name from worldclock config flow

### DIFF
--- a/homeassistant/components/worldclock/config_flow.py
+++ b/homeassistant/components/worldclock/config_flow.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any
 import zoneinfo
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
+from homeassistant.const import CONF_TIME_ZONE
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
@@ -19,7 +19,6 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
-    TextSelector,
 )
 
 from .const import CONF_TIME_FORMAT, DEFAULT_NAME, DEFAULT_TIME_STR_FORMAT, DOMAIN
@@ -55,7 +54,6 @@ async def get_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
     )
     return vol.Schema(
         {
-            vol.Required(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
             vol.Required(CONF_TIME_ZONE): SelectSelector(
                 SelectSelectorConfig(
                     options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
@@ -101,4 +99,4 @@ class WorldclockConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
-        return cast(str, options[CONF_NAME])
+        return DEFAULT_NAME

--- a/homeassistant/components/worldclock/sensor.py
+++ b/homeassistant/components/worldclock/sensor.py
@@ -6,7 +6,7 @@ from datetime import tzinfo
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
+from homeassistant.const import CONF_TIME_ZONE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -26,7 +26,7 @@ async def async_setup_entry(
         [
             WorldClockSensor(
                 time_zone,
-                entry.options[CONF_NAME],
+                entry.title,
                 entry.options[CONF_TIME_FORMAT],
                 entry.entry_id,
             )

--- a/tests/components/worldclock/test_config_flow.py
+++ b/tests/components/worldclock/test_config_flow.py
@@ -30,7 +30,6 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: DEFAULT_NAME,
             CONF_TIME_ZONE: "America/New_York",
         },
     )
@@ -38,8 +37,8 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["version"] == 1
+    assert result["title"] == DEFAULT_NAME
     assert result["options"] == {
-        CONF_NAME: DEFAULT_NAME,
         CONF_TIME_ZONE: "America/New_York",
         CONF_TIME_FORMAT: DEFAULT_TIME_STR_FORMAT,
     }
@@ -93,7 +92,6 @@ async def test_entry_already_exist(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: DEFAULT_NAME,
             CONF_TIME_ZONE: "America/New_York",
             CONF_TIME_FORMAT: DEFAULT_TIME_STR_FORMAT,
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Remove name from `worldclock` config flow.
Seems we should not need to migrate.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 