### PR TITLE
Use async_on_create_entry in bayesian

### DIFF
--- a/homeassistant/components/bayesian/config_flow.py
+++ b/homeassistant/components/bayesian/config_flow.py
@@ -33,11 +33,13 @@ from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.config_entries import (
+    SOURCE_USER,
     ConfigEntry,
     ConfigFlowResult,
     ConfigSubentry,
-    ConfigSubentryData,
     ConfigSubentryFlow,
+    FlowType,
+    SubentryFlowContext,
     SubentryFlowResult,
 )
 from homeassistant.const import (
@@ -62,7 +64,6 @@ from homeassistant.helpers.schema_config_entry_flow import (
 
 from .binary_sensor import above_greater_than_below, no_overlapping
 from .const import (
-    CONF_OBSERVATIONS,
     CONF_P_GIVEN_F,
     CONF_P_GIVEN_T,
     CONF_PRIOR,
@@ -373,26 +374,6 @@ def _validate_observation_subentry(
     return user_input
 
 
-async def _validate_subentry_from_config_entry(
-    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
-) -> dict[str, Any]:
-    # Standard behavior is to merge the result with the options.
-    # In this case, we want to add a subentry so we update the options directly.
-    observations: list[dict[str, Any]] = handler.options.setdefault(
-        CONF_OBSERVATIONS, []
-    )
-
-    if handler.parent_handler.cur_step is not None:
-        user_input[CONF_PLATFORM] = handler.parent_handler.cur_step["step_id"]
-        user_input = _validate_observation_subentry(
-            user_input[CONF_PLATFORM],
-            user_input,
-            other_subentries=handler.options[CONF_OBSERVATIONS],
-        )
-    observations.append(user_input)
-    return {}
-
-
 async def _get_description_placeholders(
     handler: SchemaCommonFlowHandler,
 ) -> dict[str, str]:
@@ -420,48 +401,12 @@ async def _get_description_placeholders(
     }
 
 
-async def _get_observation_menu_options(handler: SchemaCommonFlowHandler) -> list[str]:
-    """Return the menu options for the observation selector."""
-    options = [typ.value for typ in ObservationTypes]
-    if handler.options.get(CONF_OBSERVATIONS):
-        options.append("finish")
-    return options
-
-
 CONFIG_FLOW: dict[str, SchemaFlowMenuStep | SchemaFlowFormStep] = {
     str(USER): SchemaFlowFormStep(
         CONFIG_SCHEMA,
         validate_user_input=_validate_user,
-        next_step=str(OBSERVATION_SELECTOR),
         description_placeholders=_get_description_placeholders,
-    ),
-    str(OBSERVATION_SELECTOR): SchemaFlowMenuStep(
-        _get_observation_menu_options,
-    ),
-    str(ObservationTypes.STATE): SchemaFlowFormStep(
-        STATE_SUBSCHEMA,
-        next_step=str(OBSERVATION_SELECTOR),
-        validate_user_input=_validate_subentry_from_config_entry,
-        # Prevent the name of the bayesian sensor from being used as the suggested
-        # name of the observations
-        suggested_values=None,
-        description_placeholders=_get_description_placeholders,
-    ),
-    str(ObservationTypes.NUMERIC_STATE): SchemaFlowFormStep(
-        NUMERIC_STATE_SUBSCHEMA,
-        next_step=str(OBSERVATION_SELECTOR),
-        validate_user_input=_validate_subentry_from_config_entry,
-        suggested_values=None,
-        description_placeholders=_get_description_placeholders,
-    ),
-    str(ObservationTypes.TEMPLATE): SchemaFlowFormStep(
-        TEMPLATE_SUBSCHEMA,
-        next_step=str(OBSERVATION_SELECTOR),
-        validate_user_input=_validate_subentry_from_config_entry,
-        suggested_values=None,
-        description_placeholders=_get_description_placeholders,
-    ),
-    "finish": SchemaFlowFormStep(),
+    )
 }
 
 
@@ -497,27 +442,17 @@ class BayesianConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         name: str = options[CONF_NAME]
         return name
 
-    @callback
-    def async_create_entry(
-        self,
-        data: Mapping[str, Any],
-        **kwargs: Any,
-    ) -> ConfigFlowResult:
-        """Finish config flow and create a config entry."""
-        data = dict(data)
-        observations = data.pop(CONF_OBSERVATIONS)
-        subentries: list[ConfigSubentryData] = [
-            ConfigSubentryData(
-                data=observation,
-                title=observation[CONF_NAME],
-                subentry_type="observation",
-                unique_id=None,
-            )
-            for observation in observations
-        ]
-
-        self.async_config_flow_finished(data)
-        return super().async_create_entry(data=data, subentries=subentries, **kwargs)
+    async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
+        """Start subentry flow when config entry has been created."""
+        subentry_result = await self.hass.config_entries.subentries.async_init(
+            (result["result"].entry_id, "observation"),
+            context=SubentryFlowContext(source=SOURCE_USER),
+        )
+        result["next_flow"] = (
+            FlowType.CONFIG_SUBENTRIES_FLOW,
+            subentry_result["flow_id"],
+        )
+        return result
 
 
 class ObservationSubentryFlowHandler(ConfigSubentryFlow):

--- a/tests/components/bayesian/test_config_flow.py
+++ b/tests/components/bayesian/test_config_flow.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.bayesian.config_flow import (
-    OBSERVATION_SELECTOR,
     USER,
     ObservationTypes,
     OptionsFlowSteps,
@@ -27,6 +26,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigSubentry,
     ConfigSubentryDataWithId,
+    FlowType,
 )
 from homeassistant.const import (
     CONF_ABOVE,
@@ -72,10 +72,9 @@ async def test_config_flow_step_user(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        # We move on to the next step - the observation selector
-        assert result1["step_id"] == OBSERVATION_SELECTOR
-        assert result1["type"] is FlowResultType.MENU
-        assert result1["flow_id"] is not None
+        assert result1["type"] == FlowResultType.CREATE_ENTRY
+        assert result1["result"].title == "Office occupied"
+        assert result1["next_flow"][0] == FlowType.CONFIG_SUBENTRIES_FLOW
 
 
 async def test_subentry_flow(hass: HomeAssistant) -> None:
@@ -254,13 +253,15 @@ async def test_single_state_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        # Confirm the next step is the menu
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
-        assert result["menu_options"] == ["state", "numeric_state", "template"]
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        entry_id = result["result"].entry_id
+        sub_flow_id = result["next_flow"][1]
 
-        result = await hass.config_entries.flow.async_configure(
+        # Confirm the next step is the menu
+        result = hass.config_entries.subentries.async_get(sub_flow_id)
+        assert result["flow_id"] is not None
+
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], {"next_step_id": str(ObservationTypes.STATE)}
         )
         await hass.async_block_till_done()
@@ -268,7 +269,7 @@ async def test_single_state_observation(hass: HomeAssistant) -> None:
         assert result["step_id"] == str(ObservationTypes.STATE)
         assert result["type"] is FlowResultType.FORM
 
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.kitchen_occupancy",
@@ -279,22 +280,9 @@ async def test_single_state_observation(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
-        assert result["menu_options"] == [
-            "state",
-            "numeric_state",
-            "template",
-            "finish",
-        ]
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": "finish"}
-        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
         await hass.async_block_till_done()
 
-        entry_id = result["result"].entry_id
         config_entry = hass.config_entries.async_get_entry(entry_id)
         assert config_entry is not None
         assert type(config_entry) is ConfigEntry
@@ -341,22 +329,20 @@ async def test_single_numeric_state_observation(hass: HomeAssistant) -> None:
                 CONF_PRIOR: 20,
             },
         )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        config_entry = result["result"]
+        sub_flow_id = result["next_flow"][1]
         await hass.async_block_till_done()
 
-        # Confirm the next step is the menu
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
-
         # select numeric state observation
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": str(ObservationTypes.NUMERIC_STATE)}
+        result = await hass.config_entries.subentries.async_configure(
+            sub_flow_id, {"next_step_id": str(ObservationTypes.NUMERIC_STATE)}
         )
         await hass.async_block_till_done()
 
         assert result["step_id"] == str(ObservationTypes.NUMERIC_STATE)
         assert result["type"] is FlowResultType.FORM
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.outside_temperature",
@@ -367,21 +353,8 @@ async def test_single_numeric_state_observation(hass: HomeAssistant) -> None:
                 CONF_NAME: "20 - 35 outside",
             },
         )
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
-        assert result["menu_options"] == [
-            "state",
-            "numeric_state",
-            "template",
-            "finish",
-        ]
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": "finish"}
-        )
         await hass.async_block_till_done()
-        config_entry = result["result"]
+
         assert config_entry.options == {
             CONF_NAME: "Nice day",
             CONF_PROBABILITY_THRESHOLD: 0.51,
@@ -427,20 +400,19 @@ async def test_multi_numeric_state_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        # Confirm the next step is the menu
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        config_entry = result["result"]
+        sub_flow_id = result["next_flow"][1]
 
         # select numeric state observation
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": str(ObservationTypes.NUMERIC_STATE)}
+        result = await hass.config_entries.subentries.async_configure(
+            sub_flow_id, {"next_step_id": str(ObservationTypes.NUMERIC_STATE)}
         )
         await hass.async_block_till_done()
 
         assert result["step_id"] == str(ObservationTypes.NUMERIC_STATE)
         assert result["type"] is FlowResultType.FORM
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.outside_temperature",
@@ -451,18 +423,17 @@ async def test_multi_numeric_state_observation(hass: HomeAssistant) -> None:
                 CONF_NAME: "20 - 35 outside",
             },
         )
-
-        # Confirm the next step is the menu
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": str(ObservationTypes.NUMERIC_STATE)}
-        )
         await hass.async_block_till_done()
 
         # This should fail as overlapping ranges for the same entity are not allowed
-        current_step = result["step_id"]
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_init(
+            (config_entry.entry_id, "observation"),
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {"next_step_id": str(ObservationTypes.NUMERIC_STATE)}
+        )
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.outside_temperature",
@@ -475,11 +446,10 @@ async def test_multi_numeric_state_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         assert result["errors"] == {"base": "overlapping_ranges"}
-        assert result["step_id"] == current_step
 
         # This should fail as above should always be less than below
         current_step = result["step_id"]
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.outside_temperature",
@@ -495,7 +465,7 @@ async def test_multi_numeric_state_observation(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "above_below"}
 
         # This should work
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.outside_temperature",
@@ -506,22 +476,8 @@ async def test_multi_numeric_state_observation(hass: HomeAssistant) -> None:
                 CONF_NAME: "35 - 40 outside",
             },
         )
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
-        assert result["menu_options"] == [
-            "state",
-            "numeric_state",
-            "template",
-            "finish",
-        ]
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": "finish"}
-        )
         await hass.async_block_till_done()
 
-        config_entry = result["result"]
         assert config_entry.version == 1
         assert config_entry.options == {
             CONF_NAME: "Nice day",
@@ -582,20 +538,19 @@ async def test_single_template_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        # Confirm the next step is the menu
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        config_entry = result["result"]
+        sub_flow_id = result["next_flow"][1]
 
         # Select template observation
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": str(ObservationTypes.TEMPLATE)}
+        result = await hass.config_entries.subentries.async_configure(
+            sub_flow_id, {"next_step_id": str(ObservationTypes.TEMPLATE)}
         )
         await hass.async_block_till_done()
 
         assert result["step_id"] == str(ObservationTypes.TEMPLATE)
         assert result["type"] is FlowResultType.FORM
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_VALUE_TEMPLATE: "{{is_state('device_tracker.paulus','not_home') and ((as_timestamp(now()) - as_timestamp(states.device_tracker.paulus.last_changed)) > 300)}}",
@@ -604,21 +559,7 @@ async def test_single_template_observation(hass: HomeAssistant) -> None:
                 CONF_NAME: "Not seen in last 5 minutes",
             },
         )
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
-        assert result["menu_options"] == [
-            "state",
-            "numeric_state",
-            "template",
-            "finish",
-        ]
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": "finish"}
-        )
         await hass.async_block_till_done()
-        config_entry = result["result"]
         assert config_entry.version == 1
         assert config_entry.options == {
             CONF_NAME: "Paulus Home",
@@ -1087,13 +1028,12 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert result.get("errors") is None
 
-        # Confirm the next step is the menu
-        assert result["step_id"] == OBSERVATION_SELECTOR
-        assert result["type"] is FlowResultType.MENU
-        assert result["flow_id"] is not None
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        config_entry = result["result"]
+        sub_flow_id = result["next_flow"][1]
 
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"next_step_id": str(ObservationTypes.STATE)}
+        result = await hass.config_entries.subentries.async_configure(
+            sub_flow_id, {"next_step_id": str(ObservationTypes.STATE)}
         )
         await hass.async_block_till_done()
 
@@ -1102,7 +1042,7 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
 
         # Observations with a probability of 0 will create certainties
         with pytest.raises(vol.Invalid) as excinfo:
-            result = await hass.config_entries.flow.async_configure(
+            result = await hass.config_entries.subentries.async_configure(
                 result["flow_id"],
                 {
                     CONF_ENTITY_ID: "sensor.work_laptop",
@@ -1117,7 +1057,7 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
 
         # Observations with a probability of 1 will create certainties
         with pytest.raises(vol.Invalid) as excinfo:
-            result = await hass.config_entries.flow.async_configure(
+            result = await hass.config_entries.subentries.async_configure(
                 result["flow_id"],
                 {
                     CONF_ENTITY_ID: "sensor.work_laptop",
@@ -1133,7 +1073,7 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
         # Observations with equal probabilities have no effect
         # Try with a ObservationTypes.STATE observation
         current_step = result["step_id"]
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.work_laptop",
@@ -1148,7 +1088,7 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "equal_probabilities"}
 
         # now submit a valid result
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.work_laptop",
@@ -1159,13 +1099,15 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-        result = await hass.config_entries.flow.async_configure(
+
+        result = await hass.config_entries.subentries.async_init(
+            (config_entry.entry_id, "observation"),
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], {"next_step_id": str(ObservationTypes.NUMERIC_STATE)}
         )
-
-        await hass.async_block_till_done()
-        current_step = result["step_id"]
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.office_illuminance_lux",
@@ -1176,10 +1118,9 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-        assert result["step_id"] == current_step
         assert result["errors"] == {"base": "equal_probabilities"}
 
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_ENTITY_ID: "sensor.office_illuminance_lux",
@@ -1191,13 +1132,15 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         # Try with a ObservationTypes.TEMPLATE observation
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_init(
+            (config_entry.entry_id, "observation"),
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], {"next_step_id": str(ObservationTypes.TEMPLATE)}
         )
-
-        await hass.async_block_till_done()
         current_step = result["step_id"]
-        result = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
             {
                 CONF_VALUE_TEMPLATE: "{{ is_state('device_tracker.paulus', 'not_home') }}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Use `async_on_create_entry` in bayesian to start subentry flows.
Removes the need for having all the logic in the config flow

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 