### PR TITLE
Add support for API key authentication to pyLoad integration

### DIFF
--- a/homeassistant/components/pyload/__init__.py
+++ b/homeassistant/components/pyload/__init__.py
@@ -9,6 +9,7 @@ from pyloadapi import PyLoadAPI
 from yarl import URL
 
 from homeassistant.const import (
+    CONF_API_KEY,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
@@ -39,8 +40,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PyLoadConfigEntry) -> bo
     pyloadapi = PyLoadAPI(
         session,
         api_url=URL(entry.data[CONF_URL]),
-        username=entry.data[CONF_USERNAME],
-        password=entry.data[CONF_PASSWORD],
+        username=entry.data.get(CONF_USERNAME),
+        password=entry.data.get(CONF_PASSWORD),
+        api_key=entry.data.get(CONF_API_KEY),
     )
 
     coordinator = PyLoadCoordinator(hass, entry, pyloadapi)

--- a/homeassistant/components/pyload/config_flow.py
+++ b/homeassistant/components/pyload/config_flow.py
@@ -13,13 +13,14 @@ from yarl import URL
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
-    CONF_NAME,
+    CONF_API_KEY,
     CONF_PASSWORD,
     CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.selector import (
     TextSelector,
@@ -41,13 +42,14 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
             ),
         ),
         vol.Required(CONF_VERIFY_SSL, default=True): bool,
-        vol.Required(CONF_USERNAME): TextSelector(
+        vol.Exclusive(CONF_API_KEY, "credentials"): cv.string,
+        vol.Exclusive(CONF_USERNAME, "credentials"): TextSelector(
             TextSelectorConfig(
                 type=TextSelectorType.TEXT,
                 autocomplete="username",
             ),
         ),
-        vol.Required(CONF_PASSWORD): TextSelector(
+        vol.Optional(CONF_PASSWORD): TextSelector(
             TextSelectorConfig(
                 type=TextSelectorType.PASSWORD,
                 autocomplete="current-password",
@@ -58,13 +60,14 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 REAUTH_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): TextSelector(
+        vol.Exclusive(CONF_API_KEY, "credentials"): cv.string,
+        vol.Exclusive(CONF_USERNAME, "credentials"): TextSelector(
             TextSelectorConfig(
                 type=TextSelectorType.TEXT,
                 autocomplete="username",
             ),
         ),
-        vol.Required(CONF_PASSWORD): TextSelector(
+        vol.Optional(CONF_PASSWORD): TextSelector(
             TextSelectorConfig(
                 type=TextSelectorType.PASSWORD,
                 autocomplete="current-password",
@@ -86,8 +89,9 @@ async def validate_input(hass: HomeAssistant, user_input: dict[str, Any]) -> Non
     pyload = PyLoadAPI(
         session,
         api_url=URL(user_input[CONF_URL]),
-        username=user_input[CONF_USERNAME],
-        password=user_input[CONF_PASSWORD],
+        username=user_input.get(CONF_USERNAME),
+        password=user_input.get(CONF_PASSWORD),
+        api_key=user_input.get(CONF_API_KEY),
     )
 
     await pyload.get_status()
@@ -113,7 +117,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
                 await validate_input(self.hass, user_input)
             except CannotConnect, ParserError:
                 errors["base"] = "cannot_connect"
-            except InvalidAuth:
+            except InvalidAuth, ValueError:
                 errors["base"] = "invalid_auth"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
@@ -156,7 +160,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
                 await validate_input(self.hass, {**reauth_entry.data, **user_input})
             except CannotConnect, ParserError:
                 errors["base"] = "cannot_connect"
-            except InvalidAuth:
+            except InvalidAuth, ValueError:
                 errors["base"] = "invalid_auth"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
@@ -171,12 +175,11 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=self.add_suggested_values_to_schema(
                 REAUTH_SCHEMA,
                 {
-                    CONF_USERNAME: user_input[CONF_USERNAME]
+                    CONF_USERNAME: user_input.get(CONF_USERNAME)
                     if user_input is not None
-                    else reauth_entry.data[CONF_USERNAME]
+                    else reauth_entry.data.get(CONF_USERNAME)
                 },
             ),
-            description_placeholders={CONF_NAME: reauth_entry.data[CONF_USERNAME]},
             errors=errors,
         )
 
@@ -192,7 +195,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
                 await validate_input(self.hass, user_input)
             except CannotConnect, ParserError:
                 errors["base"] = "cannot_connect"
-            except InvalidAuth:
+            except InvalidAuth, ValueError:
                 errors["base"] = "invalid_auth"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
@@ -213,10 +216,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
                 STEP_USER_DATA_SCHEMA,
                 suggested_values,
             ),
-            description_placeholders={
-                CONF_NAME: reconfig_entry.data[CONF_USERNAME],
-                **PLACEHOLDER,
-            },
+            description_placeholders=PLACEHOLDER,
             errors=errors,
         )
 
@@ -252,7 +252,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
         except CannotConnect, ParserError:
             _LOGGER.debug("Cannot connect", exc_info=True)
             errors["base"] = "cannot_connect"
-        except InvalidAuth:
+        except InvalidAuth, ValueError:
             errors["base"] = "invalid_auth"
         except Exception:
             _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/pyload/coordinator.py
+++ b/homeassistant/components/pyload/coordinator.py
@@ -7,7 +7,6 @@ import logging
 from pyloadapi import CannotConnect, InvalidAuth, ParserError, PyLoadAPI
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -68,9 +67,6 @@ class PyLoadCoordinator(DataUpdateCoordinator[PyLoadData]):
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="setup_authentication_exception",
-                translation_placeholders={
-                    CONF_USERNAME: self.config_entry.data[CONF_USERNAME]
-                },
             ) from e
         except CannotConnect as e:
             raise UpdateFailed(
@@ -102,7 +98,4 @@ class PyLoadCoordinator(DataUpdateCoordinator[PyLoadData]):
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="setup_authentication_exception",
-                translation_placeholders={
-                    CONF_USERNAME: self.config_entry.data[CONF_USERNAME]
-                },
             ) from e

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -13,10 +13,12 @@
     "step": {
       "hassio_confirm": {
         "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {
+          "api_key": "[%key:component::pyload::config::step::user::data_description::api_key%]",
           "password": "[%key:component::pyload::config::step::user::data_description::password%]",
           "username": "[%key:component::pyload::config::step::user::data_description::username%]"
         },
@@ -25,10 +27,12 @@
       },
       "reauth_confirm": {
         "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {
+          "api_key": "[%key:component::pyload::config::step::user::data_description::api_key%]",
           "password": "[%key:component::pyload::config::step::user::data_description::password%]",
           "username": "[%key:component::pyload::config::step::user::data_description::username%]"
         },
@@ -36,12 +40,14 @@
       },
       "reconfigure": {
         "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]",
           "password": "[%key:common::config_flow::data::password%]",
           "url": "[%key:common::config_flow::data::url%]",
           "username": "[%key:common::config_flow::data::username%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
+          "api_key": "[%key:component::pyload::config::step::user::data_description::api_key%]",
           "password": "[%key:component::pyload::config::step::user::data_description::password%]",
           "url": "[%key:component::pyload::config::step::user::data_description::url%]",
           "username": "[%key:component::pyload::config::step::user::data_description::username%]",
@@ -50,15 +56,17 @@
       },
       "user": {
         "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]",
           "password": "[%key:common::config_flow::data::password%]",
           "url": "[%key:common::config_flow::data::url%]",
           "username": "[%key:common::config_flow::data::username%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "password": "The password associated with the pyLoad account.",
+          "api_key": "The API key to authenticate with pyLoad. To create a new API key, navigate to **Settings > Users > Actions > Manage API Keys** and select **Generate**.",
+          "password": "The password associated with the pyLoad account. **Deprecated:** No longer supported in pyLoad 0.5.0b3.dev97 or later.",
           "url": "Specify the full URL of your pyLoad web interface, including the protocol (HTTP or HTTPS), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: `{example_url}`",
-          "username": "The username used to access the pyLoad instance.",
+          "username": "The username used to access the pyLoad instance. **Deprecated:** No longer supported in pyLoad 0.5.0b3.dev97 or later.",
           "verify_ssl": "If checked, the SSL certificate will be validated to ensure a secure connection."
         }
       }
@@ -113,7 +121,7 @@
       "message": "Unable to send command to pyLoad due to a connection error, try again later"
     },
     "setup_authentication_exception": {
-      "message": "Authentication failed for {username}, verify your login credentials"
+      "message": "Authentication with pyLoad failed, verify your login credentials"
     },
     "setup_parse_exception": {
       "message": "Unable to parse data from pyLoad API"

--- a/tests/components/pyload/conftest.py
+++ b/tests/components/pyload/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components.pyload.const import DEFAULT_NAME, DOMAIN
 from homeassistant.const import (
+    CONF_API_KEY,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
@@ -27,15 +28,33 @@ USER_INPUT = {
     CONF_VERIFY_SSL: False,
 }
 
+USER_INPUT_API_KEY = {
+    CONF_URL: "https://pyload.local:8000/prefix",
+    CONF_API_KEY: "pl_xxx",
+    CONF_VERIFY_SSL: False,
+}
+
 REAUTH_INPUT = {
     CONF_PASSWORD: "new-password",
     CONF_USERNAME: "new-username",
+}
+
+REAUTH_INPUT_API_KEY = {
+    CONF_API_KEY: "pl_xxx",
 }
 
 NEW_INPUT = {
     CONF_URL: "https://pyload.local:8000/prefix",
     CONF_PASSWORD: "new-password",
     CONF_USERNAME: "new-username",
+    CONF_VERIFY_SSL: False,
+}
+
+NEW_INPUT_API_KEY = {
+    CONF_URL: "https://pyload.local:8000/prefix",
+    CONF_API_KEY: "pl_xxx",
+    CONF_PASSWORD: "test-password",
+    CONF_USERNAME: "test-username",
     CONF_VERIFY_SSL: False,
 }
 

--- a/tests/components/pyload/test_config_flow.py
+++ b/tests/components/pyload/test_config_flow.py
@@ -15,17 +15,22 @@ from .conftest import (
     ADDON_DISCOVERY_INFO,
     ADDON_SERVICE_INFO,
     NEW_INPUT,
+    NEW_INPUT_API_KEY,
     REAUTH_INPUT,
+    REAUTH_INPUT_API_KEY,
     USER_INPUT,
+    USER_INPUT_API_KEY,
 )
 
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize("user_input", [USER_INPUT, USER_INPUT_API_KEY])
 async def test_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_pyloadapi: AsyncMock,
+    user_input: dict[str, str],
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -36,22 +41,24 @@ async def test_form(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        user_input,
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
-    assert result["data"] == USER_INPUT
+    assert result["data"] == user_input
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.parametrize("user_input", [USER_INPUT, USER_INPUT_API_KEY])
 @pytest.mark.parametrize(
     ("exception", "expected_error"),
     [
         (InvalidAuth, "invalid_auth"),
         (CannotConnect, "cannot_connect"),
         (ParserError, "cannot_connect"),
-        (ValueError, "unknown"),
+        (ValueError, "invalid_auth"),
+        (TypeError, "unknown"),
     ],
 )
 async def test_form_errors(
@@ -60,6 +67,7 @@ async def test_form_errors(
     mock_pyloadapi: AsyncMock,
     exception: Exception,
     expected_error: str,
+    user_input: dict[str, str],
 ) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
@@ -69,7 +77,7 @@ async def test_form_errors(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        user_input,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -78,12 +86,12 @@ async def test_form_errors(
     mock_pyloadapi.get_status.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        user_input,
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
-    assert result["data"] == USER_INPUT
+    assert result["data"] == user_input
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -110,10 +118,19 @@ async def test_flow_user_already_configured(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.parametrize(
+    ("reauth_input", "new_input"),
+    [
+        (REAUTH_INPUT, NEW_INPUT),
+        (REAUTH_INPUT_API_KEY, NEW_INPUT_API_KEY),
+    ],
+)
+@pytest.mark.usefixtures("mock_pyloadapi")
 async def test_reauth(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    mock_pyloadapi: AsyncMock,
+    reauth_input: dict[str, str],
+    new_input: dict[str, str],
 ) -> None:
     """Test reauth flow."""
 
@@ -126,12 +143,12 @@ async def test_reauth(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        REAUTH_INPUT,
+        reauth_input,
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
-    assert config_entry.data == NEW_INPUT
+    assert config_entry.data == new_input
     assert len(hass.config_entries.async_entries()) == 1
 
 
@@ -139,8 +156,16 @@ async def test_reauth(
     ("side_effect", "error_text"),
     [
         (InvalidAuth, "invalid_auth"),
+        (ValueError, "invalid_auth"),
         (CannotConnect, "cannot_connect"),
         (IndexError, "unknown"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("reauth_input", "new_input"),
+    [
+        (REAUTH_INPUT, NEW_INPUT),
+        (REAUTH_INPUT_API_KEY, NEW_INPUT_API_KEY),
     ],
 )
 async def test_reauth_errors(
@@ -149,6 +174,8 @@ async def test_reauth_errors(
     mock_pyloadapi: AsyncMock,
     side_effect: Exception,
     error_text: str,
+    reauth_input: dict[str, str],
+    new_input: dict[str, str],
 ) -> None:
     """Test reauth flow."""
 
@@ -162,7 +189,7 @@ async def test_reauth_errors(
     mock_pyloadapi.get_status.side_effect = side_effect
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        REAUTH_INPUT,
+        reauth_input,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -171,21 +198,26 @@ async def test_reauth_errors(
     mock_pyloadapi.get_status.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        REAUTH_INPUT,
+        reauth_input,
     )
 
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
-    assert config_entry.data == NEW_INPUT
+    assert config_entry.data == new_input
     assert len(hass.config_entries.async_entries()) == 1
 
 
+@pytest.mark.parametrize(
+    "user_input",
+    [USER_INPUT, USER_INPUT_API_KEY],
+)
+@pytest.mark.usefixtures("mock_pyloadapi")
 async def test_reconfiguration(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    mock_pyloadapi: AsyncMock,
+    user_input: dict[str, str],
 ) -> None:
     """Test reconfiguration flow."""
 
@@ -198,12 +230,12 @@ async def test_reconfiguration(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        user_input,
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == USER_INPUT
+    assert config_entry.data == user_input
     assert len(hass.config_entries.async_entries()) == 1
 
 
@@ -211,9 +243,14 @@ async def test_reconfiguration(
     ("side_effect", "error_text"),
     [
         (InvalidAuth, "invalid_auth"),
+        (ValueError, "invalid_auth"),
         (CannotConnect, "cannot_connect"),
         (IndexError, "unknown"),
     ],
+)
+@pytest.mark.parametrize(
+    "user_input",
+    [USER_INPUT, USER_INPUT_API_KEY],
 )
 async def test_reconfigure_errors(
     hass: HomeAssistant,
@@ -221,6 +258,7 @@ async def test_reconfigure_errors(
     mock_pyloadapi: AsyncMock,
     side_effect: Exception,
     error_text: str,
+    user_input: dict[str, str],
 ) -> None:
     """Test reconfiguration flow."""
 
@@ -234,7 +272,7 @@ async def test_reconfigure_errors(
     mock_pyloadapi.get_status.side_effect = side_effect
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        user_input,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -243,14 +281,14 @@ async def test_reconfigure_errors(
     mock_pyloadapi.get_status.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        user_input,
     )
 
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == USER_INPUT
+    assert config_entry.data == user_input
     assert len(hass.config_entries.async_entries()) == 1
 
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since version 0.5.0b3.dev97 pyLoad has dropped support for basic authentication and introduced authentication via API key. This extends the config flow schemas with an additional API key field and adds a note to the username/password fields, that these are deprecated. With some time for transition, these could probably be removed in the future. For now, both authentication methods work.

Edit: I checked new integration instead of new feature by mistake. Label need to be updated

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #167765
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45024
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
