### PR TITLE
Fix OneDrive upload service to report all missing files at once

### DIFF
--- a/homeassistant/components/onedrive/services.py
+++ b/homeassistant/components/onedrive/services.py
@@ -52,12 +52,6 @@ def _read_file_contents(
             )
         if not Path(filename).exists():
             missing.append(filename)
-    if len(missing) == 1:
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="filename_does_not_exist",
-            translation_placeholders={"filename": missing[0]},
-        )
     if missing:
         raise HomeAssistantError(
             translation_domain=DOMAIN,

--- a/homeassistant/components/onedrive/services.py
+++ b/homeassistant/components/onedrive/services.py
@@ -42,6 +42,7 @@ def _read_file_contents(
     hass: HomeAssistant, filenames: list[str]
 ) -> list[tuple[str, bytes]]:
     """Return the mime types and file contents for each file."""
+    missing: list[str] = []
     results = []
     for filename in filenames:
         if not hass.config.is_allowed_path(filename):
@@ -52,11 +53,8 @@ def _read_file_contents(
             )
         filename_path = Path(filename)
         if not filename_path.exists():
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="filename_does_not_exist",
-                translation_placeholders={"filename": filename},
-            )
+            missing.append(filename)
+            continue
         if filename_path.stat().st_size > CONTENT_SIZE_LIMIT:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
@@ -68,6 +66,14 @@ def _read_file_contents(
                 },
             )
         results.append((filename_path.name, filename_path.read_bytes()))
+    if missing:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="filenames_do_not_exist",
+            translation_placeholders={
+                "filenames": ", ".join(f"`{f}`" for f in missing)
+            },
+        )
     return results
 
 

--- a/homeassistant/components/onedrive/services.py
+++ b/homeassistant/components/onedrive/services.py
@@ -43,7 +43,6 @@ def _read_file_contents(
 ) -> list[tuple[str, bytes]]:
     """Return the mime types and file contents for each file."""
     missing: list[str] = []
-    results = []
     for filename in filenames:
         if not hass.config.is_allowed_path(filename):
             raise HomeAssistantError(
@@ -51,21 +50,14 @@ def _read_file_contents(
                 translation_key="no_access_to_path",
                 translation_placeholders={"filename": filename},
             )
-        filename_path = Path(filename)
-        if not filename_path.exists():
+        if not Path(filename).exists():
             missing.append(filename)
-            continue
-        if filename_path.stat().st_size > CONTENT_SIZE_LIMIT:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="file_too_large",
-                translation_placeholders={
-                    "filename": filename,
-                    "size": str(filename_path.stat().st_size),
-                    "limit": str(CONTENT_SIZE_LIMIT),
-                },
-            )
-        results.append((filename_path.name, filename_path.read_bytes()))
+    if len(missing) == 1:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="filename_does_not_exist",
+            translation_placeholders={"filename": missing[0]},
+        )
     if missing:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
@@ -74,6 +66,21 @@ def _read_file_contents(
                 "filenames": ", ".join(f"`{f}`" for f in missing)
             },
         )
+    results = []
+    for filename in filenames:
+        filename_path = Path(filename)
+        file_size = filename_path.stat().st_size
+        if file_size > CONTENT_SIZE_LIMIT:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="file_too_large",
+                translation_placeholders={
+                    "filename": filename,
+                    "size": str(file_size),
+                    "limit": str(CONTENT_SIZE_LIMIT),
+                },
+            )
+        results.append((filename_path.name, filename_path.read_bytes()))
     return results
 
 

--- a/homeassistant/components/onedrive/strings.json
+++ b/homeassistant/components/onedrive/strings.json
@@ -102,9 +102,6 @@
     "file_too_large": {
       "message": "`{filename}` is too large ({size} > {limit})"
     },
-    "filename_does_not_exist": {
-      "message": "`{filename}` does not exist"
-    },
     "filenames_do_not_exist": {
       "message": "The following files do not exist: {filenames}"
     },

--- a/homeassistant/components/onedrive/strings.json
+++ b/homeassistant/components/onedrive/strings.json
@@ -105,6 +105,9 @@
     "filename_does_not_exist": {
       "message": "`{filename}` does not exist"
     },
+    "filenames_do_not_exist": {
+      "message": "The following file(s) do not exist: {filenames}"
+    },
     "no_access_to_path": {
       "message": "Cannot read {filename}, no access to path; `allowlist_external_dirs` may need to be adjusted in `configuration.yaml`"
     },

--- a/homeassistant/components/onedrive/strings.json
+++ b/homeassistant/components/onedrive/strings.json
@@ -106,7 +106,7 @@
       "message": "`{filename}` does not exist"
     },
     "filenames_do_not_exist": {
-      "message": "The following file(s) do not exist: {filenames}"
+      "message": "The following files do not exist: {filenames}"
     },
     "no_access_to_path": {
       "message": "Cannot read {filename}, no access to path; `allowlist_external_dirs` may need to be adjusted in `configuration.yaml`"

--- a/tests/components/onedrive/test_services.py
+++ b/tests/components/onedrive/test_services.py
@@ -194,7 +194,7 @@ async def test_filename_does_not_exist(
 ) -> None:
     """Test upload service call with a filename path that does not exist."""
     await setup_integration(hass, mock_config_entry)
-    with pytest.raises(HomeAssistantError, match="does not exist"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             UPLOAD_SERVICE,
@@ -206,6 +206,33 @@ async def test_filename_does_not_exist(
             blocking=True,
             return_response=True,
         )
+    assert exc_info.value.translation_key == "filenames_do_not_exist"
+    assert TEST_FILENAME in exc_info.value.translation_placeholders["filenames"]
+
+
+@pytest.mark.parametrize("upload_file", [MockUploadFile(exists=False)])
+async def test_multiple_filenames_do_not_exist(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test upload service reports all missing files, not just the first one."""
+    await setup_integration(hass, mock_config_entry)
+    second_filename = "other_snapshot.jpg"
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            UPLOAD_SERVICE,
+            {
+                CONF_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+                CONF_FILENAME: [TEST_FILENAME, second_filename],
+                CONF_DESTINATION_FOLDER: DESINATION_FOLDER,
+            },
+            blocking=True,
+            return_response=True,
+        )
+    assert exc_info.value.translation_key == "filenames_do_not_exist"
+    assert TEST_FILENAME in exc_info.value.translation_placeholders["filenames"]
+    assert second_filename in exc_info.value.translation_placeholders["filenames"]
 
 
 async def test_upload_service_fails_upload(

--- a/tests/components/onedrive/test_services.py
+++ b/tests/components/onedrive/test_services.py
@@ -206,8 +206,8 @@ async def test_filename_does_not_exist(
             blocking=True,
             return_response=True,
         )
-    assert exc_info.value.translation_key == "filenames_do_not_exist"
-    assert TEST_FILENAME in exc_info.value.translation_placeholders["filenames"]
+    assert exc_info.value.translation_key == "filename_does_not_exist"
+    assert exc_info.value.translation_placeholders["filename"] == TEST_FILENAME
 
 
 @pytest.mark.parametrize("upload_file", [MockUploadFile(exists=False)])

--- a/tests/components/onedrive/test_services.py
+++ b/tests/components/onedrive/test_services.py
@@ -206,8 +206,8 @@ async def test_filename_does_not_exist(
             blocking=True,
             return_response=True,
         )
-    assert exc_info.value.translation_key == "filename_does_not_exist"
-    assert exc_info.value.translation_placeholders["filename"] == TEST_FILENAME
+    assert exc_info.value.translation_key == "filenames_do_not_exist"
+    assert TEST_FILENAME in exc_info.value.translation_placeholders["filenames"]
 
 
 @pytest.mark.parametrize("upload_file", [MockUploadFile(exists=False)])


### PR DESCRIPTION
When uploading multiple files, if more than one file does not exist, only the first missing file was reported and the rest were silently ignored. This was because `_read_file_contents` raised a `HomeAssistantError` immediately on the first `Path.exists()` failure. This PR collects all missing filenames before raising, then surfaces all of them in a single `HomeAssistantError` using the new `filenames_do_not_exist` translation key.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
