### PR TITLE
Opower: fall back to usage-only reads when cost endpoint fails

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -563,9 +563,17 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
                 account, AggregateType.DAY, start, end
             )
         except ApiException as err:
-            # Fall back to coarser monthly data rather than crashing the coordinator.
-            _LOGGER.warning("Error getting daily cost reads, using monthly: %s", err)
-            return cost_reads
+            _LOGGER.warning(
+                "Error getting daily cost reads, falling back to usage-only: %s",
+                err,
+            )
+            try:
+                daily_cost_reads = await self.api.async_get_cost_reads(
+                    account, AggregateType.DAY, start, end, usage_only=True
+                )
+            except ApiException:
+                _LOGGER.warning("Usage-only daily reads also failed, using monthly")
+                return cost_reads
         _LOGGER.debug("Got %s daily cost reads", len(daily_cost_reads))
         _update_with_finer_cost_reads(cost_reads, daily_cost_reads)
         if account.read_resolution == ReadResolution.DAY:
@@ -582,11 +590,19 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
                 account, AggregateType.HOUR, start, end
             )
         except ApiException as err:
-            # Fall back to coarser data rather than crashing the coordinator.
             _LOGGER.warning(
-                "Error getting hourly cost reads, using coarser reads: %s", err
+                "Error getting hourly cost reads, falling back to usage-only: %s",
+                err,
             )
-            return cost_reads
+            try:
+                hourly_cost_reads = await self.api.async_get_cost_reads(
+                    account, AggregateType.HOUR, start, end, usage_only=True
+                )
+            except ApiException:
+                _LOGGER.warning(
+                    "Usage-only hourly reads also failed, using coarser reads"
+                )
+                return cost_reads
         _LOGGER.debug("Got %s hourly cost reads", len(hourly_cost_reads))
         _update_with_finer_cost_reads(cost_reads, hourly_cost_reads)
         _LOGGER.debug("Got %s cost reads", len(cost_reads))

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -583,7 +583,9 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
             )
         except ApiException as err:
             # Fall back to coarser data rather than crashing the coordinator.
-            _LOGGER.warning("Error getting hourly cost reads, using daily: %s", err)
+            _LOGGER.warning(
+                "Error getting hourly cost reads, using coarser reads: %s", err
+            )
             return cost_reads
         _LOGGER.debug("Got %s hourly cost reads", len(hourly_cost_reads))
         _update_with_finer_cost_reads(cost_reads, hourly_cost_reads)

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -563,8 +563,9 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
                 account, AggregateType.DAY, start, end
             )
         except ApiException as err:
-            _LOGGER.error("Error getting daily cost reads: %s", err)
-            raise
+            # Fall back to coarser monthly data rather than crashing the coordinator.
+            _LOGGER.warning("Error getting daily cost reads, using monthly: %s", err)
+            return cost_reads
         _LOGGER.debug("Got %s daily cost reads", len(daily_cost_reads))
         _update_with_finer_cost_reads(cost_reads, daily_cost_reads)
         if account.read_resolution == ReadResolution.DAY:
@@ -581,8 +582,9 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
                 account, AggregateType.HOUR, start, end
             )
         except ApiException as err:
-            _LOGGER.error("Error getting hourly cost reads: %s", err)
-            raise
+            # Fall back to coarser data rather than crashing the coordinator.
+            _LOGGER.warning("Error getting hourly cost reads, using daily: %s", err)
+            return cost_reads
         _LOGGER.debug("Got %s hourly cost reads", len(hourly_cost_reads))
         _update_with_finer_cost_reads(cost_reads, hourly_cost_reads)
         _LOGGER.debug("Got %s cost reads", len(cost_reads))

--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -299,7 +299,7 @@ async def test_coordinator_cost_reads_fallback_on_api_error(
     mock_opower_api: AsyncMock,
     failing_aggregate_type: AggregateType,
 ) -> None:
-    """Test that daily/hourly cost read failures fall back to coarser data."""
+    """Test that daily/hourly cost read failures fall back to usage-only reads."""
     coordinator = OpowerCoordinator(hass, mock_config_entry)
 
     # Use a single ELEC account with HOUR resolution so all read levels are attempted
@@ -311,20 +311,26 @@ async def test_coordinator_cost_reads_fallback_on_api_error(
     bill_read = CostRead(
         start_time=t1, end_time=t2, consumption=10.0, provided_cost=1.0
     )
+    usage_read = CostRead(
+        start_time=t1, end_time=t2, consumption=10.0, provided_cost=0.0
+    )
 
     async def side_effect(
         acc: object,
         agg_type: AggregateType,
         start: object,
         end: object,
+        usage_only: bool = False,
     ) -> list[CostRead]:
-        if agg_type == failing_aggregate_type:
+        if agg_type == failing_aggregate_type and not usage_only:
             raise ApiException(message="HTTP Error: 500", url="http://example.com")
+        if usage_only:
+            return [usage_read]
         return [bill_read]
 
     mock_opower_api.async_get_cost_reads.side_effect = side_effect
 
-    # Should NOT raise — the coordinator should fall back to coarser data
+    # Should NOT raise — the coordinator should fall back to usage-only reads
     result = await coordinator._async_update_data()
     await async_wait_recording_done(hass)
     assert result is not None

--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -326,6 +326,7 @@ async def test_coordinator_cost_reads_fallback_on_api_error(
 
     # Should NOT raise — the coordinator should fall back to coarser data
     result = await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
     assert result is not None
 
 

--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -250,8 +250,6 @@ async def test_coordinator_migration(
         ("async_get_accounts", None),
         ("async_get_forecast", None),
         ("async_get_cost_reads", AggregateType.BILL),
-        ("async_get_cost_reads", AggregateType.DAY),
-        ("async_get_cost_reads", AggregateType.HOUR),
     ],
 )
 async def test_coordinator_api_exceptions(
@@ -288,6 +286,47 @@ async def test_coordinator_api_exceptions(
 
     with pytest.raises(ApiException):
         await coordinator._async_update_data()
+
+
+@pytest.mark.parametrize(
+    "failing_aggregate_type",
+    [AggregateType.DAY, AggregateType.HOUR],
+)
+async def test_coordinator_cost_reads_fallback_on_api_error(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opower_api: AsyncMock,
+    failing_aggregate_type: AggregateType,
+) -> None:
+    """Test that daily/hourly cost read failures fall back to coarser data."""
+    coordinator = OpowerCoordinator(hass, mock_config_entry)
+
+    # Use a single ELEC account with HOUR resolution so all read levels are attempted
+    account = mock_opower_api.async_get_accounts.return_value[0]
+    mock_opower_api.async_get_accounts.return_value = [account]
+
+    t1 = dt_util.as_utc(datetime(2023, 1, 1, 0))
+    t2 = dt_util.as_utc(datetime(2023, 1, 2, 0))
+    bill_read = CostRead(
+        start_time=t1, end_time=t2, consumption=10.0, provided_cost=1.0
+    )
+
+    async def side_effect(
+        acc: object,
+        agg_type: AggregateType,
+        start: object,
+        end: object,
+    ) -> list[CostRead]:
+        if agg_type == failing_aggregate_type:
+            raise ApiException(message="HTTP Error: 500", url="http://example.com")
+        return [bill_read]
+
+    mock_opower_api.async_get_cost_reads.side_effect = side_effect
+
+    # Should NOT raise — the coordinator should fall back to coarser data
+    result = await coordinator._async_update_data()
+    assert result is not None
 
 
 async def test_coordinator_updates_with_finer_grained_data(


### PR DESCRIPTION
## Proposed change

When the Opower cost API returns an error (e.g., HTTP 500) for daily or hourly cost reads, retry with the usage-only endpoint before falling back to coarser data. This preserves consumption statistics at the original granularity (daily/hourly) rather than degrading to monthly.

Some utilities like ConEd return HTTP 500 from the REST cost endpoint for daily/hourly aggregation, while the usage-only endpoint works fine at those granularities. The account reports `read_resolution: QUARTER_HOUR`, and granular data does exist — it's specifically the cost endpoint that fails.

The fallback chain is now:
1. Try cost endpoint (includes both consumption and cost)
2. If that fails, try usage-only endpoint (consumption only, cost=0)
3. If that also fails, return whatever coarser data was already fetched

Previously, any cost read failure at the daily or hourly level would crash the `DataUpdateCoordinator`. On retry, `async_login()` would be called again within the same TOTP window, causing the reused code to be rejected — creating a permanent reauth repair loop with no user-recoverable path.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Additional information

- Affects any utility where the Opower cost API returns persistent errors at the daily/hourly level (ConEd, PSE, PG&E have all been reported)
- The TOTP reuse on retry is tracked upstream at [tronikos/opower#52](https://github.com/tronikos/opower/issues/52); this PR prevents the coordinator crash that triggers it

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

Fixes #169223