### PR TITLE
Add new params to actions of easyEnergy integration

### DIFF
--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -8,6 +8,7 @@ from typing import Final
 from easyenergy import (
     Electricity,
     ElectricityGranularity,
+    ElectricityPriceType,
     Gas,
     PriceInterval,
     VatOption,
@@ -41,7 +42,7 @@ ENERGY_USAGE_SERVICE_NAME: Final = "get_energy_usage_prices"
 ENERGY_RETURN_SERVICE_NAME: Final = "get_energy_return_prices"
 
 
-class PriceType(StrEnum):
+class ServicePriceType(StrEnum):
     """Type of price."""
 
     ENERGY_USAGE = "energy_usage"
@@ -49,26 +50,12 @@ class PriceType(StrEnum):
     GAS = "gas"
 
 
-class UsagePriceType(StrEnum):
-    """Type of usage price."""
-
-    MARKET = "market"
-    ALL_IN = "all_in"
-
-
-class Granularity(StrEnum):
-    """Price granularity."""
-
-    HOUR = "hour"
-    QUARTER = "quarter"
-
-
-GRANULARITY_MAP: Final = {
-    Granularity.HOUR.value: ElectricityGranularity.HOUR,
-    Granularity.QUARTER.value: ElectricityGranularity.QUARTER,
-}
-GRANULARITY_OPTIONS: Final = (Granularity.HOUR.value, Granularity.QUARTER.value)
-PRICE_TYPE_OPTIONS: Final = (UsagePriceType.MARKET.value, UsagePriceType.ALL_IN.value)
+GRANULARITY_OPTIONS: Final = tuple(
+    granularity.value for granularity in ElectricityGranularity
+)
+PRICE_TYPE_OPTIONS: Final = tuple(
+    electricity_price_type.value for electricity_price_type in ElectricityPriceType
+)
 
 BASE_SERVICE_SCHEMA: Final = vol.Schema(
     {
@@ -84,27 +71,27 @@ BASE_SERVICE_SCHEMA: Final = vol.Schema(
 GAS_SERVICE_SCHEMA: Final = BASE_SERVICE_SCHEMA.extend(
     {
         vol.Required(ATTR_INCL_VAT): bool,
-        vol.Optional(ATTR_PRICE_TYPE, default=UsagePriceType.MARKET.value): vol.In(
-            PRICE_TYPE_OPTIONS
-        ),
+        vol.Optional(
+            ATTR_PRICE_TYPE, default=ElectricityPriceType.MARKET.value
+        ): vol.In(PRICE_TYPE_OPTIONS),
     }
 )
 ENERGY_USAGE_SERVICE_SCHEMA: Final = BASE_SERVICE_SCHEMA.extend(
     {
         vol.Required(ATTR_INCL_VAT): bool,
-        vol.Optional(ATTR_GRANULARITY, default=Granularity.HOUR.value): vol.In(
-            GRANULARITY_OPTIONS
-        ),
-        vol.Optional(ATTR_PRICE_TYPE, default=UsagePriceType.MARKET.value): vol.In(
-            PRICE_TYPE_OPTIONS
-        ),
+        vol.Optional(
+            ATTR_GRANULARITY, default=ElectricityGranularity.HOUR.value
+        ): vol.In(GRANULARITY_OPTIONS),
+        vol.Optional(
+            ATTR_PRICE_TYPE, default=ElectricityPriceType.MARKET.value
+        ): vol.In(PRICE_TYPE_OPTIONS),
     }
 )
 ENERGY_RETURN_SERVICE_SCHEMA: Final = BASE_SERVICE_SCHEMA.extend(
     {
-        vol.Optional(ATTR_GRANULARITY, default=Granularity.HOUR.value): vol.In(
-            GRANULARITY_OPTIONS
-        ),
+        vol.Optional(
+            ATTR_GRANULARITY, default=ElectricityGranularity.HOUR.value
+        ): vol.In(GRANULARITY_OPTIONS),
     }
 )
 
@@ -176,7 +163,7 @@ def __get_coordinator(call: ServiceCall) -> EasyEnergyDataUpdateCoordinator:
 async def __get_prices(
     call: ServiceCall,
     *,
-    price_type: PriceType,
+    service_price_type: ServicePriceType,
 ) -> ServiceResponse:
     """Get prices from easyEnergy."""
     coordinator = __get_coordinator(call)
@@ -191,13 +178,13 @@ async def __get_prices(
     data: Electricity | Gas
     prices: list[dict[str, float | datetime]]
 
-    if price_type == PriceType.GAS:
+    if service_price_type == ServicePriceType.GAS:
         data = await coordinator.easyenergy.gas_prices(
             start_date=start_date,
             end_date=end_date,
             vat=vat,
         )
-        if call.data[ATTR_PRICE_TYPE] == UsagePriceType.ALL_IN.value:
+        if call.data[ATTR_PRICE_TYPE] == ElectricityPriceType.INVOICE.value:
             prices = [
                 {"timestamp": interval.starts_at, "price": interval.invoice_price}
                 for interval in data.intervals
@@ -208,12 +195,12 @@ async def __get_prices(
         data = await coordinator.easyenergy.energy_prices(
             start_date=start_date,
             end_date=end_date,
-            granularity=GRANULARITY_MAP[call.data[ATTR_GRANULARITY]],
+            granularity=ElectricityGranularity(call.data[ATTR_GRANULARITY]),
             vat=vat,
         )
 
-        if price_type == PriceType.ENERGY_USAGE:
-            if call.data[ATTR_PRICE_TYPE] == UsagePriceType.ALL_IN.value:
+        if service_price_type == ServicePriceType.ENERGY_USAGE:
+            if call.data[ATTR_PRICE_TYPE] == ElectricityPriceType.INVOICE.value:
                 prices = [
                     {"timestamp": interval.starts_at, "price": interval.invoice_price}
                     for interval in data.intervals
@@ -247,21 +234,21 @@ def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         GAS_SERVICE_NAME,
-        partial(__get_prices, price_type=PriceType.GAS),
+        partial(__get_prices, service_price_type=ServicePriceType.GAS),
         schema=GAS_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
         ENERGY_USAGE_SERVICE_NAME,
-        partial(__get_prices, price_type=PriceType.ENERGY_USAGE),
+        partial(__get_prices, service_price_type=ServicePriceType.ENERGY_USAGE),
         schema=ENERGY_USAGE_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
         ENERGY_RETURN_SERVICE_NAME,
-        partial(__get_prices, price_type=PriceType.ENERGY_RETURN),
+        partial(__get_prices, service_price_type=ServicePriceType.ENERGY_RETURN),
         schema=ENERGY_RETURN_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )

--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -5,7 +5,13 @@ from enum import StrEnum
 from functools import partial
 from typing import Final
 
-from easyenergy import Electricity, Gas, PriceInterval, VatOption
+from easyenergy import (
+    Electricity,
+    ElectricityGranularity,
+    Gas,
+    PriceInterval,
+    VatOption,
+)
 from easyenergy.const import MARKET_TIMEZONE
 import voluptuous as vol
 
@@ -27,20 +33,12 @@ ATTR_CONFIG_ENTRY: Final = "config_entry"
 ATTR_START: Final = "start"
 ATTR_END: Final = "end"
 ATTR_INCL_VAT: Final = "incl_vat"
+ATTR_GRANULARITY: Final = "granularity"
 ATTR_PRICE_TYPE: Final = "price_type"
 
 GAS_SERVICE_NAME: Final = "get_gas_prices"
 ENERGY_USAGE_SERVICE_NAME: Final = "get_energy_usage_prices"
 ENERGY_RETURN_SERVICE_NAME: Final = "get_energy_return_prices"
-BASE_SERVICE_SCHEMA: Final = {
-    vol.Required(ATTR_CONFIG_ENTRY): selector.ConfigEntrySelector(
-        {
-            "integration": DOMAIN,
-        }
-    ),
-    vol.Optional(ATTR_START): str,
-    vol.Optional(ATTR_END): str,
-}
 
 
 class PriceType(StrEnum):
@@ -58,16 +56,57 @@ class UsagePriceType(StrEnum):
     ALL_IN = "all_in"
 
 
-USAGE_SERVICE_SCHEMA: Final = vol.Schema(
+class Granularity(StrEnum):
+    """Price granularity."""
+
+    HOUR = "hour"
+    QUARTER = "quarter"
+
+
+GRANULARITY_MAP: Final = {
+    Granularity.HOUR.value: ElectricityGranularity.HOUR,
+    Granularity.QUARTER.value: ElectricityGranularity.QUARTER,
+}
+GRANULARITY_OPTIONS: Final = (Granularity.HOUR.value, Granularity.QUARTER.value)
+PRICE_TYPE_OPTIONS: Final = (UsagePriceType.MARKET.value, UsagePriceType.ALL_IN.value)
+
+BASE_SERVICE_SCHEMA: Final = vol.Schema(
     {
-        **BASE_SERVICE_SCHEMA,
+        vol.Required(ATTR_CONFIG_ENTRY): selector.ConfigEntrySelector(
+            {
+                "integration": DOMAIN,
+            }
+        ),
+        vol.Optional(ATTR_START): str,
+        vol.Optional(ATTR_END): str,
+    }
+)
+GAS_SERVICE_SCHEMA: Final = BASE_SERVICE_SCHEMA.extend(
+    {
         vol.Required(ATTR_INCL_VAT): bool,
         vol.Optional(ATTR_PRICE_TYPE, default=UsagePriceType.MARKET.value): vol.In(
-            (UsagePriceType.MARKET.value, UsagePriceType.ALL_IN.value)
+            PRICE_TYPE_OPTIONS
         ),
     }
 )
-RETURN_SERVICE_SCHEMA: Final = vol.Schema(BASE_SERVICE_SCHEMA)
+ENERGY_USAGE_SERVICE_SCHEMA: Final = BASE_SERVICE_SCHEMA.extend(
+    {
+        vol.Required(ATTR_INCL_VAT): bool,
+        vol.Optional(ATTR_GRANULARITY, default=Granularity.HOUR.value): vol.In(
+            GRANULARITY_OPTIONS
+        ),
+        vol.Optional(ATTR_PRICE_TYPE, default=UsagePriceType.MARKET.value): vol.In(
+            PRICE_TYPE_OPTIONS
+        ),
+    }
+)
+ENERGY_RETURN_SERVICE_SCHEMA: Final = BASE_SERVICE_SCHEMA.extend(
+    {
+        vol.Optional(ATTR_GRANULARITY, default=Granularity.HOUR.value): vol.In(
+            GRANULARITY_OPTIONS
+        ),
+    }
+)
 
 
 def __get_date(
@@ -169,6 +208,7 @@ async def __get_prices(
         data = await coordinator.easyenergy.energy_prices(
             start_date=start_date,
             end_date=end_date,
+            granularity=GRANULARITY_MAP[call.data[ATTR_GRANULARITY]],
             vat=vat,
         )
 
@@ -208,20 +248,20 @@ def async_setup_services(hass: HomeAssistant) -> None:
         DOMAIN,
         GAS_SERVICE_NAME,
         partial(__get_prices, price_type=PriceType.GAS),
-        schema=USAGE_SERVICE_SCHEMA,
+        schema=GAS_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
         ENERGY_USAGE_SERVICE_NAME,
         partial(__get_prices, price_type=PriceType.ENERGY_USAGE),
-        schema=USAGE_SERVICE_SCHEMA,
+        schema=ENERGY_USAGE_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
         ENERGY_RETURN_SERVICE_NAME,
         partial(__get_prices, price_type=PriceType.ENERGY_RETURN),
-        schema=RETURN_SERVICE_SCHEMA,
+        schema=ENERGY_RETURN_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )

--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -215,8 +215,8 @@ async def __get_prices(
         if price_type == PriceType.ENERGY_USAGE:
             if call.data[ATTR_PRICE_TYPE] == UsagePriceType.ALL_IN.value:
                 prices = [
-                    {"timestamp": timestamp, "price": price}
-                    for timestamp, price in data.invoice_prices.items()
+                    {"timestamp": interval.starts_at, "price": interval.invoice_price}
+                    for interval in data.intervals
                 ]
             else:
                 prices = data.timestamp_prices

--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -152,6 +152,19 @@ def __serialize_prices(prices: list[dict[str, float | datetime]]) -> ServiceResp
     }
 
 
+def __select_prices(
+    data: Electricity | Gas, use_invoice: bool
+) -> list[dict[str, float | datetime]]:
+    """Select market or invoice prices from price data."""
+    if not use_invoice:
+        return data.timestamp_prices
+
+    return [
+        {"timestamp": interval.starts_at, "price": interval.invoice_price}
+        for interval in data.intervals
+    ]
+
+
 def __get_coordinator(call: ServiceCall) -> EasyEnergyDataUpdateCoordinator:
     """Get the coordinator from the entry."""
     entry: EasyEnergyConfigEntry = service.async_get_config_entry(
@@ -184,13 +197,9 @@ async def __get_prices(
             end_date=end_date,
             vat=vat,
         )
-        if call.data[ATTR_PRICE_TYPE] == ElectricityPriceType.INVOICE.value:
-            prices = [
-                {"timestamp": interval.starts_at, "price": interval.invoice_price}
-                for interval in data.intervals
-            ]
-        else:
-            prices = data.timestamp_prices
+        prices = __select_prices(
+            data, call.data[ATTR_PRICE_TYPE] == ElectricityPriceType.INVOICE.value
+        )
     else:
         data = await coordinator.easyenergy.energy_prices(
             start_date=start_date,
@@ -200,13 +209,9 @@ async def __get_prices(
         )
 
         if service_price_type == ServicePriceType.ENERGY_USAGE:
-            if call.data[ATTR_PRICE_TYPE] == ElectricityPriceType.INVOICE.value:
-                prices = [
-                    {"timestamp": interval.starts_at, "price": interval.invoice_price}
-                    for interval in data.intervals
-                ]
-            else:
-                prices = data.timestamp_prices
+            prices = __select_prices(
+                data, call.data[ATTR_PRICE_TYPE] == ElectricityPriceType.INVOICE.value
+            )
         else:
             prices = data.timestamp_return_prices
 

--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -27,6 +27,7 @@ ATTR_CONFIG_ENTRY: Final = "config_entry"
 ATTR_START: Final = "start"
 ATTR_END: Final = "end"
 ATTR_INCL_VAT: Final = "incl_vat"
+ATTR_PRICE_TYPE: Final = "price_type"
 
 GAS_SERVICE_NAME: Final = "get_gas_prices"
 ENERGY_USAGE_SERVICE_NAME: Final = "get_energy_usage_prices"
@@ -40,13 +41,6 @@ BASE_SERVICE_SCHEMA: Final = {
     vol.Optional(ATTR_START): str,
     vol.Optional(ATTR_END): str,
 }
-SERVICE_SCHEMA: Final = vol.Schema(
-    {
-        **BASE_SERVICE_SCHEMA,
-        vol.Required(ATTR_INCL_VAT): bool,
-    }
-)
-RETURN_SERVICE_SCHEMA: Final = vol.Schema(BASE_SERVICE_SCHEMA)
 
 
 class PriceType(StrEnum):
@@ -55,6 +49,25 @@ class PriceType(StrEnum):
     ENERGY_USAGE = "energy_usage"
     ENERGY_RETURN = "energy_return"
     GAS = "gas"
+
+
+class UsagePriceType(StrEnum):
+    """Type of usage price."""
+
+    MARKET = "market"
+    ALL_IN = "all_in"
+
+
+USAGE_SERVICE_SCHEMA: Final = vol.Schema(
+    {
+        **BASE_SERVICE_SCHEMA,
+        vol.Required(ATTR_INCL_VAT): bool,
+        vol.Optional(ATTR_PRICE_TYPE, default=UsagePriceType.MARKET.value): vol.In(
+            (UsagePriceType.MARKET.value, UsagePriceType.ALL_IN.value)
+        ),
+    }
+)
+RETURN_SERVICE_SCHEMA: Final = vol.Schema(BASE_SERVICE_SCHEMA)
 
 
 def __get_date(
@@ -137,6 +150,7 @@ async def __get_prices(
         vat = VatOption.EXCLUDE
 
     data: Electricity | Gas
+    prices: list[dict[str, float | datetime]]
 
     if price_type == PriceType.GAS:
         data = await coordinator.easyenergy.gas_prices(
@@ -144,7 +158,13 @@ async def __get_prices(
             end_date=end_date,
             vat=vat,
         )
-        prices = data.timestamp_prices
+        if call.data[ATTR_PRICE_TYPE] == UsagePriceType.ALL_IN.value:
+            prices = [
+                {"timestamp": interval.starts_at, "price": interval.invoice_price}
+                for interval in data.intervals
+            ]
+        else:
+            prices = data.timestamp_prices
     else:
         data = await coordinator.easyenergy.energy_prices(
             start_date=start_date,
@@ -153,7 +173,13 @@ async def __get_prices(
         )
 
         if price_type == PriceType.ENERGY_USAGE:
-            prices = data.timestamp_prices
+            if call.data[ATTR_PRICE_TYPE] == UsagePriceType.ALL_IN.value:
+                prices = [
+                    {"timestamp": timestamp, "price": price}
+                    for timestamp, price in data.invoice_prices.items()
+                ]
+            else:
+                prices = data.timestamp_prices
         else:
             prices = data.timestamp_return_prices
 
@@ -182,14 +208,14 @@ def async_setup_services(hass: HomeAssistant) -> None:
         DOMAIN,
         GAS_SERVICE_NAME,
         partial(__get_prices, price_type=PriceType.GAS),
-        schema=SERVICE_SCHEMA,
+        schema=USAGE_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
         ENERGY_USAGE_SERVICE_NAME,
         partial(__get_prices, price_type=PriceType.ENERGY_USAGE),
-        schema=SERVICE_SCHEMA,
+        schema=USAGE_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(

--- a/homeassistant/components/easyenergy/services.yaml
+++ b/homeassistant/components/easyenergy/services.yaml
@@ -42,6 +42,16 @@ get_energy_usage_prices:
       default: true
       selector:
         boolean:
+    granularity:
+      required: false
+      default: hour
+      selector:
+        select:
+          options:
+            - label: Hour
+              value: hour
+            - label: Quarter
+              value: quarter
     price_type:
       required: false
       default: market
@@ -69,6 +79,16 @@ get_energy_return_prices:
       selector:
         config_entry:
           integration: easyenergy
+    granularity:
+      required: false
+      default: hour
+      selector:
+        select:
+          options:
+            - label: Hour
+              value: hour
+            - label: Quarter
+              value: quarter
     start:
       required: false
       example: "2024-01-01 00:00:00"

--- a/homeassistant/components/easyenergy/services.yaml
+++ b/homeassistant/components/easyenergy/services.yaml
@@ -10,6 +10,16 @@ get_gas_prices:
       default: true
       selector:
         boolean:
+    price_type:
+      required: false
+      default: market
+      selector:
+        select:
+          options:
+            - label: Market price
+              value: market
+            - label: All-in price
+              value: all_in
     start:
       required: false
       example: "2024-01-01 00:00:00"
@@ -32,6 +42,16 @@ get_energy_usage_prices:
       default: true
       selector:
         boolean:
+    price_type:
+      required: false
+      default: market
+      selector:
+        select:
+          options:
+            - label: Market price
+              value: market
+            - label: All-in price
+              value: all_in
     start:
       required: false
       example: "2024-01-01 00:00:00"

--- a/homeassistant/components/easyenergy/services.yaml
+++ b/homeassistant/components/easyenergy/services.yaml
@@ -19,7 +19,7 @@ get_gas_prices:
             - label: Market price
               value: market
             - label: All-in price
-              value: all_in
+              value: invoice
     start:
       required: false
       example: "2024-01-01 00:00:00"
@@ -61,7 +61,7 @@ get_energy_usage_prices:
             - label: Market price
               value: market
             - label: All-in price
-              value: all_in
+              value: invoice
     start:
       required: false
       example: "2024-01-01 00:00:00"

--- a/homeassistant/components/easyenergy/services.yaml
+++ b/homeassistant/components/easyenergy/services.yaml
@@ -15,11 +15,10 @@ get_gas_prices:
       default: market
       selector:
         select:
+          translation_key: price_type_selector
           options:
-            - label: Market price
-              value: market
-            - label: All-in price
-              value: invoice
+            - market
+            - invoice
     start:
       required: false
       example: "2024-01-01 00:00:00"
@@ -47,21 +46,19 @@ get_energy_usage_prices:
       default: hour
       selector:
         select:
+          translation_key: granularity_selector
           options:
-            - label: Hour
-              value: hour
-            - label: Quarter
-              value: quarter
+            - hour
+            - quarter
     price_type:
       required: false
       default: market
       selector:
         select:
+          translation_key: price_type_selector
           options:
-            - label: Market price
-              value: market
-            - label: All-in price
-              value: invoice
+            - market
+            - invoice
     start:
       required: false
       example: "2024-01-01 00:00:00"
@@ -84,11 +81,10 @@ get_energy_return_prices:
       default: hour
       selector:
         select:
+          translation_key: granularity_selector
           options:
-            - label: Hour
-              value: hour
-            - label: Quarter
-              value: quarter
+            - hour
+            - quarter
     start:
       required: false
       example: "2024-01-01 00:00:00"

--- a/homeassistant/components/easyenergy/strings.json
+++ b/homeassistant/components/easyenergy/strings.json
@@ -54,6 +54,20 @@
       "message": "Invalid date provided. Got {date}"
     }
   },
+  "selector": {
+    "granularity_selector": {
+      "options": {
+        "hour": "Hour",
+        "quarter": "Quarter"
+      }
+    },
+    "price_type_selector": {
+      "options": {
+        "invoice": "All-in price",
+        "market": "Market price"
+      }
+    }
+  },
   "services": {
     "get_energy_return_prices": {
       "description": "Requests return energy prices from easyEnergy.",

--- a/homeassistant/components/easyenergy/strings.json
+++ b/homeassistant/components/easyenergy/strings.json
@@ -123,7 +123,7 @@
           "name": "VAT included"
         },
         "price_type": {
-          "description": "The type of usage prices to retrieve.",
+          "description": "The type of prices to retrieve.",
           "name": "Price type"
         },
         "start": {

--- a/homeassistant/components/easyenergy/strings.json
+++ b/homeassistant/components/easyenergy/strings.json
@@ -88,6 +88,10 @@
           "description": "[%key:component::easyenergy::services::get_gas_prices::fields::incl_vat::description%]",
           "name": "[%key:component::easyenergy::services::get_gas_prices::fields::incl_vat::name%]"
         },
+        "price_type": {
+          "description": "[%key:component::easyenergy::services::get_gas_prices::fields::price_type::description%]",
+          "name": "[%key:component::easyenergy::services::get_gas_prices::fields::price_type::name%]"
+        },
         "start": {
           "description": "[%key:component::easyenergy::services::get_gas_prices::fields::start::description%]",
           "name": "[%key:component::easyenergy::services::get_gas_prices::fields::start::name%]"
@@ -109,6 +113,10 @@
         "incl_vat": {
           "description": "Whether the prices should include VAT.",
           "name": "VAT included"
+        },
+        "price_type": {
+          "description": "The type of usage prices to retrieve.",
+          "name": "Price type"
         },
         "start": {
           "description": "Specifies the date and time from which to retrieve prices. Defaults to today if omitted.",

--- a/homeassistant/components/easyenergy/strings.json
+++ b/homeassistant/components/easyenergy/strings.json
@@ -66,6 +66,10 @@
           "description": "[%key:component::easyenergy::services::get_gas_prices::fields::end::description%]",
           "name": "[%key:component::easyenergy::services::get_gas_prices::fields::end::name%]"
         },
+        "granularity": {
+          "description": "[%key:component::easyenergy::services::get_energy_usage_prices::fields::granularity::description%]",
+          "name": "[%key:component::easyenergy::services::get_energy_usage_prices::fields::granularity::name%]"
+        },
         "start": {
           "description": "[%key:component::easyenergy::services::get_gas_prices::fields::start::description%]",
           "name": "[%key:component::easyenergy::services::get_gas_prices::fields::start::name%]"
@@ -83,6 +87,10 @@
         "end": {
           "description": "[%key:component::easyenergy::services::get_gas_prices::fields::end::description%]",
           "name": "[%key:component::easyenergy::services::get_gas_prices::fields::end::name%]"
+        },
+        "granularity": {
+          "description": "The interval size for the electricity prices.",
+          "name": "Granularity"
         },
         "incl_vat": {
           "description": "[%key:component::easyenergy::services::get_gas_prices::fields::incl_vat::description%]",

--- a/tests/components/easyenergy/test_init.py
+++ b/tests/components/easyenergy/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the easyEnergy integration."""
 
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 from easyenergy import EasyEnergyConnectionError, EasyEnergyNoDataError
@@ -62,3 +63,28 @@ async def test_config_flow_entry_not_ready(
 
     assert mock_request.call_count == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.freeze_time("2026-04-19 14:00:00+00:00")
+async def test_no_energy_tomorrow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_easyenergy: MagicMock
+) -> None:
+    """Test the coordinator handles missing tomorrow energy prices."""
+    mock_easyenergy.energy_prices.side_effect = [
+        mock_easyenergy.energy_prices.return_value,
+        EasyEnergyNoDataError,
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.runtime_data.data.energy_tomorrow is None
+    assert mock_easyenergy.energy_prices.call_count == 2
+    mock_easyenergy.energy_prices.assert_any_call(
+        start_date=date(2026, 4, 19), end_date=date(2026, 4, 19)
+    )
+    mock_easyenergy.energy_prices.assert_any_call(
+        start_date=date(2026, 4, 20), end_date=date(2026, 4, 20)
+    )

--- a/tests/components/easyenergy/test_services.py
+++ b/tests/components/easyenergy/test_services.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components.easyenergy.const import DOMAIN
 from homeassistant.components.easyenergy.services import (
     ATTR_CONFIG_ENTRY,
+    ATTR_PRICE_TYPE,
     ENERGY_RETURN_SERVICE_NAME,
     ENERGY_USAGE_SERVICE_NAME,
     GAS_SERVICE_NAME,
@@ -137,6 +138,65 @@ async def test_service_filters_datetime_range(
         mock_easyenergy.gas_prices.assert_not_called()
 
 
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("service", "expected_prices"),
+    [
+        (
+            GAS_SERVICE_NAME,
+            [
+                {"timestamp": "2026-04-18 22:00:00+00:00", "price": 1.4227},
+            ],
+        ),
+        (
+            ENERGY_USAGE_SERVICE_NAME,
+            [
+                {"timestamp": "2026-04-19 00:00:00+00:00", "price": 0.26476},
+                {"timestamp": "2026-04-19 01:00:00+00:00", "price": 0.25756},
+                {"timestamp": "2026-04-19 02:00:00+00:00", "price": 0.25782},
+            ],
+        ),
+    ],
+)
+async def test_usage_services_all_in_price_type(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_easyenergy: MagicMock,
+    service: str,
+    expected_prices: list[dict[str, str | float]],
+) -> None:
+    """Test usage services can return all-in prices."""
+    mock_easyenergy.reset_mock()
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        service,
+        {
+            ATTR_CONFIG_ENTRY: mock_config_entry.entry_id,
+            ATTR_PRICE_TYPE: "all_in",
+            "incl_vat": True,
+            "start": "2026-04-19 02:00:00+02:00",
+            "end": "2026-04-19 05:00:00+02:00",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response == {"prices": expected_prices}
+
+    expected_call = {
+        "start_date": date(2026, 4, 19),
+        "end_date": date(2026, 4, 19),
+        "vat": VatOption.INCLUDE,
+    }
+    if service == GAS_SERVICE_NAME:
+        mock_easyenergy.gas_prices.assert_called_once_with(**expected_call)
+        mock_easyenergy.energy_prices.assert_not_called()
+    else:
+        mock_easyenergy.energy_prices.assert_called_once_with(**expected_call)
+        mock_easyenergy.gas_prices.assert_not_called()
+
+
 @pytest.fixture
 def config_entry_data(
     mock_config_entry: MockConfigEntry, request: pytest.FixtureRequest
@@ -200,6 +260,40 @@ async def test_service_schema_validation_vat(
     error_message: str,
 ) -> None:
     """Test easyEnergy service schema validation for VAT."""
+
+    with pytest.raises(vol.er.Error, match=error_message):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {ATTR_CONFIG_ENTRY: mock_config_entry.entry_id} | service_data,
+            blocking=True,
+            return_response=True,
+        )
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize("service", [GAS_SERVICE_NAME, ENERGY_USAGE_SERVICE_NAME])
+@pytest.mark.parametrize(
+    ("service_data", "error_message"),
+    [
+        (
+            {"incl_vat": True, ATTR_PRICE_TYPE: "incorrect price type"},
+            "value must be one of .+",
+        ),
+        (
+            {"incl_vat": True, ATTR_PRICE_TYPE: True},
+            "value must be one of .+",
+        ),
+    ],
+)
+async def test_service_schema_validation_usage_price_type(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    service_data: dict[str, str | bool],
+    error_message: str,
+) -> None:
+    """Test usage service schema validation for price type."""
 
     with pytest.raises(vol.er.Error, match=error_message):
         await hass.services.async_call(

--- a/tests/components/easyenergy/test_services.py
+++ b/tests/components/easyenergy/test_services.py
@@ -3,7 +3,7 @@
 from datetime import date
 from unittest.mock import MagicMock
 
-from easyenergy import VatOption
+from easyenergy import ElectricityGranularity, VatOption
 import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components.easyenergy.const import DOMAIN
 from homeassistant.components.easyenergy.services import (
     ATTR_CONFIG_ENTRY,
+    ATTR_GRANULARITY,
     ATTR_PRICE_TYPE,
     ENERGY_RETURN_SERVICE_NAME,
     ENERGY_USAGE_SERVICE_NAME,
@@ -134,6 +135,7 @@ async def test_service_filters_datetime_range(
         mock_easyenergy.gas_prices.assert_called_once_with(**expected_call)
         mock_easyenergy.energy_prices.assert_not_called()
     else:
+        expected_call["granularity"] = ElectricityGranularity.HOUR
         mock_easyenergy.energy_prices.assert_called_once_with(**expected_call)
         mock_easyenergy.gas_prices.assert_not_called()
 
@@ -193,8 +195,52 @@ async def test_usage_services_all_in_price_type(
         mock_easyenergy.gas_prices.assert_called_once_with(**expected_call)
         mock_easyenergy.energy_prices.assert_not_called()
     else:
+        expected_call["granularity"] = ElectricityGranularity.HOUR
         mock_easyenergy.energy_prices.assert_called_once_with(**expected_call)
         mock_easyenergy.gas_prices.assert_not_called()
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "service",
+    [
+        ENERGY_USAGE_SERVICE_NAME,
+        ENERGY_RETURN_SERVICE_NAME,
+    ],
+)
+async def test_energy_services_quarter_granularity(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_easyenergy: MagicMock,
+    service: str,
+) -> None:
+    """Test energy services can request quarter-hour prices."""
+    service_data: dict[str, str | bool] = {
+        ATTR_CONFIG_ENTRY: mock_config_entry.entry_id,
+        ATTR_GRANULARITY: "quarter",
+        "start": "2026-04-19",
+        "end": "2026-04-19",
+    }
+    if service == ENERGY_USAGE_SERVICE_NAME:
+        service_data["incl_vat"] = True
+
+    mock_easyenergy.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        service_data,
+        blocking=True,
+        return_response=True,
+    )
+
+    mock_easyenergy.energy_prices.assert_called_once_with(
+        start_date=date(2026, 4, 19),
+        end_date=date(2026, 4, 19),
+        granularity=ElectricityGranularity.QUARTER,
+        vat=VatOption.INCLUDE,
+    )
+    mock_easyenergy.gas_prices.assert_not_called()
 
 
 @pytest.fixture
@@ -300,6 +346,49 @@ async def test_service_schema_validation_usage_price_type(
             DOMAIN,
             service,
             {ATTR_CONFIG_ENTRY: mock_config_entry.entry_id} | service_data,
+            blocking=True,
+            return_response=True,
+        )
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "service",
+    [
+        ENERGY_USAGE_SERVICE_NAME,
+        ENERGY_RETURN_SERVICE_NAME,
+    ],
+)
+@pytest.mark.parametrize(
+    ("service_data", "error_message"),
+    [
+        (
+            {ATTR_GRANULARITY: "incorrect granularity"},
+            "value must be one of .+",
+        ),
+        (
+            {ATTR_GRANULARITY: True},
+            "value must be one of .+",
+        ),
+    ],
+)
+async def test_service_schema_validation_granularity(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    service_data: dict[str, str | bool],
+    error_message: str,
+) -> None:
+    """Test energy service schema validation for granularity."""
+    data = {ATTR_CONFIG_ENTRY: mock_config_entry.entry_id} | service_data
+    if service == ENERGY_USAGE_SERVICE_NAME:
+        data["incl_vat"] = True
+
+    with pytest.raises(vol.er.Error, match=error_message):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            data,
             blocking=True,
             return_response=True,
         )

--- a/tests/components/easyenergy/test_services.py
+++ b/tests/components/easyenergy/test_services.py
@@ -160,14 +160,14 @@ async def test_service_filters_datetime_range(
         ),
     ],
 )
-async def test_usage_services_all_in_price_type(
+async def test_usage_services_invoice_price_type(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_easyenergy: MagicMock,
     service: str,
     expected_prices: list[dict[str, str | float]],
 ) -> None:
-    """Test usage services can return all-in prices."""
+    """Test usage services can return invoice prices."""
     mock_easyenergy.reset_mock()
 
     response = await hass.services.async_call(
@@ -175,7 +175,7 @@ async def test_usage_services_all_in_price_type(
         service,
         {
             ATTR_CONFIG_ENTRY: mock_config_entry.entry_id,
-            ATTR_PRICE_TYPE: "all_in",
+            ATTR_PRICE_TYPE: "invoice",
             "incl_vat": True,
             "start": "2026-04-19 02:00:00+02:00",
             "end": "2026-04-19 05:00:00+02:00",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability for more configuration options in the actions (services) of the easyEnergy integration, such as choosing between market or all-in price and the granularity (interval) between hourly and 15-minute prices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45025
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
