### PR TITLE
Require admin access for hassio Supervisor services

### DIFF
--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -29,6 +29,7 @@ from homeassistant.helpers import (
     device_registry as dr,
     selector,
 )
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.util.dt import now
 
 from .const import (
@@ -196,8 +197,8 @@ def async_register_app_services(
             ) from err
 
     for service in simple_app_services:
-        hass.services.async_register(
-            DOMAIN, service, async_simple_app_service_handler, schema=SCHEMA_APP
+        async_register_admin_service(
+            hass, DOMAIN, service, async_simple_app_service_handler, schema=SCHEMA_APP
         )
 
     async def async_app_stdin_service_handler(service: ServiceCall) -> None:
@@ -220,7 +221,8 @@ def async_register_app_services(
                 f"Failed to write stdin to app {app_slug}: {err}"
             ) from err
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_APP_STDIN,
         async_app_stdin_service_handler,
@@ -247,8 +249,12 @@ def async_register_app_services(
             ) from err
 
     for service in simple_addon_services:
-        hass.services.async_register(
-            DOMAIN, service, async_simple_addon_service_handler, schema=SCHEMA_ADDON
+        async_register_admin_service(
+            hass,
+            DOMAIN,
+            service,
+            async_simple_addon_service_handler,
+            schema=SCHEMA_ADDON,
         )
 
     async def async_addon_stdin_service_handler(service: ServiceCall) -> None:
@@ -267,7 +273,8 @@ def async_register_app_services(
                 f"Failed to write stdin to app {addon_slug}: {err}"
             ) from err
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_ADDON_STDIN,
         async_addon_stdin_service_handler,
@@ -294,8 +301,12 @@ def async_register_host_services(
             raise HomeAssistantError(f"Failed to {action} the host: {err}") from err
 
     for service in simple_host_services:
-        hass.services.async_register(
-            DOMAIN, service, async_simple_host_service_handler, schema=SCHEMA_NO_DATA
+        async_register_admin_service(
+            hass,
+            DOMAIN,
+            service,
+            async_simple_host_service_handler,
+            schema=SCHEMA_NO_DATA,
         )
 
 
@@ -319,7 +330,8 @@ def async_register_backup_restore_services(
 
         return {"backup": backup.slug}
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_BACKUP_FULL,
         async_full_backup_service_handler,
@@ -345,7 +357,8 @@ def async_register_backup_restore_services(
 
         return {"backup": backup.slug}
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_BACKUP_PARTIAL,
         async_partial_backup_service_handler,
@@ -367,7 +380,8 @@ def async_register_backup_restore_services(
                 f"Failed to full restore from backup {backup_slug}: {err}"
             ) from err
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_RESTORE_FULL,
         async_full_restore_service_handler,
@@ -389,7 +403,8 @@ def async_register_backup_restore_services(
                 f"Failed to partial restore from backup {backup_slug}: {err}"
             ) from err
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_RESTORE_PARTIAL,
         async_partial_restore_service_handler,
@@ -434,6 +449,6 @@ def async_register_network_storage_services(
                 translation_placeholders={"name": device.name, "error": str(error)},
             ) from error
 
-    hass.services.async_register(
-        DOMAIN, SERVICE_MOUNT_RELOAD, async_mount_reload, SCHEMA_MOUNT_RELOAD
+    async_register_admin_service(
+        hass, DOMAIN, SERVICE_MOUNT_RELOAD, async_mount_reload, SCHEMA_MOUNT_RELOAD
     )


### PR DESCRIPTION
## Proposed change

Wrap all Supervisor service registrations in `homeassistant/components/hassio/services.py` with `async_register_admin_service` so that non-admin users can no longer invoke destructive or system-wide operations through `call_service` / `POST /api/services/hassio/...`.

Affected services:

- `app_start`, `app_stop`, `app_restart`, `app_stdin`
- `addon_start`, `addon_stop`, `addon_restart`, `addon_stdin` (legacy aliases)
- `host_reboot`, `host_shutdown`
- `backup_full`, `backup_partial`
- `restore_full`, `restore_partial`
- `mount_reload`

These were registered with the bare `hass.services.async_register`, meaning any authenticated user (not just admins) could trigger them. Impact ranges from arbitrary addon control and host shutdown to full-instance rollback via `restore_full` and credential exfiltration via `backup_full`.

When adding a new non-admin user, the UI already warns:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that ongoing audit.

The default `ServiceCall` context has `user_id=None`, which the admin handler treats as a system call, so internal callers and existing tests are unaffected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr