### PR TITLE
Require admin for backup.create and backup.create_automatic services

### DIFF
--- a/homeassistant/components/backup/services.py
+++ b/homeassistant/components/backup/services.py
@@ -2,6 +2,7 @@
 
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.hassio import is_hassio
+from homeassistant.helpers.service import async_register_admin_service
 
 from .const import DATA_MANAGER, DOMAIN
 
@@ -30,7 +31,9 @@ async def _async_handle_create_automatic_service(call: ServiceCall) -> None:
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register services."""
     if not is_hassio(hass):
-        hass.services.async_register(DOMAIN, "create", _async_handle_create_service)
-    hass.services.async_register(
-        DOMAIN, "create_automatic", _async_handle_create_automatic_service
+        async_register_admin_service(
+            hass, DOMAIN, "create", _async_handle_create_service
+        )
+    async_register_admin_service(
+        hass, DOMAIN, "create_automatic", _async_handle_create_automatic_service
     )

--- a/tests/components/backup/test_init.py
+++ b/tests/components/backup/test_init.py
@@ -7,12 +7,12 @@ import pytest
 
 from homeassistant.components.backup.const import DATA_MANAGER, DOMAIN
 from homeassistant.config_entries import SOURCE_SYSTEM, ConfigEntryState
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceNotFound
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import ServiceNotFound, Unauthorized
 
 from .common import setup_backup_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockUser
 from tests.typing import WebSocketGenerator
 
 
@@ -157,3 +157,22 @@ async def test_setup_entry(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.parametrize("service", ["create", "create_automatic"])
+@pytest.mark.usefixtures("supervisor_client")
+async def test_services_require_admin(
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    service: str,
+) -> None:
+    """Test backup services require admin."""
+    await setup_backup_integration(hass, with_hassio=False)
+
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            context=Context(user_id=hass_read_only_user.id),
+            blocking=True,
+        )

--- a/tests/components/backup/test_init.py
+++ b/tests/components/backup/test_init.py
@@ -159,15 +159,23 @@ async def test_setup_entry(
     assert entry.state is ConfigEntryState.LOADED
 
 
-@pytest.mark.parametrize("service", ["create", "create_automatic"])
+@pytest.mark.parametrize(
+    ("service", "with_hassio"),
+    [
+        ("create", False),
+        ("create_automatic", False),
+        ("create_automatic", True),
+    ],
+)
 @pytest.mark.usefixtures("supervisor_client")
 async def test_services_require_admin(
     hass: HomeAssistant,
     hass_read_only_user: MockUser,
     service: str,
+    with_hassio: bool,
 ) -> None:
     """Test backup services require admin."""
-    await setup_backup_integration(hass, with_hassio=False)
+    await setup_backup_integration(hass, with_hassio=with_hassio)
 
     with pytest.raises(Unauthorized):
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `backup.create` and `backup.create_automatic` actions are registered with a bare `hass.services.async_register`, so any user can invoke them. Every WebSocket command in `backup/websocket.py` is gated with `@require_admin`; the actions regressed when they were split out into `services.py`. This change registers them with `async_register_admin_service` to match the WebSocket gating.

When adding a new non-admin user, the UI tells the operator:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr