### PR TITLE
Require admin for diagnostics download and application credentials list

### DIFF
--- a/homeassistant/components/application_credentials/__init__.py
+++ b/homeassistant/components/application_credentials/__init__.py
@@ -155,7 +155,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DATA_COMPONENT] = storage_collection
 
     collection.DictStorageCollectionWebsocket(
-        storage_collection, DOMAIN, DOMAIN, CREATE_FIELDS, UPDATE_FIELDS
+        storage_collection,
+        DOMAIN,
+        DOMAIN,
+        CREATE_FIELDS,
+        UPDATE_FIELDS,
+        admin_only=True,
     ).async_setup(hass)
 
     websocket_api.async_register_command(hass, handle_integration_list)

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -245,6 +245,7 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
     extra_urls = ["/api/diagnostics/{d_type}/{d_id}/{sub_type}/{sub_id}"]
     name = "api:diagnostics"
 
+    @http.require_admin
     async def get(
         self,
         request: web.Request,

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -545,13 +545,21 @@ class StorageCollectionWebsocket[_StorageCollectionT: StorageCollection]:
         model_name: str,
         create_schema: VolDictType,
         update_schema: VolDictType,
+        *,
+        admin_only: bool = False,
     ) -> None:
-        """Initialize a websocket CRUD."""
+        """Initialize a websocket CRUD.
+
+        When ``admin_only`` is set, the ``/list`` and ``/subscribe`` commands
+        are also restricted to admin users (the mutating commands are always
+        admin-only). Use this for collections whose items contain secrets.
+        """
         self.storage_collection = storage_collection
         self.api_prefix = api_prefix
         self.model_name = model_name
         self.create_schema = create_schema
         self.update_schema = update_schema
+        self.admin_only = admin_only
 
         self._remove_subscription: CALLBACK_TYPE | None = None
         self._subscribers: set[tuple[websocket_api.ActiveConnection, int]] = set()
@@ -566,10 +574,18 @@ class StorageCollectionWebsocket[_StorageCollectionT: StorageCollection]:
     @callback
     def async_setup(self, hass: HomeAssistant) -> None:
         """Set up the websocket commands."""
+        list_handler: websocket_api.const.WebSocketCommandHandler = self.ws_list_item
+        subscribe_handler: websocket_api.const.WebSocketCommandHandler = (
+            self._ws_subscribe
+        )
+        if self.admin_only:
+            list_handler = websocket_api.require_admin(list_handler)
+            subscribe_handler = websocket_api.require_admin(subscribe_handler)
+
         websocket_api.async_register_command(
             hass,
             f"{self.api_prefix}/list",
-            self.ws_list_item,
+            list_handler,
             websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
                 {vol.Required("type"): f"{self.api_prefix}/list"}
             ),
@@ -592,7 +608,7 @@ class StorageCollectionWebsocket[_StorageCollectionT: StorageCollection]:
         websocket_api.async_register_command(
             hass,
             f"{self.api_prefix}/subscribe",
-            self._ws_subscribe,
+            subscribe_handler,
             websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
                 {vol.Required("type"): f"{self.api_prefix}/subscribe"}
             ),

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -267,6 +267,22 @@ async def test_websocket_create(ws_client: ClientFixture) -> None:
     ]
 
 
+@pytest.mark.parametrize("cmd", ["list", "subscribe"])
+async def test_websocket_list_subscribe_require_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+    cmd: str,
+) -> None:
+    """Test that list and subscribe are restricted to admin users."""
+    ws = await hass_ws_client(access_token=hass_read_only_access_token)
+    await ws.send_json({"id": 1, "type": f"{DOMAIN}/{cmd}"})
+    resp = await ws.receive_json()
+    assert resp["id"] == 1
+    assert not resp["success"]
+    assert resp["error"]["code"] == "unauthorized"
+
+
 async def test_websocket_create_invalid_domain(ws_client: ClientFixture) -> None:
     """Test websocket create command."""
     client = await ws_client()

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -331,6 +331,22 @@ async def test_download_diagnostics(
     }
 
 
+async def test_download_diagnostics_requires_admin(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test diagnostics download is restricted to admin users."""
+    config_entry = MockConfigEntry(domain="fake_integration")
+    config_entry.add_to_hass(hass)
+
+    client = await hass_client(hass_read_only_access_token)
+    response = await client.get(
+        f"/api/diagnostics/config_entry/{config_entry.entry_id}"
+    )
+    assert response.status == HTTPStatus.UNAUTHORIZED
+
+
 async def test_failure_scenarios(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:


### PR DESCRIPTION
## Proposed change

When adding a new admin in the UI, we mention to the user:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

Two endpoints that return data containing secrets (refresh tokens, API keys, OAuth client secrets) were reachable by any authenticated user — they now require admin:

- **`GET /api/diagnostics/{d_type}/{d_id}[/{sub_type}/{sub_id}]`** — `DownloadDiagnosticsView.get` returns the integration's `config_entry_diagnostics` / `device_diagnostics` payloads. The sibling websocket commands `diagnostics/list` and `diagnostics/get` (which return only metadata) were already gated with `@websocket_api.require_admin`; the HTTP view that returns the actual sensitive payload was not. Added `@http.require_admin`.
- **`application_credentials/list` and `application_credentials/subscribe`** — the storage collection items contain `client_secret`. `StorageCollectionWebsocket` already gates `/create`, `/update`, and `/delete` with `require_admin` but not `/list` and `/subscribe`. Added an `admin_only` flag to `StorageCollectionWebsocket.__init__` that wraps `/list` and `/subscribe` with `websocket_api.require_admin`, and opted application_credentials into it. Other consumers (scenes, scripts, persons, zones, etc.) keep the existing default of allowing non-admins to list/subscribe.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr