### PR TITLE
Filter history API responses by per-entity read permissions

### DIFF
--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 
@@ -13,6 +14,9 @@ from .models import PermissionLookup
 from .types import PolicyType
 from .util import test_all
 
+if TYPE_CHECKING:
+    from ..models import User
+
 POLICY_SCHEMA = vol.Schema({vol.Optional(CAT_ENTITIES): ENTITY_POLICY_SCHEMA})
 
 __all__ = [
@@ -22,8 +26,19 @@ __all__ = [
     "PermissionLookup",
     "PolicyPermissions",
     "PolicyType",
+    "filter_entity_ids_by_permission",
     "merge_policies",
 ]
+
+
+def filter_entity_ids_by_permission(
+    user: User, entity_ids: Iterable[str], key: str
+) -> list[str]:
+    """Filter entity IDs to those the user can access for the given policy key."""
+    if user.is_admin or user.permissions.access_all_entities(key):
+        return list(entity_ids)
+    check_entity = user.permissions.check_entity
+    return [entity_id for entity_id in entity_ids if check_entity(entity_id, key)]
 
 
 class AbstractPermissions:

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -9,7 +9,7 @@ from typing import cast
 from aiohttp import web
 import voluptuous as vol
 
-from homeassistant.auth.models import User
+from homeassistant.auth.permissions import filter_entity_ids_by_permission
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components import frontend
 from homeassistant.components.http import KEY_HASS, KEY_HASS_USER, HomeAssistantView
@@ -85,16 +85,11 @@ class HistoryPeriodView(HomeAssistantView):
                     "Invalid filter_entity_id", HTTPStatus.BAD_REQUEST
                 )
 
-        user: User = request[KEY_HASS_USER]
-        if not user.is_admin:
-            entity_perm = user.permissions.check_entity
-            entity_ids = [
-                entity_id
-                for entity_id in entity_ids
-                if entity_perm(entity_id, POLICY_READ)
-            ]
-            if not entity_ids:
-                return self.json([])
+        entity_ids = filter_entity_ids_by_permission(
+            request[KEY_HASS_USER], entity_ids, POLICY_READ
+        )
+        if not entity_ids:
+            return self.json([])
 
         now = dt_util.utcnow()
         if datetime_:

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -9,8 +9,10 @@ from typing import cast
 from aiohttp import web
 import voluptuous as vol
 
+from homeassistant.auth.models import User
+from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components import frontend
-from homeassistant.components.http import KEY_HASS, HomeAssistantView
+from homeassistant.components.http import KEY_HASS, KEY_HASS_USER, HomeAssistantView
 from homeassistant.components.recorder import get_instance, history
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import CONF_EXCLUDE, CONF_INCLUDE
@@ -82,6 +84,17 @@ class HistoryPeriodView(HomeAssistantView):
                 return self.json_message(
                     "Invalid filter_entity_id", HTTPStatus.BAD_REQUEST
                 )
+
+        user: User = request[KEY_HASS_USER]
+        if not user.is_admin:
+            entity_perm = user.permissions.check_entity
+            entity_ids = [
+                entity_id
+                for entity_id in entity_ids
+                if entity_perm(entity_id, POLICY_READ)
+            ]
+            if not entity_ids:
+                return self.json([])
 
         now = dt_util.utcnow()
         if datetime_:

--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 import voluptuous as vol
 
+from homeassistant.auth.permissions import filter_entity_ids_by_permission
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components import websocket_api
 from homeassistant.components.recorder import get_instance, history
@@ -139,15 +140,12 @@ async def ws_get_history_during_period(
             connection.send_error(msg["id"], "invalid_entity_ids", "Invalid entity_ids")
             return
 
-    user = connection.user
-    if not user.is_admin:
-        entity_perm = user.permissions.check_entity
-        entity_ids = [
-            entity_id for entity_id in entity_ids if entity_perm(entity_id, POLICY_READ)
-        ]
-        if not entity_ids:
-            connection.send_result(msg["id"], {})
-            return
+    entity_ids = filter_entity_ids_by_permission(
+        connection.user, entity_ids, POLICY_READ
+    )
+    if not entity_ids:
+        connection.send_result(msg["id"], {})
+        return
 
     include_start_time_state = msg["include_start_time_state"]
     no_attributes = msg["no_attributes"]
@@ -455,15 +453,12 @@ async def ws_stream(
             connection.send_error(msg["id"], "invalid_entity_ids", "Invalid entity_ids")
             return
 
-    user = connection.user
-    if not user.is_admin:
-        entity_perm = user.permissions.check_entity
-        entity_ids = [
-            entity_id for entity_id in entity_ids if entity_perm(entity_id, POLICY_READ)
-        ]
-        if not entity_ids:
-            _async_send_empty_response(connection, msg_id, start_time, end_time)
-            return
+    entity_ids = filter_entity_ids_by_permission(
+        connection.user, entity_ids, POLICY_READ
+    )
+    if not entity_ids:
+        _async_send_empty_response(connection, msg_id, start_time, end_time)
+        return
 
     include_start_time_state = msg["include_start_time_state"]
     significant_changes_only = msg["significant_changes_only"]

--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 import voluptuous as vol
 
+from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components import websocket_api
 from homeassistant.components.recorder import get_instance, history
 from homeassistant.components.websocket_api import ActiveConnection, messages
@@ -136,6 +137,16 @@ async def ws_get_history_during_period(
     for entity_id in entity_ids:
         if not hass.states.get(entity_id) and not valid_entity_id(entity_id):
             connection.send_error(msg["id"], "invalid_entity_ids", "Invalid entity_ids")
+            return
+
+    user = connection.user
+    if not user.is_admin:
+        entity_perm = user.permissions.check_entity
+        entity_ids = [
+            entity_id for entity_id in entity_ids if entity_perm(entity_id, POLICY_READ)
+        ]
+        if not entity_ids:
+            connection.send_result(msg["id"], {})
             return
 
     include_start_time_state = msg["include_start_time_state"]
@@ -442,6 +453,16 @@ async def ws_stream(
     for entity_id in entity_ids:
         if not hass.states.get(entity_id) and not valid_entity_id(entity_id):
             connection.send_error(msg["id"], "invalid_entity_ids", "Invalid entity_ids")
+            return
+
+    user = connection.user
+    if not user.is_admin:
+        entity_perm = user.permissions.check_entity
+        entity_ids = [
+            entity_id for entity_id in entity_ids if entity_perm(entity_id, POLICY_READ)
+        ]
+        if not entity_ids:
+            _async_send_empty_response(connection, msg_id, start_time, end_time)
             return
 
     include_start_time_state = msg["include_start_time_state"]

--- a/tests/auth/permissions/test_init.py
+++ b/tests/auth/permissions/test_init.py
@@ -1,0 +1,49 @@
+"""Tests for the permissions module."""
+
+from homeassistant.auth.permissions import filter_entity_ids_by_permission
+from homeassistant.auth.permissions.const import POLICY_READ
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockUser
+
+
+async def test_filter_entity_ids_by_permission_admin(hass: HomeAssistant) -> None:
+    """Test admins receive the input entity IDs unchanged."""
+    user = MockUser(is_owner=True)
+    user.mock_policy({"entities": {"entity_ids": {"light.allowed": True}}})
+    assert user.is_admin
+
+    assert filter_entity_ids_by_permission(
+        user, ["light.allowed", "light.forbidden"], POLICY_READ
+    ) == ["light.allowed", "light.forbidden"]
+
+
+async def test_filter_entity_ids_by_permission_access_all(hass: HomeAssistant) -> None:
+    """Test users with access_all_entities receive the input unchanged."""
+    user = MockUser()
+    user.mock_policy({"entities": {"all": True}})
+    assert not user.is_admin
+
+    assert filter_entity_ids_by_permission(
+        user, ["light.a", "light.b"], POLICY_READ
+    ) == ["light.a", "light.b"]
+
+
+async def test_filter_entity_ids_by_permission_filtered(hass: HomeAssistant) -> None:
+    """Test users without full access have entity IDs filtered."""
+    user = MockUser()
+    user.mock_policy({"entities": {"entity_ids": {"light.allowed": True}}})
+    assert not user.is_admin
+
+    assert filter_entity_ids_by_permission(
+        user, ["light.allowed", "light.forbidden"], POLICY_READ
+    ) == ["light.allowed"]
+
+
+async def test_filter_entity_ids_by_permission_empty(hass: HomeAssistant) -> None:
+    """Test users with no permitted entities receive an empty list."""
+    user = MockUser()
+    user.mock_policy({})
+    assert not user.is_admin
+
+    assert filter_entity_ids_by_permission(user, ["light.forbidden"], POLICY_READ) == []

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -8,6 +8,7 @@ from unittest.mock import sentinel
 from freezegun import freeze_time
 import pytest
 
+from homeassistant.auth.models import Credentials
 from homeassistant.components import history
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.recorder.models import process_timestamp
@@ -17,6 +18,7 @@ from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
+from tests.common import CLIENT_ID, MockUser
 from tests.components.recorder.common import (
     assert_dict_of_states_equal_without_context_and_last_changed,
     assert_multiple_states_equal_without_context,
@@ -770,3 +772,55 @@ async def test_history_with_invalid_entity_ids(
     response_json = await response.json()
     assert response_contains1 in str(response_json)
     assert response_contains2 in str(response_json)
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_fetch_period_api_filters_unauthorized_entities(
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test history is filtered by per-entity read permissions for non-admins."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"light.kitchen": True}}}
+    )
+    await async_setup_component(hass, "history", {})
+
+    hass.states.async_set("light.kitchen", "on")
+    hass.states.async_set("light.cow", "on")
+    await async_wait_recording_done(hass)
+
+    read_only_user_credential = Credentials(
+        id="mock-read-only-credential-id",
+        auth_provider_type="homeassistant",
+        auth_provider_id=None,
+        data={"username": "readonly"},
+        is_new=False,
+    )
+    await hass.auth.async_link_user(hass_read_only_user, read_only_user_credential)
+    refresh_token = await hass.auth.async_create_refresh_token(
+        hass_read_only_user, CLIENT_ID, credential=read_only_user_credential
+    )
+    token = hass.auth.async_create_access_token(refresh_token)
+    client = await hass_client(token)
+
+    now = dt_util.utcnow().isoformat()
+    response = await client.get(
+        f"/api/history/period/{now}",
+        params={"filter_entity_id": "light.kitchen,light.cow"},
+    )
+    assert response.status == HTTPStatus.OK
+    response_json = await response.json()
+    assert all(
+        state["entity_id"] == "light.kitchen"
+        for entity_states in response_json
+        for state in entity_states
+    )
+
+    response = await client.get(
+        f"/api/history/period/{now}",
+        params={"filter_entity_id": "light.cow"},
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == []

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -8,7 +8,6 @@ from unittest.mock import sentinel
 from freezegun import freeze_time
 import pytest
 
-from homeassistant.auth.models import Credentials
 from homeassistant.components import history
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.recorder.models import process_timestamp
@@ -18,7 +17,7 @@ from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import CLIENT_ID, MockUser
+from tests.common import MockUser
 from tests.components.recorder.common import (
     assert_dict_of_states_equal_without_context_and_last_changed,
     assert_multiple_states_equal_without_context,
@@ -778,6 +777,7 @@ async def test_history_with_invalid_entity_ids(
 async def test_fetch_period_api_filters_unauthorized_entities(
     hass: HomeAssistant,
     hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test history is filtered by per-entity read permissions for non-admins."""
@@ -791,19 +791,7 @@ async def test_fetch_period_api_filters_unauthorized_entities(
     hass.states.async_set("light.cow", "on")
     await async_wait_recording_done(hass)
 
-    read_only_user_credential = Credentials(
-        id="mock-read-only-credential-id",
-        auth_provider_type="homeassistant",
-        auth_provider_id=None,
-        data={"username": "readonly"},
-        is_new=False,
-    )
-    await hass.auth.async_link_user(hass_read_only_user, read_only_user_credential)
-    refresh_token = await hass.auth.async_create_refresh_token(
-        hass_read_only_user, CLIENT_ID, credential=read_only_user_credential
-    )
-    token = hass.auth.async_create_access_token(refresh_token)
-    client = await hass_client(token)
+    client = await hass_client(hass_read_only_access_token)
 
     now = dt_util.utcnow().isoformat()
     response = await client.get(

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, patch
 from freezegun import freeze_time
 import pytest
 
+from homeassistant.auth.models import Credentials
 from homeassistant.components import history
 from homeassistant.components.history import websocket_api
 from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE, STATE_OFF, STATE_ON
@@ -15,7 +16,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.common import CLIENT_ID, MockUser, async_fire_time_changed
 from tests.components.recorder.common import (
     async_recorder_block_till_done,
     async_wait_recording_done,
@@ -2174,3 +2175,132 @@ async def test_history_stream_live_chained_events(
         "id": 1,
         "type": "event",
     }
+
+
+async def _async_get_read_only_token(
+    hass: HomeAssistant, hass_read_only_user: MockUser
+) -> str:
+    """Create an access token for the read-only user."""
+    credential = Credentials(
+        id="mock-read-only-credential-id",
+        auth_provider_type="homeassistant",
+        auth_provider_id=None,
+        data={"username": "readonly"},
+        is_new=False,
+    )
+    await hass.auth.async_link_user(hass_read_only_user, credential)
+    refresh_token = await hass.auth.async_create_refresh_token(
+        hass_read_only_user, CLIENT_ID, credential=credential
+    )
+    return hass.auth.async_create_access_token(refresh_token)
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_history_during_period_filters_unauthorized_entities(
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test history_during_period filters by per-entity read permissions."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"sensor.allowed": True}}}
+    )
+    now = dt_util.utcnow()
+
+    await async_setup_component(hass, "history", {})
+    await async_recorder_block_till_done(hass)
+    hass.states.async_set("sensor.allowed", "on")
+    hass.states.async_set("sensor.forbidden", "on")
+    await async_wait_recording_done(hass)
+
+    token = await _async_get_read_only_token(hass, hass_read_only_user)
+    client = await hass_ws_client(access_token=token)
+
+    await client.send_json_auto_id(
+        {
+            "type": "history/history_during_period",
+            "start_time": now.isoformat(),
+            "entity_ids": ["sensor.allowed", "sensor.forbidden"],
+            "include_start_time_state": True,
+            "significant_changes_only": False,
+            "no_attributes": True,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert "sensor.forbidden" not in response["result"]
+    assert "sensor.allowed" in response["result"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "history/history_during_period",
+            "start_time": now.isoformat(),
+            "entity_ids": ["sensor.forbidden"],
+            "include_start_time_state": True,
+            "significant_changes_only": False,
+            "no_attributes": True,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {}
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_history_stream_filters_unauthorized_entities(
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test history/stream filters by per-entity read permissions."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"sensor.allowed": True}}}
+    )
+    now = dt_util.utcnow()
+
+    await async_setup_component(hass, "history", {})
+    await async_recorder_block_till_done(hass)
+    hass.states.async_set("sensor.allowed", "on")
+    hass.states.async_set("sensor.forbidden", "on")
+    await async_wait_recording_done(hass)
+
+    end_time = dt_util.utcnow() + timedelta(seconds=1)
+    token = await _async_get_read_only_token(hass, hass_read_only_user)
+    client = await hass_ws_client(access_token=token)
+
+    await client.send_json_auto_id(
+        {
+            "type": "history/stream",
+            "start_time": now.isoformat(),
+            "end_time": end_time.isoformat(),
+            "entity_ids": ["sensor.allowed", "sensor.forbidden"],
+            "include_start_time_state": True,
+            "significant_changes_only": False,
+            "no_attributes": True,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    response = await client.receive_json()
+    assert response["type"] == "event"
+    assert "sensor.forbidden" not in response["event"]["states"]
+    assert "sensor.allowed" in response["event"]["states"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "history/stream",
+            "start_time": now.isoformat(),
+            "end_time": end_time.isoformat(),
+            "entity_ids": ["sensor.forbidden"],
+            "include_start_time_state": True,
+            "significant_changes_only": False,
+            "no_attributes": True,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    response = await client.receive_json()
+    assert response["type"] == "event"
+    assert response["event"]["states"] == {}

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -7,7 +7,6 @@ from unittest.mock import ANY, patch
 from freezegun import freeze_time
 import pytest
 
-from homeassistant.auth.models import Credentials
 from homeassistant.components import history
 from homeassistant.components.history import websocket_api
 from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE, STATE_OFF, STATE_ON
@@ -16,7 +15,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import CLIENT_ID, MockUser, async_fire_time_changed
+from tests.common import MockUser, async_fire_time_changed
 from tests.components.recorder.common import (
     async_recorder_block_till_done,
     async_wait_recording_done,
@@ -2177,28 +2176,11 @@ async def test_history_stream_live_chained_events(
     }
 
 
-async def _async_get_read_only_token(
-    hass: HomeAssistant, hass_read_only_user: MockUser
-) -> str:
-    """Create an access token for the read-only user."""
-    credential = Credentials(
-        id="mock-read-only-credential-id",
-        auth_provider_type="homeassistant",
-        auth_provider_id=None,
-        data={"username": "readonly"},
-        is_new=False,
-    )
-    await hass.auth.async_link_user(hass_read_only_user, credential)
-    refresh_token = await hass.auth.async_create_refresh_token(
-        hass_read_only_user, CLIENT_ID, credential=credential
-    )
-    return hass.auth.async_create_access_token(refresh_token)
-
-
 @pytest.mark.usefixtures("recorder_mock")
 async def test_history_during_period_filters_unauthorized_entities(
     hass: HomeAssistant,
     hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history_during_period filters by per-entity read permissions."""
@@ -2214,8 +2196,7 @@ async def test_history_during_period_filters_unauthorized_entities(
     hass.states.async_set("sensor.forbidden", "on")
     await async_wait_recording_done(hass)
 
-    token = await _async_get_read_only_token(hass, hass_read_only_user)
-    client = await hass_ws_client(access_token=token)
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
 
     await client.send_json_auto_id(
         {
@@ -2251,6 +2232,7 @@ async def test_history_during_period_filters_unauthorized_entities(
 async def test_history_stream_filters_unauthorized_entities(
     hass: HomeAssistant,
     hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history/stream filters by per-entity read permissions."""
@@ -2267,8 +2249,7 @@ async def test_history_stream_filters_unauthorized_entities(
     await async_wait_recording_done(hass)
 
     end_time = dt_util.utcnow() + timedelta(seconds=1)
-    token = await _async_get_read_only_token(hass, hass_read_only_user)
-    client = await hass_ws_client(access_token=token)
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
 
     await client.send_json_auto_id(
         {


### PR DESCRIPTION
## Proposed change

The `/api/history/period` REST endpoint and the `history/history_during_period` and `history/stream` websocket commands returned historical state for any requested entity without consulting the per-entity read policy. For installations that have configured per-entity policies to restrict an entity from a specific user, that user could still read the entity's history through the history component.

This PR mirrors the existing safe shape from `APIStatesView.get` (`homeassistant/components/api/__init__.py`): admins are unaffected; non-admin users get the requested `entity_ids` filtered through `user.permissions.check_entity(entity_id, POLICY_READ)` before the data is fetched. For the websocket stream, filtering happens before the live state-change subscription is created, so updates to disallowed entities are never even subscribed-to. If no entity remains after filtering, an empty result is returned.

When adding a new admin in the UI we mention:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.