### PR TITLE
fix(waterfurnace): correct Python 2 except syntax in backfill to Python 3

### DIFF
--- a/homeassistant/components/waterfurnace/coordinator.py
+++ b/homeassistant/components/waterfurnace/coordinator.py
@@ -274,7 +274,7 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
                     break
                 batch_end = batch_start
                 continue
-            except UpdateFailed, WFException:
+            except (UpdateFailed, WFException):
                 _LOGGER.exception("Error fetching energy data during backfill")
                 break
 


### PR DESCRIPTION
## Summary

Fixes a Python 2 syntax error in the `_async_backfill` method of `WaterFurnaceEnergyCoordinator`.

## Problem

Line 277 of `homeassistant/components/waterfurnace/coordinator.py` uses Python 2 multi-exception syntax:

```python
except UpdateFailed, WFException:
```

In Python 3, this is parsed as:
```python
except UpdateFailed as WFException:  # assigns exception to variable named WFException
```

This means **`WFException` errors are silently not caught** during backfill — they will propagate up and crash the background task instead of being logged and handled gracefully.

## Fix

Use proper Python 3 tuple syntax:

```python
except (UpdateFailed, WFException):
```

## Testing

This is a pure syntax/correctness fix. Both exception types are now properly caught and logged via `_LOGGER.exception`.

Fixes: #169237

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>