### PR TITLE
fix: the emulated hue api responds to philips hue-co... in hue_api.py

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -159,8 +159,7 @@ class HueUsernameView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle a POST request."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("Only local IPs allowed", HTTPStatus.UNAUTHORIZED)
 
         try:
@@ -188,8 +187,7 @@ class HueAllGroupsStateView(HomeAssistantView):
     @core.callback
     def get(self, request: web.Request, username: str) -> web.Response:
         """Process a request to make the Brilliant Lightpad work."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("Only local IPs allowed", HTTPStatus.UNAUTHORIZED)
 
         return self.json({})
@@ -209,8 +207,7 @@ class HueGroupView(HomeAssistantView):
     @core.callback
     def put(self, request: web.Request, username: str) -> web.Response:
         """Process a request to make the Logitech Pop working."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("Only local IPs allowed", HTTPStatus.UNAUTHORIZED)
 
         return self.json(
@@ -240,8 +237,7 @@ class HueAllLightsStateView(HomeAssistantView):
     @core.callback
     def get(self, request: web.Request, username: str) -> web.Response:
         """Process a request to get the list of available lights."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("Only local IPs allowed", HTTPStatus.UNAUTHORIZED)
 
         return self.json(create_list_of_entities(self.config, request))
@@ -261,8 +257,7 @@ class HueFullStateView(HomeAssistantView):
     @core.callback
     def get(self, request: web.Request, username: str) -> web.Response:
         """Process a request to get the list of available lights."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("only local IPs allowed", HTTPStatus.UNAUTHORIZED)
         if username != HUE_API_USERNAME:
             return self.json(UNAUTHORIZED_USER)
@@ -290,8 +285,7 @@ class HueConfigView(HomeAssistantView):
     @core.callback
     def get(self, request: web.Request, username: str = "") -> web.Response:
         """Process a request to get the configuration."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("only local IPs allowed", HTTPStatus.UNAUTHORIZED)
 
         json_response = create_config_model(self.config, request)
@@ -313,8 +307,7 @@ class HueOneLightStateView(HomeAssistantView):
     @core.callback
     def get(self, request: web.Request, username: str, entity_id: str) -> web.Response:
         """Process a request to get the state of an individual light."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("Only local IPs allowed", HTTPStatus.UNAUTHORIZED)
 
         hass = request.app[KEY_HASS]
@@ -357,9 +350,11 @@ class HueOneLightChangeView(HomeAssistantView):
         self, request: web.Request, username: str, entity_number: str
     ) -> web.Response:
         """Process a request to set the state of an individual light."""
-        assert request.remote is not None
-        if not _remote_is_allowed(request.remote):
+        if request.remote is None or not _remote_is_allowed(request.remote):
             return self.json_message("Only local IPs allowed", HTTPStatus.UNAUTHORIZED)
+
+        if username != HUE_API_USERNAME:
+            return self.json(UNAUTHORIZED_USER)
 
         config = self.config
         hass = request.app[KEY_HASS]


### PR DESCRIPTION
## Summary
Fix high severity security issue in `homeassistant/components/emulated_hue/hue_api.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `homeassistant/components/emulated_hue/hue_api.py:381` |

**Description**: The emulated Hue API responds to Philips Hue-compatible requests without requiring Home Assistant authentication credentials. Any device on the local network that discovers the emulated Hue bridge via UPnP or mDNS can send PUT requests to change the state of any Home Assistant entity exposed through the emulated Hue interface — including lights, switches, and potentially security-relevant devices such as alarm panels or smart locks — without providing any Home Assistant credentials.

## Changes
- `homeassistant/components/emulated_hue/hue_api.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
