### PR TITLE
Use runtime_data in xiaomi_aqara

### DIFF
--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -27,11 +27,12 @@ from .const import (
     CONF_SID,
     DEFAULT_DISCOVERY_RETRY,
     DOMAIN,
-    GATEWAYS_KEY,
     KEY_SETUP_LOCK,
     KEY_UNSUB_STOP,
     LISTENER_KEY,
 )
+
+type XiaomiAqaraConfigEntry = ConfigEntry[XiaomiGateway]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,11 +139,10 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: XiaomiAqaraConfigEntry) -> bool:
     """Set up the xiaomi aqara components from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     setup_lock = hass.data[DOMAIN].setdefault(KEY_SETUP_LOCK, asyncio.Lock())
-    hass.data[DOMAIN].setdefault(GATEWAYS_KEY, {})
 
     # Connect to Xiaomi Aqara Gateway
     xiaomi_gateway = await hass.async_add_executor_job(
@@ -155,7 +155,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_PORT],
         entry.data[CONF_PROTOCOL],
     )
-    hass.data[DOMAIN][GATEWAYS_KEY][entry.entry_id] = xiaomi_gateway
+    entry.runtime_data = xiaomi_gateway
 
     async with setup_lock:
         if LISTENER_KEY not in hass.data[DOMAIN]:
@@ -204,7 +204,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, config_entry: XiaomiAqaraConfigEntry
+) -> bool:
     """Unload a config entry."""
     if config_entry.data[CONF_KEY] is not None:
         platforms = GATEWAY_PLATFORMS
@@ -214,14 +216,11 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, platforms
     )
-    if unload_ok:
-        hass.data[DOMAIN][GATEWAYS_KEY].pop(config_entry.entry_id)
 
     if not hass.config_entries.async_loaded_entries(DOMAIN):
         # No gateways left, stop Xiaomi socket
         unsub_stop = hass.data[DOMAIN].pop(KEY_UNSUB_STOP)
         unsub_stop()
-        hass.data[DOMAIN].pop(GATEWAYS_KEY)
         _LOGGER.debug("Shutting down Xiaomi Gateway Listener")
         multicast = hass.data[DOMAIN].pop(LISTENER_KEY)
         multicast.stop_listen()
@@ -229,25 +228,27 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     return unload_ok
 
 
-def _add_gateway_to_schema(hass, schema):
+def _add_gateway_to_schema(hass: HomeAssistant, schema: vol.Schema) -> vol.Schema:
     """Extend a voluptuous schema with a gateway validator."""
 
-    def gateway(sid):
+    def gateway(sid: str) -> XiaomiGateway:
         """Convert sid to a gateway."""
         sid = str(sid).replace(":", "").lower()
 
-        for gateway in hass.data[DOMAIN][GATEWAYS_KEY].values():
-            if gateway.sid == sid:
-                return gateway
+        for entry in hass.config_entries.async_loaded_entries(DOMAIN):
+            entry_gateway = entry.runtime_data
+            if entry_gateway.sid == sid:
+                return entry_gateway
 
         raise vol.Invalid(f"Unknown gateway sid {sid}")
 
     kwargs = {}
-    if (xiaomi_data := hass.data.get(DOMAIN)) is not None:
-        gateways = list(xiaomi_data[GATEWAYS_KEY].values())
+    gateways = [
+        entry.runtime_data for entry in hass.config_entries.async_loaded_entries(DOMAIN)
+    ]
 
-        # If the user has only 1 gateway, make it the default for services.
-        if len(gateways) == 1:
-            kwargs["default"] = gateways[0].sid
+    # If the user has only 1 gateway, make it the default for services.
+    if len(gateways) == 1:
+        kwargs["default"] = gateways[0].sid
 
     return schema.extend({vol.Required(ATTR_GW_MAC, **kwargs): gateway})

--- a/homeassistant/components/xiaomi_aqara/binary_sensor.py
+++ b/homeassistant/components/xiaomi_aqara/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, GATEWAYS_KEY
+from . import XiaomiAqaraConfigEntry
 from .entity import XiaomiDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,14 +34,12 @@ ATTR_DENSITY = "Density"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: XiaomiAqaraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Xiaomi devices."""
     entities: list[XiaomiBinarySensor] = []
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    gateway = hass.data[DOMAIN][GATEWAYS_KEY][config_entry.entry_id]
+    gateway = config_entry.runtime_data
     for entity in gateway.devices["binary_sensor"]:
         model = entity["model"]
         if model in ("motion", "sensor_motion", "sensor_motion.aq2"):

--- a/homeassistant/components/xiaomi_aqara/binary_sensor.py
+++ b/homeassistant/components/xiaomi_aqara/binary_sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
@@ -147,7 +146,7 @@ class XiaomiBinarySensor(XiaomiDevice, BinarySensorEntity):
         xiaomi_hub: XiaomiGateway,
         data_key: str,
         device_class: BinarySensorDeviceClass | None,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiSmokeSensor."""
         self._data_key = data_key
@@ -167,7 +166,7 @@ class XiaomiNatgasSensor(XiaomiBinarySensor):
         self,
         device: dict[str, Any],
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiSmokeSensor."""
         self._density = None
@@ -224,7 +223,7 @@ class XiaomiMotionSensor(XiaomiBinarySensor):
         device: dict[str, Any],
         hass: HomeAssistant,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiMotionSensor."""
         self._hass = hass
@@ -333,7 +332,7 @@ class XiaomiDoorSensor(XiaomiBinarySensor, RestoreEntity):
         self,
         device: dict[str, Any],
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiDoorSensor."""
         self._open_since = 0
@@ -400,7 +399,7 @@ class XiaomiWaterLeakSensor(XiaomiBinarySensor):
         self,
         device: dict[str, Any],
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiWaterLeakSensor."""
         if "proto" not in device or int(device["proto"][0:1]) == 1:
@@ -451,7 +450,7 @@ class XiaomiSmokeSensor(XiaomiBinarySensor):
         self,
         device: dict[str, Any],
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiSmokeSensor."""
         self._density = 0
@@ -508,7 +507,7 @@ class XiaomiVibration(XiaomiBinarySensor):
         name: str,
         data_key: str,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiVibration."""
         self._last_action = None
@@ -556,7 +555,7 @@ class XiaomiButton(XiaomiBinarySensor):
         data_key: str,
         hass: HomeAssistant,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiButton."""
         self._hass = hass
@@ -623,7 +622,7 @@ class XiaomiCube(XiaomiBinarySensor):
         device: dict[str, Any],
         hass: HomeAssistant,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the Xiaomi Cube."""
         self._hass = hass

--- a/homeassistant/components/xiaomi_aqara/const.py
+++ b/homeassistant/components/xiaomi_aqara/const.py
@@ -2,7 +2,6 @@
 
 DOMAIN = "xiaomi_aqara"
 
-GATEWAYS_KEY = "gateways"
 LISTENER_KEY = "listener"
 KEY_UNSUB_STOP = "unsub_stop"
 KEY_SETUP_LOCK = "setup_lock"

--- a/homeassistant/components/xiaomi_aqara/cover.py
+++ b/homeassistant/components/xiaomi_aqara/cover.py
@@ -5,7 +5,6 @@ from typing import Any
 from xiaomi_gateway import XiaomiGateway
 
 from homeassistant.components.cover import ATTR_POSITION, CoverEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -48,7 +47,7 @@ class XiaomiGenericCover(XiaomiDevice, CoverEntity):
         name: str,
         data_key: str,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiGenericCover."""
         self._data_key = data_key

--- a/homeassistant/components/xiaomi_aqara/cover.py
+++ b/homeassistant/components/xiaomi_aqara/cover.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, GATEWAYS_KEY
+from . import XiaomiAqaraConfigEntry
 from .entity import XiaomiDevice
 
 ATTR_CURTAIN_LEVEL = "curtain_level"
@@ -20,14 +20,12 @@ DATA_KEY_PROTO_V2 = "curtain_status"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: XiaomiAqaraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Xiaomi devices."""
     entities = []
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    gateway = hass.data[DOMAIN][GATEWAYS_KEY][config_entry.entry_id]
+    gateway = config_entry.runtime_data
     for device in gateway.devices["cover"]:
         model = device["model"]
         if model in ("curtain", "curtain.aq2", "curtain.hagl04"):

--- a/homeassistant/components/xiaomi_aqara/entity.py
+++ b/homeassistant/components/xiaomi_aqara/entity.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from xiaomi_gateway import XiaomiGateway
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_VOLTAGE, CONF_MAC
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -15,6 +14,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
+from . import XiaomiAqaraConfigEntry
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ class XiaomiDevice(Entity):
         device: dict[str, Any],
         device_type: str,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the Xiaomi device."""
         self._is_available = True

--- a/homeassistant/components/xiaomi_aqara/light.py
+++ b/homeassistant/components/xiaomi_aqara/light.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import color as color_util
 
-from .const import DOMAIN, GATEWAYS_KEY
+from . import XiaomiAqaraConfigEntry
 from .entity import XiaomiDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,14 +26,12 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: XiaomiAqaraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Xiaomi devices."""
     entities = []
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    gateway = hass.data[DOMAIN][GATEWAYS_KEY][config_entry.entry_id]
+    gateway = config_entry.runtime_data
     for device in gateway.devices["light"]:
         model = device["model"]
         if model in ("gateway", "gateway.v3"):

--- a/homeassistant/components/xiaomi_aqara/light.py
+++ b/homeassistant/components/xiaomi_aqara/light.py
@@ -13,7 +13,6 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import color as color_util
@@ -52,7 +51,7 @@ class XiaomiGatewayLight(XiaomiDevice, LightEntity):
         device: dict[str, Any],
         name: str,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiGatewayLight."""
         self._data_key = "rgb"

--- a/homeassistant/components/xiaomi_aqara/lock.py
+++ b/homeassistant/components/xiaomi_aqara/lock.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN, GATEWAYS_KEY
+from . import XiaomiAqaraConfigEntry
 from .entity import XiaomiDevice
 
 FINGER_KEY = "fing_verified"
@@ -27,13 +27,11 @@ UNLOCK_MAINTAIN_TIME = 5
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: XiaomiAqaraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Xiaomi devices."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    gateway = hass.data[DOMAIN][GATEWAYS_KEY][config_entry.entry_id]
+    gateway = config_entry.runtime_data
     async_add_entities(
         XiaomiAqaraLock(device, "Lock", gateway, config_entry)
         for device in gateway.devices["lock"]

--- a/homeassistant/components/xiaomi_aqara/lock.py
+++ b/homeassistant/components/xiaomi_aqara/lock.py
@@ -7,7 +7,6 @@ from typing import Any
 from xiaomi_gateway import XiaomiGateway
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
@@ -47,7 +46,7 @@ class XiaomiAqaraLock(LockEntity, XiaomiDevice):
         device: dict[str, Any],
         name: str,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiAqaraLock."""
         self._attr_changed_by = "0"

--- a/homeassistant/components/xiaomi_aqara/sensor.py
+++ b/homeassistant/components/xiaomi_aqara/sensor.py
@@ -25,7 +25,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import BATTERY_MODELS, DOMAIN, GATEWAYS_KEY, POWER_MODELS
+from . import XiaomiAqaraConfigEntry
+from .const import BATTERY_MODELS, POWER_MODELS
 from .entity import XiaomiDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -87,14 +88,12 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: XiaomiAqaraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Xiaomi devices."""
     entities: list[XiaomiSensor | XiaomiBatterySensor] = []
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    gateway = hass.data[DOMAIN][GATEWAYS_KEY][config_entry.entry_id]
+    gateway = config_entry.runtime_data
     for device in gateway.devices["sensor"]:
         if device["model"] == "sensor_ht":
             entities.append(

--- a/homeassistant/components/xiaomi_aqara/sensor.py
+++ b/homeassistant/components/xiaomi_aqara/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     LIGHT_LUX,
@@ -174,7 +173,7 @@ class XiaomiSensor(XiaomiDevice, SensorEntity):
         name: str,
         data_key: str,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiSensor."""
         self._data_key = data_key

--- a/homeassistant/components/xiaomi_aqara/switch.py
+++ b/homeassistant/components/xiaomi_aqara/switch.py
@@ -6,7 +6,6 @@ from typing import Any
 from xiaomi_gateway import XiaomiGateway
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -145,7 +144,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchEntity):
         data_key: str,
         supports_power_consumption: bool,
         xiaomi_hub: XiaomiGateway,
-        config_entry: ConfigEntry,
+        config_entry: XiaomiAqaraConfigEntry,
     ) -> None:
         """Initialize the XiaomiPlug."""
         self._data_key = data_key

--- a/homeassistant/components/xiaomi_aqara/switch.py
+++ b/homeassistant/components/xiaomi_aqara/switch.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, GATEWAYS_KEY
+from . import XiaomiAqaraConfigEntry
 from .entity import XiaomiDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,14 +30,12 @@ IN_USE = "inuse"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: XiaomiAqaraConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Perform the setup for Xiaomi devices."""
     entities = []
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=hass-use-runtime-data
-    gateway = hass.data[DOMAIN][GATEWAYS_KEY][config_entry.entry_id]
+    gateway = config_entry.runtime_data
     for device in gateway.devices["switch"]:
         model = device["model"]
         if model == "plug":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `xiaomi_aqara` integration to store the per-entry `XiaomiGateway`
instance on `ConfigEntry.runtime_data` instead of the legacy
`hass.data[DOMAIN][GATEWAYS_KEY][entry.entry_id]` mapping.

- Introduce a typed config entry alias
  `XiaomiAqaraConfigEntry = ConfigEntry[XiaomiGateway]` in `__init__.py` and
  use it in `async_setup_entry`/`async_unload_entry`.
- Update all platform modules (`binary_sensor`, `cover`, `light`, `lock`,
  `sensor`, `switch`) to read the gateway from `config_entry.runtime_data`
  using the new typed alias, removing the `pylint: disable-next=hass-use-runtime-data`
  workarounds.
- Update the service-schema gateway lookup in `_add_gateway_to_schema` to
  iterate `hass.config_entries.async_loaded_entries(DOMAIN)` and read each
  entry's `runtime_data`. Also add type hints to the helper.
- Remove the now-unused `GATEWAYS_KEY` constant from `const.py`.
- Domain-level keys `LISTENER_KEY`, `KEY_UNSUB_STOP`, and `KEY_SETUP_LOCK`
  are not per-entry data and remain in `hass.data[DOMAIN]`; the file-level
  `pylint: disable=hass-use-runtime-data` in `__init__.py` is kept for those
  legacy accesses.

No functional change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/168809
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr