### PR TITLE
Migrate waze_travel_time to use HassKey for shared semaphore

### DIFF
--- a/homeassistant/components/waze_travel_time/__init__.py
+++ b/homeassistant/components/waze_travel_time/__init__.py
@@ -49,7 +49,7 @@ from .const import (
     DOMAIN,
     METRIC_UNITS,
     REGIONS,
-    SEMAPHORE,
+    SEMAPHORE_KEY,
     UNITS,
     VEHICLE_TYPES,
 )
@@ -115,8 +115,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Load the saved entities."""
-    if SEMAPHORE not in hass.data.setdefault(DOMAIN, {}):
-        hass.data.setdefault(DOMAIN, {})[SEMAPHORE] = asyncio.Semaphore(1)
+    if SEMAPHORE_KEY not in hass.data:
+        hass.data[SEMAPHORE_KEY] = asyncio.Semaphore(1)
 
     httpx_client = get_async_client(hass)
     client = WazeRouteCalculator(

--- a/homeassistant/components/waze_travel_time/const.py
+++ b/homeassistant/components/waze_travel_time/const.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+
+from homeassistant.util.hass_dict import HassKey
+
 DOMAIN = "waze_travel_time"
-SEMAPHORE = "semaphore"
+SEMAPHORE_KEY: HassKey[asyncio.Semaphore] = HassKey(DOMAIN)
 
 CONF_BASE_COORDINATES = "base_coordinates"
 CONF_DESTINATION = "destination"

--- a/homeassistant/components/waze_travel_time/coordinator.py
+++ b/homeassistant/components/waze_travel_time/coordinator.py
@@ -1,5 +1,4 @@
 """The Waze Travel Time data coordinator."""
-# pylint: disable=hass-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import asyncio
 from collections.abc import Collection
@@ -32,7 +31,7 @@ from .const import (
     CONF_VEHICLE_TYPE,
     DOMAIN,
     IMPERIAL_UNITS,
-    SEMAPHORE,
+    SEMAPHORE_KEY,
 )
 from .helpers import base_coordinates_to_tuple
 
@@ -197,7 +196,7 @@ class WazeTravelTimeCoordinator(DataUpdateCoordinator[WazeTravelTimeData]):
             self._origin,
             self._destination,
         )
-        await self.hass.data[DOMAIN][SEMAPHORE].acquire()
+        await self.hass.data[SEMAPHORE_KEY].acquire()
         try:
             if origin_coordinates is None or destination_coordinates is None:
                 raise UpdateFailed("Unable to determine origin or destination")
@@ -258,6 +257,6 @@ class WazeTravelTimeCoordinator(DataUpdateCoordinator[WazeTravelTimeData]):
             await asyncio.sleep(SECONDS_BETWEEN_API_CALLS)
 
         finally:
-            self.hass.data[DOMAIN][SEMAPHORE].release()
+            self.hass.data[SEMAPHORE_KEY].release()
 
         return travel_data


### PR DESCRIPTION
## Proposed change

The `waze_travel_time` coordinator uses a shared `asyncio.Semaphore` to serialize calls to the Waze API across all config entries. It was stored in `hass.data[DOMAIN][SEMAPHORE]` using the legacy untyped pattern, which required a `# pylint: disable=hass-use-runtime-data` escape hatch on the coordinator module.

This PR replaces the untyped string lookup with a typed `HassKey[asyncio.Semaphore]`, removes the now-unneeded `pylint: disable` directive, and drops the obsolete `SEMAPHORE` string constant. The per-entry data is already stored on `entry.runtime_data`; the shared semaphore is the only remaining `hass.data` use, and `HassKey` is the recommended pattern for that case.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #168806
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.