### PR TITLE
fix: the owntracks integration receives gps location... in __init__.py

### DIFF
--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -171,6 +171,14 @@ async def handle_webhook(
         _LOGGER.warning("Received invalid JSON from OwnTracks")
         return web.json_response([])
 
+    # When a secret is configured, only accept encrypted messages to prevent spoofing
+    if context.secret and message.get("_type") != "encrypted":
+        _LOGGER.warning(
+            "Rejecting unencrypted OwnTracks webhook message. "
+            "Enable encryption in the OwnTracks app when a secret is configured."
+        )
+        return web.Response(status=403)
+
     # Android doesn't populate topic
     if "topic" not in message:
         headers = request.headers


### PR DESCRIPTION
## Summary
Fix high severity security issue in `homeassistant/components/owntracks/__init__.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-005 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-005` |
| **File** | `homeassistant/components/owntracks/__init__.py:169` |

**Description**: The OwnTracks integration receives GPS location data via a webhook endpoint and uses it to drive presence detection automations. If the endpoint does not enforce authentication or validate that incoming messages originate from legitimate OwnTracks devices (e.g., via a shared secret or HMAC signature), an attacker can POST spoofed location data to falsely indicate that the home owner is present or away, triggering security-critical automations.

## Changes
- `homeassistant/components/owntracks/init.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
