### PR TITLE
fix: the remote_calendar and generic camera componen... in client.py

### DIFF
--- a/homeassistant/components/remote_calendar/client.py
+++ b/homeassistant/components/remote_calendar/client.py
@@ -1,6 +1,25 @@
 """HTTP client for fetching remote calendar data."""
 
-from httpx import AsyncClient, Auth, BasicAuth, Response, Timeout
+from ipaddress import ip_address
+from urllib.parse import urlparse
+
+from httpx import AsyncClient, Auth, BasicAuth, InvalidURL, Response, Timeout
+
+from homeassistant.util.network import is_invalid, is_local
+
+
+def _validate_url(url: str) -> None:
+    """Raise InvalidURL if the URL targets an internal or private network address."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise InvalidURL(f"Invalid URL scheme: {parsed.scheme!r}")
+    host = parsed.hostname or ""
+    try:
+        addr = ip_address(host)
+        if is_local(addr) or is_invalid(addr):
+            raise InvalidURL(f"URL targets a private/internal address: {host!r}")
+    except ValueError:
+        pass  # hostname rather than IP address — skip IP-range check
 
 
 async def get_calendar(
@@ -10,6 +29,7 @@ async def get_calendar(
     password: str | None = None,
 ) -> Response:
     """Make an HTTP GET request using Home Assistant's async HTTPX client with timeout."""
+    _validate_url(url)
     auth: Auth | None = None
     if username is not None and password is not None:
         auth = BasicAuth(username, password)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `homeassistant/components/remote_calendar/client.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-007 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-007` |
| **File** | `homeassistant/components/remote_calendar/client.py:3` |

**Description**: The remote_calendar and generic camera components accept user-configured URLs to fetch calendar data and camera streams. Without validation against an allowlist of permitted schemes and hosts, an attacker with admin access (or who exploits another vulnerability allowing configuration modification) can set the URL to an internal network address, causing the Home Assistant server to act as a proxy to internal services — including cloud instance metadata endpoints that expose cloud provider credentials.

## Changes
- `homeassistant/components/remote_calendar/client.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
