### PR TITLE
Migrate yeelight to use HassKey for shared custom effects

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     CONF_NIGHTLIGHT_SWITCH_TYPE,
     CONF_SAVE_ON_CHANGE,
     CONF_TRANSITION,
-    DATA_CUSTOM_EFFECTS,
+    DATA_CUSTOM_EFFECTS_KEY,
     DEFAULT_MODE_MUSIC,
     DEFAULT_NAME,
     DEFAULT_NIGHTLIGHT_SWITCH,
@@ -116,10 +116,7 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Yeelight bulbs."""
     conf = config.get(DOMAIN, {})
-    # pylint: disable-next=hass-use-runtime-data
-    hass.data[DOMAIN] = {
-        DATA_CUSTOM_EFFECTS: conf.get(CONF_CUSTOM_EFFECTS, {}),
-    }
+    hass.data[DATA_CUSTOM_EFFECTS_KEY] = conf.get(CONF_CUSTOM_EFFECTS, [])
     # Make sure the scanner is always started in case we are
     # going to retry via ConfigEntryNotReady and the bulb has changed
     # ip

--- a/homeassistant/components/yeelight/const.py
+++ b/homeassistant/components/yeelight/const.py
@@ -1,10 +1,13 @@
 """Support for Xiaomi Yeelight WiFi color bulb."""
 
 from datetime import timedelta
+from typing import Any
 
 from homeassistant.const import Platform
+from homeassistant.util.hass_dict import HassKey
 
 DOMAIN = "yeelight"
+DATA_CUSTOM_EFFECTS_KEY: HassKey[list[dict[str, Any]]] = HassKey(DOMAIN)
 
 
 STATE_CHANGE_TIME = 0.40  # seconds
@@ -42,8 +45,6 @@ CONF_FLOW_PARAMS = "flow_params"
 CONF_CUSTOM_EFFECTS = "custom_effects"
 CONF_NIGHTLIGHT_SWITCH_TYPE = "nightlight_switch_type"
 CONF_NIGHTLIGHT_SWITCH = "nightlight_switch"
-
-DATA_CUSTOM_EFFECTS = "custom_effects"
 
 ATTR_COUNT = "count"
 ATTR_ACTION = "action"

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -217,7 +217,9 @@ def _transitions_config_parser(transitions):
 
 
 @callback
-def _parse_custom_effects(effects_config) -> dict[str, dict[str, Any]]:
+def _parse_custom_effects(
+    effects_config: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
     effects = {}
     for config in effects_config:
         params = config[CONF_FLOW_PARAMS]

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -51,9 +51,8 @@ from .const import (
     CONF_NIGHTLIGHT_SWITCH,
     CONF_SAVE_ON_CHANGE,
     CONF_TRANSITION,
-    DATA_CUSTOM_EFFECTS,
+    DATA_CUSTOM_EFFECTS_KEY,
     DATA_UPDATED,
-    DOMAIN,
     MODELS_WITH_DELAYED_ON_TRANSITION,
     POWER_STATE_CHANGE_TIME,
 )
@@ -280,8 +279,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Yeelight from a config entry."""
-    # pylint: disable-next=hass-use-runtime-data
-    custom_effects = _parse_custom_effects(hass.data[DOMAIN][DATA_CUSTOM_EFFECTS])
+    custom_effects = _parse_custom_effects(hass.data[DATA_CUSTOM_EFFECTS_KEY])
 
     device = config_entry.runtime_data
     _LOGGER.debug("Adding %s", device.name)


### PR DESCRIPTION
## Proposed change

The `yeelight` integration stores YAML-configured custom effects in `hass.data[DOMAIN][DATA_CUSTOM_EFFECTS]` so the light platform can read them when setting up entities. Per-entry data already lives on `entry.runtime_data` (typed `YeelightConfigEntry`); the custom-effects list is the only remaining `hass.data` use, and was using the legacy untyped pattern with two `# pylint: disable=hass-use-runtime-data` escape hatches (one in `__init__.py`, one in `light.py`).

This PR replaces the untyped string lookup with a typed `HassKey[list[dict[str, Any]]]`, drops the `DATA_CUSTOM_EFFECTS` string constant, and removes both `pylint: disable` directives. The default for the unconfigured case is changed from `{}` to `[]` to match the iterated list shape (no behavioral change — both iterate as empty).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #168810
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.