### PR TITLE
homematicip_cloud: migrate entity names to has_entity_name

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -189,17 +189,15 @@ class HomematicipCloudConnectionSensor(HomematicipGenericEntity, BinarySensorEnt
     @property
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
-        # Adds a sensor to the existing HAP device.
-        # Name must be set explicitly for has_entity_name to work correctly.
-        home_name = getattr(self._home, "name", None)
+        # Merges into the existing HAP device registered in __init__.py.
+        # Name must match __init__.py logic for has_entity_name to work.
         label = self._home.label or ""
-        name = f"{home_name} {label}" if home_name else label
         return DeviceInfo(
             identifiers={
                 # Serial numbers of Homematic IP device
                 (DOMAIN, self._home.id)
             },
-            name=name,
+            name=label,
         )
 
     @property

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -180,27 +180,26 @@ async def async_setup_entry(
 class HomematicipCloudConnectionSensor(HomematicipGenericEntity, BinarySensorEntity):
     """Representation of the HomematicIP cloud connection sensor."""
 
+    _attr_translation_key = "cloud_connection"
+
     def __init__(self, hap: HomematicipHAP) -> None:
         """Initialize the cloud connection sensor."""
         super().__init__(hap, hap.home, feature_id="cloud_connection")
 
     @property
-    def name(self) -> str:
-        """Return the name cloud connection entity."""
-
-        name = "Cloud Connection"
-        # Add a prefix to the name if the homematic ip home has a name.
-        return name if not self._home.name else f"{self._home.name} {name}"
-
-    @property
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
-        # Adds a sensor to the existing HAP device
+        # Adds a sensor to the existing HAP device.
+        # Name must be set explicitly for has_entity_name to work correctly.
+        home_name = getattr(self._home, "name", None)
+        label = self._home.label or ""
+        name = f"{home_name} {label}" if home_name else label
         return DeviceInfo(
             identifiers={
                 # Serial numbers of Homematic IP device
                 (DOMAIN, self._home.id)
-            }
+            },
+            name=name,
         )
 
     @property
@@ -579,6 +578,7 @@ class HomematicipPluggableMainsFailureSurveillanceSensor(
 class HomematicipSecurityZoneSensorGroup(HomematicipGenericEntity, BinarySensorEntity):
     """Representation of the HomematicIP security zone sensor group."""
 
+    _attr_has_entity_name = False
     _attr_device_class = BinarySensorDeviceClass.SAFETY
 
     def __init__(

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -74,6 +74,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
     basically enabled in the hmip app.
     """
 
+    _attr_has_entity_name = False
     _attr_supported_features = (
         ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
     )

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -320,6 +320,7 @@ class HomematicipGarageDoorModule(HomematicipGenericEntity, CoverEntity):
 class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
     """Representation of the HomematicIP cover shutter group."""
 
+    _attr_has_entity_name = False
     _attr_device_class = CoverDeviceClass.SHUTTER
 
     def __init__(self, hap: HomematicipHAP, device, post: str = "ShutterGroup") -> None:

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -256,7 +256,10 @@ class HomematicipGenericEntity(Entity):
                     stripped = label_str[len(device_label) :].strip()
                     if stripped:
                         self._attr_name = stripped
-                        return
+                    # Otherwise channel label equals device label (modulo
+                    # whitespace); leave _attr_name unset so HA composes just
+                    # the device name without duplicating it.
+                    return
                 self._attr_name = label_str
                 return
             # Fallback: use post suffix or generic channel name.
@@ -292,7 +295,9 @@ class HomematicipGenericEntity(Entity):
                     stripped = label_str[len(device_label) :].strip()
                     if stripped:
                         self._attr_name = stripped
-                        return
+                    # Otherwise channel label equals device label (modulo
+                    # whitespace); leave _attr_name unset.
+                    return
                 self._attr_name = label_str
                 return
 

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -74,6 +74,7 @@ GROUP_ATTRIBUTES = {
 class HomematicipGenericEntity(Entity):
     """Representation of the HomematicIP generic entity."""
 
+    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(
@@ -112,6 +113,14 @@ class HomematicipGenericEntity(Entity):
         # Marker showing that the HmIP device hase been removed.
         self.hmip_device_removed = False
 
+        # Compute entity name based on has_entity_name mode.
+        if not self._attr_has_entity_name:
+            # Legacy mode (groups, special entities): compose the full name
+            # including device/group label and home prefix.
+            self._attr_name = self._compute_legacy_name()
+        else:
+            self._setup_entity_name()
+
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes."""
@@ -120,6 +129,14 @@ class HomematicipGenericEntity(Entity):
             device_id = str(self._device.id)
             home_id = str(self._device.homeId)
 
+            # Include the home name in the device name so that the
+            # previous "{home} {device}" naming is preserved after
+            # switching to has_entity_name=True.
+            device_name = self._device.label
+            home_name = getattr(self._home, "name", None)
+            if device_name and home_name:
+                device_name = f"{home_name} {device_name}"
+
             return DeviceInfo(
                 identifiers={
                     # Serial numbers of Homematic IP device
@@ -127,7 +144,7 @@ class HomematicipGenericEntity(Entity):
                 },
                 manufacturer=self._device.oem,
                 model=self._device.modelType,
-                name=self._device.label,
+                name=device_name,
                 sw_version=self._device.firmwareVersion,
                 # Link to the homematic ip access point.
                 via_device=(DOMAIN, home_id),
@@ -200,37 +217,87 @@ class HomematicipGenericEntity(Entity):
             self.async_remove(force_remove=True), eager_start=False
         )
 
-    @property
-    def name(self) -> str:
-        """Return the name of the generic entity."""
+    def _compute_legacy_name(self) -> str:
+        """Compute the full legacy name for entities without has_entity_name.
 
-        name = ""
-        # Try to get a label from a channel.
-        functional_channels = getattr(self._device, "functionalChannels", None)
-        if functional_channels and self.functional_channel:
-            if self._is_multi_channel:
-                label = getattr(self.functional_channel, "label", None)
-                if label:
-                    name = str(label)
-            elif len(functional_channels) > 1:
-                label = getattr(functional_channels[1], "label", None)
-                if label:
-                    name = str(label)
-
-        # Use device label, if name is not defined by channel label.
-        if not name:
-            name = self._device.label or ""
-            if self._post:
-                name = f"{name} {self._post}"
-            elif self._is_multi_channel:
-                name = f"{name} Channel{self.get_channel_index()}"
-
-        # Add a prefix to the name if the homematic ip home has a name.
+        Used by group entities and other special cases where has_entity_name
+        is False. Includes device/group label, post suffix, and home prefix.
+        """
+        name = self._device.label or ""
+        if self._post:
+            name = f"{name} {self._post}" if name else self._post
         home_name = getattr(self._home, "name", None)
         if name and home_name:
             name = f"{home_name} {name}"
-
         return name
+
+    def _setup_entity_name(self) -> None:
+        """Set up entity naming for has_entity_name mode.
+
+        With has_entity_name=True, HA composes the full friendly name as
+        "{device_name} {entity_name}". This method sets the appropriate
+        naming attributes.
+
+        For multi-channel entities, channel labels provide _attr_name (dynamic).
+        For entities with _post, _attr_name is derived from the post suffix,
+        with the first letter capitalized for display consistency.
+        For primary entities, HA uses device_class as the name.
+        """
+        # Multi-channel entities: use channel label as entity name.
+        if self._is_multi_channel and self.functional_channel:
+            label = getattr(self.functional_channel, "label", None)
+            if label:
+                label_str = str(label)
+                device_label = self._device.label or ""
+                # Strip device name prefix from channel label to avoid
+                # duplication when HA composes "{device_name} {entity_name}".
+                # E.g., device "Licht Flur" + channel "Licht Flur 5" -> "5".
+                if device_label and label_str.startswith(device_label):
+                    stripped = label_str[len(device_label) :].strip()
+                    if stripped:
+                        self._attr_name = stripped
+                        return
+                self._attr_name = label_str
+                return
+            # Fallback: use post suffix or generic channel name.
+            if self._post:
+                self._attr_name = self._post[0].upper() + self._post[1:]
+            else:
+                self._attr_name = f"Channel{self.get_channel_index()}"
+            return
+
+        # Entities with a post suffix: use it as the entity name,
+        # capitalizing the first letter for display consistency.
+        if self._post:
+            self._attr_name = self._post[0].upper() + self._post[1:]
+            return
+
+        # Non-multi-channel entities on devices with multiple channels:
+        # use the first functional channel's label as name context.
+        # This preserves names like "Treppe CH" for single-function entities
+        # on multi-channel devices (e.g., HmIP-BSL switch channel).
+        functional_channels = getattr(self._device, "functionalChannels", None)
+        if functional_channels and len(functional_channels) > 1:
+            ch1 = (
+                functional_channels.get(1)
+                if isinstance(functional_channels, dict)
+                else functional_channels[1]
+            )
+            label = getattr(ch1, "label", None) if ch1 else None
+            if label:
+                label_str = str(label)
+                device_label = self._device.label or ""
+                # Strip device name prefix to avoid duplication.
+                if device_label and label_str.startswith(device_label):
+                    stripped = label_str[len(device_label) :].strip()
+                    if stripped:
+                        self._attr_name = stripped
+                        return
+                self._attr_name = label_str
+                return
+
+        # Primary entity on device: leave unset so HA derives name from
+        # device_class or translation_key.
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/homematicip_cloud/event.py
+++ b/homeassistant/components/homematicip_cloud/event.py
@@ -82,7 +82,6 @@ class HomematicipDoorBellEvent(HomematicipGenericEntity, EventEntity):
         super().__init__(
             hap,
             device,
-            post=description.key,
             channel=channel,
             is_multi_channel=False,
             feature_id="doorbell",

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -1070,9 +1070,7 @@ class HmipSmokeDetectorSensor(HomematicipGenericEntity, SensorEntity):
         description: HmipSmokeDetectorSensorDescription,
     ) -> None:
         """Initialize the smoke detector sensor."""
-        super().__init__(
-            hap, device, post=description.key, feature_id="smoke_detector_sensor"
-        )
+        super().__init__(hap, device, feature_id="smoke_detector_sensor")
         self.entity_description = description
         self._sensor_unique_id = f"{device.id}_{description.key}"
 

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -37,6 +37,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "cloud_connection": {
+        "name": "Cloud connection"
+      }
+    },
     "light": {
       "optical_signal_light": {
         "state_attributes": {

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -142,6 +142,8 @@ class HomematicipSwitch(HomematicipMultiSwitch, SwitchEntity):
 class HomematicipGroupSwitch(HomematicipGenericEntity, SwitchEntity):
     """Representation of the HomematicIP switching group."""
 
+    _attr_has_entity_name = False
+
     def __init__(self, hap: HomematicipHAP, device, post: str = "Group") -> None:
         """Initialize switching group."""
         device.modelType = f"HmIP-{post}"

--- a/homeassistant/components/homematicip_cloud/weather.py
+++ b/homeassistant/components/homematicip_cloud/weather.py
@@ -75,11 +75,6 @@ class HomematicipWeatherSensor(HomematicipGenericEntity, WeatherEntity):
         super().__init__(hap, device, feature_id="weather")
 
     @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return self._device.label
-
-    @property
     def native_temperature(self) -> float:
         """Return the platform temperature."""
         return self._device.actualTemperature
@@ -118,6 +113,7 @@ class HomematicipWeatherSensorPro(HomematicipWeatherSensor):
 class HomematicipHomeWeather(HomematicipGenericEntity, WeatherEntity):
     """Representation of the HomematicIP home weather."""
 
+    _attr_has_entity_name = False
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
     _attr_attribution = "Powered by Homematic IP"

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -44,7 +44,9 @@ def get_and_check_entity_basics(
     assert ha_state is not None
     if device_model:
         assert ha_state.attributes[ATTR_MODEL_TYPE] == device_model
-    assert ha_state.name == entity_name
+    assert ha_state.name == entity_name, (
+        f"Expected '{entity_name}', got '{ha_state.name}'"
+    )
 
     hmip_device = mock_hap.hmip_device_by_entity_id.get(entity_id)
 

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -131,8 +131,8 @@ async def test_hmip_home_cloud_connection_sensor(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipCloudConnectionSensor."""
-    entity_id = "binary_sensor.cloud_connection"
-    entity_name = "Home Cloud Connection"
+    entity_id = "binary_sensor.home_cloud_connection"
+    entity_name = "Home Cloud connection"
     device_model = None
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
         test_devices=["Cloud Connection"]
@@ -154,11 +154,11 @@ async def test_hmip_acceleration_sensor(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipAccelerationSensor."""
-    entity_id = "binary_sensor.garagentor"
-    entity_name = "Garagentor"
+    entity_id = "binary_sensor.garagentor_moving"
+    entity_name = "Garagentor Moving"
     device_model = "HmIP-SAM"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Garagentor"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -193,11 +193,11 @@ async def test_hmip_tilt_vibration_sensor(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTiltVibrationSensor."""
-    entity_id = "binary_sensor.garage_neigungs_und_erschutterungssensor"
-    entity_name = "Garage Neigungs- und Erschütterungssensor"
+    entity_id = "binary_sensor.garage_neigungs_und_erschutterungssensor_moving"
+    entity_name = "Garage Neigungs- und Erschütterungssensor Moving"
     device_model = "HmIP-STV"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Garage Neigungs- und Erschütterungssensor"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -231,11 +231,11 @@ async def test_hmip_contact_interface(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipContactInterface."""
-    entity_id = "binary_sensor.kontakt_schnittstelle_unterputz_1_fach"
-    entity_name = "Kontakt-Schnittstelle Unterputz – 1-fach"
+    entity_id = "binary_sensor.kontakt_schnittstelle_unterputz_1_fach_opening"
+    entity_name = "Kontakt-Schnittstelle Unterputz – 1-fach Opening"
     device_model = "HmIP-FCI1"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Kontakt-Schnittstelle Unterputz – 1-fach"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -256,11 +256,11 @@ async def test_hmip_shutter_contact(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipShutterContact."""
-    entity_id = "binary_sensor.fenstergriffsensor"
-    entity_name = "Fenstergriffsensor"
+    entity_id = "binary_sensor.fenstergriffsensor_door"
+    entity_name = "Fenstergriffsensor Door"
     device_model = "HmIP-SRH"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Fenstergriffsensor"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -298,11 +298,11 @@ async def test_hmip_shutter_contact_optical(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipShutterContact."""
-    entity_id = "binary_sensor.sitzplatzture"
-    entity_name = "Sitzplatzt\u00fcre"
+    entity_id = "binary_sensor.sitzplatzture_door"
+    entity_name = "Sitzplatzt\u00fcre Door"
     device_model = "HmIP-SWDO-PL"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Sitzplatzt\u00fcre"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -330,11 +330,11 @@ async def test_hmip_motion_detector(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipMotionDetector."""
-    entity_id = "binary_sensor.bewegungsmelder_fur_55er_rahmen_innen"
-    entity_name = "Bewegungsmelder für 55er Rahmen – innen"
+    entity_id = "binary_sensor.bewegungsmelder_fur_55er_rahmen_innen_motion"
+    entity_name = "Bewegungsmelder für 55er Rahmen – innen Motion"
     device_model = "HmIP-SMI55"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Bewegungsmelder für 55er Rahmen – innen"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -351,12 +351,10 @@ async def test_hmip_presence_detector(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipPresenceDetector."""
-    entity_id = "binary_sensor.spi_1"
-    entity_name = "SPI_1"
+    entity_id = "binary_sensor.spi_1_presence"
+    entity_name = "SPI_1 Presence"
     device_model = "HmIP-SPI"
-    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
-    )
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(test_devices=["SPI_1"])
 
     ha_state, hmip_device = get_and_check_entity_basics(
         hass, mock_hap, entity_id, entity_name, device_model
@@ -377,11 +375,11 @@ async def test_hmip_pluggable_mains_failure_surveillance_sensor(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipPresenceDetector."""
-    entity_id = "binary_sensor.netzausfalluberwachung"
-    entity_name = "Netzausfallüberwachung"
+    entity_id = "binary_sensor.netzausfalluberwachung_power"
+    entity_name = "Netzausfallüberwachung Power"
     device_model = "HmIP-PMFS"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Netzausfallüberwachung"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -398,11 +396,11 @@ async def test_hmip_smoke_detector(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSmokeDetector."""
-    entity_id = "binary_sensor.rauchwarnmelder"
-    entity_name = "Rauchwarnmelder"
+    entity_id = "binary_sensor.rauchwarnmelder_smoke"
+    entity_name = "Rauchwarnmelder Smoke"
     device_model = "HmIP-SWSD"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Rauchwarnmelder"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -453,11 +451,11 @@ async def test_hmip_water_detector(
     hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipWaterDetector."""
-    entity_id = "binary_sensor.wassersensor"
-    entity_name = "Wassersensor"
+    entity_id = "binary_sensor.wassersensor_moisture"
+    entity_name = "Wassersensor Moisture"
     device_model = "HmIP-SWD"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Wassersensor"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -212,8 +212,8 @@ async def test_hap_with_name(
 ) -> None:
     """Test hap with name."""
     home_name = "TestName"
-    entity_id = "light.treppe_testname_treppe_ch"
-    entity_name = "Treppe TestName Treppe CH"
+    entity_id = "light.testname_treppe_ch"
+    entity_name = "TestName Treppe CH"
     device_model = "HmIP-BSL"
 
     hmip_config_entry.add_to_hass(hass)

--- a/tests/components/homematicip_cloud/test_entity.py
+++ b/tests/components/homematicip_cloud/test_entity.py
@@ -1,0 +1,115 @@
+"""Unit tests for HomematicipGenericEntity naming helpers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from homeassistant.components.homematicip_cloud.entity import HomematicipGenericEntity
+
+
+def _make_entity(
+    *,
+    device_label: str,
+    channels: dict[int, str],
+    channel: int,
+    is_multi_channel: bool,
+    post: str | None = None,
+) -> HomematicipGenericEntity:
+    """Build a HomematicipGenericEntity bypassing __init__ for unit testing.
+
+    Only the attributes read by _setup_entity_name() are populated.
+    """
+    entity = HomematicipGenericEntity.__new__(HomematicipGenericEntity)
+    entity._device = SimpleNamespace(
+        label=device_label,
+        functionalChannels={
+            idx: SimpleNamespace(label=label, index=idx)
+            for idx, label in channels.items()
+        },
+    )
+    entity._post = post
+    entity._channel = channel
+    entity._channel_real_index = channel
+    entity._is_multi_channel = is_multi_channel
+    entity.functional_channel = entity._device.functionalChannels.get(channel)
+    entity._attr_name = None
+    return entity
+
+
+@pytest.mark.parametrize(
+    ("device_label", "channel_label"),
+    [
+        ("Thermostat EG Wohnzimmer", "Thermostat EG Wohnzimmer"),
+        ("Thermostat EG Wohnzimmer", "Thermostat EG Wohnzimmer "),
+        ("Thermostat EG Wohnzimmer ", "Thermostat EG Wohnzimmer "),
+    ],
+    ids=["exact-match", "trailing-space-on-channel", "trailing-space-on-both"],
+)
+def test_multi_channel_label_equals_device_label_leaves_name_unset(
+    device_label: str, channel_label: str
+) -> None:
+    """When channel label equals device label, _attr_name must stay None.
+
+    Otherwise HA composes "{device_name} {entity_name}" and the user sees the
+    label duplicated, e.g. "Thermostat EG Wohnzimmer Thermostat EG Wohnzimmer".
+    """
+    entity = _make_entity(
+        device_label=device_label,
+        channels={3: channel_label, 1: "primary"},
+        channel=3,
+        is_multi_channel=True,
+    )
+    entity._setup_entity_name()
+    assert entity._attr_name is None
+
+
+def test_multi_channel_label_extends_device_label_keeps_suffix() -> None:
+    """When channel label starts with device label + suffix, keep the suffix."""
+    entity = _make_entity(
+        device_label="Licht Flur",
+        channels={5: "Licht Flur 5"},
+        channel=5,
+        is_multi_channel=True,
+    )
+    entity._setup_entity_name()
+    assert entity._attr_name == "5"
+
+
+def test_multi_channel_label_unrelated_to_device_label_uses_full_label() -> None:
+    """When channel label does not start with device label, use it verbatim."""
+    entity = _make_entity(
+        device_label="DRS8-4",
+        channels={2: "Flur OG Lampe"},
+        channel=2,
+        is_multi_channel=True,
+    )
+    entity._setup_entity_name()
+    assert entity._attr_name == "Flur OG Lampe"
+
+
+def test_primary_entity_with_channel_1_label_equals_device_label_unset() -> None:
+    """Non-multi-channel entity on device whose ch1 label equals device label.
+
+    Same duplication risk as the multi-channel case; same fix.
+    """
+    entity = _make_entity(
+        device_label="Thermostat EG Wohnzimmer",
+        channels={1: "Thermostat EG Wohnzimmer ", 2: "other"},
+        channel=2,  # non-multi-channel entity sits on some channel
+        is_multi_channel=False,
+    )
+    entity._setup_entity_name()
+    assert entity._attr_name is None
+
+
+def test_post_suffix_capitalised() -> None:
+    """Post suffix becomes the entity name with first letter uppercased."""
+    entity = _make_entity(
+        device_label="Bewegungsmelder Küche",
+        channels={1: "primary"},
+        channel=1,
+        is_multi_channel=False,
+        post="battery",
+    )
+    entity._setup_entity_name()
+    assert entity._attr_name == "Battery"

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -807,7 +807,7 @@ async def test_hmip_water_valve_current_water_flow(
 ) -> None:
     """Test HomematicipCurrentWaterFlow."""
     entity_id = "sensor.bewaesserungsaktor_currentwaterflow"
-    entity_name = "Bewaesserungsaktor currentWaterFlow"
+    entity_name = "Bewaesserungsaktor CurrentWaterFlow"
     device_model = "ELV-SH-WSM"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
         test_devices=["Bewaesserungsaktor"]
@@ -830,7 +830,7 @@ async def test_hmip_water_valve_water_volume(
 ) -> None:
     """Test HomematicipWaterVolume."""
     entity_id = "sensor.bewaesserungsaktor_watervolume"
-    entity_name = "Bewaesserungsaktor waterVolume"
+    entity_name = "Bewaesserungsaktor WaterVolume"
     device_model = "ELV-SH-WSM"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
         test_devices=["Bewaesserungsaktor"]
@@ -850,7 +850,7 @@ async def test_hmip_water_valve_water_volume_since_open(
 ) -> None:
     """Test HomematicipWaterVolumeSinceOpen."""
     entity_id = "sensor.bewaesserungsaktor_watervolumesinceopen"
-    entity_name = "Bewaesserungsaktor waterVolumeSinceOpen"
+    entity_name = "Bewaesserungsaktor WaterVolumeSinceOpen"
     device_model = "ELV-SH-WSM"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
         test_devices=["Bewaesserungsaktor"]
@@ -870,7 +870,7 @@ async def test_hmip_smoke_detector_dirt_level(
 ) -> None:
     """Test HomematicipSmokeDetectorDirtLevel."""
     entity_id = "sensor.rauchwarnmelder_dirt_level"
-    entity_name = "Rauchwarnmelder Dirt_level"
+    entity_name = "Rauchwarnmelder Dirt level"
     device_model = "HmIP-SWSD"
 
     # Pre-register the entity as enabled before platform loads
@@ -910,7 +910,7 @@ async def test_hmip_smoke_detector_alarm_counter(
 ) -> None:
     """Test HomematicipSmokeDetectorAlarmCounter."""
     entity_id = "sensor.rauchwarnmelder_smoke_alarm_counter"
-    entity_name = "Rauchwarnmelder Smoke_alarm_counter"
+    entity_name = "Rauchwarnmelder Alarm counter"
     device_model = "HmIP-SWSD"
 
     # Pre-register the entity as enabled before platform loads
@@ -947,7 +947,7 @@ async def test_hmip_smoke_detector_test_counter(
 ) -> None:
     """Test HomematicipSmokeDetectorTestCounter."""
     entity_id = "sensor.rauchwarnmelder_smoke_test_counter"
-    entity_name = "Rauchwarnmelder Smoke_test_counter"
+    entity_name = "Rauchwarnmelder Test counter"
     device_model = "HmIP-SWSD"
 
     # Pre-register the entity as enabled before platform loads


### PR DESCRIPTION
## Proposed change

This is step 2 in modernizing the homematicip_cloud integration, following the unique ID migration (#166580). It switches entity naming from a custom `name` property override to HA's standard `has_entity_name` model, which is a prerequisite for adopting entity descriptions (planned next, starting with binary_sensor using the eheimdigital generics pattern as discussed with @joostlek on Discord).

The shared entity base now enables `has_entity_name` and computes entity names during initialization. Device names (including the home name prefix) move into `DeviceInfo`, while entity-specific names come from `_attr_name`, `device_class`, or `translation_key`. Group entities and other special cases keep legacy naming for now.

Also adds the missing translation for the cloud connection binary sensor.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: #166052
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [x] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure