### PR TITLE
Discover Fibaro FGMS001 v2.8 as a motion sensor for Z-Wave

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -47,6 +47,7 @@ from .helpers import (
     is_opening_state_notification_value,
 )
 from .models import (
+    FirmwareVersionRange,
     NewZWaveDiscoverySchema,
     ValueType,
     ZwaveDiscoveryInfo,
@@ -1343,6 +1344,28 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
             key="window_door_is_tilted",
             name="Window/door is tilted",
             device_class=BinarySensorDeviceClass.WINDOW,
+        ),
+        entity_class=ZWaveBooleanBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        # Fibaro FGMS001 Motion Sensor (0x010F:0x0800:0x1001).
+        # On firmware <= 2.8 the device supports Binary Sensor CC v1, which
+        # does not give us any information about the type of the sensor.
+        # As a result it is exposed via the generic "Any" sensor type,
+        # which fits no other discovery schema.
+        platform=Platform.BINARY_SENSOR,
+        manufacturer_id={0x010F},
+        product_id={0x1001},
+        product_type={0x0800},
+        firmware_version_range=FirmwareVersionRange(max="2.8"),
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SENSOR_BINARY},
+            property={"Any"},
+            type={ValueType.BOOLEAN},
+        ),
+        entity_description=BinarySensorEntityDescription(
+            key="motion",
+            device_class=BinarySensorDeviceClass.MOTION,
         ),
         entity_class=ZWaveBooleanBinarySensor,
     ),

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -1348,15 +1348,25 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_class=ZWaveBooleanBinarySensor,
     ),
     NewZWaveDiscoverySchema(
-        # Fibaro FGMS001 Motion Sensor (0x010F:0x0800:0x1001).
+        # Fibaro FGMS001 Motion Sensor:
         # On firmware <= 2.8 the device supports Binary Sensor CC v1, which
         # does not give us any information about the type of the sensor.
         # As a result it is exposed via the generic "Any" sensor type,
         # which fits no other discovery schema.
         platform=Platform.BINARY_SENSOR,
         manufacturer_id={0x010F},
-        product_id={0x1001},
-        product_type={0x0800},
+        product_type={0x0800, 0x0801, 0x8800},
+        product_id={
+            0x1001,
+            0x1002,
+            0x2001,
+            0x2002,
+            0x3001,
+            0x3002,
+            0x4001,
+            0x4002,
+            0x6001,
+        },
         firmware_version_range=FirmwareVersionRange(max="2.8"),
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SENSOR_BINARY},

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -598,6 +598,17 @@ def hoppe_ehandle_connectsense_state_fixture() -> NodeDataType:
     )
 
 
+@pytest.fixture(name="fibaro_fgms001_v2_8_state")
+def fibaro_fgms001_v2_8_state_fixture() -> NodeDataType:
+    """Load node state fixture data for Fibaro FGMS001 on firmware 2.8."""
+    return cast(
+        NodeDataType,
+        # Note: this fixture was created from a simulated device.
+        # If necessary, replace it with one created from a real FGMS001
+        load_json_object_fixture("fibaro_fgms001_v2_8_state.json", DOMAIN),
+    )
+
+
 # model fixtures
 
 
@@ -1490,5 +1501,15 @@ def hoppe_ehandle_connectsense_fixture(
 ) -> Node:
     """Load node for Hoppe eHandle ConnectSense."""
     node = Node(client, hoppe_ehandle_connectsense_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="fibaro_fgms001_v2_8")
+def fibaro_fgms001_v2_8_fixture(
+    client: MagicMock, fibaro_fgms001_v2_8_state: NodeDataType
+) -> Node:
+    """Load node for Fibaro FGMS001 on firmware 2.8."""
+    node = Node(client, fibaro_fgms001_v2_8_state)
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/fixtures/fibaro_fgms001_v2_8_state.json
+++ b/tests/components/zwave_js/fixtures/fibaro_fgms001_v2_8_state.json
@@ -1,0 +1,198 @@
+{
+  "nodeId": 2,
+  "index": 0,
+  "status": 4,
+  "ready": true,
+  "isListening": true,
+  "isRouting": true,
+  "isSecure": false,
+  "manufacturerId": 271,
+  "productId": 4097,
+  "productType": 2048,
+  "firmwareVersion": "2.8",
+  "deviceConfig": {
+    "filename": "/data/db/devices/0x010f/fgms001.json",
+    "manufacturerId": 271,
+    "manufacturer": "Fibargroup",
+    "label": "FGMS001",
+    "description": "Motion Sensor",
+    "devices": [
+      {
+        "productType": 2048,
+        "productId": 4097
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "paramInformation": {
+      "_map": {}
+    }
+  },
+  "label": "FGMS001",
+  "interviewAttempts": 1,
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 9600, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing End Node"
+    },
+    "generic": {
+      "key": 7,
+      "label": "Notification Sensor"
+    },
+    "specific": {
+      "key": 1,
+      "label": "Notification Sensor"
+    }
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x010f:0x0800:0x1001:2.8",
+  "highestSecurityClass": -1,
+  "isControllerNode": false,
+  "keepAwake": false,
+  "protocol": 0,
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 48,
+      "commandClassName": "Binary Sensor",
+      "property": "Any",
+      "propertyName": "Any",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Sensor state (Any)",
+        "ccSpecific": {
+          "sensorType": 255
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 4097
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 2048
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 271
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions",
+        "stateful": true,
+        "secret": false
+      },
+      "value": ["2.8"]
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 2,
+      "index": 0,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing End Node"
+        },
+        "generic": {
+          "key": 7,
+          "label": "Notification Sensor"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Notification Sensor"
+        }
+      },
+      "commandClasses": [
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 48,
+          "name": "Binary Sensor",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
 )
 from homeassistant.components.zwave_js.const import DOMAIN
+from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -25,7 +26,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -1511,3 +1516,46 @@ async def test_legacy_door_open_state_stale_repair_issue_cleaned_up(
         )
         is None
     )
+
+
+async def test_fibaro_fgms001_v2_8_motion_discovery(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    fibaro_fgms001_v2_8: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test the Fibaro FGMS001 on firmware 2.8 is discovered as a motion sensor.
+
+    The device exposes its motion state via the Sensor Binary CC under the
+    "Any" sensor type. Without the device-specific discovery override the
+    value would either fall through to the disabled legacy boolean schema
+    or be misclassified, so we assert that exactly one binary_sensor entity
+    with device_class=motion is created and no light entity exists.
+    """
+    device = device_registry.async_get_device(
+        identifiers={get_device_id(client.driver, fibaro_fgms001_v2_8)}
+    )
+    assert device is not None
+
+    entries = er.async_entries_for_device(
+        entity_registry, device.id, include_disabled_entities=True
+    )
+
+    motion_entries = [
+        entry
+        for entry in entries
+        if entry.domain == BINARY_SENSOR_DOMAIN
+        and entry.original_device_class == BinarySensorDeviceClass.MOTION
+    ]
+    assert len(motion_entries) == 1
+    motion_entry = motion_entries[0]
+    assert motion_entry.disabled_by is None
+
+    state = hass.states.get(motion_entry.entity_id)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.MOTION
+
+    assert not [entry for entry in entries if entry.domain == Platform.LIGHT]

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -15,7 +15,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
 )
 from homeassistant.components.zwave_js.const import DOMAIN
-from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -26,11 +25,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-    issue_registry as ir,
-)
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -1516,46 +1511,3 @@ async def test_legacy_door_open_state_stale_repair_issue_cleaned_up(
         )
         is None
     )
-
-
-async def test_fibaro_fgms001_v2_8_motion_discovery(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    device_registry: dr.DeviceRegistry,
-    client: MagicMock,
-    fibaro_fgms001_v2_8: Node,
-    integration: MockConfigEntry,
-) -> None:
-    """Test the Fibaro FGMS001 on firmware 2.8 is discovered as a motion sensor.
-
-    The device exposes its motion state via the Sensor Binary CC under the
-    "Any" sensor type. Without the device-specific discovery override the
-    value would either fall through to the disabled legacy boolean schema
-    or be misclassified, so we assert that exactly one binary_sensor entity
-    with device_class=motion is created and no light entity exists.
-    """
-    device = device_registry.async_get_device(
-        identifiers={get_device_id(client.driver, fibaro_fgms001_v2_8)}
-    )
-    assert device is not None
-
-    entries = er.async_entries_for_device(
-        entity_registry, device.id, include_disabled_entities=True
-    )
-
-    motion_entries = [
-        entry
-        for entry in entries
-        if entry.domain == BINARY_SENSOR_DOMAIN
-        and entry.original_device_class == BinarySensorDeviceClass.MOTION
-    ]
-    assert len(motion_entries) == 1
-    motion_entry = motion_entries[0]
-    assert motion_entry.disabled_by is None
-
-    state = hass.states.get(motion_entry.entity_id)
-    assert state is not None
-    assert state.state == STATE_OFF
-    assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.MOTION
-
-    assert not [entry for entry in entries if entry.domain == Platform.LIGHT]

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -7,6 +7,10 @@ import pytest
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
 
+from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+    BinarySensorDeviceClass,
+)
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode
 from homeassistant.components.number import (
@@ -28,8 +32,10 @@ from homeassistant.components.zwave_js.discovery import (
 from homeassistant.components.zwave_js.discovery_data_template import (
     DynamicCurrentTempClimateDataTemplate,
 )
+from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     STATE_OFF,
     STATE_UNKNOWN,
@@ -658,3 +664,47 @@ async def test_nabu_casa_zwa2_legacy(
     assert state.attributes["friendly_name"] == "Home Assistant Connect ZWA-2 LED", (
         "The LED should have the correct friendly name"
     )
+
+
+@pytest.mark.parametrize("platforms", [[Platform.BINARY_SENSOR, Platform.LIGHT]])
+async def test_fibaro_fgms001_v2_8_motion_discovery(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    fibaro_fgms001_v2_8: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test the Fibaro FGMS001 on firmware 2.8 is discovered as a motion sensor.
+
+    The device exposes its motion state via the Sensor Binary CC under the
+    "Any" sensor type. Without the device-specific discovery override the
+    value would either fall through to the disabled legacy boolean schema
+    or be misclassified, so we assert that exactly one binary_sensor entity
+    with device_class=motion is created and no light entity exists.
+    """
+    device = device_registry.async_get_device(
+        identifiers={get_device_id(client.driver, fibaro_fgms001_v2_8)}
+    )
+    assert device is not None
+
+    entries = er.async_entries_for_device(
+        entity_registry, device.id, include_disabled_entities=True
+    )
+
+    motion_entries = [
+        entry
+        for entry in entries
+        if entry.domain == BINARY_SENSOR_DOMAIN
+        and entry.original_device_class == BinarySensorDeviceClass.MOTION
+    ]
+    assert len(motion_entries) == 1
+    motion_entry = motion_entries[0]
+    assert motion_entry.disabled_by is None
+
+    state = hass.states.get(motion_entry.entity_id)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.MOTION
+
+    assert not [entry for entry in entries if entry.domain == Platform.LIGHT]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a targeted discovery schema for the Fibaro FGMS001 Motion Sensor to actually detect it as a motion sensor rather than a light entity.
On firmware <= 2.8 the device supports Binary Sensor CC v1, which does not give us any information about the type of the sensor. As a result it is exposed via the generic "Any" sensor type, which fits no other discovery schema.

Note that this change will only take effect once https://github.com/zwave-js/zwave-js/pull/8765 is released. Until then it does nothing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. **tested manually with a simulated device**
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
