### PR TITLE
Reduce image logbook spam

### DIFF
--- a/homeassistant/components/logbook/const.py
+++ b/homeassistant/components/logbook/const.py
@@ -11,9 +11,13 @@ from homeassistant.const import EVENT_CALL_SERVICE, EVENT_LOGBOOK_ENTRY
 # Domains that are always continuous
 #
 # These are hard coded here to avoid importing
-# the entire counter and proximity integrations
+# the entire counter, image, and proximity integrations
 # to get the name of the domain.
-ALWAYS_CONTINUOUS_DOMAINS = {"counter", "proximity"}
+ALWAYS_CONTINUOUS_DOMAINS = {
+    "counter",
+    "image",
+    "proximity",
+}
 
 # Domains that are continuous if there is a UOM set on the entity
 CONDITIONALLY_CONTINUOUS_DOMAINS = {SENSOR_DOMAIN}


### PR DESCRIPTION
## Proposed change

Treat the `image` domain as a continuous/high-churn domain in logbook filtering.

Roborock map image entities can update frequently during cleaning, which can cause repeated Activity/Logbook entries even though the updates are expected behavior.

This keeps the image entity state updates intact, but avoids surfacing those high-frequency image updates as user-facing logbook activity.

## Type of change

- [x] Bugfix
- [x] New integration
- [x] New feature
- [x] Dependency upgrade
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #161039

## Checklist

- [x] The code change is tested and works locally.