### PR TITLE
Require hass in Template

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -759,15 +759,7 @@ def dynamic_template(value: Any) -> template_helper.Template:
     if not template_helper.is_template_string(str(value)):
         raise vol.Invalid("template value does not contain a dynamic template")
     if not (hass := _async_get_hass_or_none()):
-        from .frame import ReportBehavior, report_usage  # noqa: PLC0415
-
-        report_usage(
-            (
-                "validates schema outside the event loop, "
-                "which will stop working in HA Core 2025.10"
-            ),
-            core_behavior=ReportBehavior.LOG,
-        )
+        raise vol.Invalid("Validates schema outside the event loop")
 
     template_value = template_helper.Template(str(value), hass)
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -36,7 +36,7 @@ from homeassistant.core import (
     callback,
     split_entity_id,
 )
-from homeassistant.exceptions import HomeAssistantError, TemplateError
+from homeassistant.exceptions import TemplateError
 from homeassistant.util import dt as dt_util
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.event_type import EventType
@@ -989,14 +989,6 @@ class TrackTemplateResultInfo:
         self._has_super_template = has_super_template
 
         self._last_result: dict[Template, bool | str | TemplateError] = {}
-
-        for track_template_ in track_templates:
-            if track_template_.template.hass:
-                continue
-
-            raise HomeAssistantError(
-                "Calls async_track_template_result with template without hass"
-            )
 
         self._rate_limit = KeyedRateLimit(hass)
         self._info: dict[Template, RenderInfo] = {}

--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -267,26 +267,14 @@ class Template:
         "template",
     )
 
-    def __init__(self, template: str, hass: HomeAssistant | None = None) -> None:
+    def __init__(self, template: str, hass: HomeAssistant) -> None:
         """Instantiate a template.
 
         Note: A valid hass instance should always be passed in. The hass parameter
         will be non optional in Home Assistant Core 2025.10.
         """
-        from homeassistant.helpers.frame import (  # noqa: PLC0415
-            ReportBehavior,
-            report_usage,
-        )
-
         if not isinstance(template, str):
             raise TypeError("Expected template to be a string")
-
-        if not hass:
-            report_usage(
-                "creates a template object without passing hass",
-                core_behavior=ReportBehavior.LOG,
-                breaks_in_ha_version="2025.10",
-            )
 
         self.template: str = template.strip()
         self._compiled_code: CodeType | None = None
@@ -302,8 +290,6 @@ class Template:
 
     @property
     def _env(self) -> TemplateEnvironment:
-        if self.hass is None:
-            return _NO_HASS_ENV
         # Bypass cache if a custom log function is specified
         if self._log_fn is not None:
             return TemplateEnvironment(
@@ -1160,6 +1146,3 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         compiled = super().compile(source)
         self.template_cache[source] = compiled
         return compiled
-
-
-_NO_HASS_ENV = TemplateEnvironment(None)

--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -268,11 +268,7 @@ class Template:
     )
 
     def __init__(self, template: str, hass: HomeAssistant) -> None:
-        """Instantiate a template.
-
-        Note: A valid hass instance should always be passed in. The hass parameter
-        will be non optional in Home Assistant Core 2025.10.
-        """
+        """Instantiate a template."""
         if not isinstance(template, str):
             raise TypeError("Expected template to be a string")
 

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -80,12 +80,11 @@ async def test_template_render_info_collision(hass: HomeAssistant) -> None:
         template_obj.async_render_to_info()
 
 
-@pytest.mark.usefixtures("hass")
-def test_template_equality() -> None:
+def test_template_equality(hass: HomeAssistant) -> None:
     """Test template comparison and hashing."""
-    template_one = template.Template("{{ template_one }}")
-    template_one_1 = template.Template("{{ template_one }}")
-    template_two = template.Template("{{ template_two }}")
+    template_one = template.Template("{{ template_one }}", hass)
+    template_one_1 = template.Template("{{ template_one }}", hass)
+    template_two = template.Template("{{ template_two }}", hass)
 
     assert template_one == template_one_1
     assert template_one != template_two
@@ -95,7 +94,7 @@ def test_template_equality() -> None:
     assert str(template_one_1) == "Template<template=({{ template_one }}) renders=0>"
 
     with pytest.raises(TypeError):
-        template.Template(["{{ template_one }}"])
+        template.Template(["{{ template_one }}"], hass)
 
 
 def test_invalid_template(hass: HomeAssistant) -> None:
@@ -143,7 +142,7 @@ def test_invalid_entity_id(hass: HomeAssistant) -> None:
 def test_raise_exception_on_error(hass: HomeAssistant) -> None:
     """Test raising an exception on error."""
     with pytest.raises(TemplateError):
-        template.Template("{{ invalid_syntax").ensure_valid()
+        template.Template("{{ invalid_syntax", hass).ensure_valid()
 
 
 def test_iterating_all_states(hass: HomeAssistant) -> None:
@@ -1896,28 +1895,30 @@ def test_render_complex_handling_non_template_values(hass: HomeAssistant) -> Non
     ) == {True: 1, False: 2}
 
 
-@pytest.mark.usefixtures("hass")
-async def test_cache_garbage_collection() -> None:
+async def test_cache_garbage_collection(hass: HomeAssistant) -> None:
     """Test caching a template."""
     template_string = (
         "{% set dict = {'foo': 'x&y', 'bar': 42} %} {{ dict | urlencode }}"
     )
     tpl = template.Template(
         (template_string),
+        hass,
     )
     tpl.ensure_valid()
-    assert template._NO_HASS_ENV.template_cache.get(template_string)
+    env = tpl._env
+    assert env.template_cache.get(template_string)
 
     tpl2 = template.Template(
         (template_string),
+        hass,
     )
     tpl2.ensure_valid()
-    assert template._NO_HASS_ENV.template_cache.get(template_string)
+    assert env.template_cache.get(template_string)
 
     del tpl
-    assert template._NO_HASS_ENV.template_cache.get(template_string)
+    assert env.template_cache.get(template_string)
     del tpl2
-    assert not template._NO_HASS_ENV.template_cache.get(template_string)
+    assert not env.template_cache.get(template_string)
 
 
 def test_is_template_string() -> None:
@@ -2289,20 +2290,3 @@ def test_template_output_exceeds_maximum_size(hass: HomeAssistant) -> None:
     """Test template output exceeds maximum size."""
     with pytest.raises(TemplateError):
         render(hass, "{{ 'a' * 1024 * 257 }}")
-
-
-def test_warn_no_hass(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
-    """Test deprecation warning when instantiating Template without hass."""
-
-    message = "Detected code that creates a template object without passing hass"
-    template.Template("blah")
-    assert message in caplog.text
-    caplog.clear()
-
-    template.Template("blah", None)
-    assert message in caplog.text
-    caplog.clear()
-
-    template.Template("blah", hass)
-    assert message not in caplog.text
-    caplog.clear()

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1954,8 +1954,7 @@ async def test_numeric_state_using_input_number(hass: HomeAssistant) -> None:
         )
 
 
-@pytest.mark.usefixtures("hass")
-async def test_extract_entities() -> None:
+async def test_extract_entities(hass: HomeAssistant) -> None:
     """Test extracting entities."""
     assert condition.async_extract_entities(
         {
@@ -2011,7 +2010,7 @@ async def test_extract_entities() -> None:
                     "entity_id": ["sensor.temperature_9", "sensor.temperature_10"],
                     "below": 110,
                 },
-                Template("{{ is_state('light.example', 'on') }}"),
+                Template("{{ is_state('light.example', 'on') }}", hass),
             ],
         }
     ) == {
@@ -2028,8 +2027,7 @@ async def test_extract_entities() -> None:
     }
 
 
-@pytest.mark.usefixtures("hass")
-async def test_extract_devices() -> None:
+async def test_extract_devices(hass: HomeAssistant) -> None:
     """Test extracting devices."""
     assert condition.async_extract_devices(
         {
@@ -2072,7 +2070,7 @@ async def test_extract_devices() -> None:
                         },
                     ],
                 },
-                Template("{{ is_state('light.example', 'on') }}"),
+                Template("{{ is_state('light.example', 'on') }}", hass),
             ],
         }
     ) == {"abcd", "qwer", "abcd_not", "qwer_not", "abcd_or", "qwer_or"}

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -747,36 +747,6 @@ def test_dynamic_template(hass: HomeAssistant) -> None:
         schema(value)
 
 
-async def test_dynamic_template_no_hass(hass: HomeAssistant) -> None:
-    """Test dynamic template validator."""
-    schema = vol.Schema(cv.dynamic_template)
-
-    for value in (
-        None,
-        1,
-        "{{ partial_print }",
-        "{% if True %}Hello",
-        ["test"],
-        "just a string",
-        # Filter added as an extension by Home Assistant
-        "{{ ['group.foo']|expand|map(attribute='entity_id')|list }}",
-    ):
-        with pytest.raises(vol.Invalid):
-            await hass.async_add_executor_job(schema, value)
-
-    options = (
-        "{{ beer }}",
-        "{% if 1 == 1 %}Hello{% else %}World{% endif %}",
-        # Function 'expand' added as an extension by Home Assistant, no error
-        # because non existing functions are not detected by Jinja2
-        "{{ expand('group.foo')|map(attribute='entity_id')|list }}",
-        # Non existing function 'no_such_function' is not detected by Jinja2
-        "{{ no_such_function('group.foo')|map(attribute='entity_id')|list }}",
-    )
-    for value in options:
-        await hass.async_add_executor_job(schema, value)
-
-
 @pytest.mark.usefixtures("hass")
 def test_template_complex() -> None:
     """Test template_complex validator."""

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -22,7 +22,7 @@ from homeassistant.core import (
     HomeAssistant,
     callback,
 )
-from homeassistant.exceptions import HomeAssistantError, TemplateError
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
 from homeassistant.helpers.event import (
@@ -4973,27 +4973,3 @@ async def test_async_track_state_report_change_event(hass: HomeAssistant) -> Non
         "light.bowl": ["on", "on", "off", "off"],
         "light.top": ["on", "on", "off", "off"],
     }
-
-
-async def test_async_track_template_no_hass_fails(hass: HomeAssistant) -> None:
-    """Test async_track_template with a template without hass now fails."""
-    message = "Calls async_track_template_result with template without hass"
-
-    with pytest.raises(HomeAssistantError, match=message):
-        async_track_template(hass, Template("blah"), lambda x, y, z: None)
-
-    async_track_template(hass, Template("blah", hass), lambda x, y, z: None)
-
-
-async def test_async_track_template_result_no_hass_fails(hass: HomeAssistant) -> None:
-    """Test async_track_template_result with a template without hass now fails."""
-    message = "Calls async_track_template_result with template without hass"
-
-    with pytest.raises(HomeAssistantError, match=message):
-        async_track_template_result(
-            hass, [TrackTemplate(Template("blah"), None)], lambda x, y, z: None
-        )
-
-    async_track_template_result(
-        hass, [TrackTemplate(Template("blah", hass), None)], lambda x, y, z: None
-    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Template class now requires that `hass` is passed in.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecated code about not passing in `hass` in a `Template` was removed


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
