### PR TITLE
Add target flow level and mode end time sensors to Duco integration

### DIFF
--- a/homeassistant/components/duco/icons.json
+++ b/homeassistant/components/duco/icons.json
@@ -10,7 +10,7 @@
       "target_flow_level": {
         "default": "mdi:gauge"
       },
-      "time_state_remain": {
+      "time_state_end": {
         "default": "mdi:timer-outline"
       },
       "ventilation_state": {

--- a/homeassistant/components/duco/icons.json
+++ b/homeassistant/components/duco/icons.json
@@ -7,6 +7,12 @@
       "iaq_rh": {
         "default": "mdi:water-percent"
       },
+      "target_flow_level": {
+        "default": "mdi:gauge"
+      },
+      "time_state_remain": {
+        "default": "mdi:timer-outline"
+      },
       "ventilation_state": {
         "default": "mdi:tune-variant"
       }

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -67,6 +68,28 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda node: node.sensor.temp if node.sensor else None,
         node_types=(NodeType.UCCO2, NodeType.BSRH, NodeType.UCRH),
+    ),
+    DucoSensorEntityDescription(
+        key="target_flow_level",
+        translation_key="target_flow_level",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        suggested_display_precision=0,
+        value_fn=lambda node: (
+            node.ventilation.flow_lvl_tgt if node.ventilation else None
+        ),
+        node_types=(NodeType.BOX,),
+    ),
+    DucoSensorEntityDescription(
+        key="time_state_remain",
+        translation_key="time_state_remain",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
+        value_fn=lambda node: (
+            node.ventilation.time_state_remain if node.ventilation else None
+        ),
+        node_types=(NodeType.BOX,),
     ),
     DucoSensorEntityDescription(
         key="box_temperature",

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 import logging
 
 from duco.models import Node, NodeType, VentilationState
@@ -20,11 +21,11 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfTemperature,
-    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import DucoConfigEntry, DucoCoordinator
@@ -39,7 +40,7 @@ PARALLEL_UPDATES = 0
 class DucoSensorEntityDescription(SensorEntityDescription):
     """Duco sensor entity description."""
 
-    value_fn: Callable[[Node], int | float | str | None]
+    value_fn: Callable[[Node], datetime | int | float | str | None]
     node_types: tuple[NodeType, ...]
 
 
@@ -81,13 +82,15 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         node_types=(NodeType.BOX,),
     ),
     DucoSensorEntityDescription(
-        key="time_state_remain",
-        translation_key="time_state_remain",
-        device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=UnitOfTime.SECONDS,
-        suggested_display_precision=0,
+        key="time_state_end",
+        translation_key="time_state_end",
+        device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda node: (
-            node.ventilation.time_state_remain if node.ventilation else None
+            dt_util.utc_from_timestamp(node.ventilation.time_state_end).replace(
+                second=0, microsecond=0
+            )
+            if node.ventilation and node.ventilation.time_state_end != 0
+            else None
         ),
         node_types=(NodeType.BOX,),
     ),
@@ -233,7 +236,7 @@ class DucoSensorEntity(DucoEntity, SensorEntity):
         )
 
     @property
-    def native_value(self) -> int | float | str | None:
+    def native_value(self) -> datetime | int | float | str | None:
         """Return the sensor value."""
         return self.entity_description.value_fn(self._node)
 

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -56,6 +56,12 @@
       "iaq_rh": {
         "name": "Humidity air quality index"
       },
+      "target_flow_level": {
+        "name": "Target flow level"
+      },
+      "time_state_remain": {
+        "name": "Mode time remaining"
+      },
       "ventilation_state": {
         "name": "Ventilation state",
         "state": {

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -59,8 +59,8 @@
       "target_flow_level": {
         "name": "Target flow level"
       },
-      "time_state_remain": {
-        "name": "Mode time remaining"
+      "time_state_end": {
+        "name": "Mode end time"
       },
       "ventilation_state": {
         "name": "Ventilation state",

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -391,7 +391,7 @@
     'state': '27.9',
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_mode_time_remaining-entry]
+# name: test_sensor_entities_state[sensor.living_mode_end_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -405,7 +405,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.living_mode_time_remaining',
+    'entity_id': 'sensor.living_mode_end_time',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -413,37 +413,33 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mode time remaining',
+    'object_id_base': 'Mode end time',
     'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
     }),
-    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Mode time remaining',
+    'original_name': 'Mode end time',
     'platform': 'duco',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'time_state_remain',
-    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_remain',
-    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    'translation_key': 'time_state_end',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_end',
+    'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_mode_time_remaining-state]
+# name: test_sensor_entities_state[sensor.living_mode_end_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Living Mode time remaining',
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+      'device_class': 'timestamp',
+      'friendly_name': 'Living Mode end time',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.living_mode_time_remaining',
+    'entity_id': 'sensor.living_mode_end_time',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_sensor_entities_state[sensor.living_signal_strength-entry]

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -391,6 +391,61 @@
     'state': '27.9',
   })
 # ---
+# name: test_sensor_entities_state[sensor.living_mode_time_remaining-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_mode_time_remaining',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mode time remaining',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Mode time remaining',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_state_remain',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_remain',
+    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_mode_time_remaining-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Living Mode time remaining',
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_mode_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_sensor_entities_state[sensor.living_signal_strength-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -444,6 +499,63 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-60',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_target_flow_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_target_flow_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Target flow level',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Target flow level',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'target_flow_level',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_target_flow_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_target_flow_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living Target flow level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_target_flow_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
   })
 # ---
 # name: test_sensor_entities_state[sensor.living_ventilation_state-entry]


### PR DESCRIPTION
## Proposed change

Adds two new sensor entities to the Duco integration for the BOX node:

- **Target flow level** (`target_flow_level`): the actual airflow target as reported by the Duco box, in percent (0–100 %). Uses `SensorStateClass.MEASUREMENT` and `PERCENTAGE` as unit. Useful because the fan entity exposes abstract speed levels (33 / 66 / 100 %) that do not match the real firmware-configured airflow percentages.
- **Mode time remaining** (`time_state_remain`): the number of seconds remaining in the current timed ventilation mode. Uses `SensorDeviceClass.DURATION` and `UnitOfTime.SECONDS`. Returns 0 when no timer is active.

Both sensors are scoped to `NodeType.BOX` and read from `node.ventilation.flow_lvl_tgt` resp. `node.ventilation.time_state_remain`, which are already fetched by the coordinator.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45039

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
