### PR TITLE
Remove hassio onboarding bypass for backup endpoints

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -51,7 +51,7 @@ NO_TIMEOUT = re.compile(
     r")$"
 )
 
-# Authenticated users manage backups + download logs, changelog and documentation
+# Admin users manage backups + download logs, changelog and documentation
 PATHS_ADMIN = re.compile(
     r"^(?:"
     r"|backups/[a-f0-9]{8}(/info|/download|/restore/full|/restore/partial)?"
@@ -131,9 +131,8 @@ class HassIOView(HomeAssistantView):
         """Return a client request with proxy origin for Hass.io supervisor.
 
         Use cases:
-        - Onboarding allows restoring backups
         - Load Supervisor panel and add-on logo unauthenticated
-        - User upload/restore backups
+        - Admin users upload/restore backups and access logs
         """
         # No bullshit
         if path != unquote(path):

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -24,11 +24,9 @@ from aiohttp.web_exceptions import HTTPBadGateway
 
 from homeassistant.components.http import (
     KEY_AUTHENTICATED,
-    KEY_HASS,
     KEY_HASS_USER,
     HomeAssistantView,
 )
-from homeassistant.components.onboarding import async_is_onboarded
 
 from .const import X_HASS_SOURCE
 
@@ -50,15 +48,6 @@ NO_TIMEOUT = re.compile(
     r"|observer/logs/(follow|boots/-?\d+(/follow)?)"
     r"|supervisor/logs/(follow|boots/-?\d+(/follow)?)"
     r"|addons/[^/]+/logs/(follow|boots/-?\d+(/follow)?)"
-    r")$"
-)
-
-# fmt: off
-# Onboarding can upload backups and restore it
-PATHS_NOT_ONBOARDED = re.compile(
-    r"^(?:"
-    r"|backups/[a-f0-9]{8}(/info|/new/upload|/download|/restore/full|/restore/partial)?"
-    r"|backups/new/upload"
     r")$"
 )
 
@@ -150,18 +139,11 @@ class HassIOView(HomeAssistantView):
         if path != unquote(path):
             return web.Response(status=HTTPStatus.BAD_REQUEST)
 
-        hass = request.app[KEY_HASS]
         is_admin = request[KEY_AUTHENTICATED] and request[KEY_HASS_USER].is_admin
         authorized = is_admin
 
         if is_admin:
             allowed_paths = PATHS_ADMIN
-
-        elif not async_is_onboarded(hass):
-            allowed_paths = PATHS_NOT_ONBOARDED
-
-            # During onboarding we need the user to manage backups
-            authorized = True
 
         else:
             # Either unauthenticated or not an admin

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -166,115 +166,26 @@ async def test_forward_request_onboarded_noauth_unallowed_paths(
     assert len(aioclient_mock.mock_calls) == 0
 
 
-@pytest.mark.parametrize(
-    ("path", "authenticated"),
-    [
-        ("addons/bl_b392/logo", False),
-        ("addons/bl_b392/icon", False),
-        ("backups/1234abcd/info", True),
-    ],
-)
-async def test_forward_request_not_onboarded_get(
-    hassio_noauth_client: TestClient,
-    aioclient_mock: AiohttpClientMocker,
-    path: str,
-    authenticated: bool,
-    mock_not_onboarded,
-) -> None:
-    """Test fetching normal path."""
-    aioclient_mock.get(f"http://127.0.0.1/{path}", text="response")
-
-    resp = await hassio_noauth_client.get(f"/api/hassio/{path}")
-
-    # Check we got right response
-    assert resp.status == HTTPStatus.OK
-    body = await resp.text()
-    assert body == "response"
-
-    # Check we forwarded command
-    assert len(aioclient_mock.mock_calls) == 1
-    expected_headers = {
-        "X-Hass-Source": "core.http",
-    }
-    if authenticated:
-        expected_headers["Authorization"] = "Bearer 123456"
-
-    assert aioclient_mock.mock_calls[0][3] == expected_headers
-
-
+@pytest.mark.usefixtures("mock_not_onboarded")
 @pytest.mark.parametrize(
     "path",
     [
-        "backups/new/upload",
+        "backups/1234abcd/info",
+        "backups/1234abcd/download",
         "backups/1234abcd/restore/full",
         "backups/1234abcd/restore/partial",
+        "backups/new/upload",
     ],
 )
-async def test_forward_request_not_onboarded_post(
+async def test_forward_request_not_onboarded_backup_unauthorized(
     hassio_noauth_client: TestClient,
     aioclient_mock: AiohttpClientMocker,
     path: str,
-    mock_not_onboarded,
 ) -> None:
-    """Test fetching normal path."""
-    aioclient_mock.get(f"http://127.0.0.1/{path}", text="response")
-
+    """Test backup endpoints reject unauthenticated requests during onboarding."""
     resp = await hassio_noauth_client.get(f"/api/hassio/{path}")
 
-    # Check we got right response
-    assert resp.status == HTTPStatus.OK
-    body = await resp.text()
-    assert body == "response"
-
-    # Check we forwarded command
-    assert len(aioclient_mock.mock_calls) == 1
-    # We only expect a single header.
-    assert aioclient_mock.mock_calls[0][3] == {
-        "X-Hass-Source": "core.http",
-        "Authorization": "Bearer 123456",
-    }
-
-
-@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
-async def test_forward_request_not_onboarded_unallowed_methods(
-    hassio_noauth_client: TestClient, aioclient_mock: AiohttpClientMocker, method: str
-) -> None:
-    """Test fetching normal path."""
-    resp = await hassio_noauth_client.request(method, "/api/hassio/addons/bl_b392/icon")
-
-    # Check we got right response
-    assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
-
-    # Check we did not forward command
-    assert len(aioclient_mock.mock_calls) == 0
-
-
-@pytest.mark.parametrize(
-    ("bad_path", "expected_status"),
-    [
-        # Caught by bullshit filter
-        ("addons/bl_b392/%252E./icon", HTTPStatus.BAD_REQUEST),
-        # Unauthenticated path
-        ("supervisor/info", HTTPStatus.UNAUTHORIZED),
-        ("supervisor/logs", HTTPStatus.UNAUTHORIZED),
-        ("supervisor/logs/follow", HTTPStatus.UNAUTHORIZED),
-        ("addons/bl_b392/logs", HTTPStatus.UNAUTHORIZED),
-        ("addons/bl_b392/logs/follow", HTTPStatus.UNAUTHORIZED),
-    ],
-)
-async def test_forward_request_not_onboarded_unallowed_paths(
-    hassio_noauth_client: TestClient,
-    aioclient_mock: AiohttpClientMocker,
-    bad_path: str,
-    expected_status: int,
-    mock_not_onboarded,
-) -> None:
-    """Test fetching normal path."""
-    resp = await hassio_noauth_client.get(f"/api/hassio/{bad_path}")
-
-    # Check we got right response
-    assert resp.status == expected_status
-    # Check we didn't forward command
+    assert resp.status == HTTPStatus.UNAUTHORIZED
     assert len(aioclient_mock.mock_calls) == 0
 
 
@@ -402,7 +313,6 @@ async def test_bad_gateway_when_cannot_find_supervisor(
 async def test_backup_upload_headers(
     hassio_client: TestClient,
     aioclient_mock: AiohttpClientMocker,
-    mock_not_onboarded,
 ) -> None:
     """Test that we forward the full header for backup upload."""
     content_type = "multipart/form-data; boundary='--webkit'"
@@ -422,7 +332,7 @@ async def test_backup_upload_headers(
 
 
 async def test_backup_download_headers(
-    hassio_client: TestClient, aioclient_mock: AiohttpClientMocker, mock_not_onboarded
+    hassio_client: TestClient, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that we forward the full header for backup download."""
     content_disposition = "attachment; filename=test.tar"

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -1,8 +1,6 @@
 """The tests for the hassio component."""
 
-from collections.abc import Generator
 from http import HTTPStatus
-from unittest.mock import patch
 
 from aiohttp import StreamReader
 from aiohttp.test_utils import TestClient
@@ -10,15 +8,6 @@ import pytest
 
 from tests.common import MockUser
 from tests.test_util.aiohttp import AiohttpClientMocker
-
-
-@pytest.fixture
-def mock_not_onboarded() -> Generator[None]:
-    """Mock that we're not onboarded."""
-    with patch(
-        "homeassistant.components.hassio.http.async_is_onboarded", return_value=False
-    ):
-        yield
 
 
 @pytest.fixture
@@ -166,24 +155,24 @@ async def test_forward_request_onboarded_noauth_unallowed_paths(
     assert len(aioclient_mock.mock_calls) == 0
 
 
-@pytest.mark.usefixtures("mock_not_onboarded")
 @pytest.mark.parametrize(
-    "path",
+    ("method", "path"),
     [
-        "backups/1234abcd/info",
-        "backups/1234abcd/download",
-        "backups/1234abcd/restore/full",
-        "backups/1234abcd/restore/partial",
-        "backups/new/upload",
+        ("GET", "backups/1234abcd/info"),
+        ("GET", "backups/1234abcd/download"),
+        ("POST", "backups/1234abcd/restore/full"),
+        ("POST", "backups/1234abcd/restore/partial"),
+        ("POST", "backups/new/upload"),
     ],
 )
-async def test_forward_request_not_onboarded_backup_unauthorized(
+async def test_forward_request_backup_unauthenticated_rejected(
     hassio_noauth_client: TestClient,
     aioclient_mock: AiohttpClientMocker,
+    method: str,
     path: str,
 ) -> None:
-    """Test backup endpoints reject unauthenticated requests during onboarding."""
-    resp = await hassio_noauth_client.get(f"/api/hassio/{path}")
+    """Test backup endpoints reject unauthenticated requests."""
+    resp = await hassio_noauth_client.request(method, f"/api/hassio/{path}")
 
     assert resp.status == HTTPStatus.UNAUTHORIZED
     assert len(aioclient_mock.mock_calls) == 0

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -155,16 +155,16 @@ async def test_forward_request_onboarded_noauth_unallowed_paths(
     assert len(aioclient_mock.mock_calls) == 0
 
 
-@pytest.mark.parametrize(
-    ("method", "path"),
-    [
-        ("GET", "backups/1234abcd/info"),
-        ("GET", "backups/1234abcd/download"),
-        ("POST", "backups/1234abcd/restore/full"),
-        ("POST", "backups/1234abcd/restore/partial"),
-        ("POST", "backups/new/upload"),
-    ],
-)
+BACKUP_NON_ADMIN_REJECTED_PARAMS = [
+    ("GET", "backups/1234abcd/info"),
+    ("GET", "backups/1234abcd/download"),
+    ("POST", "backups/1234abcd/restore/full"),
+    ("POST", "backups/1234abcd/restore/partial"),
+    ("POST", "backups/new/upload"),
+]
+
+
+@pytest.mark.parametrize(("method", "path"), BACKUP_NON_ADMIN_REJECTED_PARAMS)
 async def test_forward_request_backup_unauthenticated_rejected(
     hassio_noauth_client: TestClient,
     aioclient_mock: AiohttpClientMocker,
@@ -173,6 +173,20 @@ async def test_forward_request_backup_unauthenticated_rejected(
 ) -> None:
     """Test backup endpoints reject unauthenticated requests."""
     resp = await hassio_noauth_client.request(method, f"/api/hassio/{path}")
+
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+    assert len(aioclient_mock.mock_calls) == 0
+
+
+@pytest.mark.parametrize(("method", "path"), BACKUP_NON_ADMIN_REJECTED_PARAMS)
+async def test_forward_request_backup_non_admin_rejected(
+    hassio_user_client: TestClient,
+    aioclient_mock: AiohttpClientMocker,
+    method: str,
+    path: str,
+) -> None:
+    """Test backup endpoints reject authenticated non-admin requests."""
+    resp = await hassio_user_client.request(method, f"/api/hassio/{path}")
 
     assert resp.status == HTTPStatus.UNAUTHORIZED
     assert len(aioclient_mock.mock_calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The frontend stopped using these endpoints during onboarding with home-assistant/frontend#23920, which first shipped in Core 2025.3.0 (frontend 20250226.0). Some unused remnants stayed in the frontend until home-assistant/frontend#29170, but they were no longer active.

The hassio backup endpoints now require admin authentication regardless of onboarding state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
