### PR TITLE
Register a stub transport for ESPHome serial proxies via USB

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -81,11 +81,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     if "usb" in hass.config.components:
         async_register_serial_port_scanner(hass, _async_scan_serial_ports)
-        unregister_serialx_transport = serial_proxy.register_serialx_transport(
-            hass.loop
-        )
         hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, lambda _: unregister_serialx_transport()
+            EVENT_HOMEASSISTANT_STOP,
+            serial_proxy.register_serialx_transport(hass.loop),
         )
 
     return True

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP,
     __version__ as ha_version,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -80,7 +81,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     if "usb" in hass.config.components:
         async_register_serial_port_scanner(hass, _async_scan_serial_ports)
-        serial_proxy.set_hass_loop(hass.loop)
+        unregister_serialx_transport = serial_proxy.register_serialx_transport(
+            hass.loop
+        )
+        hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP, lambda _: unregister_serialx_transport()
+        )
 
     return True
 

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import cast
 
 from aioesphomeapi import APIClient
@@ -24,12 +25,6 @@ from .entry_data import ESPHomeConfigEntry
 # aioesphomeapi client. We cannot make any assumptions here, some packages run separate
 # asyncio event loops in dedicated threads.
 _HASS_LOOP: asyncio.AbstractEventLoop | None = None
-
-
-def set_hass_loop(loop: asyncio.AbstractEventLoop) -> None:
-    """Store a reference to the Core event loop."""
-    global _HASS_LOOP  # noqa: PLW0603  # pylint: disable=global-statement
-    _HASS_LOOP = loop
 
 
 def build_url(entry_id: str, port_name: str) -> URL:
@@ -103,9 +98,23 @@ class HassESPHomeSerialTransport(ESPHomeSerialTransport):
     _serial_cls = HassESPHomeSerial
 
 
-register_uri_handler(
-    scheme="esphome-hass://",
-    unique_scheme="esphome-hass-internal://",  # The unique scheme must differ
-    sync_cls=HassESPHomeSerial,
-    async_transport_cls=HassESPHomeSerialTransport,
-)
+def register_serialx_transport(
+    loop: asyncio.AbstractEventLoop,
+) -> Callable[[], None]:
+    """Register the ESPHome URI handler and return an unregister callable."""
+    global _HASS_LOOP  # noqa: PLW0603  # pylint: disable=global-statement
+    _HASS_LOOP = loop
+
+    unregister = register_uri_handler(
+        scheme="esphome-hass://",
+        unique_scheme="esphome-hass-internal://",  # The unique scheme must differ
+        sync_cls=HassESPHomeSerial,
+        async_transport_cls=HassESPHomeSerialTransport,
+    )
+
+    def _unregister() -> None:
+        global _HASS_LOOP  # noqa: PLW0603  # pylint: disable=global-statement
+        unregister()
+        _HASS_LOOP = None
+
+    return _unregister

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -16,7 +16,7 @@ from serialx.platforms.serial_esphome import (
 from yarl import URL
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant, async_get_hass
+from homeassistant.core import Event, HomeAssistant, async_get_hass, callback
 
 from .const import DOMAIN
 from .entry_data import ESPHomeConfigEntry
@@ -100,8 +100,8 @@ class HassESPHomeSerialTransport(ESPHomeSerialTransport):
 
 def register_serialx_transport(
     loop: asyncio.AbstractEventLoop,
-) -> Callable[[], None]:
-    """Register the ESPHome URI handler and return an unregister callable."""
+) -> Callable[[Event], None]:
+    """Register the ESPHome URI handler."""
     global _HASS_LOOP  # noqa: PLW0603  # pylint: disable=global-statement
     _HASS_LOOP = loop
 
@@ -112,7 +112,8 @@ def register_serialx_transport(
         async_transport_cls=HassESPHomeSerialTransport,
     )
 
-    def _unregister() -> None:
+    @callback
+    def _unregister(event: Event) -> None:
         global _HASS_LOOP  # noqa: PLW0603  # pylint: disable=global-statement
         unregister()
         _HASS_LOOP = None

--- a/homeassistant/components/esphome/serial_proxy.py
+++ b/homeassistant/components/esphome/serial_proxy.py
@@ -20,8 +20,6 @@ from homeassistant.core import HomeAssistant, async_get_hass
 from .const import DOMAIN
 from .entry_data import ESPHomeConfigEntry
 
-SCHEME = "esphome-hass://"
-
 # This is required so that serialx can safely query Core for an instance of an
 # aioesphomeapi client. We cannot make any assumptions here, some packages run separate
 # asyncio event loops in dedicated threads.
@@ -106,8 +104,8 @@ class HassESPHomeSerialTransport(ESPHomeSerialTransport):
 
 
 register_uri_handler(
-    scheme=SCHEME,
-    unique_scheme=SCHEME,
+    scheme="esphome-hass://",
+    unique_scheme="esphome-hass-internal://",  # The unique scheme must differ
     sync_cls=HassESPHomeSerial,
     async_transport_cls=HassESPHomeSerialTransport,
 )

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -33,6 +33,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import USBMatcher, async_get_usb
 from homeassistant.util.hass_dict import HassKey
 
+from . import serial_proxy_stub  # noqa: F401
 from .const import DOMAIN
 from .models import SerialDevice, USBDevice
 from .utils import (

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -33,9 +33,9 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import USBMatcher, async_get_usb
 from homeassistant.util.hass_dict import HassKey
 
-from . import serial_proxy_stub  # noqa: F401
 from .const import DOMAIN
 from .models import SerialDevice, USBDevice
+from .serial_proxy_stub import register_serialx_transport
 from .utils import (
     scan_serial_ports,
     usb_device_from_path,
@@ -187,6 +187,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[_USB_DATA] = usb_discovery
     websocket_api.async_register_command(hass, websocket_usb_scan)
     websocket_api.async_register_command(hass, websocket_usb_list_serial_ports)
+
+    unregister_serialx_transport = register_serialx_transport()
+    hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP, lambda _: unregister_serialx_transport()
+    )
 
     return True
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -188,10 +188,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websocket_api.async_register_command(hass, websocket_usb_scan)
     websocket_api.async_register_command(hass, websocket_usb_list_serial_ports)
 
-    unregister_serialx_transport = register_serialx_transport()
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, lambda _: unregister_serialx_transport()
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, register_serialx_transport())
 
     return True
 

--- a/homeassistant/components/usb/serial_proxy_stub.py
+++ b/homeassistant/components/usb/serial_proxy_stub.py
@@ -17,7 +17,7 @@ class HassESPHomeSerialStub(ESPHomeSerial):
 
 
 class HassESPHomeSerialStubTransport(ESPHomeSerialTransport):
-    """Transport variant that constructs :class:`HassESPHomeSerial`."""
+    """Transport variant that constructs `HassESPHomeSerialStub`."""
 
     transport_name = "esphome-hass"
     _serial_cls = HassESPHomeSerialStub

--- a/homeassistant/components/usb/serial_proxy_stub.py
+++ b/homeassistant/components/usb/serial_proxy_stub.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from serialx import register_uri_handler
 from serialx.platforms.serial_esphome import ESPHomeSerial, ESPHomeSerialTransport
 
+from homeassistant.core import Event, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 
 
@@ -25,12 +26,18 @@ class HassESPHomeSerialStubTransport(ESPHomeSerialTransport):
     _serial_cls = HassESPHomeSerialStub
 
 
-def register_serialx_transport() -> Callable[[], None]:
-    """Register the stub URI handler and return an unregister callable."""
-    return register_uri_handler(
+def register_serialx_transport() -> Callable[[Event], None]:
+    """Register the stub URI handler."""
+    unregister = register_uri_handler(
         scheme="esphome-hass://",
         unique_scheme="esphome-hass-usb://",
         sync_cls=HassESPHomeSerialStub,
         async_transport_cls=HassESPHomeSerialStubTransport,
         weight=-1,  # We want the ESPHome integration transport to take precedence
     )
+
+    @callback
+    def _unregister(event: Event) -> None:
+        unregister()
+
+    return _unregister

--- a/homeassistant/components/usb/serial_proxy_stub.py
+++ b/homeassistant/components/usb/serial_proxy_stub.py
@@ -1,0 +1,32 @@
+"""ESPHome serial proxy URI handler stub for serialx."""
+
+from __future__ import annotations
+
+from serialx import register_uri_handler
+from serialx.platforms.serial_esphome import ESPHomeSerial, ESPHomeSerialTransport
+
+from homeassistant.exceptions import ConfigEntryNotReady
+
+
+class HassESPHomeSerialStub(ESPHomeSerial):
+    """ESPHomeSerial that throws `ConfigEntryNotReady` until ESPHome itself loads."""
+
+    async def _async_open(self) -> None:
+        """Open a connection."""
+        raise ConfigEntryNotReady("ESPHome has not loaded yet")
+
+
+class HassESPHomeSerialStubTransport(ESPHomeSerialTransport):
+    """Transport variant that constructs :class:`HassESPHomeSerial`."""
+
+    transport_name = "esphome-hass"
+    _serial_cls = HassESPHomeSerialStub
+
+
+register_uri_handler(
+    scheme="esphome-hass://",
+    unique_scheme="esphome-hass-usb://",
+    sync_cls=HassESPHomeSerialStub,
+    async_transport_cls=HassESPHomeSerialStubTransport,
+    weight=-1,  # We want the ESPHome integration transport to take precedence
+)

--- a/homeassistant/components/usb/serial_proxy_stub.py
+++ b/homeassistant/components/usb/serial_proxy_stub.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from serialx import register_uri_handler
 from serialx.platforms.serial_esphome import ESPHomeSerial, ESPHomeSerialTransport
 
@@ -23,10 +25,12 @@ class HassESPHomeSerialStubTransport(ESPHomeSerialTransport):
     _serial_cls = HassESPHomeSerialStub
 
 
-register_uri_handler(
-    scheme="esphome-hass://",
-    unique_scheme="esphome-hass-usb://",
-    sync_cls=HassESPHomeSerialStub,
-    async_transport_cls=HassESPHomeSerialStubTransport,
-    weight=-1,  # We want the ESPHome integration transport to take precedence
-)
+def register_serialx_transport() -> Callable[[], None]:
+    """Register the stub URI handler and return an unregister callable."""
+    return register_uri_handler(
+        scheme="esphome-hass://",
+        unique_scheme="esphome-hass-usb://",
+        sync_cls=HassESPHomeSerialStub,
+        async_transport_cls=HassESPHomeSerialStubTransport,
+        weight=-1,  # We want the ESPHome integration transport to take precedence
+    )

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1758,6 +1758,8 @@ async def test_list_serial_ports_os_error(
 
 async def test_serial_proxy_stub_sync(hass: HomeAssistant) -> None:
     """Test ESPHome serial proxy stub."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
     serial_cls = serial_for_url("esphome-hass-usb://192.0.2.1")
     assert isinstance(serial_cls, HassESPHomeSerialStub)
 

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -7,15 +7,17 @@ import os
 from unittest.mock import MagicMock, Mock, call, patch, sentinel
 
 import pytest
-from serialx import SerialPortInfo
+from serialx import SerialPortInfo, create_serial_connection, serial_for_url
 
 from homeassistant import config_entries
 from homeassistant.components import usb
 from homeassistant.components.usb import DOMAIN, async_scan_serial_ports
 from homeassistant.components.usb.models import SerialDevice, USBDevice
+from homeassistant.components.usb.serial_proxy_stub import HassESPHomeSerialStub
 from homeassistant.components.usb.utils import usb_device_from_path
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -1752,3 +1754,18 @@ async def test_list_serial_ports_os_error(
     assert not response["success"]
     assert response["error"]["code"] == "unknown_error"
     assert "Permission denied" in response["error"]["message"]
+
+
+async def test_serial_proxy_stub_sync(hass: HomeAssistant) -> None:
+    """Test ESPHome serial proxy stub."""
+    serial_cls = serial_for_url("esphome-hass-usb://192.0.2.1")
+    assert isinstance(serial_cls, HassESPHomeSerialStub)
+
+    # Nothing actually opens, it just throws an error
+    with pytest.raises(ConfigEntryNotReady):
+        await create_serial_connection(
+            loop=asyncio.get_running_loop(),
+            protocol_factory=asyncio.Protocol,
+            url="esphome-hass-usb://192.0.2.1",
+            baudrate=115200,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Integrations that depend on `usb` but not `esphome` can load earlier than the ESPHome integration, before the `esphome-hass://` URI handler is registered with serialx. This causes them to fail with `serialx.common.UnknownUriScheme`.

This PR registers a second handler for `esphome-hass://` with a lower weight. Integrations that try to connect before ESPHome has loaded will immediately fail with `ConfigEntryNotReady`. Once ESPHome loads, the real implementation of this serial transport will take over.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
