### PR TITLE
prusalink: populate serial number and firmware version in device info

### DIFF
--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -27,6 +27,7 @@ from .coordinator import (
     PrusaLinkConfigEntry,
     PrusaLinkUpdateCoordinator,
     StatusCoordinator,
+    VersionUpdateCoordinator,
 )
 
 PLATFORMS: list[Platform] = [
@@ -54,6 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PrusaLinkConfigEntry) ->
         "status": StatusCoordinator(hass, entry, api),
         "job": JobUpdateCoordinator(hass, entry, api),
         "info": InfoUpdateCoordinator(hass, entry, api),
+        "version": VersionUpdateCoordinator(hass, entry, api),
     }
     for coordinator in coordinators.values():
         await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/prusalink/coordinator.py
+++ b/homeassistant/components/prusalink/coordinator.py
@@ -16,6 +16,7 @@ from pyprusalink import (
     PrinterInfo,
     PrinterStatus,
     PrusaLink,
+    VersionInfo,
 )
 from pyprusalink.types import InvalidAuth, PrusaLinkError
 
@@ -32,7 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 # rapidly-changing metrics.
 _MINIMUM_REFRESH_INTERVAL = 1.0
 
-T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo)
+T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo, VersionInfo)
 
 
 type PrusaLinkConfigEntry = ConfigEntry[dict[str, PrusaLinkUpdateCoordinator]]
@@ -124,3 +125,11 @@ class InfoUpdateCoordinator(PrusaLinkUpdateCoordinator[PrinterInfo]):
     async def _fetch_data(self) -> PrinterInfo:
         """Fetch the printer data."""
         return await self.api.get_info()
+
+
+class VersionUpdateCoordinator(PrusaLinkUpdateCoordinator[VersionInfo]):
+    """Version update coordinator."""
+
+    async def _fetch_data(self) -> VersionInfo:
+        """Fetch the version data."""
+        return await self.api.get_version()

--- a/homeassistant/components/prusalink/entity.py
+++ b/homeassistant/components/prusalink/entity.py
@@ -17,9 +17,14 @@ class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this PrusaLink device."""
+        coordinators = self.coordinator.config_entry.runtime_data
+        info_data = coordinators["info"].data or {}
+        version_data = coordinators["version"].data or {}
         return DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
             name=self.coordinator.config_entry.title,
             manufacturer="Prusa",
+            serial_number=info_data.get("serial"),
+            sw_version=version_data.get("firmware"),
             configuration_url=self.coordinator.api.client.host,
         )

--- a/tests/components/prusalink/conftest.py
+++ b/tests/components/prusalink/conftest.py
@@ -33,6 +33,7 @@ def mock_version_api() -> Generator[dict[str, str]]:
         "server": "2.1.2",
         "text": "PrusaLink",
         "hostname": "PrusaXL",
+        "firmware": "6.1.2+11023",
     }
     with patch("pyprusalink.PrusaLink.get_version", return_value=resp):
         yield resp

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -12,12 +12,28 @@ from homeassistant.components.prusalink.config_flow import ConfigFlow
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 pytestmark = pytest.mark.usefixtures("mock_api")
+
+
+async def test_device_info(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test device info is populated with serial number and firmware version."""
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    )
+    assert device is not None
+    assert device.serial_number == "serial-1337"
+    assert device.sw_version == "6.1.2+11023"
 
 
 async def test_unloading(


### PR DESCRIPTION
## Proposed change

Exposes two additional fields in the PrusaLink device registry entry:

- **`serial_number`** — sourced from `/api/v1/info` (`serial` field), already fetched by `InfoUpdateCoordinator`
- **`sw_version`** — sourced from `/api/version` (`firmware` field), fetched by a new lightweight `VersionUpdateCoordinator`

Both API endpoints are available in the currently published `pyprusalink==2.1.1` and require no library update. This is part of a series of incremental improvements to the prusalink integration.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- The `VersionUpdateCoordinator` polls on the same 30-second interval as existing coordinators. Firmware version rarely changes but polling is consistent with the existing pattern.
- No entities depend on `VersionUpdateCoordinator` for state — it is used solely for `device_info`.
- The `mock_version_api` test fixture was updated to include the `firmware` field which was previously absent.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass with `python -m pytest tests/components/prusalink/`
- [x] There is no commented out code in this PR