### PR TITLE
Fix Duco diagnostics crash on connection error

### DIFF
--- a/homeassistant/components/duco/diagnostics.py
+++ b/homeassistant/components/duco/diagnostics.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
+from .const import DOMAIN
 from .coordinator import DucoConfigEntry
 
 TO_REDACT = {
@@ -40,8 +41,8 @@ async def async_get_config_entry_diagnostics(
         write_remaining = await coordinator.client.async_get_write_req_remaining()
     except DucoConnectionError as err:
         raise HomeAssistantError(
-            translation_domain="duco",
-            translation_key="diagnostics_connection_error",
+            translation_domain=DOMAIN,
+            translation_key="connection_error",
         ) from err
 
     return async_redact_data(

--- a/homeassistant/components/duco/diagnostics.py
+++ b/homeassistant/components/duco/diagnostics.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import asdict
 from typing import Any
+
+from duco.exceptions import DucoConnectionError
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from .coordinator import DucoConfigEntry
 
@@ -32,11 +34,15 @@ async def async_get_config_entry_diagnostics(
     board = asdict(coordinator.board_info)
     board.pop("time")
 
-    lan_info, duco_diags, write_remaining = await asyncio.gather(
-        coordinator.client.async_get_lan_info(),
-        coordinator.client.async_get_diagnostics(),
-        coordinator.client.async_get_write_req_remaining(),
-    )
+    try:
+        lan_info = await coordinator.client.async_get_lan_info()
+        duco_diags = await coordinator.client.async_get_diagnostics()
+        write_remaining = await coordinator.client.async_get_write_req_remaining()
+    except DucoConnectionError as err:
+        raise HomeAssistantError(
+            translation_domain="duco",
+            translation_key="diagnostics_connection_error",
+        ) from err
 
     return async_redact_data(
         {

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -87,8 +87,8 @@
     "cannot_connect": {
       "message": "An error occurred while trying to connect to the Duco instance: {error}"
     },
-    "diagnostics_connection_error": {
-      "message": "Failed to retrieve diagnostics data: could not connect to the Duco device."
+    "connection_error": {
+      "message": "Could not connect to the Duco device."
     },
     "failed_to_set_state": {
       "message": "Failed to set ventilation state: {error}"

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -87,6 +87,9 @@
     "cannot_connect": {
       "message": "An error occurred while trying to connect to the Duco instance: {error}"
     },
+    "diagnostics_connection_error": {
+      "message": "Failed to retrieve diagnostics data: could not connect to the Duco device."
+    },
     "failed_to_set_state": {
       "message": "Failed to set ventilation state: {error}"
     },

--- a/tests/components/duco/test_diagnostics.py
+++ b/tests/components/duco/test_diagnostics.py
@@ -50,6 +50,7 @@ async def test_diagnostics_connection_error(
         "Server disconnected"
     )
     assert await async_setup_component(hass, DIAGNOSTICS_DOMAIN, {})
+    await hass.async_block_till_done()
     client = await hass_client()
     response = await client.get(
         f"/api/diagnostics/config_entry/{mock_config_entry.entry_id}"

--- a/tests/components/duco/test_diagnostics.py
+++ b/tests/components/duco/test_diagnostics.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from unittest.mock import AsyncMock
 
+from duco.exceptions import DucoConnectionError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.diagnostics import DOMAIN as DIAGNOSTICS_DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -27,3 +31,27 @@ async def test_diagnostics(
         await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
         == snapshot
     )
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "failing_method",
+    ["async_get_lan_info", "async_get_diagnostics", "async_get_write_req_remaining"],
+)
+async def test_diagnostics_connection_error(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    failing_method: str,
+) -> None:
+    """Test that a connection error during diagnostics returns a 500 response."""
+    getattr(mock_duco_client, failing_method).side_effect = DucoConnectionError(
+        "Server disconnected"
+    )
+    assert await async_setup_component(hass, DIAGNOSTICS_DOMAIN, {})
+    client = await hass_client()
+    response = await client.get(
+        f"/api/diagnostics/config_entry/{mock_config_entry.entry_id}"
+    )
+    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## Proposed change

The Duco diagnostics platform crashed with an unhandled `DucoConnectionError` when the device was unreachable during a diagnostics download. The exception propagated all the way up instead of returning a meaningful error to the user.

This PR wraps each API call in `async_get_config_entry_diagnostics` with a try/except that catches `DucoConnectionError` and raises `HomeAssistantError`, which Home Assistant handles gracefully.

> [!IMPORTANT]
> This fixes a crash in the diagnostics platform when the device is temporarily offline. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is a beta fix for the Duco integration introduced in: https://github.com/home-assistant/core/pull/169298

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/exceptions/#perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
