### PR TITLE
Add set_heating_schedule service to bsblan

### DIFF
--- a/homeassistant/components/bsblan/const.py
+++ b/homeassistant/components/bsblan/const.py
@@ -24,3 +24,32 @@ CONF_HEATING_CIRCUITS: Final = "heating_circuits"
 
 DEFAULT_HEATING_CIRCUITS: Final = (1,)
 DEFAULT_PORT: Final = 80
+
+HEATING_CIRCUIT_IDENTIFIER_SEPARATOR: Final = "-circuit-"
+WATER_HEATER_IDENTIFIER_SUFFIX: Final = "-water-heater"
+
+
+def heating_circuit_identifier(mac: str, circuit: int) -> str:
+    """Return the device identifier for a heating circuit sub-device."""
+    return f"{mac}{HEATING_CIRCUIT_IDENTIFIER_SEPARATOR}{circuit}"
+
+
+def water_heater_identifier(mac: str) -> str:
+    """Return the device identifier for the water heater sub-device."""
+    return f"{mac}{WATER_HEATER_IDENTIFIER_SUFFIX}"
+
+
+def circuit_from_identifier(identifier: str) -> int | None:
+    """Return the heating circuit number from a sub-device identifier."""
+    prefix, separator, suffix = identifier.rpartition(
+        HEATING_CIRCUIT_IDENTIFIER_SEPARATOR
+    )
+    if separator and prefix and suffix.isdigit():
+        return int(suffix)
+    return None
+
+
+def is_water_heater_identifier(identifier: str) -> bool:
+    """Return whether the device identifier belongs to the water heater."""
+    prefix = identifier.removesuffix(WATER_HEATER_IDENTIFIER_SUFFIX)
+    return bool(prefix) and prefix != identifier

--- a/homeassistant/components/bsblan/const.py
+++ b/homeassistant/components/bsblan/const.py
@@ -45,7 +45,9 @@ def circuit_from_identifier(identifier: str) -> int | None:
         HEATING_CIRCUIT_IDENTIFIER_SEPARATOR
     )
     if separator and prefix and suffix.isdigit():
-        return int(suffix)
+        circuit = int(suffix)
+        if circuit >= 1:
+            return circuit
     return None
 
 

--- a/homeassistant/components/bsblan/entity.py
+++ b/homeassistant/components/bsblan/entity.py
@@ -5,7 +5,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BSBLanData, get_bsblan_device_info
-from .const import DEFAULT_PORT, DOMAIN
+from .const import (
+    DEFAULT_PORT,
+    DOMAIN,
+    heating_circuit_identifier,
+    water_heater_identifier,
+)
 from .coordinator import BSBLanCoordinator, BSBLanFastCoordinator, BSBLanSlowCoordinator
 
 
@@ -48,7 +53,7 @@ class BSBLanCircuitEntity(BSBLanEntity):
         port = coordinator.config_entry.data.get(CONF_PORT, DEFAULT_PORT)
         main_info = get_bsblan_device_info(data.device, data.info, host, port)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{mac}-circuit-{circuit}")},
+            identifiers={(DOMAIN, heating_circuit_identifier(mac, circuit))},
             translation_key="heating_circuit",
             translation_placeholders={"circuit": str(circuit)},
             via_device=(DOMAIN, mac),
@@ -96,7 +101,7 @@ class BSBLanWaterHeaterDeviceEntity(BSBLanDualCoordinatorEntity):
         port = fast_coordinator.config_entry.data.get(CONF_PORT, DEFAULT_PORT)
         main_info = get_bsblan_device_info(data.device, data.info, host, port)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{mac}-water-heater")},
+            identifiers={(DOMAIN, water_heater_identifier(mac))},
             translation_key="water_heater",
             via_device=(DOMAIN, mac),
             manufacturer=main_info["manufacturer"],

--- a/homeassistant/components/bsblan/icons.json
+++ b/homeassistant/components/bsblan/icons.json
@@ -7,6 +7,9 @@
     }
   },
   "services": {
+    "set_heating_schedule": {
+      "service": "mdi:calendar-clock"
+    },
     "set_hot_water_schedule": {
       "service": "mdi:calendar-clock"
     },

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -4,7 +4,7 @@ from datetime import time
 import logging
 from typing import TYPE_CHECKING
 
-from bsblan import BSBLANError, DaySchedule, DHWSchedule, TimeSlot
+from bsblan import BSBLANError, DaySchedule, DHWSchedule, HeatingSchedule, TimeSlot
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
@@ -29,6 +29,16 @@ ATTR_FRIDAY_SLOTS = "friday_slots"
 ATTR_SATURDAY_SLOTS = "saturday_slots"
 ATTR_SUNDAY_SLOTS = "sunday_slots"
 
+_DAY_ATTRS: tuple[tuple[str, str], ...] = (
+    ("monday", ATTR_MONDAY_SLOTS),
+    ("tuesday", ATTR_TUESDAY_SLOTS),
+    ("wednesday", ATTR_WEDNESDAY_SLOTS),
+    ("thursday", ATTR_THURSDAY_SLOTS),
+    ("friday", ATTR_FRIDAY_SLOTS),
+    ("saturday", ATTR_SATURDAY_SLOTS),
+    ("sunday", ATTR_SUNDAY_SLOTS),
+)
+
 
 # Schema for a single time slot
 _SLOT_SCHEMA = vol.Schema(
@@ -39,16 +49,36 @@ _SLOT_SCHEMA = vol.Schema(
 )
 
 
+_WEEKLY_SCHEDULE_FIELDS: dict[vol.Marker, object] = {
+    vol.Optional(ATTR_MONDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_TUESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_WEDNESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_THURSDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_FRIDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_SATURDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_SUNDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+}
+
+
 SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): cv.string,
-        vol.Optional(ATTR_MONDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_TUESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_WEDNESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_THURSDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_FRIDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_SATURDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_SUNDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        **_WEEKLY_SCHEDULE_FIELDS,
+    }
+)
+
+
+SERVICE_SET_HEATING_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        **_WEEKLY_SCHEDULE_FIELDS,
+    }
+)
+
+
+SYNC_TIME_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
     }
 )
 
@@ -98,11 +128,22 @@ def _convert_time_slots_to_day_schedule(
     return DaySchedule(slots=time_slots)
 
 
-async def set_hot_water_schedule(service_call: ServiceCall) -> None:
-    """Set hot water heating schedule."""
-    device_id = service_call.data[ATTR_DEVICE_ID]
+def _build_weekly_schedule_days(
+    service_call: ServiceCall,
+) -> dict[str, DaySchedule | None]:
+    """Build a dict of day-name -> DaySchedule from the service call data."""
+    return {
+        day_name: _convert_time_slots_to_day_schedule(service_call.data.get(attr_name))
+        for day_name, attr_name in _DAY_ATTRS
+    }
 
-    # Get the device and config entry
+
+def _resolve_config_entry(
+    service_call: ServiceCall,
+) -> tuple[BSBLanConfigEntry, dr.DeviceEntry]:
+    """Resolve device_id from a service call into a loaded BSBLAN config entry."""
+    device_id: str = service_call.data[ATTR_DEVICE_ID]
+
     device_registry = dr.async_get(service_call.hass)
     device_entry = device_registry.async_get(device_id)
 
@@ -113,7 +154,6 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
             translation_placeholders={"device_id": device_id},
         )
 
-    # Find the config entry for this device
     matching_entries: list[BSBLanConfigEntry] = [
         entry
         for entry in service_call.hass.config_entries.async_entries(DOMAIN)
@@ -129,7 +169,6 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
 
     entry = matching_entries[0]
 
-    # Verify the config entry is loaded
     if entry.state is not ConfigEntryState.LOADED:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
@@ -137,56 +176,35 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
             translation_placeholders={"device_name": device_entry.name or device_id},
         )
 
+    return entry, device_entry
+
+
+def _circuit_from_device(device_entry: dr.DeviceEntry) -> int:
+    """Extract the heating circuit number from a sub-device identifier."""
+    for domain, identifier in device_entry.identifiers:
+        if domain != DOMAIN:
+            continue
+        prefix, sep, suffix = identifier.rpartition("-circuit-")
+        if sep and prefix and suffix.isdigit():
+            return int(suffix)
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="not_a_heating_circuit_device",
+        translation_placeholders={"device_name": device_entry.name or device_entry.id},
+    )
+
+
+async def set_hot_water_schedule(service_call: ServiceCall) -> None:
+    """Set hot water heating schedule."""
+    entry, _ = _resolve_config_entry(service_call)
     client = entry.runtime_data.client
 
-    # Convert time slots to DaySchedule objects
-    monday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_MONDAY_SLOTS)
-    )
-    tuesday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_TUESDAY_SLOTS)
-    )
-    wednesday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_WEDNESDAY_SLOTS)
-    )
-    thursday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_THURSDAY_SLOTS)
-    )
-    friday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_FRIDAY_SLOTS)
-    )
-    saturday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_SATURDAY_SLOTS)
-    )
-    sunday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_SUNDAY_SLOTS)
-    )
+    days = _build_weekly_schedule_days(service_call)
+    dhw_schedule = DHWSchedule(**days)
 
-    # Create the DHWSchedule object
-    dhw_schedule = DHWSchedule(
-        monday=monday,
-        tuesday=tuesday,
-        wednesday=wednesday,
-        thursday=thursday,
-        friday=friday,
-        saturday=saturday,
-        sunday=sunday,
-    )
-
-    LOGGER.debug(
-        "Setting hot water schedule - Monday: %s, Tuesday: %s, Wednesday: %s, "
-        "Thursday: %s, Friday: %s, Saturday: %s, Sunday: %s",
-        monday,
-        tuesday,
-        wednesday,
-        thursday,
-        friday,
-        saturday,
-        sunday,
-    )
+    LOGGER.debug("Setting hot water schedule: %s", dhw_schedule)
 
     try:
-        # Call the BSB-LAN API to set the schedule
         await client.set_hot_water_schedule(dhw_schedule)
     except BSBLANError as err:
         raise HomeAssistantError(
@@ -199,54 +217,39 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
     await entry.runtime_data.slow_coordinator.async_request_refresh()
 
 
+async def set_heating_schedule(service_call: ServiceCall) -> None:
+    """Set heating circuit schedule."""
+    entry, device_entry = _resolve_config_entry(service_call)
+    client = entry.runtime_data.client
+
+    circuit = _circuit_from_device(device_entry)
+    days = _build_weekly_schedule_days(service_call)
+    heating_schedule = HeatingSchedule(**days)
+
+    LOGGER.debug(
+        "Setting heating schedule for circuit %d: %s", circuit, heating_schedule
+    )
+
+    try:
+        await client.set_heating_schedule(heating_schedule, circuit=circuit)
+    except BSBLANError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="set_heating_schedule_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
+    # Refresh the slow coordinator to get the updated schedule
+    await entry.runtime_data.slow_coordinator.async_request_refresh()
+
+
 async def async_sync_time(service_call: ServiceCall) -> None:
     """Synchronize BSB-LAN device time with Home Assistant."""
-    device_id: str = service_call.data[ATTR_DEVICE_ID]
-
-    # Get the device and config entry
-    device_registry = dr.async_get(service_call.hass)
-    device_entry = device_registry.async_get(device_id)
-
-    if device_entry is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="invalid_device_id",
-            translation_placeholders={"device_id": device_id},
-        )
-
-    # Find the config entry for this device
-    matching_entries: list[BSBLanConfigEntry] = [
-        entry
-        for entry in service_call.hass.config_entries.async_entries(DOMAIN)
-        if entry.entry_id in device_entry.config_entries
-    ]
-
-    if not matching_entries:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="no_config_entry_for_device",
-            translation_placeholders={"device_id": device_entry.name or device_id},
-        )
-
-    entry = matching_entries[0]
-
-    # Verify the config entry is loaded
-    if entry.state is not ConfigEntryState.LOADED:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="config_entry_not_loaded",
-            translation_placeholders={"device_name": device_entry.name or device_id},
-        )
-
+    entry, device_entry = _resolve_config_entry(service_call)
     client = entry.runtime_data.client
-    await async_sync_device_time(client, device_entry.name or device_id)
-
-
-SYNC_TIME_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_DEVICE_ID): cv.string,
-    }
-)
+    await async_sync_device_time(
+        client, device_entry.name or service_call.data[ATTR_DEVICE_ID]
+    )
 
 
 @callback
@@ -257,6 +260,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
         "set_hot_water_schedule",
         set_hot_water_schedule,
         schema=SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        "set_heating_schedule",
+        set_heating_schedule,
+        schema=SERVICE_SET_HEATING_SCHEDULE_SCHEMA,
     )
 
     hass.services.async_register(

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
-from .const import DOMAIN
+from .const import DOMAIN, circuit_from_identifier, is_water_heater_identifier
 from .helpers import async_sync_device_time
 
 if TYPE_CHECKING:
@@ -179,24 +179,39 @@ def _resolve_config_entry(
     return entry, device_entry
 
 
+def _device_name(device_entry: dr.DeviceEntry) -> str:
+    """Return the best available display name for a device."""
+    return device_entry.name_by_user or device_entry.name or device_entry.id
+
+
 def _circuit_from_device(device_entry: dr.DeviceEntry) -> int:
     """Extract the heating circuit number from a sub-device identifier."""
     for domain, identifier in device_entry.identifiers:
-        if domain != DOMAIN:
-            continue
-        prefix, sep, suffix = identifier.rpartition("-circuit-")
-        if sep and prefix and suffix.isdigit():
-            return int(suffix)
+        if domain == DOMAIN and (circuit := circuit_from_identifier(identifier)):
+            return circuit
     raise ServiceValidationError(
         translation_domain=DOMAIN,
         translation_key="not_a_heating_circuit_device",
-        translation_placeholders={"device_name": device_entry.name or device_entry.id},
+        translation_placeholders={"device_name": _device_name(device_entry)},
+    )
+
+
+def _ensure_water_heater_device(device_entry: dr.DeviceEntry) -> None:
+    """Validate the service targets the water heater sub-device."""
+    for domain, identifier in device_entry.identifiers:
+        if domain == DOMAIN and is_water_heater_identifier(identifier):
+            return
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="not_a_water_heater_device",
+        translation_placeholders={"device_name": _device_name(device_entry)},
     )
 
 
 async def set_hot_water_schedule(service_call: ServiceCall) -> None:
     """Set hot water heating schedule."""
-    entry, _ = _resolve_config_entry(service_call)
+    entry, device_entry = _resolve_config_entry(service_call)
+    _ensure_water_heater_device(device_entry)
     client = entry.runtime_data.client
 
     days = _build_weekly_schedule_days(service_call)

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -187,7 +187,10 @@ def _device_name(device_entry: dr.DeviceEntry) -> str:
 def _circuit_from_device(device_entry: dr.DeviceEntry) -> int:
     """Extract the heating circuit number from a sub-device identifier."""
     for domain, identifier in device_entry.identifiers:
-        if domain == DOMAIN and (circuit := circuit_from_identifier(identifier)):
+        if domain != DOMAIN:
+            continue
+        circuit = circuit_from_identifier(identifier)
+        if circuit is not None:
             return circuit
     raise ServiceValidationError(
         translation_domain=DOMAIN,

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -164,7 +164,7 @@ def _resolve_config_entry(
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="no_config_entry_for_device",
-            translation_placeholders={"device_id": device_entry.name or device_id},
+            translation_placeholders={"device_id": _device_name(device_entry)},
         )
 
     entry = matching_entries[0]
@@ -173,7 +173,7 @@ def _resolve_config_entry(
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="config_entry_not_loaded",
-            translation_placeholders={"device_name": device_entry.name or device_id},
+            translation_placeholders={"device_name": _device_name(device_entry)},
         )
 
     return entry, device_entry
@@ -265,9 +265,7 @@ async def async_sync_time(service_call: ServiceCall) -> None:
     """Synchronize BSB-LAN device time with Home Assistant."""
     entry, device_entry = _resolve_config_entry(service_call)
     client = entry.runtime_data.client
-    await async_sync_device_time(
-        client, device_entry.name or service_call.data[ATTR_DEVICE_ID]
-    )
+    await async_sync_device_time(client, _device_name(device_entry))
 
 
 @callback

--- a/homeassistant/components/bsblan/services.yaml
+++ b/homeassistant/components/bsblan/services.yaml
@@ -6,8 +6,6 @@ sync_time:
       selector:
         device:
           integration: bsblan
-          entity:
-            - domain: button
 
 set_hot_water_schedule:
   fields:

--- a/homeassistant/components/bsblan/services.yaml
+++ b/homeassistant/components/bsblan/services.yaml
@@ -6,6 +6,8 @@ sync_time:
       selector:
         device:
           integration: bsblan
+          entity:
+            - domain: button
 
 set_hot_water_schedule:
   fields:
@@ -15,8 +17,10 @@ set_hot_water_schedule:
       selector:
         device:
           integration: bsblan
+          entity:
+            - domain: water_heater
     monday_slots:
-      selector:
+      selector: &slot_selector
         object:
           multiple: true
           label_field: start_time
@@ -31,92 +35,39 @@ set_hot_water_schedule:
               selector:
                 time:
     tuesday_slots:
-      selector:
-        object:
-          multiple: true
-          label_field: start_time
-          description_field: end_time
-          fields:
-            start_time:
-              required: true
-              selector:
-                time:
-            end_time:
-              required: true
-              selector:
-                time:
+      selector: *slot_selector
     wednesday_slots:
-      selector:
-        object:
-          multiple: true
-          label_field: start_time
-          description_field: end_time
-          fields:
-            start_time:
-              required: true
-              selector:
-                time:
-            end_time:
-              required: true
-              selector:
-                time:
+      selector: *slot_selector
     thursday_slots:
-      selector:
-        object:
-          multiple: true
-          label_field: start_time
-          description_field: end_time
-          fields:
-            start_time:
-              required: true
-              selector:
-                time:
-            end_time:
-              required: true
-              selector:
-                time:
+      selector: *slot_selector
     friday_slots:
-      selector:
-        object:
-          multiple: true
-          label_field: start_time
-          description_field: end_time
-          fields:
-            start_time:
-              required: true
-              selector:
-                time:
-            end_time:
-              required: true
-              selector:
-                time:
+      selector: *slot_selector
     saturday_slots:
-      selector:
-        object:
-          multiple: true
-          label_field: start_time
-          description_field: end_time
-          fields:
-            start_time:
-              required: true
-              selector:
-                time:
-            end_time:
-              required: true
-              selector:
-                time:
+      selector: *slot_selector
     sunday_slots:
+      selector: *slot_selector
+
+set_heating_schedule:
+  fields:
+    device_id:
+      required: true
+      example: "abc123device456"
       selector:
-        object:
-          multiple: true
-          label_field: start_time
-          description_field: end_time
-          fields:
-            start_time:
-              required: true
-              selector:
-                time:
-            end_time:
-              required: true
-              selector:
-                time:
+        device:
+          integration: bsblan
+          entity:
+            - domain: climate
+    monday_slots:
+      selector: *slot_selector
+    tuesday_slots:
+      selector: *slot_selector
+    wednesday_slots:
+      selector: *slot_selector
+    thursday_slots:
+      selector: *slot_selector
+    friday_slots:
+      selector: *slot_selector
+    saturday_slots:
+      selector: *slot_selector
+    sunday_slots:
+      selector: *slot_selector

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -124,8 +124,14 @@
     "no_config_entry_for_device": {
       "message": "No configuration entry found for device: {device_id}"
     },
+    "not_a_heating_circuit_device": {
+      "message": "The selected device ({device_name}) is not a heating circuit. Please select a heating circuit sub-device."
+    },
     "set_data_error": {
       "message": "An error occurred while sending the data to the BSB-LAN device"
+    },
+    "set_heating_schedule_failed": {
+      "message": "Failed to set heating schedule: {error}"
     },
     "set_operation_mode_error": {
       "message": "An error occurred while setting the operation mode"
@@ -150,6 +156,44 @@
     }
   },
   "services": {
+    "set_heating_schedule": {
+      "description": "Sets the heating schedule for a BSB-LAN heating circuit.",
+      "fields": {
+        "device_id": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::device_id::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::device_id::name%]"
+        },
+        "friday_slots": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::friday_slots::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::friday_slots::name%]"
+        },
+        "monday_slots": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::monday_slots::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::monday_slots::name%]"
+        },
+        "saturday_slots": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::saturday_slots::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::saturday_slots::name%]"
+        },
+        "sunday_slots": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::sunday_slots::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::sunday_slots::name%]"
+        },
+        "thursday_slots": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::thursday_slots::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::thursday_slots::name%]"
+        },
+        "tuesday_slots": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::tuesday_slots::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::tuesday_slots::name%]"
+        },
+        "wednesday_slots": {
+          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::wednesday_slots::description%]",
+          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::wednesday_slots::name%]"
+        }
+      },
+      "name": "Set heating schedule"
+    },
     "set_hot_water_schedule": {
       "description": "Set the hot water heating schedule for a BSB-LAN device.",
       "fields": {

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -163,8 +163,8 @@
       "description": "Sets the heating schedule for a BSB-LAN heating circuit.",
       "fields": {
         "device_id": {
-          "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::device_id::description%]",
-          "name": "[%key:component::bsblan::services::set_hot_water_schedule::fields::device_id::name%]"
+          "description": "The heating circuit sub-device to configure.",
+          "name": "Heating circuit"
         },
         "friday_slots": {
           "description": "[%key:component::bsblan::services::set_hot_water_schedule::fields::friday_slots::description%]",

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -127,6 +127,9 @@
     "not_a_heating_circuit_device": {
       "message": "The selected device ({device_name}) is not a heating circuit. Please select a heating circuit sub-device."
     },
+    "not_a_water_heater_device": {
+      "message": "The selected device ({device_name}) is not a water heater. Please select the water heater sub-device."
+    },
     "set_data_error": {
       "message": "An error occurred while sending the data to the BSB-LAN device"
     },

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -9,7 +9,11 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.bsblan.const import DOMAIN
+from homeassistant.components.bsblan.const import (
+    DOMAIN,
+    heating_circuit_identifier,
+    water_heater_identifier,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
@@ -40,6 +44,19 @@ def device_entry(
 ) -> dr.DeviceEntry:
     """Get the device entry for testing."""
     device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    assert device is not None
+    return device
+
+
+@pytest.fixture
+def water_heater_device_entry(
+    device_registry: dr.DeviceRegistry,
+    setup_integration: None,
+) -> dr.DeviceEntry:
+    """Get the water heater sub-device entry for testing."""
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, water_heater_identifier(TEST_DEVICE_MAC))}
+    )
     assert device is not None
     return device
 
@@ -119,13 +136,13 @@ def device_entry(
 async def test_set_hot_water_schedule(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
     service_data: dict[str, Any],
     expected_schedules: dict[str, DaySchedule],
 ) -> None:
     """Test setting hot water schedule with various configurations."""
     # Call the service with device_id and slot fields
-    service_call_data = {"device_id": device_entry.id}
+    service_call_data = {"device_id": water_heater_device_entry.id}
     service_call_data.update(service_data)
 
     await hass.services.async_call(
@@ -216,7 +233,7 @@ async def test_no_config_entry_for_device(
 async def test_config_entry_not_loaded(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test error when config entry is not loaded."""
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
@@ -226,7 +243,7 @@ async def test_config_entry_not_loaded(
             DOMAIN,
             "set_hot_water_schedule",
             {
-                "device_id": device_entry.id,
+                "device_id": water_heater_device_entry.id,
                 "monday_slots": [
                     {"start_time": time(6, 0), "end_time": time(8, 0)},
                 ],
@@ -241,12 +258,34 @@ async def test_config_entry_not_loaded(
 async def test_api_error(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test error when BSB-LAN API call fails."""
     mock_bsblan.set_hot_water_schedule.side_effect = BSBLANError("API Error")
 
     with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_hot_water_schedule",
+            {
+                "device_id": water_heater_device_entry.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "set_schedule_failed"
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_set_hot_water_schedule_rejects_main_device(
+    hass: HomeAssistant,
+    device_entry: dr.DeviceEntry,
+) -> None:
+    """Test that picking the main device for hot water schedule is rejected."""
+    with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             "set_hot_water_schedule",
@@ -259,7 +298,7 @@ async def test_api_error(
             blocking=True,
         )
 
-    assert exc_info.value.translation_key == "set_schedule_failed"
+    assert exc_info.value.translation_key == "not_a_water_heater_device"
 
 
 @pytest.mark.usefixtures("setup_integration")
@@ -276,7 +315,7 @@ async def test_api_error(
 )
 async def test_time_validation_errors(
     hass: HomeAssistant,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
     start_time: time | str,
     end_time: time | str,
     expected_error: str,
@@ -287,7 +326,7 @@ async def test_time_validation_errors(
             DOMAIN,
             "set_hot_water_schedule",
             {
-                "device_id": device_entry.id,
+                "device_id": water_heater_device_entry.id,
                 "monday_slots": [
                     {"start_time": start_time, "end_time": end_time},
                 ],
@@ -302,7 +341,7 @@ async def test_time_validation_errors(
 async def test_unprovided_days_are_none(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test that unprovided days are sent as None to BSB-LAN API."""
     # Only provide Monday and Tuesday, leave other days unprovided
@@ -310,7 +349,7 @@ async def test_unprovided_days_are_none(
         DOMAIN,
         "set_hot_water_schedule",
         {
-            "device_id": device_entry.id,
+            "device_id": water_heater_device_entry.id,
             "monday_slots": [
                 {"start_time": time(6, 0), "end_time": time(8, 0)},
             ],
@@ -346,7 +385,7 @@ async def test_unprovided_days_are_none(
 async def test_string_time_formats(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test service with string time formats."""
     # Test with string time formats
@@ -354,7 +393,7 @@ async def test_string_time_formats(
         DOMAIN,
         "set_hot_water_schedule",
         {
-            "device_id": device_entry.id,
+            "device_id": water_heater_device_entry.id,
             "monday_slots": [
                 {"start_time": "06:00:00", "end_time": "08:00:00"},  # With seconds
             ],
@@ -382,7 +421,7 @@ async def test_string_time_formats(
 @pytest.mark.usefixtures("setup_integration")
 async def test_non_standard_time_types(
     hass: HomeAssistant,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test service with non-standard time types raises error."""
     # Test with integer time values - schema validation will reject these
@@ -391,7 +430,7 @@ async def test_non_standard_time_types(
             DOMAIN,
             "set_hot_water_schedule",
             {
-                "device_id": device_entry.id,
+                "device_id": water_heater_device_entry.id,
                 "monday_slots": [
                     {"start_time": 600, "end_time": 800},
                 ],
@@ -630,7 +669,7 @@ async def test_set_heating_schedule(
 ) -> None:
     """Test setting the heating schedule for a circuit sub-device."""
     circuit_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-circuit-1")}
+        identifiers={(DOMAIN, heating_circuit_identifier(TEST_DEVICE_MAC, 1))}
     )
     assert circuit_device is not None
 
@@ -681,7 +720,7 @@ async def test_set_heating_schedule_circuit_2(
     await hass.async_block_till_done()
 
     circuit_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-circuit-2")}
+        identifiers={(DOMAIN, heating_circuit_identifier(TEST_DEVICE_MAC, 2))}
     )
     assert circuit_device is not None
 
@@ -730,7 +769,7 @@ async def test_set_heating_schedule_api_error(
 ) -> None:
     """Test error when the heating schedule API call fails."""
     circuit_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-circuit-1")}
+        identifiers={(DOMAIN, heating_circuit_identifier(TEST_DEVICE_MAC, 1))}
     )
     assert circuit_device is not None
     mock_bsblan.set_heating_schedule.side_effect = BSBLANError("API Error")

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -791,6 +791,33 @@ async def test_set_heating_schedule_rejects_zero_circuit_device(
 
 
 @pytest.mark.usefixtures("setup_integration")
+async def test_set_heating_schedule_time_validation_error(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test validation error when a heating schedule slot ends before it starts."""
+    circuit_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, heating_circuit_identifier(TEST_DEVICE_MAC, 1))}
+    )
+    assert circuit_device is not None
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_heating_schedule",
+            {
+                "device_id": circuit_device.id,
+                "monday_slots": [
+                    {"start_time": time(13, 0), "end_time": time(11, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "end_time_before_start_time"
+
+
+@pytest.mark.usefixtures("setup_integration")
 async def test_set_heating_schedule_api_error(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -762,6 +762,35 @@ async def test_set_heating_schedule_rejects_main_device(
 
 
 @pytest.mark.usefixtures("setup_integration")
+async def test_set_heating_schedule_rejects_zero_circuit_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that circuit zero is rejected as an invalid circuit sub-device."""
+    circuit_device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-circuit-0")},
+        name="Invalid heating circuit",
+    )
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_heating_schedule",
+            {
+                "device_id": circuit_device.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "not_a_heating_circuit_device"
+
+
+@pytest.mark.usefixtures("setup_integration")
 async def test_set_heating_schedule_api_error(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -620,3 +620,132 @@ async def test_sync_time_service_entry_not_loaded(
             {"device_id": unloaded_device.id},
             blocking=True,
         )
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_set_heating_schedule(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test setting the heating schedule for a circuit sub-device."""
+    circuit_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-circuit-1")}
+    )
+    assert circuit_device is not None
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_heating_schedule",
+        {
+            "device_id": circuit_device.id,
+            "monday_slots": [
+                {"start_time": time(6, 0), "end_time": time(8, 0)},
+                {"start_time": time(17, 0), "end_time": time(21, 0)},
+            ],
+            "tuesday_slots": [
+                {"start_time": time(6, 0), "end_time": time(8, 0)},
+            ],
+        },
+        blocking=True,
+    )
+
+    assert len(mock_bsblan.set_heating_schedule.mock_calls) == 1
+    call_args = mock_bsblan.set_heating_schedule.call_args
+
+    heating_schedule = call_args.args[0]
+    assert call_args.kwargs["circuit"] == 1
+    assert heating_schedule.monday == DaySchedule(
+        slots=[
+            TimeSlot(start=time(6, 0), end=time(8, 0)),
+            TimeSlot(start=time(17, 0), end=time(21, 0)),
+        ]
+    )
+    assert heating_schedule.tuesday == DaySchedule(
+        slots=[TimeSlot(start=time(6, 0), end=time(8, 0))]
+    )
+    # Unprovided days should be None
+    assert heating_schedule.wednesday is None
+    assert heating_schedule.sunday is None
+
+
+async def test_set_heating_schedule_circuit_2(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry_dual_circuit: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that the circuit number is derived from a circuit-2 sub-device."""
+    mock_config_entry_dual_circuit.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_dual_circuit.entry_id)
+    await hass.async_block_till_done()
+
+    circuit_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-circuit-2")}
+    )
+    assert circuit_device is not None
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_heating_schedule",
+        {
+            "device_id": circuit_device.id,
+            "monday_slots": [
+                {"start_time": time(6, 0), "end_time": time(8, 0)},
+            ],
+        },
+        blocking=True,
+    )
+
+    assert mock_bsblan.set_heating_schedule.call_args.kwargs["circuit"] == 2
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_set_heating_schedule_rejects_main_device(
+    hass: HomeAssistant,
+    device_entry: dr.DeviceEntry,
+) -> None:
+    """Test that picking the main device for heating schedule is rejected."""
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_heating_schedule",
+            {
+                "device_id": device_entry.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "not_a_heating_circuit_device"
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_set_heating_schedule_api_error(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test error when the heating schedule API call fails."""
+    circuit_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-circuit-1")}
+    )
+    assert circuit_device is not None
+    mock_bsblan.set_heating_schedule.side_effect = BSBLANError("API Error")
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_heating_schedule",
+            {
+                "device_id": circuit_device.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "set_heating_schedule_failed"


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request adds support for setting heating schedules for BSB-LAN heating circuits in Home Assistant, alongside significant refactoring and improvements to the service implementation and configuration. The changes introduce a new `set_heating_schedule` service, refactor shared schedule logic for maintainability, enhance error handling, and update documentation and tests accordingly.

**New Feature: Heating Schedule Service**
- Added a new `set_heating_schedule` service for BSB-LAN heating circuits, including schema, icon, documentation, and localized strings. This allows users to configure weekly heating schedules for specific heating circuit sub-devices. [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R63-R84) [[2]](diffhunk://#diff-d160a8d7c6df7e9888daf56e8211877ed14c17e26bf3f0e3ffc350eaf1af56e7L34-R73) [[3]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R159-R196) [[4]](diffhunk://#diff-8cd2bf7da5217e022e7aa6acc0d15cc1f4bbcb63637674c4723b2742f0a90704R10-R12)

**Refactoring and Shared Logic**
- Refactored schedule-related logic in `services.py` to share code between hot water and heating schedules, reducing duplication and improving maintainability. Introduced shared utility functions for building weekly schedules and resolving devices/config entries. [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R34-R43) [[2]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L103-L107) [[3]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L134-L191)

**Error Handling and Validation**
- Improved error handling: added validation to ensure only heating circuit sub-devices can use the new service, with clear error messages and translation keys for user feedback. [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L134-L191) [[2]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R127-R135)

**Service Configuration and UI**
- Updated `services.yaml` to add selectors for the new service and to simplify slot selectors using YAML anchors, improving the UI experience for both hot water and heating schedule configuration. [[1]](diffhunk://#diff-d160a8d7c6df7e9888daf56e8211877ed14c17e26bf3f0e3ffc350eaf1af56e7R9-R10) [[2]](diffhunk://#diff-d160a8d7c6df7e9888daf56e8211877ed14c17e26bf3f0e3ffc350eaf1af56e7R20-R23) [[3]](diffhunk://#diff-d160a8d7c6df7e9888daf56e8211877ed14c17e26bf3f0e3ffc350eaf1af56e7L34-R73)

**Testing**
- Added comprehensive tests for the new service, including success cases, circuit number extraction, rejection of invalid devices, and error propagation from the API.

These changes collectively improve the flexibility and robustness of the BSB-LAN integration for Home Assistant, making it easier for users to manage both hot water and heating schedules.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45048
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
