### PR TITLE
Require admin for addon panel register and delete

### DIFF
--- a/homeassistant/components/hassio/addon_panel.py
+++ b/homeassistant/components/hassio/addon_panel.py
@@ -8,7 +8,7 @@ from aiohasupervisor.models import IngressPanel
 from aiohttp import web
 
 from homeassistant.components import frontend
-from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http import HomeAssistantView, require_admin
 from homeassistant.core import HomeAssistant
 
 from .handler import get_supervisor_client
@@ -43,6 +43,7 @@ class HassIOAddonPanel(HomeAssistantView):
         self.hass = hass
         self.client = get_supervisor_client(hass)
 
+    @require_admin
     async def post(self, request: web.Request, addon: str) -> web.Response:
         """Handle new add-on panel requests."""
         panels = await self.get_panels()
@@ -56,6 +57,7 @@ class HassIOAddonPanel(HomeAssistantView):
         _register_panel(self.hass, addon, panels[addon])
         return web.Response()
 
+    @require_admin
     async def delete(self, request: web.Request, addon: str) -> web.Response:
         """Handle remove add-on panel requests."""
         frontend.async_remove_panel(self.hass, addon)

--- a/tests/components/hassio/test_addon_panel.py
+++ b/tests/components/hassio/test_addon_panel.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockUser
 from tests.typing import ClientSessionGenerator
 
 
@@ -91,6 +92,42 @@ async def test_hassio_addon_panel_api(
 
 
 @pytest.mark.usefixtures("hassio_env")
+async def test_hassio_addon_panel_api_non_admin(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    ingress_panels: AsyncMock,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test register panel api fails with non admin user."""
+    ingress_panels.return_value = {
+        "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
+    }
+
+    with patch(
+        "homeassistant.components.hassio.addon_panel._register_panel",
+    ) as mock_panel:
+        await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
+
+        ingress_panels.assert_called_once()
+        mock_panel.assert_called_once()
+
+        mock_panel.reset_mock()
+        hass_admin_user.groups = []
+        hass_client = await hass_client()
+
+        # Both should return unauthorized regardless of enabled as the endpoint requires
+        # admin and the user is not admin
+        resp = await hass_client.post("/api/hassio_push/panel/test2")
+        assert resp.status == HTTPStatus.UNAUTHORIZED
+
+        resp = await hass_client.post("/api/hassio_push/panel/test1")
+        assert resp.status == HTTPStatus.UNAUTHORIZED
+
+        mock_panel.assert_not_called()
+
+
+@pytest.mark.usefixtures("hassio_env")
 async def test_hassio_addon_panel_registration(
     hass: HomeAssistant, ingress_panels: AsyncMock
 ) -> None:
@@ -118,3 +155,49 @@ async def test_hassio_addon_panel_registration(
             require_admin=True,
             config={"addon": "test_addon"},
         )
+
+
+@pytest.mark.usefixtures("hassio_env")
+async def test_hassio_addon_panel_api_delete(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, ingress_panels: AsyncMock
+) -> None:
+    """Test panel api delete."""
+    ingress_panels.return_value = {
+        "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
+    }
+    await async_setup_component(hass, "hassio", {})
+    await hass.async_block_till_done()
+
+    hass_client = await hass_client()
+
+    with patch(
+        "homeassistant.components.hassio.addon_panel.frontend.async_remove_panel"
+    ) as mock_remove:
+        resp = await hass_client.delete("/api/hassio_push/panel/test1")
+        assert resp.status == HTTPStatus.OK
+        mock_remove.assert_called_once_with(hass, "test1")
+
+
+@pytest.mark.usefixtures("hassio_env")
+async def test_hassio_addon_panel_api_delete_non_admin(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    ingress_panels: AsyncMock,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test panel api delete fails with non admin user."""
+    ingress_panels.return_value = {
+        "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
+    }
+    await async_setup_component(hass, "hassio", {})
+    await hass.async_block_till_done()
+
+    hass_admin_user.groups = []
+    hass_client = await hass_client()
+
+    with patch(
+        "homeassistant.components.hassio.addon_panel.frontend.async_remove_panel"
+    ) as mock_remove:
+        resp = await hass_client.delete("/api/hassio_push/panel/test1")
+        assert resp.status == HTTPStatus.UNAUTHORIZED
+        mock_remove.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Admin role is required to register or delete an addon panel via `/api/hassio_push/panel/{addon}`.


## Proposed change

Admin role is required to register a new panel for an addon or to delete a panel for an addon as these are system-wide behaviors.

When adding a new non-admin user, the UI tells the operator:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
