### PR TITLE
Bump freebox-api to 1.3.1

### DIFF
--- a/homeassistant/components/freebox/manifest.json
+++ b/homeassistant/components/freebox/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["freebox_api"],
-  "requirements": ["freebox-api==1.3.0"],
+  "requirements": ["freebox-api==1.3.1"],
   "zeroconf": ["_fbx-api._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1025,7 +1025,7 @@ forecast-solar==5.0.0
 fortiosapi==1.0.5
 
 # homeassistant.components.freebox
-freebox-api==1.3.0
+freebox-api==1.3.1
 
 # homeassistant.components.free_mobile
 freesms==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -910,7 +910,7 @@ foobot_async==1.0.0
 forecast-solar==5.0.0
 
 # homeassistant.components.freebox
-freebox-api==1.3.0
+freebox-api==1.3.1
 
 # homeassistant.components.fressnapf_tracker
 fressnapftracker==0.2.2


### PR DESCRIPTION
## Proposed change

Bump `freebox-api` from `1.3.0` to `1.3.1` for the Freebox integration.

This fixes multiple warnings reported by Home Assistant:
`Detected blocking call to ... inside the event loop by integration 'freebox'`

Release notes: https://github.com/hacf-fr/freebox-api/releases/tag/v1.3.1  
Diff: https://github.com/hacf-fr/freebox-api/compare/v1.3.0...v1.3.1  
Upstream PR: https://github.com/hacf-fr/freebox-api/pull/912


## Type of change

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #159206, fixes #120094
- This PR is related to issue: #166062
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.