### PR TITLE
Expose more port metadata when listing serial ports

### DIFF
--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -14,6 +14,10 @@ class SerialDevice:
     manufacturer: str | None
     description: str | None
 
+    bcd_device: int | None = None
+    interface_description: str | None = None
+    interface_num: int | None = None
+
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class USBDevice(SerialDevice):

--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -13,8 +13,6 @@ class SerialDevice:
     serial_number: str | None
     manufacturer: str | None
     description: str | None
-
-    bcd_device: int | None = None
     interface_description: str | None = None
     interface_num: int | None = None
 
@@ -25,3 +23,6 @@ class USBDevice(SerialDevice):
 
     vid: str
     pid: str
+
+    # bcdDevice descriptor, often the firmware revision
+    bcd_device: int | None = None

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -26,6 +26,9 @@ def usb_device_from_port(port: SerialPortInfo) -> USBDevice:
         serial_number=port.serial_number,
         manufacturer=port.manufacturer,
         description=port.product,
+        bcd_device=port.bcd_device,
+        interface_description=port.interface_description,
+        interface_num=port.interface_num,
     )
 
 
@@ -36,6 +39,9 @@ def serial_device_from_port(port: SerialPortInfo) -> SerialDevice:
         serial_number=port.serial_number,
         manufacturer=port.manufacturer,
         description=port.product,
+        bcd_device=port.bcd_device,
+        interface_description=port.interface_description,
+        interface_num=port.interface_num,
     )
 
 

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -39,7 +39,6 @@ def serial_device_from_port(port: SerialPortInfo) -> SerialDevice:
         serial_number=port.serial_number,
         manufacturer=port.manufacturer,
         description=port.product,
-        bcd_device=port.bcd_device,
         interface_description=port.interface_description,
         interface_num=port.interface_num,
     )

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1342,6 +1342,9 @@ async def test_async_scan_serial_ports(hass: HomeAssistant) -> None:
             serial_number="10B41DE589FC",
             manufacturer="Nabu Casa",
             description="ZBT-2",
+            bcd_device=257,
+            interface_description="Nabu Casa ZBT-2",
+            interface_num=0,
         ),
     ]
 
@@ -1690,6 +1693,9 @@ async def test_list_serial_ports(
             serial_number="001234",
             manufacturer="Silicon Labs",
             description="CP2102 USB to UART",
+            bcd_device=257,
+            interface_description="CP2102 USB to UART Bridge",
+            interface_num=0,
         ),
         SerialDevice(
             device="/dev/ttyS0",
@@ -1707,19 +1713,27 @@ async def test_list_serial_ports(
     result = response["result"]
     assert len(result) == 2
 
-    assert result[0]["device"] == "/dev/ttyUSB0"
-    assert result[0]["vid"] == "10C4"
-    assert result[0]["pid"] == "EA60"
-    assert result[0]["serial_number"] == "001234"
-    assert result[0]["manufacturer"] == "Silicon Labs"
-    assert result[0]["description"] == "CP2102 USB to UART"
+    assert result[0] == {
+        "device": "/dev/ttyUSB0",
+        "vid": "10C4",
+        "pid": "EA60",
+        "serial_number": "001234",
+        "manufacturer": "Silicon Labs",
+        "description": "CP2102 USB to UART",
+        "bcd_device": 257,
+        "interface_description": "CP2102 USB to UART Bridge",
+        "interface_num": 0,
+    }
 
-    assert result[1]["device"] == "/dev/ttyS0"
-    assert result[1]["serial_number"] is None
-    assert result[1]["manufacturer"] is None
-    assert result[1]["description"] == "ttyS0"
-    assert "vid" not in result[1]
-    assert "pid" not in result[1]
+    assert result[1] == {
+        "device": "/dev/ttyS0",
+        "serial_number": None,
+        "manufacturer": None,
+        "description": "ttyS0",
+        "bcd_device": None,
+        "interface_description": None,
+        "interface_num": None,
+    }
 
 
 async def test_list_serial_ports_require_admin(

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1730,7 +1730,6 @@ async def test_list_serial_ports(
         "serial_number": None,
         "manufacturer": None,
         "description": "ttyS0",
-        "bcd_device": None,
         "interface_description": None,
         "interface_num": None,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a few new fields to the `SerialDevice` and `USBDevice` models:
- `interface_description`: text describing what the serial port is for
- `interface_num`: if the port is part of a group, what its index is in the group
- `bcd_device`: USB only, this is a 16-bit integer and is often times a firmware version

Note: `description` will be renamed to `product` in a future PR, since that is the correct field name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
