### PR TITLE
Require admin on APIs to create/delete config entries from Supervisor discovery

### DIFF
--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -13,7 +13,7 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPServiceUnavailable
 
 from homeassistant import config_entries
-from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http import HomeAssistantView, require_admin
 from homeassistant.const import ATTR_SERVICE, EVENT_HOMEASSISTANT_START
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import discovery_flow
@@ -82,6 +82,7 @@ class HassIODiscovery(HomeAssistantView):
         self.hass = hass
         self._supervisor_client = get_supervisor_client(hass)
 
+    @require_admin
     async def post(self, request: web.Request, uuid: str) -> web.Response:
         """Handle new discovery requests."""
         # Fetch discovery data and prevent injections
@@ -94,6 +95,7 @@ class HassIODiscovery(HomeAssistantView):
         await self.async_process_new(data)
         return web.Response()
 
+    @require_admin
     async def delete(self, request: web.Request, uuid: str) -> web.Response:
         """Handle remove discovery requests."""
         data: dict[str, Any] = await request.json()

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -5,13 +5,14 @@ from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-from aiohasupervisor import SupervisorError
+from aiohasupervisor import SupervisorError, SupervisorNotFoundError
 from aiohasupervisor.models import Discovery
 from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
+from homeassistant.config_entries import ConfigEntries
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.discovery_flow import DiscoveryKey
@@ -21,6 +22,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import (
     MockConfigEntry,
     MockModule,
+    MockUser,
     mock_config_flow,
     mock_integration,
     mock_platform,
@@ -194,7 +196,154 @@ async def test_hassio_discovery_webhook(
     )
 
 
+async def test_hassio_discovery_webhook_non_admin(
+    hass: HomeAssistant,
+    hassio_client: TestClient,
+    mock_mqtt: type[config_entries.ConfigFlow],
+    addon_installed: AsyncMock,
+    get_discovery_message: AsyncMock,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test discovery webhook fails for non-admin users."""
+    addon_installed.return_value.name = "Mosquitto Test"
+
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    hass_admin_user.groups = []
+    get_discovery_message.reset_mock()
+    uuid = uuid4()
+
+    resp = await hassio_client.post(
+        f"/api/hassio_push/discovery/{uuid!s}",
+        json={"addon": "mosquitto", "service": "mqtt", "uuid": str(uuid)},
+    )
+    await hass.async_block_till_done()
+
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+    get_discovery_message.assert_not_called()
+    mock_mqtt.async_step_hassio.assert_not_called()
+
+
 TEST_UUID = str(uuid4())
+
+
+@pytest.mark.usefixtures("hassio_client", "addon_installed", "get_addon_discovery_info")
+async def test_delete_hassio_discovery(
+    hass: HomeAssistant, get_discovery_message: AsyncMock, hassio_client: TestClient
+) -> None:
+    """Test deleting a discovery item removes the config entry."""
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(
+        domain=MQTT_DOMAIN,
+        discovery_keys={
+            "hassio": (DiscoveryKey(domain="hassio", key=TEST_UUID, version=1),)
+        },
+        unique_id=(uuid := uuid4()).hex,
+        state=config_entries.ConfigEntryState.LOADED,
+        source=config_entries.SOURCE_HASSIO,
+    )
+    entry.add_to_hass(hass)
+
+    get_discovery_message.side_effect = SupervisorNotFoundError()
+
+    with patch.object(ConfigEntries, "async_remove") as mock_remove:
+        resp = await hassio_client.delete(
+            f"/api/hassio_push/discovery/{uuid.hex}",
+            json={"service": "mqtt", "uuid": uuid.hex},
+        )
+        await hass.async_block_till_done()
+
+        assert resp.status == HTTPStatus.OK
+        get_discovery_message.assert_called_once_with(uuid)
+        mock_remove.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.usefixtures("hassio_client", "addon_installed", "get_addon_discovery_info")
+async def test_delete_hassio_discovery_fails_when_discovery_exists(
+    hass: HomeAssistant,
+    get_discovery_message: AsyncMock,
+    hassio_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test deleting a discovery item fails when discovery exists."""
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(
+        domain=MQTT_DOMAIN,
+        discovery_keys={
+            "hassio": (DiscoveryKey(domain="hassio", key=TEST_UUID, version=1),)
+        },
+        unique_id=(uuid := uuid4()).hex,
+        state=config_entries.ConfigEntryState.LOADED,
+        source=config_entries.SOURCE_HASSIO,
+    )
+    entry.add_to_hass(hass)
+
+    get_discovery_message.return_value = Discovery(
+        addon="mosquitto",
+        service="mqtt",
+        uuid=(uuid := uuid4()),
+        config={
+            "broker": "mock-broker",
+            "port": 1883,
+            "username": "mock-user",
+            "password": "mock-pass",
+            "protocol": "3.1.1",
+        },
+    )
+
+    with patch.object(ConfigEntries, "async_remove") as mock_remove:
+        resp = await hassio_client.delete(
+            f"/api/hassio_push/discovery/{uuid.hex}",
+            json={"service": "mqtt", "uuid": uuid.hex},
+        )
+        await hass.async_block_till_done()
+
+        assert resp.status == HTTPStatus.OK
+        get_discovery_message.assert_called_once_with(uuid)
+        mock_remove.assert_not_called()
+        assert "Retrieve wrong unload for mqtt" in caplog.text
+
+
+@pytest.mark.usefixtures("hassio_client", "addon_installed", "get_addon_discovery_info")
+async def test_delete_hassio_discovery_non_admin(
+    hass: HomeAssistant,
+    get_discovery_message: AsyncMock,
+    hassio_client: TestClient,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test deleting a discovery item fails for non-admin users."""
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(
+        domain=MQTT_DOMAIN,
+        discovery_keys={
+            "hassio": (DiscoveryKey(domain="hassio", key=TEST_UUID, version=1),)
+        },
+        unique_id=(uuid := uuid4()).hex,
+        state=config_entries.ConfigEntryState.LOADED,
+        source=config_entries.SOURCE_HASSIO,
+    )
+    entry.add_to_hass(hass)
+
+    hass_admin_user.groups = []
+
+    with patch.object(ConfigEntries, "async_remove") as mock_remove:
+        resp = await hassio_client.delete(
+            f"/api/hassio_push/discovery/{uuid.hex}",
+            json={"service": "mqtt", "uuid": uuid.hex},
+        )
+        await hass.async_block_till_done()
+
+        assert resp.status == HTTPStatus.UNAUTHORIZED
+        get_discovery_message.assert_not_called()
+        mock_remove.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

An admin role is now required to use `POST /api/hassio_push/discovery/{uuid}` and `DELETE /api/hassio_push/discovery/{uuid}`, the APIs that inform core about new discovery items in Supervisor in order to create or delete config entries.


## Proposed change

The APIs that Supervisor uses to inform core about the addition or removal discovery items in order to create or delete config entries now require an admin role to use.

The only input to these APIs is the UUID and service of a discovery item in Supervisor. And before processing the request it confirms with Supervisor. If Supervisor does not know about the discovery item the create call will fail. And if Supervisor still has record of a discovery item with a given UUID and service the delete call will fail. So they weren't really vulnerable to any particular spoofing but as the only intended client is Supervisor they should require admin.

When adding a new non-admin user, the UI tells the operator:

> The user group feature is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.

This PR is part of that audit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
