### PR TITLE
Handle ZHA dynamic entity add/remove events

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -171,7 +171,10 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
         self._unsubs.append(
             async_dispatcher_connect(
                 self.hass,
-                f"{SIGNAL_REMOVE_ENTITY}_{self.unique_id}",
+                (
+                    f"{SIGNAL_REMOVE_ENTITY}_"
+                    f"{self.entity_data.entity.PLATFORM}_{self.unique_id}"
+                ),
                 self.async_remove,
             )
         )

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -27,7 +27,12 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from .const import DOMAIN
-from .helpers import SIGNAL_REMOVE_ENTITIES, EntityData, convert_zha_error_to_ha_error
+from .helpers import (
+    SIGNAL_REMOVE_ENTITIES,
+    SIGNAL_REMOVE_ENTITY,
+    EntityData,
+    convert_zha_error_to_ha_error,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +166,13 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
                 self.hass,
                 remove_signal,
                 partial(self.async_remove, force_remove=True),
+            )
+        )
+        self._unsubs.append(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SIGNAL_REMOVE_ENTITY}_{self.unique_id}",
+                self.async_remove,
             )
         )
         self.entity_data.device_proxy.gateway_proxy.register_entity_reference(

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -201,6 +201,7 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
         for unsub in self._unsubs[:]:
             unsub()
             self._unsubs.remove(unsub)
+        self.entity_data.device_proxy.gateway_proxy.remove_entity_reference(self)
         await super().async_will_remove_from_hass()
         self.remove_future.set_result(True)
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -121,10 +121,7 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
-from homeassistant.helpers.entity_platform import (
-    DATA_DOMAIN_ENTITIES,
-    AddEntitiesCallback,
-)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.logging import HomeAssistantQueueHandler
 
@@ -211,6 +208,7 @@ DEBUG_RELAY_LOGGERS = [DEBUG_COMP_ZHA, DEBUG_COMP_ZIGPY, DEBUG_LIB_ZHA]
 ZHA_GW_MSG_LOG_ENTRY = "log_entry"
 ZHA_GW_MSG_LOG_OUTPUT = "log_output"
 SIGNAL_REMOVE_ENTITIES = "zha_remove_entities"
+SIGNAL_REMOVE_ENTITY = "zha_remove_entity"
 GROUP_ENTITY_DOMAINS = [Platform.LIGHT, Platform.SWITCH, Platform.FAN]
 SIGNAL_ADD_ENTITIES = "zha_add_entities"
 ENTITIES = "entities"
@@ -519,28 +517,24 @@ class ZHADeviceProxy(EventBase):
         self, event: DeviceEntityRemovedEvent
     ) -> None:
         """Handle an entity being removed from a device at runtime."""
+        if not event.remove:
+            # Soft removal: signal the entity to unload itself; the registry
+            # entry is kept so the user can manually delete it.
+            async_dispatcher_send(
+                self.gateway_proxy.hass,
+                f"{SIGNAL_REMOVE_ENTITY}_{event.unique_id}",
+            )
+            return
+
+        # Hard removal: deleting the registry entry triggers the entity's
+        # registry-update listener which removes the state. Done here (not in
+        # the entity) so it works even when no live entity is loaded.
         entity_registry = er.async_get(self.gateway_proxy.hass)
         domain = Platform(event.platform)
-        entity_id = entity_registry.async_get_entity_id(domain, DOMAIN, event.unique_id)
-        if entity_id is None:
-            return
-
-        if event.remove:
-            # Fully remove the entity: deleting the registry entry triggers
-            # the entity's registry-update listener which removes the state.
+        if entity_id := entity_registry.async_get_entity_id(
+            domain, DOMAIN, event.unique_id
+        ):
             entity_registry.async_remove(entity_id)
-            return
-
-        # Otherwise, only unload the live entity so it shows as unavailable;
-        # the registry entry is kept so the user can manually delete it.
-        domain_entities = self.gateway_proxy.hass.data.get(
-            DATA_DOMAIN_ENTITIES, {}
-        ).get(domain, {})
-        if (entity := domain_entities.get(entity_id)) is not None:
-            self.gateway_proxy.hass.async_create_task(
-                entity.async_remove(),
-                f"ZHA remove entity {entity_id}",
-            )
 
 
 class EntityReference(NamedTuple):

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -518,15 +518,14 @@ class ZHADeviceProxy(EventBase):
     ) -> None:
         """Handle an entity being removed from a device at runtime."""
         if not event.remove:
-            # Soft remove: signal the entity to unload; registry entry stays.
-            # Signal keyed by (platform, unique_id) - the ZHA identity tuple.
+            # Soft remove: signal the entity to unload; registry entry stays
             async_dispatcher_send(
                 self.gateway_proxy.hass,
                 f"{SIGNAL_REMOVE_ENTITY}_{event.platform}_{event.unique_id}",
             )
             return
 
-        # Hard remove: registry deletion works without a live entity loaded.
+        # Hard remove: delete from registry, also works without a live entity loaded
         entity_registry = er.async_get(self.gateway_proxy.hass)
         domain = Platform(event.platform)
         if entity_id := entity_registry.async_get_entity_id(

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -521,17 +521,26 @@ class ZHADeviceProxy(EventBase):
         """Handle an entity being removed from a device at runtime."""
         entity_registry = er.async_get(self.gateway_proxy.hass)
         domain = Platform(event.platform)
-        if entity_id := entity_registry.async_get_entity_id(
-            domain, DOMAIN, event.unique_id
-        ):
-            domain_entities = self.gateway_proxy.hass.data.get(
-                DATA_DOMAIN_ENTITIES, {}
-            ).get(domain, {})
-            if (entity := domain_entities.get(entity_id)) is not None:
-                self.gateway_proxy.hass.async_create_task(
-                    entity.async_remove(),
-                    f"ZHA remove entity {entity_id}",
-                )
+        entity_id = entity_registry.async_get_entity_id(domain, DOMAIN, event.unique_id)
+        if entity_id is None:
+            return
+
+        if event.remove:
+            # Fully remove the entity: deleting the registry entry triggers
+            # the entity's registry-update listener which removes the state.
+            entity_registry.async_remove(entity_id)
+            return
+
+        # Otherwise, only unload the live entity so it shows as unavailable;
+        # the registry entry is kept so the user can manually delete it.
+        domain_entities = self.gateway_proxy.hass.data.get(
+            DATA_DOMAIN_ENTITIES, {}
+        ).get(domain, {})
+        if (entity := domain_entities.get(entity_id)) is not None:
+            self.gateway_proxy.hass.async_create_task(
+                entity.async_remove(),
+                f"ZHA remove entity {entity_id}",
+            )
 
 
 class EntityReference(NamedTuple):

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -518,19 +518,15 @@ class ZHADeviceProxy(EventBase):
     ) -> None:
         """Handle an entity being removed from a device at runtime."""
         if not event.remove:
-            # Soft removal: signal the entity to unload itself; the registry
-            # entry is kept so the user can manually delete it. The signal is
-            # keyed by (platform, unique_id) since that is the ZHA entity
-            # identity tuple - a unique_id can repeat across platforms.
+            # Soft remove: signal the entity to unload; registry entry stays.
+            # Signal keyed by (platform, unique_id) - the ZHA identity tuple.
             async_dispatcher_send(
                 self.gateway_proxy.hass,
                 f"{SIGNAL_REMOVE_ENTITY}_{event.platform}_{event.unique_id}",
             )
             return
 
-        # Hard removal: deleting the registry entry triggers the entity's
-        # registry-update listener which removes the state. Done here (not in
-        # the entity) so it works even when no live entity is loaded.
+        # Hard remove: registry deletion works without a live entity loaded.
         entity_registry = er.async_get(self.gateway_proxy.hass)
         domain = Platform(event.platform)
         if entity_id := entity_registry.async_get_entity_id(

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -855,13 +855,12 @@ class ZHAGatewayProxy(EventBase):
 
     def remove_entity_reference(self, entity: ZHAEntity) -> None:
         """Remove entity reference for given entity_id if found."""
-        if entity.zha_device.ieee in self.ha_entity_refs:
-            entity_refs = self.ha_entity_refs.get(entity.zha_device.ieee)
-            self.ha_entity_refs[entity.zha_device.ieee] = [
-                e
-                for e in entity_refs  # type: ignore[union-attr]
-                if e.ha_entity_id != entity.entity_id
-            ]
+        ieee = entity.entity_data.device_proxy.device.ieee
+        if (entity_refs := self._ha_entity_refs.get(ieee)) is None:
+            return
+        self._ha_entity_refs[ieee] = [
+            e for e in entity_refs if e.ha_entity_id != entity.entity_id
+        ]
 
     def _async_get_or_create_device_proxy(self, zha_device: Device) -> ZHADeviceProxy:
         """Get or create a ZHA device."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -519,10 +519,12 @@ class ZHADeviceProxy(EventBase):
         """Handle an entity being removed from a device at runtime."""
         if not event.remove:
             # Soft removal: signal the entity to unload itself; the registry
-            # entry is kept so the user can manually delete it.
+            # entry is kept so the user can manually delete it. The signal is
+            # keyed by (platform, unique_id) since that is the ZHA entity
+            # identity tuple - a unique_id can repeat across platforms.
             async_dispatcher_send(
                 self.gateway_proxy.hass,
-                f"{SIGNAL_REMOVE_ENTITY}_{event.unique_id}",
+                f"{SIGNAL_REMOVE_ENTITY}_{event.platform}_{event.unique_id}",
             )
             return
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -121,7 +121,10 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    DATA_DOMAIN_ENTITIES,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.logging import HomeAssistantQueueHandler
 
@@ -517,10 +520,18 @@ class ZHADeviceProxy(EventBase):
     ) -> None:
         """Handle an entity being removed from a device at runtime."""
         entity_registry = er.async_get(self.gateway_proxy.hass)
+        domain = Platform(event.platform)
         if entity_id := entity_registry.async_get_entity_id(
-            Platform(event.platform), DOMAIN, event.unique_id
+            domain, DOMAIN, event.unique_id
         ):
-            entity_registry.async_remove(entity_id)
+            domain_entities = self.gateway_proxy.hass.data.get(
+                DATA_DOMAIN_ENTITIES, {}
+            ).get(domain, {})
+            if (entity := domain_entities.get(entity_id)) is not None:
+                self.gateway_proxy.hass.async_create_task(
+                    entity.async_remove(),
+                    f"ZHA remove entity {entity_id}",
+                )
 
 
 class EntityReference(NamedTuple):

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -77,6 +77,8 @@ from zha.zigbee.cluster_handlers import ClusterBindEvent, ClusterConfigureReport
 from zha.zigbee.device import (
     ClusterHandlerConfigurationComplete,
     Device,
+    DeviceEntityAddedEvent,
+    DeviceEntityRemovedEvent,
     DeviceFirmwareInfoUpdatedEvent,
     ZHAEvent,
 )
@@ -494,6 +496,32 @@ class ZHADeviceProxy(EventBase):
                 },
             },
         )
+
+    @callback
+    def handle_zha_device_entity_added_event(
+        self, event: DeviceEntityAddedEvent
+    ) -> None:
+        """Handle a new entity being added to a device at runtime."""
+        ha_zha_data = get_zha_data(self.gateway_proxy.hass)
+        for entity in self.device.platform_entities.values():
+            if entity.unique_id == event.unique_id:
+                ha_zha_data.platforms[Platform(entity.PLATFORM)].append(
+                    EntityData(entity=entity, device_proxy=self, group_proxy=None)
+                )
+                async_dispatcher_send(self.gateway_proxy.hass, SIGNAL_ADD_ENTITIES)
+                break
+
+    @callback
+    def handle_zha_device_entity_removed_event(
+        self, event: DeviceEntityRemovedEvent
+    ) -> None:
+        """Handle an entity being removed from a device at runtime."""
+        entity_registry = er.async_get(self.gateway_proxy.hass)
+        entity_refs = self.gateway_proxy.ha_entity_refs.get(self.device.ieee, [])
+        for entity_ref in entity_refs:
+            if entity_ref.entity_data.entity.unique_id == event.unique_id:
+                entity_registry.async_remove(entity_ref.ha_entity_id)
+                break
 
 
 class EntityReference(NamedTuple):

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -121,10 +121,7 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
-from homeassistant.helpers.entity_platform import (
-    DATA_DOMAIN_ENTITIES,
-    AddEntitiesCallback,
-)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.logging import HomeAssistantQueueHandler
 
@@ -505,37 +502,25 @@ class ZHADeviceProxy(EventBase):
         self, event: DeviceEntityAddedEvent
     ) -> None:
         """Handle a new entity being added to a device at runtime."""
+        key = (event.platform, event.unique_id)
+        if (entity := self.device.platform_entities.get(key)) is None:
+            return
         ha_zha_data = get_zha_data(self.gateway_proxy.hass)
-        for entity in self.device.platform_entities.values():
-            if entity.unique_id == event.unique_id:
-                ha_zha_data.platforms[Platform(entity.PLATFORM)].append(
-                    EntityData(entity=entity, device_proxy=self, group_proxy=None)
-                )
-                async_dispatcher_send(self.gateway_proxy.hass, SIGNAL_ADD_ENTITIES)
-                break
+        ha_zha_data.platforms[Platform(event.platform)].append(
+            EntityData(entity=entity, device_proxy=self, group_proxy=None)
+        )
+        async_dispatcher_send(self.gateway_proxy.hass, SIGNAL_ADD_ENTITIES)
 
     @callback
     def handle_zha_device_entity_removed_event(
         self, event: DeviceEntityRemovedEvent
     ) -> None:
         """Handle an entity being removed from a device at runtime."""
-        entity_refs = self.gateway_proxy.ha_entity_refs.get(self.device.ieee, [])
-        for entity_ref in entity_refs:
-            if entity_ref.entity_data.entity.unique_id == event.unique_id:
-                self.gateway_proxy.hass.async_create_task(
-                    self._async_remove_entity(entity_ref.ha_entity_id),
-                    f"ZHA remove entity {entity_ref.ha_entity_id}",
-                )
-                break
-
-    async def _async_remove_entity(self, entity_id: str) -> None:
-        """Remove a single entity from its platform without deleting the registry entry."""
-        domain = entity_id.partition(".")[0]
-        domain_entities = self.gateway_proxy.hass.data.get(
-            DATA_DOMAIN_ENTITIES, {}
-        ).get(domain, {})
-        if (entity := domain_entities.get(entity_id)) is not None:
-            await entity.async_remove()
+        entity_registry = er.async_get(self.gateway_proxy.hass)
+        if entity_id := entity_registry.async_get_entity_id(
+            Platform(event.platform), DOMAIN, event.unique_id
+        ):
+            entity_registry.async_remove(entity_id)
 
 
 class EntityReference(NamedTuple):

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -121,7 +121,10 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    DATA_DOMAIN_ENTITIES,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.logging import HomeAssistantQueueHandler
 
@@ -516,12 +519,23 @@ class ZHADeviceProxy(EventBase):
         self, event: DeviceEntityRemovedEvent
     ) -> None:
         """Handle an entity being removed from a device at runtime."""
-        entity_registry = er.async_get(self.gateway_proxy.hass)
         entity_refs = self.gateway_proxy.ha_entity_refs.get(self.device.ieee, [])
         for entity_ref in entity_refs:
             if entity_ref.entity_data.entity.unique_id == event.unique_id:
-                entity_registry.async_remove(entity_ref.ha_entity_id)
+                self.gateway_proxy.hass.async_create_task(
+                    self._async_remove_entity(entity_ref.ha_entity_id),
+                    f"ZHA remove entity {entity_ref.ha_entity_id}",
+                )
                 break
+
+    async def _async_remove_entity(self, entity_id: str) -> None:
+        """Remove a single entity from its platform without deleting the registry entry."""
+        domain = entity_id.partition(".")[0]
+        domain_entities = self.gateway_proxy.hass.data.get(
+            DATA_DOMAIN_ENTITIES, {}
+        ).get(domain, {})
+        if (entity := domain_entities.get(entity_id)) is not None:
+            await entity.async_remove()
 
 
 class EntityReference(NamedTuple):

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -237,17 +237,18 @@ async def test_handle_device_entity_removed_unknown_unique_id(
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
-    zha_device_proxy.device.emit(
-        DeviceEntityRemovedEvent.event_type,
-        DeviceEntityRemovedEvent(
-            platform=ZhaPlatform.SWITCH,
-            unique_id="nonexistent_unique_id",
-            remove=True,
-        ),
-    )
-    await hass.async_block_till_done()
+    for remove in (False, True):
+        zha_device_proxy.device.emit(
+            DeviceEntityRemovedEvent.event_type,
+            DeviceEntityRemovedEvent(
+                platform=ZhaPlatform.SWITCH,
+                unique_id="nonexistent_unique_id",
+                remove=remove,
+            ),
+        )
+        await hass.async_block_till_done()
 
-    # The original entity is untouched.
-    registry = er.async_get(hass)
-    assert registry.async_get(entity_id) is not None
-    assert hass.states.get(entity_id) is not None
+        # The original entity is untouched.
+        registry = er.async_get(hass)
+        assert registry.async_get(entity_id) is not None
+        assert hass.states.get(entity_id) is not None

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -1,6 +1,6 @@
 """Test ZHA handling of runtime device entity added/removed events."""
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Generator
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +11,7 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
 from homeassistant.components.zha.helpers import (
+    SIGNAL_ADD_ENTITIES,
     ZHADeviceProxy,
     ZHAGatewayProxy,
     get_zha_data,
@@ -26,7 +27,7 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 
 @pytest.fixture(autouse=True)
-def switch_platform_only():
+def switch_platform_only() -> Generator[None]:
     """Only set up the switch and required base platforms to speed up tests."""
     with patch(
         "homeassistant.components.zha.PLATFORMS",
@@ -72,7 +73,17 @@ async def _create_switch_device(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     zha_device_proxy = gateway_proxy.get_device_proxy(zigpy_device.ieee)
+    assert zha_device_proxy is not None
     return zha_device_proxy, gateway_proxy, zigpy_device
+
+
+def _get_switch_platform_entity(zha_device_proxy: ZHADeviceProxy):
+    """Return the underlying ZHA switch platform entity for the device."""
+    return next(
+        entity
+        for entity in zha_device_proxy.device.platform_entities.values()
+        if entity.PLATFORM == Platform.SWITCH
+    )
 
 
 async def test_handle_device_entity_added(
@@ -80,48 +91,45 @@ async def test_handle_device_entity_added(
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test that a runtime DeviceEntityAddedEvent populates platform data and dispatches signal."""
+    """Test that DeviceEntityAddedEvent re-creates a previously removed entity."""
     zha_device_proxy, _, _ = await _create_switch_device(
         hass, setup_zha, zigpy_device_mock
     )
+    platform_entity = _get_switch_platform_entity(zha_device_proxy)
+    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    assert entity_id is not None
 
-    # Get the switch platform entity from the ZHA device
-    switch_entities = [
-        entity
-        for entity in zha_device_proxy.device.platform_entities.values()
-        if entity.PLATFORM == Platform.SWITCH
-    ]
-    assert len(switch_entities) > 0
-    platform_entity = switch_entities[0]
+    # Remove first so the re-add has visible side effects (state reappears).
+    zha_device_proxy.device.emit(
+        DeviceEntityRemovedEvent.event_type,
+        DeviceEntityRemovedEvent(
+            platform=ZhaPlatform.SWITCH,
+            unique_id=platform_entity.unique_id,
+            remove=True,
+        ),
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id) is None
 
     ha_zha_data = get_zha_data(hass)
-
-    # The platform entity list should be empty (cleared after initial entity creation)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
 
-    # Fire the entity added event
-    with patch(
-        "homeassistant.components.zha.helpers.async_dispatcher_send"
-    ) as mock_dispatch:
-        zha_device_proxy.handle_zha_device_entity_added_event(
-            DeviceEntityAddedEvent(
-                platform=ZhaPlatform(platform_entity.PLATFORM),
-                unique_id=platform_entity.unique_id,
-            )
-        )
+    # Fire the entity-added event through the device emitter to exercise
+    # the on_all_events -> _handle_event_protocol -> handler wiring.
+    zha_device_proxy.device.emit(
+        DeviceEntityAddedEvent.event_type,
+        DeviceEntityAddedEvent(
+            platform=ZhaPlatform.SWITCH,
+            unique_id=platform_entity.unique_id,
+        ),
+    )
+    await hass.async_block_till_done()
 
-        # Verify EntityData was appended to the platform list
-        assert len(ha_zha_data.platforms[Platform.SWITCH]) == 1
-        entity_data = ha_zha_data.platforms[Platform.SWITCH][0]
-        assert entity_data.entity is platform_entity
-        assert entity_data.device_proxy is zha_device_proxy
-        assert entity_data.group_proxy is None
+    # The platform list is drained by SIGNAL_ADD_ENTITIES handler.
+    assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
 
-        # Verify SIGNAL_ADD_ENTITIES was dispatched
-        mock_dispatch.assert_called_once_with(hass, "zha_add_entities")
-
-    # Clean up
-    ha_zha_data.platforms[Platform.SWITCH].clear()
+    # The entity is back and reachable as a HA state.
+    assert hass.states.get(entity_id) is not None
 
 
 async def test_handle_device_entity_added_unknown_unique_id(
@@ -140,16 +148,19 @@ async def test_handle_device_entity_added_unknown_unique_id(
     with patch(
         "homeassistant.components.zha.helpers.async_dispatcher_send"
     ) as mock_dispatch:
-        zha_device_proxy.handle_zha_device_entity_added_event(
+        zha_device_proxy.device.emit(
+            DeviceEntityAddedEvent.event_type,
             DeviceEntityAddedEvent(
                 platform=ZhaPlatform.SWITCH,
                 unique_id="nonexistent_unique_id",
-            )
+            ),
         )
+        await hass.async_block_till_done()
 
-        # Nothing should be added and no signal dispatched
+        # Nothing should be added and SIGNAL_ADD_ENTITIES is never dispatched.
         assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
-        mock_dispatch.assert_not_called()
+        for call in mock_dispatch.call_args_list:
+            assert call.args != (hass, SIGNAL_ADD_ENTITIES)
 
 
 async def test_handle_device_entity_removed(
@@ -162,7 +173,6 @@ async def test_handle_device_entity_removed(
         hass, setup_zha, zigpy_device_mock
     )
 
-    # Verify entity exists and has a state
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
@@ -171,20 +181,21 @@ async def test_handle_device_entity_removed(
     assert entry is not None
     assert hass.states.get(entity_id) is not None
 
-    # Fire the entity removed event with remove=False
-    zha_device_proxy.handle_zha_device_entity_removed_event(
+    # Fire through the device emitter so the on_all_events wiring is exercised.
+    zha_device_proxy.device.emit(
+        DeviceEntityRemovedEvent.event_type,
         DeviceEntityRemovedEvent(
             platform=ZhaPlatform.SWITCH,
             unique_id=entry.unique_id,
             remove=False,
-        )
+        ),
     )
     await hass.async_block_till_done()
 
-    # The registry entry is preserved so the user can manually delete it
+    # Registry entry preserved so the user can manually delete it.
     assert registry.async_get(entity_id) is not None
 
-    # The entity state is set to unavailable
+    # State is set to unavailable.
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
@@ -208,20 +219,18 @@ async def test_handle_device_entity_removed_with_remove_flag(
     assert entry is not None
     assert hass.states.get(entity_id) is not None
 
-    # Fire the entity removed event with remove=True
-    zha_device_proxy.handle_zha_device_entity_removed_event(
+    zha_device_proxy.device.emit(
+        DeviceEntityRemovedEvent.event_type,
         DeviceEntityRemovedEvent(
             platform=ZhaPlatform.SWITCH,
             unique_id=entry.unique_id,
             remove=True,
-        )
+        ),
     )
     await hass.async_block_till_done()
 
-    # The registry entry is removed
+    # Registry entry and state are both gone.
     assert registry.async_get(entity_id) is None
-
-    # The entity state is also gone
     assert hass.states.get(entity_id) is None
 
 
@@ -238,15 +247,17 @@ async def test_handle_device_entity_removed_unknown_unique_id(
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
-    # Fire event with a unique_id that doesn't match any entity
-    zha_device_proxy.handle_zha_device_entity_removed_event(
+    zha_device_proxy.device.emit(
+        DeviceEntityRemovedEvent.event_type,
         DeviceEntityRemovedEvent(
             platform=ZhaPlatform.SWITCH,
             unique_id="nonexistent_unique_id",
-        )
+            remove=True,
+        ),
     )
     await hass.async_block_till_done()
 
-    # Verify the entity was NOT removed
+    # The original entity is untouched.
     registry = er.async_get(hass)
     assert registry.async_get(entity_id) is not None
+    assert hass.states.get(entity_id) is not None

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -14,7 +14,6 @@ from zigpy.zcl.clusters import general
 from homeassistant.components.zha.helpers import (
     SIGNAL_ADD_ENTITIES,
     ZHADeviceProxy,
-    ZHAGatewayProxy,
     get_zha_data,
     get_zha_gateway,
     get_zha_gateway_proxy,
@@ -46,7 +45,7 @@ async def _create_switch_device(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
-) -> tuple[ZHADeviceProxy, ZHAGatewayProxy, Device]:
+) -> ZHADeviceProxy:
     """Create a basic switch device for testing."""
     await setup_zha()
     gateway = get_zha_gateway(hass)
@@ -75,7 +74,7 @@ async def _create_switch_device(
 
     zha_device_proxy = gateway_proxy.get_device_proxy(zigpy_device.ieee)
     assert zha_device_proxy is not None
-    return zha_device_proxy, gateway_proxy, zigpy_device
+    return zha_device_proxy
 
 
 def _get_switch_platform_entity(zha_device_proxy: ZHADeviceProxy) -> PlatformEntity:
@@ -93,9 +92,7 @@ async def test_handle_device_entity_added(
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that DeviceEntityAddedEvent re-creates a previously removed entity."""
-    zha_device_proxy, _, _ = await _create_switch_device(
-        hass, setup_zha, zigpy_device_mock
-    )
+    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
     platform_entity = _get_switch_platform_entity(zha_device_proxy)
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
@@ -139,9 +136,7 @@ async def test_handle_device_entity_added_unknown_unique_id(
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that a DeviceEntityAddedEvent with unknown unique_id is a no-op."""
-    zha_device_proxy, _, _ = await _create_switch_device(
-        hass, setup_zha, zigpy_device_mock
-    )
+    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
 
     ha_zha_data = get_zha_data(hass)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
@@ -170,9 +165,7 @@ async def test_handle_device_entity_removed(
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that DeviceEntityRemovedEvent with remove=False only unloads the entity."""
-    zha_device_proxy, _, _ = await _create_switch_device(
-        hass, setup_zha, zigpy_device_mock
-    )
+    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
 
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
@@ -208,9 +201,7 @@ async def test_handle_device_entity_removed_with_remove_flag(
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that DeviceEntityRemovedEvent with remove=True deletes the registry entry."""
-    zha_device_proxy, _, _ = await _create_switch_device(
-        hass, setup_zha, zigpy_device_mock
-    )
+    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
 
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
@@ -241,9 +232,7 @@ async def test_handle_device_entity_removed_unknown_unique_id(
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that a DeviceEntityRemovedEvent with unknown unique_id is a no-op."""
-    zha_device_proxy, _, _ = await _create_switch_device(
-        hass, setup_zha, zigpy_device_mock
-    )
+    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
 
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -205,6 +205,42 @@ async def test_handle_device_entity_removed(
     assert state.state == STATE_UNAVAILABLE
 
 
+async def test_handle_device_entity_removed_other_platform_does_not_unload(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that a soft remove for a different platform does not unload the switch.
+
+    The (platform, unique_id) tuple is the ZHA entity identity; entities on
+    different platforms can share a unique_id without colliding.
+    """
+    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
+
+    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    assert entity_id is not None
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+    # Soft-remove an entity on a different platform but reusing this
+    # unique_id; the switch must remain loaded and available.
+    zha_device_proxy.device.emit(
+        DeviceEntityRemovedEvent.event_type,
+        DeviceEntityRemovedEvent(
+            platform=ZhaPlatform.SENSOR,
+            unique_id=entry.unique_id,
+            remove=False,
+        ),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
 async def test_handle_device_entity_removed_with_remove_flag(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -305,3 +305,29 @@ async def test_handle_device_entity_removed_unknown_unique_id(
         registry = er.async_get(hass)
         assert registry.async_get(entity_id) is not None
         assert hass.states.get(entity_id) is not None
+
+
+async def test_remove_entity_reference_when_ieee_already_cleared(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test entity teardown when _ha_entity_refs already lost the ieee.
+
+    Simulates the race where ``handle_device_removed`` pops the ieee entry
+    before the entity finishes tearing down. The early-return guard must
+    keep the popped key out of the dict.
+    """
+    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
+
+    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    assert entity_id is not None
+
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    ieee = zha_device_proxy.device.ieee
+    gateway_proxy._ha_entity_refs.pop(ieee, None)
+
+    er.async_get(hass).async_remove(entity_id)
+    await hass.async_block_till_done()
+
+    assert ieee not in gateway_proxy._ha_entity_refs

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -12,7 +12,6 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
 from homeassistant.components.zha.helpers import (
-    SIGNAL_ADD_ENTITIES,
     ZHADeviceProxy,
     get_zha_data,
     get_zha_gateway,
@@ -155,10 +154,9 @@ async def test_handle_device_entity_added_unknown_unique_id(
         )
         await hass.async_block_till_done()
 
-        # Nothing should be added and SIGNAL_ADD_ENTITIES is never dispatched.
+        # Nothing should be added and no dispatcher signal is fired.
         assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
-        for call in mock_dispatch.call_args_list:
-            assert call.args != (hass, SIGNAL_ADD_ENTITIES)
+        mock_dispatch.assert_not_called()
 
 
 async def test_handle_device_entity_removed(

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -10,6 +10,7 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
 from homeassistant.components.zha.helpers import (
+    SIGNAL_ADD_ENTITIES,
     ZHADeviceProxy,
     ZHAGatewayProxy,
     get_zha_data,
@@ -17,8 +18,9 @@ from homeassistant.components.zha.helpers import (
     get_zha_gateway_proxy,
 )
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .common import find_entity_id
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
@@ -98,26 +100,22 @@ async def test_handle_device_entity_added(
     # The platform entity list should be empty (cleared after initial entity creation)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
 
+    # Listen for the add entities signal
+    signal_calls: list[bool] = []
+
+    @callback
+    def _signal_listener() -> None:
+        signal_calls.append(True)
+
+    async_dispatcher_connect(hass, SIGNAL_ADD_ENTITIES, _signal_listener)
+
     # Fire the entity added event
-    with patch(
-        "homeassistant.components.zha.helpers.async_dispatcher_send"
-    ) as mock_dispatch:
-        zha_device_proxy.handle_zha_device_entity_added_event(
-            DeviceEntityAddedEvent(unique_id=platform_entity.unique_id)
-        )
+    zha_device_proxy.handle_zha_device_entity_added_event(
+        DeviceEntityAddedEvent(unique_id=platform_entity.unique_id)
+    )
 
-        # Verify EntityData was appended to the platform list
-        assert len(ha_zha_data.platforms[Platform.SWITCH]) == 1
-        entity_data = ha_zha_data.platforms[Platform.SWITCH][0]
-        assert entity_data.entity is platform_entity
-        assert entity_data.device_proxy is zha_device_proxy
-        assert entity_data.group_proxy is None
-
-        # Verify SIGNAL_ADD_ENTITIES was dispatched
-        mock_dispatch.assert_called_once_with(hass, "zha_add_entities")
-
-    # Clean up
-    ha_zha_data.platforms[Platform.SWITCH].clear()
+    # Verify the signal was dispatched
+    assert len(signal_calls) == 1
 
 
 async def test_handle_device_entity_added_unknown_unique_id(
@@ -133,16 +131,21 @@ async def test_handle_device_entity_added_unknown_unique_id(
     ha_zha_data = get_zha_data(hass)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
 
-    with patch(
-        "homeassistant.components.zha.helpers.async_dispatcher_send"
-    ) as mock_dispatch:
-        zha_device_proxy.handle_zha_device_entity_added_event(
-            DeviceEntityAddedEvent(unique_id="nonexistent_unique_id")
-        )
+    signal_calls: list[bool] = []
 
-        # Nothing should be added and no signal dispatched
-        assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
-        mock_dispatch.assert_not_called()
+    @callback
+    def _signal_listener() -> None:
+        signal_calls.append(True)
+
+    async_dispatcher_connect(hass, SIGNAL_ADD_ENTITIES, _signal_listener)
+
+    zha_device_proxy.handle_zha_device_entity_added_event(
+        DeviceEntityAddedEvent(unique_id="nonexistent_unique_id")
+    )
+
+    # Nothing should be added and no signal dispatched
+    assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
+    assert len(signal_calls) == 0
 
 
 async def test_handle_device_entity_removed(

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -28,16 +28,8 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 @pytest.fixture(autouse=True)
 def switch_platform_only() -> Generator[None]:
-    """Only set up the switch and required base platforms to speed up tests."""
-    with patch(
-        "homeassistant.components.zha.PLATFORMS",
-        (
-            Platform.DEVICE_TRACKER,
-            Platform.SENSOR,
-            Platform.SELECT,
-            Platform.SWITCH,
-        ),
-    ):
+    """Only set up the switch platform to speed up tests."""
+    with patch("homeassistant.components.zha.PLATFORMS", (Platform.SWITCH,)):
         yield
 
 

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from zha.application import Platform as ZhaPlatform
+from zha.application.platforms import PlatformEntity
 from zha.zigbee.device import DeviceEntityAddedEvent, DeviceEntityRemovedEvent
 from zigpy.device import Device
 from zigpy.profiles import zha
@@ -77,7 +78,7 @@ async def _create_switch_device(
     return zha_device_proxy, gateway_proxy, zigpy_device
 
 
-def _get_switch_platform_entity(zha_device_proxy: ZHADeviceProxy):
+def _get_switch_platform_entity(zha_device_proxy: ZHADeviceProxy) -> PlatformEntity:
     """Return the underlying ZHA switch platform entity for the device."""
     return next(
         entity

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -10,7 +10,6 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
 from homeassistant.components.zha.helpers import (
-    SIGNAL_ADD_ENTITIES,
     ZHADeviceProxy,
     ZHAGatewayProxy,
     get_zha_data,
@@ -18,9 +17,8 @@ from homeassistant.components.zha.helpers import (
     get_zha_gateway_proxy,
 )
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .common import find_entity_id
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
@@ -100,22 +98,26 @@ async def test_handle_device_entity_added(
     # The platform entity list should be empty (cleared after initial entity creation)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
 
-    # Listen for the add entities signal
-    signal_calls: list[bool] = []
-
-    @callback
-    def _signal_listener() -> None:
-        signal_calls.append(True)
-
-    async_dispatcher_connect(hass, SIGNAL_ADD_ENTITIES, _signal_listener)
-
     # Fire the entity added event
-    zha_device_proxy.handle_zha_device_entity_added_event(
-        DeviceEntityAddedEvent(unique_id=platform_entity.unique_id)
-    )
+    with patch(
+        "homeassistant.components.zha.helpers.async_dispatcher_send"
+    ) as mock_dispatch:
+        zha_device_proxy.handle_zha_device_entity_added_event(
+            DeviceEntityAddedEvent(unique_id=platform_entity.unique_id)
+        )
 
-    # Verify the signal was dispatched
-    assert len(signal_calls) == 1
+        # Verify EntityData was appended to the platform list
+        assert len(ha_zha_data.platforms[Platform.SWITCH]) == 1
+        entity_data = ha_zha_data.platforms[Platform.SWITCH][0]
+        assert entity_data.entity is platform_entity
+        assert entity_data.device_proxy is zha_device_proxy
+        assert entity_data.group_proxy is None
+
+        # Verify SIGNAL_ADD_ENTITIES was dispatched
+        mock_dispatch.assert_called_once_with(hass, "zha_add_entities")
+
+    # Clean up
+    ha_zha_data.platforms[Platform.SWITCH].clear()
 
 
 async def test_handle_device_entity_added_unknown_unique_id(
@@ -131,21 +133,16 @@ async def test_handle_device_entity_added_unknown_unique_id(
     ha_zha_data = get_zha_data(hass)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
 
-    signal_calls: list[bool] = []
+    with patch(
+        "homeassistant.components.zha.helpers.async_dispatcher_send"
+    ) as mock_dispatch:
+        zha_device_proxy.handle_zha_device_entity_added_event(
+            DeviceEntityAddedEvent(unique_id="nonexistent_unique_id")
+        )
 
-    @callback
-    def _signal_listener() -> None:
-        signal_calls.append(True)
-
-    async_dispatcher_connect(hass, SIGNAL_ADD_ENTITIES, _signal_listener)
-
-    zha_device_proxy.handle_zha_device_entity_added_event(
-        DeviceEntityAddedEvent(unique_id="nonexistent_unique_id")
-    )
-
-    # Nothing should be added and no signal dispatched
-    assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
-    assert len(signal_calls) == 0
+        # Nothing should be added and no signal dispatched
+        assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
+        mock_dispatch.assert_not_called()
 
 
 async def test_handle_device_entity_removed(

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -16,7 +16,7 @@ from homeassistant.components.zha.helpers import (
     get_zha_gateway,
     get_zha_gateway_proxy,
 )
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -150,17 +150,18 @@ async def test_handle_device_entity_removed(
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test that a runtime DeviceEntityRemovedEvent removes the HA entity."""
+    """Test that a runtime DeviceEntityRemovedEvent unloads the HA entity."""
     zha_device_proxy, gateway_proxy, _ = await _create_switch_device(
         hass, setup_zha, zigpy_device_mock
     )
 
-    # Verify entity exists
+    # Verify entity exists and has a state
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
     registry = er.async_get(hass)
     assert registry.async_get(entity_id) is not None
+    assert hass.states.get(entity_id) is not None
 
     # Get the unique_id of the platform entity backing this HA entity
     entity_refs = gateway_proxy.ha_entity_refs[zha_device_proxy.device.ieee]
@@ -173,8 +174,13 @@ async def test_handle_device_entity_removed(
     )
     await hass.async_block_till_done()
 
-    # Verify the entity was removed from the entity registry
-    assert registry.async_get(entity_id) is None
+    # The registry entry is preserved so the user can manually delete it
+    assert registry.async_get(entity_id) is not None
+
+    # The entity state is set to unavailable
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_handle_device_entity_removed_unknown_unique_id(

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -1,0 +1,201 @@
+"""Test ZHA handling of runtime device entity added/removed events."""
+
+from collections.abc import Callable, Coroutine
+from unittest.mock import patch
+
+import pytest
+from zha.zigbee.device import DeviceEntityAddedEvent, DeviceEntityRemovedEvent
+from zigpy.device import Device
+from zigpy.profiles import zha
+from zigpy.zcl.clusters import general
+
+from homeassistant.components.zha.helpers import (
+    ZHADeviceProxy,
+    ZHAGatewayProxy,
+    get_zha_data,
+    get_zha_gateway,
+    get_zha_gateway_proxy,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .common import find_entity_id
+from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+
+
+@pytest.fixture(autouse=True)
+def switch_platform_only():
+    """Only set up the switch and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (
+            Platform.DEVICE_TRACKER,
+            Platform.SENSOR,
+            Platform.SELECT,
+            Platform.SWITCH,
+        ),
+    ):
+        yield
+
+
+async def _create_switch_device(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> tuple[ZHADeviceProxy, ZHAGatewayProxy, Device]:
+    """Create a basic switch device for testing."""
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+    gateway_proxy = get_zha_gateway_proxy(hass)
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    general.OnOff.cluster_id,
+                    general.Groups.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+            }
+        },
+        ieee="01:2d:6f:00:0a:90:69:e8",
+        node_descriptor=b"\x02@\x8c\x02\x10RR\x00\x00\x00R\x00\x00",
+    )
+
+    gateway.get_or_create_device(zigpy_device)
+    await gateway.async_device_initialized(zigpy_device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    zha_device_proxy = gateway_proxy.get_device_proxy(zigpy_device.ieee)
+    return zha_device_proxy, gateway_proxy, zigpy_device
+
+
+async def test_handle_device_entity_added(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that a runtime DeviceEntityAddedEvent populates platform data and dispatches signal."""
+    zha_device_proxy, _, _ = await _create_switch_device(
+        hass, setup_zha, zigpy_device_mock
+    )
+
+    # Get the switch platform entity from the ZHA device
+    switch_entities = [
+        entity
+        for entity in zha_device_proxy.device.platform_entities.values()
+        if entity.PLATFORM == Platform.SWITCH
+    ]
+    assert len(switch_entities) > 0
+    platform_entity = switch_entities[0]
+
+    ha_zha_data = get_zha_data(hass)
+
+    # The platform entity list should be empty (cleared after initial entity creation)
+    assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
+
+    # Fire the entity added event
+    with patch(
+        "homeassistant.components.zha.helpers.async_dispatcher_send"
+    ) as mock_dispatch:
+        zha_device_proxy.handle_zha_device_entity_added_event(
+            DeviceEntityAddedEvent(unique_id=platform_entity.unique_id)
+        )
+
+        # Verify EntityData was appended to the platform list
+        assert len(ha_zha_data.platforms[Platform.SWITCH]) == 1
+        entity_data = ha_zha_data.platforms[Platform.SWITCH][0]
+        assert entity_data.entity is platform_entity
+        assert entity_data.device_proxy is zha_device_proxy
+        assert entity_data.group_proxy is None
+
+        # Verify SIGNAL_ADD_ENTITIES was dispatched
+        mock_dispatch.assert_called_once_with(hass, "zha_add_entities")
+
+    # Clean up
+    ha_zha_data.platforms[Platform.SWITCH].clear()
+
+
+async def test_handle_device_entity_added_unknown_unique_id(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that a DeviceEntityAddedEvent with unknown unique_id is a no-op."""
+    zha_device_proxy, _, _ = await _create_switch_device(
+        hass, setup_zha, zigpy_device_mock
+    )
+
+    ha_zha_data = get_zha_data(hass)
+    assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
+
+    with patch(
+        "homeassistant.components.zha.helpers.async_dispatcher_send"
+    ) as mock_dispatch:
+        zha_device_proxy.handle_zha_device_entity_added_event(
+            DeviceEntityAddedEvent(unique_id="nonexistent_unique_id")
+        )
+
+        # Nothing should be added and no signal dispatched
+        assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
+        mock_dispatch.assert_not_called()
+
+
+async def test_handle_device_entity_removed(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that a runtime DeviceEntityRemovedEvent removes the HA entity."""
+    zha_device_proxy, gateway_proxy, _ = await _create_switch_device(
+        hass, setup_zha, zigpy_device_mock
+    )
+
+    # Verify entity exists
+    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    assert entity_id is not None
+
+    registry = er.async_get(hass)
+    assert registry.async_get(entity_id) is not None
+
+    # Get the unique_id of the platform entity backing this HA entity
+    entity_refs = gateway_proxy.ha_entity_refs[zha_device_proxy.device.ieee]
+    target_ref = next(ref for ref in entity_refs if ref.ha_entity_id == entity_id)
+    target_unique_id = target_ref.entity_data.entity.unique_id
+
+    # Fire the entity removed event
+    zha_device_proxy.handle_zha_device_entity_removed_event(
+        DeviceEntityRemovedEvent(unique_id=target_unique_id)
+    )
+    await hass.async_block_till_done()
+
+    # Verify the entity was removed from the entity registry
+    assert registry.async_get(entity_id) is None
+
+
+async def test_handle_device_entity_removed_unknown_unique_id(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that a DeviceEntityRemovedEvent with unknown unique_id is a no-op."""
+    zha_device_proxy, _, _ = await _create_switch_device(
+        hass, setup_zha, zigpy_device_mock
+    )
+
+    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    assert entity_id is not None
+
+    # Fire event with a unique_id that doesn't match any entity ref
+    zha_device_proxy.handle_zha_device_entity_removed_event(
+        DeviceEntityRemovedEvent(unique_id="nonexistent_unique_id")
+    )
+    await hass.async_block_till_done()
+
+    # Verify the entity was NOT removed
+    registry = er.async_get(hass)
+    assert registry.async_get(entity_id) is not None

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -157,7 +157,7 @@ async def test_handle_device_entity_removed(
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test that a runtime DeviceEntityRemovedEvent marks the entity as no longer provided."""
+    """Test that DeviceEntityRemovedEvent with remove=False only unloads the entity."""
     zha_device_proxy, _, _ = await _create_switch_device(
         hass, setup_zha, zigpy_device_mock
     )
@@ -171,11 +171,12 @@ async def test_handle_device_entity_removed(
     assert entry is not None
     assert hass.states.get(entity_id) is not None
 
-    # Fire the entity removed event
+    # Fire the entity removed event with remove=False
     zha_device_proxy.handle_zha_device_entity_removed_event(
         DeviceEntityRemovedEvent(
             platform=ZhaPlatform.SWITCH,
             unique_id=entry.unique_id,
+            remove=False,
         )
     )
     await hass.async_block_till_done()
@@ -187,6 +188,41 @@ async def test_handle_device_entity_removed(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_handle_device_entity_removed_with_remove_flag(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that DeviceEntityRemovedEvent with remove=True deletes the registry entry."""
+    zha_device_proxy, _, _ = await _create_switch_device(
+        hass, setup_zha, zigpy_device_mock
+    )
+
+    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    assert entity_id is not None
+
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    assert hass.states.get(entity_id) is not None
+
+    # Fire the entity removed event with remove=True
+    zha_device_proxy.handle_zha_device_entity_removed_event(
+        DeviceEntityRemovedEvent(
+            platform=ZhaPlatform.SWITCH,
+            unique_id=entry.unique_id,
+            remove=True,
+        )
+    )
+    await hass.async_block_till_done()
+
+    # The registry entry is removed
+    assert registry.async_get(entity_id) is None
+
+    # The entity state is also gone
+    assert hass.states.get(entity_id) is None
 
 
 async def test_handle_device_entity_removed_unknown_unique_id(

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -17,7 +17,7 @@ from homeassistant.components.zha.helpers import (
     get_zha_gateway,
     get_zha_gateway_proxy,
 )
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -157,18 +157,19 @@ async def test_handle_device_entity_removed(
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test that a runtime DeviceEntityRemovedEvent removes the HA entity."""
+    """Test that a runtime DeviceEntityRemovedEvent marks the entity as no longer provided."""
     zha_device_proxy, _, _ = await _create_switch_device(
         hass, setup_zha, zigpy_device_mock
     )
 
-    # Verify entity exists
+    # Verify entity exists and has a state
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
     registry = er.async_get(hass)
     entry = registry.async_get(entity_id)
     assert entry is not None
+    assert hass.states.get(entity_id) is not None
 
     # Fire the entity removed event
     zha_device_proxy.handle_zha_device_entity_removed_event(
@@ -179,8 +180,13 @@ async def test_handle_device_entity_removed(
     )
     await hass.async_block_till_done()
 
-    # Verify the entity was removed from the entity registry
-    assert registry.async_get(entity_id) is None
+    # The registry entry is preserved so the user can manually delete it
+    assert registry.async_get(entity_id) is not None
+
+    # The entity state is set to unavailable
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_handle_device_entity_removed_unknown_unique_id(

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
+from zha.application import Platform as ZhaPlatform
 from zha.zigbee.device import DeviceEntityAddedEvent, DeviceEntityRemovedEvent
 from zigpy.device import Device
 from zigpy.profiles import zha
@@ -16,7 +17,7 @@ from homeassistant.components.zha.helpers import (
     get_zha_gateway,
     get_zha_gateway_proxy,
 )
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -103,7 +104,10 @@ async def test_handle_device_entity_added(
         "homeassistant.components.zha.helpers.async_dispatcher_send"
     ) as mock_dispatch:
         zha_device_proxy.handle_zha_device_entity_added_event(
-            DeviceEntityAddedEvent(unique_id=platform_entity.unique_id)
+            DeviceEntityAddedEvent(
+                platform=ZhaPlatform(platform_entity.PLATFORM),
+                unique_id=platform_entity.unique_id,
+            )
         )
 
         # Verify EntityData was appended to the platform list
@@ -137,7 +141,10 @@ async def test_handle_device_entity_added_unknown_unique_id(
         "homeassistant.components.zha.helpers.async_dispatcher_send"
     ) as mock_dispatch:
         zha_device_proxy.handle_zha_device_entity_added_event(
-            DeviceEntityAddedEvent(unique_id="nonexistent_unique_id")
+            DeviceEntityAddedEvent(
+                platform=ZhaPlatform.SWITCH,
+                unique_id="nonexistent_unique_id",
+            )
         )
 
         # Nothing should be added and no signal dispatched
@@ -150,37 +157,30 @@ async def test_handle_device_entity_removed(
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test that a runtime DeviceEntityRemovedEvent unloads the HA entity."""
-    zha_device_proxy, gateway_proxy, _ = await _create_switch_device(
+    """Test that a runtime DeviceEntityRemovedEvent removes the HA entity."""
+    zha_device_proxy, _, _ = await _create_switch_device(
         hass, setup_zha, zigpy_device_mock
     )
 
-    # Verify entity exists and has a state
+    # Verify entity exists
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
     registry = er.async_get(hass)
-    assert registry.async_get(entity_id) is not None
-    assert hass.states.get(entity_id) is not None
-
-    # Get the unique_id of the platform entity backing this HA entity
-    entity_refs = gateway_proxy.ha_entity_refs[zha_device_proxy.device.ieee]
-    target_ref = next(ref for ref in entity_refs if ref.ha_entity_id == entity_id)
-    target_unique_id = target_ref.entity_data.entity.unique_id
+    entry = registry.async_get(entity_id)
+    assert entry is not None
 
     # Fire the entity removed event
     zha_device_proxy.handle_zha_device_entity_removed_event(
-        DeviceEntityRemovedEvent(unique_id=target_unique_id)
+        DeviceEntityRemovedEvent(
+            platform=ZhaPlatform.SWITCH,
+            unique_id=entry.unique_id,
+        )
     )
     await hass.async_block_till_done()
 
-    # The registry entry is preserved so the user can manually delete it
-    assert registry.async_get(entity_id) is not None
-
-    # The entity state is set to unavailable
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    # Verify the entity was removed from the entity registry
+    assert registry.async_get(entity_id) is None
 
 
 async def test_handle_device_entity_removed_unknown_unique_id(
@@ -196,9 +196,12 @@ async def test_handle_device_entity_removed_unknown_unique_id(
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
-    # Fire event with a unique_id that doesn't match any entity ref
+    # Fire event with a unique_id that doesn't match any entity
     zha_device_proxy.handle_zha_device_entity_removed_event(
-        DeviceEntityRemovedEvent(unique_id="nonexistent_unique_id")
+        DeviceEntityRemovedEvent(
+            platform=ZhaPlatform.SWITCH,
+            unique_id="nonexistent_unique_id",
+        )
     )
     await hass.async_block_till_done()
 

--- a/tests/components/zha/test_device_entity_events.py
+++ b/tests/components/zha/test_device_entity_events.py
@@ -129,6 +129,16 @@ async def test_handle_device_entity_added(
     # The entity is back and reachable as a HA state.
     assert hass.states.get(entity_id) is not None
 
+    # Exactly one entity reference is recorded for this entity_id (no stale
+    # leftovers from the remove + re-add cycle).
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    matching_refs = [
+        ref
+        for ref in gateway_proxy.ha_entity_refs[zha_device_proxy.device.ieee]
+        if ref.ha_entity_id == entity_id
+    ]
+    assert len(matching_refs) == 1
+
 
 async def test_handle_device_entity_added_unknown_unique_id(
     hass: HomeAssistant,
@@ -224,6 +234,13 @@ async def test_handle_device_entity_removed_with_remove_flag(
     # Registry entry and state are both gone.
     assert registry.async_get(entity_id) is None
     assert hass.states.get(entity_id) is None
+
+    # No stale entity reference is left in the gateway proxy.
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    assert all(
+        ref.ha_entity_id != entity_id
+        for ref in gateway_proxy.ha_entity_refs[zha_device_proxy.device.ieee]
+    )
 
 
 async def test_handle_device_entity_removed_unknown_unique_id(

--- a/tests/components/zha/test_dynamic_entities.py
+++ b/tests/components/zha/test_dynamic_entities.py
@@ -187,17 +187,21 @@ async def test_dynamic_entity_lifecycle(
     assert hass.states.get(binary_sensor_id) == binary_sensor_state_before
 
 
-async def test_handle_device_entity_added_unknown_unique_id(
+async def test_unknown_unique_id_is_noop(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test that a DeviceEntityAddedEvent with unknown unique_id is a no-op."""
+    """Test that add/remove events with an unknown unique_id are no-ops."""
     zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
 
-    ha_zha_data = get_zha_data(hass)
-    assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
+    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    assert entity_id is not None
 
+    ha_zha_data = get_zha_data(hass)
+    registry = er.async_get(hass)
+
+    # Added: nothing queued, no dispatcher signal fired.
     with patch(
         "homeassistant.components.zha.helpers.async_dispatcher_send"
     ) as mock_dispatch:
@@ -210,22 +214,10 @@ async def test_handle_device_entity_added_unknown_unique_id(
         )
         await hass.async_block_till_done()
 
-        # Nothing should be added and no dispatcher signal is fired.
         assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
         mock_dispatch.assert_not_called()
 
-
-async def test_handle_device_entity_removed_unknown_unique_id(
-    hass: HomeAssistant,
-    setup_zha: Callable[..., Coroutine[None]],
-    zigpy_device_mock: Callable[..., Device],
-) -> None:
-    """Test that a DeviceEntityRemovedEvent with unknown unique_id is a no-op."""
-    zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
-
-    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
-    assert entity_id is not None
-
+    # Removed (both flag values): the existing entity is untouched.
     for remove in (False, True):
         zha_device_proxy.device.emit(
             DeviceEntityRemovedEvent.event_type,
@@ -237,8 +229,6 @@ async def test_handle_device_entity_removed_unknown_unique_id(
         )
         await hass.async_block_till_done()
 
-        # The original entity is untouched.
-        registry = er.async_get(hass)
         assert registry.async_get(entity_id) is not None
         assert hass.states.get(entity_id) is not None
 

--- a/tests/components/zha/test_dynamic_entities.py
+++ b/tests/components/zha/test_dynamic_entities.py
@@ -26,18 +26,27 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 
 @pytest.fixture(autouse=True)
-def switch_platform_only() -> Generator[None]:
-    """Only set up the switch platform to speed up tests."""
-    with patch("homeassistant.components.zha.PLATFORMS", (Platform.SWITCH,)):
+def platforms_only() -> Generator[None]:
+    """Only set up the switch + binary_sensor platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.zha.PLATFORMS",
+        (Platform.SWITCH, Platform.BINARY_SENSOR),
+    ):
         yield
 
 
-async def _create_switch_device(
+async def _create_device(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> ZHADeviceProxy:
-    """Create a basic switch device for testing."""
+    """Create a device exposing a switch and a binary_sensor that share a unique_id.
+
+    OnOff input on an occupancy-sensor device type yields a switch entity
+    and a binary_sensor entity (Opening) keyed on the same `(ieee, ep, 6)`
+    base unique_id but on different platforms - a useful collision shape
+    for verifying that runtime add/remove events are scoped per platform.
+    """
     await setup_zha()
     gateway = get_zha_gateway(hass)
     gateway_proxy = get_zha_gateway_proxy(hass)
@@ -50,8 +59,8 @@ async def _create_switch_device(
                     general.OnOff.cluster_id,
                     general.Groups.cluster_id,
                 ],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_OUTPUT: [general.OnOff.cluster_id],
+                SIG_EP_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
                 SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
@@ -68,12 +77,14 @@ async def _create_switch_device(
     return zha_device_proxy
 
 
-def _get_switch_platform_entity(zha_device_proxy: ZHADeviceProxy) -> PlatformEntity:
-    """Return the underlying ZHA switch platform entity for the device."""
+def _get_platform_entity(
+    zha_device_proxy: ZHADeviceProxy, platform: Platform
+) -> PlatformEntity:
+    """Return the underlying ZHA platform entity for the given platform."""
     return next(
         entity
         for entity in zha_device_proxy.device.platform_entities.values()
-        if entity.PLATFORM == Platform.SWITCH
+        if platform == entity.PLATFORM
     )
 
 
@@ -82,11 +93,28 @@ async def test_dynamic_entity_lifecycle(
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test the full hard-remove -> re-add -> soft-remove cycle."""
-    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
-    platform_entity = _get_switch_platform_entity(zha_device_proxy)
+    """Test the full hard-remove -> re-add -> soft-remove cycle.
+
+    Also confirms that the binary_sensor sharing the same unique_id but on a
+    different platform is never disturbed - the (platform, unique_id) tuple
+    is the ZHA entity identity.
+    """
+    zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
+    platform_entity = _get_platform_entity(zha_device_proxy, Platform.SWITCH)
+    binary_sensor_entity = _get_platform_entity(
+        zha_device_proxy, Platform.BINARY_SENSOR
+    )
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
+    binary_sensor_id = find_entity_id(Platform.BINARY_SENSOR, zha_device_proxy, hass)
     assert entity_id is not None
+    assert binary_sensor_id is not None
+
+    # Same unique_id, different platforms - the collision shape we care about.
+    assert platform_entity.unique_id == binary_sensor_entity.unique_id
+    assert platform_entity.PLATFORM != binary_sensor_entity.PLATFORM
+
+    binary_sensor_state_before = hass.states.get(binary_sensor_id)
+    assert binary_sensor_state_before is not None
 
     # Hard remove: state and registry entry both go away.
     zha_device_proxy.device.emit(
@@ -101,6 +129,9 @@ async def test_dynamic_entity_lifecycle(
     registry = er.async_get(hass)
     assert registry.async_get(entity_id) is None
     assert hass.states.get(entity_id) is None
+    # The binary_sensor with the same unique_id is untouched.
+    assert registry.async_get(binary_sensor_id) is not None
+    assert hass.states.get(binary_sensor_id) == binary_sensor_state_before
 
     ha_zha_data = get_zha_data(hass)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
@@ -117,6 +148,7 @@ async def test_dynamic_entity_lifecycle(
     await hass.async_block_till_done()
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
     assert hass.states.get(entity_id) is not None
+    assert hass.states.get(binary_sensor_id) == binary_sensor_state_before
 
     # Exactly one entity reference is tracked; the remove + re-add cycle did
     # not leave a stale entry behind.
@@ -144,6 +176,8 @@ async def test_dynamic_entity_lifecycle(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+    # The binary_sensor with the same unique_id is still untouched.
+    assert hass.states.get(binary_sensor_id) == binary_sensor_state_before
 
 
 async def test_handle_device_entity_added_unknown_unique_id(
@@ -152,7 +186,7 @@ async def test_handle_device_entity_added_unknown_unique_id(
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that a DeviceEntityAddedEvent with unknown unique_id is a no-op."""
-    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
+    zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
 
     ha_zha_data = get_zha_data(hass)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
@@ -174,49 +208,13 @@ async def test_handle_device_entity_added_unknown_unique_id(
         mock_dispatch.assert_not_called()
 
 
-async def test_handle_device_entity_removed_other_platform_does_not_unload(
-    hass: HomeAssistant,
-    setup_zha: Callable[..., Coroutine[None]],
-    zigpy_device_mock: Callable[..., Device],
-) -> None:
-    """Test that a soft remove for a different platform does not unload the switch.
-
-    The (platform, unique_id) tuple is the ZHA entity identity; entities on
-    different platforms can share a unique_id without colliding.
-    """
-    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
-
-    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
-    assert entity_id is not None
-    registry = er.async_get(hass)
-    entry = registry.async_get(entity_id)
-    assert entry is not None
-    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
-
-    # Soft-remove an entity on a different platform but reusing this
-    # unique_id; the switch must remain loaded and available.
-    zha_device_proxy.device.emit(
-        DeviceEntityRemovedEvent.event_type,
-        DeviceEntityRemovedEvent(
-            platform=ZhaPlatform.SENSOR,
-            unique_id=entry.unique_id,
-            remove=False,
-        ),
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-
-
 async def test_handle_device_entity_removed_with_remove_flag(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that DeviceEntityRemovedEvent with remove=True deletes the registry entry."""
-    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
+    zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
 
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
@@ -254,7 +252,7 @@ async def test_handle_device_entity_removed_unknown_unique_id(
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that a DeviceEntityRemovedEvent with unknown unique_id is a no-op."""
-    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
+    zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
 
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
@@ -287,7 +285,7 @@ async def test_remove_entity_reference_when_ieee_already_cleared(
     before the entity finishes tearing down. The early-return guard must
     keep the popped key out of the dict.
     """
-    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
+    zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
 
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None

--- a/tests/components/zha/test_dynamic_entities.py
+++ b/tests/components/zha/test_dynamic_entities.py
@@ -1,4 +1,4 @@
-"""Test ZHA handling of runtime device entity added/removed events."""
+"""Test ZHA dynamic entity lifecycle (runtime add/remove and reference cleanup)."""
 
 from collections.abc import Callable, Coroutine, Generator
 from unittest.mock import patch

--- a/tests/components/zha/test_dynamic_entities.py
+++ b/tests/components/zha/test_dynamic_entities.py
@@ -77,18 +77,18 @@ def _get_switch_platform_entity(zha_device_proxy: ZHADeviceProxy) -> PlatformEnt
     )
 
 
-async def test_handle_device_entity_added(
+async def test_dynamic_entity_lifecycle(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
 ) -> None:
-    """Test that DeviceEntityAddedEvent re-creates a previously removed entity."""
+    """Test the full hard-remove -> re-add -> soft-remove cycle."""
     zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
     platform_entity = _get_switch_platform_entity(zha_device_proxy)
     entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
     assert entity_id is not None
 
-    # Remove first so the re-add has visible side effects (state reappears).
+    # Hard remove: state and registry entry both go away.
     zha_device_proxy.device.emit(
         DeviceEntityRemovedEvent.event_type,
         DeviceEntityRemovedEvent(
@@ -98,13 +98,15 @@ async def test_handle_device_entity_added(
         ),
     )
     await hass.async_block_till_done()
+    registry = er.async_get(hass)
+    assert registry.async_get(entity_id) is None
     assert hass.states.get(entity_id) is None
 
     ha_zha_data = get_zha_data(hass)
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
 
-    # Fire the entity-added event through the device emitter to exercise
-    # the on_all_events -> _handle_event_protocol -> handler wiring.
+    # Re-add: emitter exercises the on_all_events -> _handle_event_protocol
+    # -> handler wiring; the entity reappears as a HA state.
     zha_device_proxy.device.emit(
         DeviceEntityAddedEvent.event_type,
         DeviceEntityAddedEvent(
@@ -113,15 +115,11 @@ async def test_handle_device_entity_added(
         ),
     )
     await hass.async_block_till_done()
-
-    # The platform list is drained by SIGNAL_ADD_ENTITIES handler.
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
-
-    # The entity is back and reachable as a HA state.
     assert hass.states.get(entity_id) is not None
 
-    # Exactly one entity reference is recorded for this entity_id (no stale
-    # leftovers from the remove + re-add cycle).
+    # Exactly one entity reference is tracked; the remove + re-add cycle did
+    # not leave a stale entry behind.
     gateway_proxy = get_zha_gateway_proxy(hass)
     matching_refs = [
         ref
@@ -129,6 +127,23 @@ async def test_handle_device_entity_added(
         if ref.ha_entity_id == entity_id
     ]
     assert len(matching_refs) == 1
+
+    # Soft remove: registry entry is kept, state goes unavailable.
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    zha_device_proxy.device.emit(
+        DeviceEntityRemovedEvent.event_type,
+        DeviceEntityRemovedEvent(
+            platform=ZhaPlatform.SWITCH,
+            unique_id=entry.unique_id,
+            remove=False,
+        ),
+    )
+    await hass.async_block_till_done()
+    assert registry.async_get(entity_id) is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_handle_device_entity_added_unknown_unique_id(
@@ -157,42 +172,6 @@ async def test_handle_device_entity_added_unknown_unique_id(
         # Nothing should be added and no dispatcher signal is fired.
         assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
         mock_dispatch.assert_not_called()
-
-
-async def test_handle_device_entity_removed(
-    hass: HomeAssistant,
-    setup_zha: Callable[..., Coroutine[None]],
-    zigpy_device_mock: Callable[..., Device],
-) -> None:
-    """Test that DeviceEntityRemovedEvent with remove=False only unloads the entity."""
-    zha_device_proxy = await _create_switch_device(hass, setup_zha, zigpy_device_mock)
-
-    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
-    assert entity_id is not None
-
-    registry = er.async_get(hass)
-    entry = registry.async_get(entity_id)
-    assert entry is not None
-    assert hass.states.get(entity_id) is not None
-
-    # Fire through the device emitter so the on_all_events wiring is exercised.
-    zha_device_proxy.device.emit(
-        DeviceEntityRemovedEvent.event_type,
-        DeviceEntityRemovedEvent(
-            platform=ZhaPlatform.SWITCH,
-            unique_id=entry.unique_id,
-            remove=False,
-        ),
-    )
-    await hass.async_block_till_done()
-
-    # Registry entry preserved so the user can manually delete it.
-    assert registry.async_get(entity_id) is not None
-
-    # State is set to unavailable.
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_handle_device_entity_removed_other_platform_does_not_unload(

--- a/tests/components/zha/test_dynamic_entities.py
+++ b/tests/components/zha/test_dynamic_entities.py
@@ -17,7 +17,7 @@ from homeassistant.components.zha.helpers import (
     get_zha_gateway,
     get_zha_gateway_proxy,
 )
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -113,8 +113,12 @@ async def test_dynamic_entity_lifecycle(
     assert platform_entity.unique_id == binary_sensor_entity.unique_id
     assert platform_entity.PLATFORM != binary_sensor_entity.PLATFORM
 
+    switch_state_before = hass.states.get(entity_id)
     binary_sensor_state_before = hass.states.get(binary_sensor_id)
+    assert switch_state_before is not None
+    assert switch_state_before.state == STATE_OFF
     assert binary_sensor_state_before is not None
+    assert binary_sensor_state_before.state == STATE_OFF
 
     # Hard remove: state and registry entry both go away.
     zha_device_proxy.device.emit(
@@ -146,8 +150,11 @@ async def test_dynamic_entity_lifecycle(
         ),
     )
     await hass.async_block_till_done()
+    # The platform listener drained the queue when SIGNAL_ADD_ENTITIES fired.
     assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
-    assert hass.states.get(entity_id) is not None
+    switch_state_after = hass.states.get(entity_id)
+    assert switch_state_after is not None
+    assert switch_state_after.state == switch_state_before.state
     assert hass.states.get(binary_sensor_id) == binary_sensor_state_before
 
     # Exactly one entity reference is tracked; the remove + re-add cycle did
@@ -206,44 +213,6 @@ async def test_handle_device_entity_added_unknown_unique_id(
         # Nothing should be added and no dispatcher signal is fired.
         assert len(ha_zha_data.platforms[Platform.SWITCH]) == 0
         mock_dispatch.assert_not_called()
-
-
-async def test_handle_device_entity_removed_with_remove_flag(
-    hass: HomeAssistant,
-    setup_zha: Callable[..., Coroutine[None]],
-    zigpy_device_mock: Callable[..., Device],
-) -> None:
-    """Test that DeviceEntityRemovedEvent with remove=True deletes the registry entry."""
-    zha_device_proxy = await _create_device(hass, setup_zha, zigpy_device_mock)
-
-    entity_id = find_entity_id(Platform.SWITCH, zha_device_proxy, hass)
-    assert entity_id is not None
-
-    registry = er.async_get(hass)
-    entry = registry.async_get(entity_id)
-    assert entry is not None
-    assert hass.states.get(entity_id) is not None
-
-    zha_device_proxy.device.emit(
-        DeviceEntityRemovedEvent.event_type,
-        DeviceEntityRemovedEvent(
-            platform=ZhaPlatform.SWITCH,
-            unique_id=entry.unique_id,
-            remove=True,
-        ),
-    )
-    await hass.async_block_till_done()
-
-    # Registry entry and state are both gone.
-    assert registry.async_get(entity_id) is None
-    assert hass.states.get(entity_id) is None
-
-    # No stale entity reference is left in the gateway proxy.
-    gateway_proxy = get_zha_gateway_proxy(hass)
-    assert all(
-        ref.ha_entity_id != entity_id
-        for ref in gateway_proxy.ha_entity_refs[zha_device_proxy.device.ieee]
-    )
 
 
 async def test_handle_device_entity_removed_unknown_unique_id(


### PR DESCRIPTION
## Proposed change

This PR adds support for the ZHA entity add/remove events, so Core can add entities to an existing device at runtime, or remove them. This will be useful for the few devices that dynamically change their exposed endpoints, like the Ubisys LD6.

- The `DeviceEntityAddedEvent` is pretty straight-forward – it just adds the entity.
- The `DeviceEntityRemovedEvent` has a `remove: bool` flag that specifies whether Core should just unload the entity, or also remove it from the entity registry.
  - This is useful, as we want to unload existing entities during a re-interview, but not completely remove them then.
  - However, if ZHA is certain an entity is not coming back, it can send a removed event with an explicit `remove=True`.

The `remove_entity_reference` method was also fixed to work and is now actually called when an entity is removed.

For the ZHA side of things:
- https://github.com/zigpy/zha/pull/517
- I've also confirmed this works as expected with the upcoming re-interview functionality.

Side note: A future PR could migrate `ZHAEntity` from its `self._unsubs` list (cleared in `async_will_remove_from_hass`) to Core's built-in `self.async_on_remove(...)` that's used by other integrations, so we can drop the ZHA cleanup loop. This isn't added in this PR, just something I noticed whilst working on this.

## AI summary

<details><summary>LLM summary (click to expand – useful)</summary>
<p>

Wires up two new events from the ZHA library so the integration can react when devices add or remove entities at runtime, rather than only on full setup.

This is the Core side of [zigpy/zha#517](https://github.com/zigpy/zha/pull/517) and lays the groundwork for upcoming re-interview support in ZHA, where a device's entity set can change after the integration is already running.

## What it adds

`ZHADeviceProxy` now subscribes to two new events emitted by `zha.zigbee.device.Device`:

- **`DeviceEntityAddedEvent`** → the new entity is queued into `ha_zha_data.platforms[<platform>]` and `SIGNAL_ADD_ENTITIES` is dispatched, which the platform's existing `async_setup_entry` listener drains.
- **`DeviceEntityRemovedEvent`** → behaviour depends on the upstream `remove` flag:
  - `remove=False` (soft) → fires a per-entity dispatcher signal `f"{SIGNAL_REMOVE_ENTITY}_{platform}_{unique_id}"`. The entity unloads itself; its registry entry is kept and the state goes `unavailable`. Used when an entity has temporarily disappeared but may come back.
  - `remove=True` (hard) → calls `entity_registry.async_remove(entity_id)`. The registry entry is deleted and HA's standard registry-update flow clears the state. Used when the entity is gone for good.

The split lets ZHA decide between "temporarily unload" and "fully remove from the registry" based on what it knows about the device.

## How it fits the existing ZHA pattern

The signal pattern mirrors the pre-existing whole-device removal flow (`handle_device_removed` / `SIGNAL_REMOVE_ENTITIES_{ieee}`) — just at finer granularity:

| | Whole-device removal (existing) | Per-entity removal (this PR) |
|---|---|---|
| Trigger | `DeviceRemovedEvent` | `DeviceEntityRemovedEvent` |
| Signal | `SIGNAL_REMOVE_ENTITIES_{ieee}` | `SIGNAL_REMOVE_ENTITY_{platform}_{unique_id}` |
| Subscriber | `ZHAEntity.async_added_to_hass` | Same |
| Reaction | `partial(self.async_remove, force_remove=True)` | `self.async_remove` (soft) or registry deletion (hard) |

Hard removal is handled centrally in `helpers.py` rather than per-entity so it works even when no live entity is loaded (orphans, disabled entities, race with platform setup).

The signal is keyed by `(platform, unique_id)` because that is the upstream zha-lib entity identity tuple — a `unique_id` can repeat across platforms.

## Side fix: `ZHAGatewayProxy.remove_entity_reference`

While wiring this up, the existing `remove_entity_reference` method on `ZHAGatewayProxy` was repaired and put to use:

- It was bit-rotted (`entity.zha_device.ieee` referenced a non-existent attribute) and had no callers.
- It's now invoked from `ZHAEntity.async_will_remove_from_hass`, so `_ha_entity_refs` stays in sync across all entity teardown paths (soft remove, hard remove, whole-device removal, integration unload).

Without this, hard remove + re-add cycles introduced by this PR would have leaked stale `EntityReference` entries that surface in `zha_device_info[ENTITIES]` and the websocket API.

## Future cleanup (out of scope)

The new dispatcher subscription in `ZHAEntity.async_added_to_hass` follows the file's existing `self._unsubs.append(async_dispatcher_connect(...))` pattern. ZHA hand-rolls this list and tears it down in `async_will_remove_from_hass`, which is functionally equivalent to HA core's built-in `self.async_on_remove(...)` mechanism used by Z-Wave JS, Matter, MQTT, ESPHome, etc. Migrating ZHA to `async_on_remove` would let us drop `_unsubs` and the manual cleanup loop — worth doing as a follow-up PR.

</p>
</details> 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
