### PR TITLE
Event entity automation triggers

### DIFF
--- a/homeassistant/components/homeassistant/triggers/event_entity.py
+++ b/homeassistant/components/homeassistant/triggers/event_entity.py
@@ -1,0 +1,104 @@
+"""Offer event entity listening automation rules."""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HassJob,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_EVENT_TYPE = "event_type"
+CONF_ENTITY_ID = "entity_id"
+
+TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_PLATFORM): "event_entity",
+        vol.Required(CONF_ENTITY_ID): cv.entity_ids_or_uuids,
+        vol.Required(CONF_EVENT_TYPE): cv.match_all,
+    }
+)
+
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate trigger config."""
+    if not isinstance(config, dict):
+        raise vol.Invalid("Expected a dictionary")
+
+    config = TRIGGER_SCHEMA(config)
+
+    registry = er.async_get(hass)
+    config[CONF_ENTITY_ID] = er.async_validate_entity_ids(
+        registry, cv.entity_ids_or_uuids(config[CONF_ENTITY_ID])
+    )
+
+    return config
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+    *,
+    platform_type: str = "event_entity",
+) -> CALLBACK_TYPE:
+    """Listen for state changes based on configuration."""
+    entity_id = config[CONF_ENTITY_ID]
+    event_type = config[CONF_EVENT_TYPE]
+
+    job = HassJob(action, f"event trigger {trigger_info}")
+    trigger_data = trigger_info["trigger_data"]
+
+    @callback
+    def state_automation_listener(event: Event[EventStateChangedData]) -> None:
+        """Listen for state changes and calls action."""
+        entity = event.data["entity_id"]
+        from_s = event.data["old_state"]
+        to_s = event.data["new_state"]
+
+        if not from_s or from_s.state == "unavailable":
+            return
+
+        if not to_s or to_s.state in ("unavailable", "unknown"):
+            return
+
+        if to_s.attributes["event_type"] == event_type:
+            hass.async_run_hass_job(
+                job,
+                {
+                    "trigger": {
+                        **trigger_data,
+                        "platform": platform_type,
+                        "entity_id": entity,
+                        "event_type": event_type,
+                        "description": f"{event_type} event of {entity}",
+                    }
+                },
+                event.context,
+            )
+
+    unsub = async_track_state_change_event(hass, entity_id, state_automation_listener)
+
+    @callback
+    def async_remove() -> None:
+        """Remove state listeners async."""
+        unsub()
+
+    return async_remove

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -98,6 +98,7 @@ _PLATFORM_ALIASES = {
     "state": "homeassistant",
     "time_pattern": "homeassistant",
     "time": "homeassistant",
+    "event_entity": "homeassistant",
 }
 
 DATA_PLUGGABLE_ACTIONS: HassKey[defaultdict[tuple, PluggableActionsEntry]] = HassKey(

--- a/tests/components/homeassistant/triggers/test_event_entity.py
+++ b/tests/components/homeassistant/triggers/test_event_entity.py
@@ -1,0 +1,454 @@
+"""The tests for the event entity automation."""
+
+import pytest
+
+from homeassistant.components import automation
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ENTITY_MATCH_ALL,
+    SERVICE_TURN_OFF,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import Context, HomeAssistant, ServiceCall
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import mock_component
+
+
+@pytest.fixture(autouse=True)
+def setup_comp(hass: HomeAssistant) -> None:
+    """Initialize components."""
+    mock_component(hass, "group")
+
+
+async def test_if_fires_on_event(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test for firing on event entity change."""
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "some": (
+                            "{{ trigger.platform }}"
+                            " - {{ trigger.entity_id }}"
+                            " - {{ trigger.event_type }}"
+                            " - {{ trigger.description }}"
+                        )
+                    },
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    context = Context()
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_press"},
+        context=context,
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    assert service_calls[0].context.parent_id == context.id
+    assert service_calls[0].data["some"] == (
+        "event_entity - event.doorbell - button_press"
+        " - button_press event of event.doorbell"
+    )
+
+    await hass.services.async_call(
+        automation.DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_MATCH_ALL},
+        blocking=True,
+    )
+    assert len(service_calls) == 2
+
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:02.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 2
+
+
+async def test_if_fires_on_event_uuid(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test for firing on event entity change using a registry id."""
+    entry = entity_registry.async_get_or_create(
+        "event", "test", "1234", suggested_object_id="doorbell"
+    )
+    assert entry.entity_id == "event.doorbell"
+
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": entry.id,
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    context = Context()
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_press"},
+        context=context,
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    assert service_calls[0].context.parent_id == context.id
+
+
+async def test_if_fires_on_multiple_entities(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test for firing when multiple entity ids are configured."""
+    hass.states.async_set(
+        "event.front",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    hass.states.async_set(
+        "event.back",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": ["event.front", "event.back"],
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "event.front",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+
+    hass.states.async_set(
+        "event.back",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 2
+
+
+async def test_if_not_fires_on_other_event_type(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that the trigger does not fire for non-matching event types."""
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_long_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:02.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+
+
+async def test_if_fires_on_repeated_event_type(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that the trigger fires every time the event entity state changes."""
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:02.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 2
+
+
+async def test_if_not_fires_when_to_unavailable(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that the trigger does not fire when transitioning to unavailable."""
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("event.doorbell", STATE_UNAVAILABLE, {})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+
+async def test_if_not_fires_when_to_unknown(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that the trigger does not fire when transitioning to unknown."""
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("event.doorbell", STATE_UNKNOWN, {})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+
+async def test_if_not_fires_from_unavailable(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that the first event after an unavailable state is suppressed."""
+    hass.states.async_set("event.doorbell", STATE_UNAVAILABLE, {})
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # First valid state after unavailable should not trigger
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # Subsequent state changes should trigger
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+
+
+async def test_if_fires_from_unknown(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that the first event after an unknown state still triggers."""
+    hass.states.async_set("event.doorbell", STATE_UNKNOWN, {})
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+
+
+async def test_if_not_fires_for_other_entity(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that the trigger only fires for the configured entity."""
+    hass.states.async_set(
+        "event.doorbell",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    hass.states.async_set(
+        "event.other",
+        "2026-01-01T00:00:00.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event_entity",
+                    "entity_id": "event.doorbell",
+                    "event_type": "button_press",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "event.other",
+        "2026-01-01T00:00:01.000+00:00",
+        {"event_type": "button_press"},
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There are these event.* entities (https://www.home-assistant.io/integrations/event/) that are all over the place in home assistant. They are used in a first-class way in many areas of the ecosystem. But there is no first-class to trigger an automation from them, despite that being the most obvious use case for them. The official documentation suggests copying some yaml into the automation editor to filter out certain states that the lay user probably does not fully understand.

This PR adds a new kind of trigger specialized to handling state changes from these entities so that they can be easily used in automations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/51755

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
