### PR TITLE
Fix bang olufsen flaky tests in Python 3.14.3

### DIFF
--- a/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
+++ b/tests/components/bang_olufsen/snapshots/test_diagnostics.ambr
@@ -124,7 +124,7 @@
     'battery_level': dict({
       'attributes': dict({
         'device_class': 'battery',
-        'friendly_name': 'Living room Balance Battery',
+        'friendly_name': 'Lounge room A5 Battery',
         'state_class': 'measurement',
         'unit_of_measurement': '%',
       }),
@@ -134,7 +134,7 @@
     'charging': dict({
       'attributes': dict({
         'device_class': 'battery_charging',
-        'friendly_name': 'Living room Balance Charging',
+        'friendly_name': 'Lounge room A5 Charging',
       }),
       'entity_id': 'binary_sensor.lounge_room_a5_charging',
       'state': 'off',
@@ -174,12 +174,12 @@
             'Lounge room A5': '1111.1111111.44444444@products.bang-olufsen.com',
           }),
           'self': dict({
-            'Living room Balance': '1111.1111111.44444444@products.bang-olufsen.com',
+            'Lounge room A5': '1111.1111111.44444444@products.bang-olufsen.com',
           }),
         }),
         'device_class': 'speaker',
         'entity_picture_local': None,
-        'friendly_name': 'Living room Balance',
+        'friendly_name': 'Lounge room A5',
         'group_members': list([
           'media_player.lounge_room_a5',
           'listener_not_in_hass-1111.1111111.33333333@products.bang-olufsen.com',

--- a/tests/components/bang_olufsen/test_binary_sensor.py
+++ b/tests/components/bang_olufsen/test_binary_sensor.py
@@ -2,14 +2,19 @@
 
 from unittest.mock import AsyncMock
 
-from mozart_api.models import BatteryState
+from mozart_api.models import BatteryState, BeolinkSelf
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .conftest import mock_websocket_connection
-from .const import TEST_BATTERY, TEST_BATTERY_CHARGING_BINARY_SENSOR_ENTITY_ID
+from .const import (
+    TEST_BATTERY,
+    TEST_BATTERY_CHARGING_BINARY_SENSOR_ENTITY_ID,
+    TEST_FRIENDLY_NAME_4,
+    TEST_JID_4,
+)
 
 from tests.common import MockConfigEntry
 
@@ -23,6 +28,9 @@ async def test_battery_charging(
     """Test the battery charging time entity."""
     # Ensure battery entities are created
     mock_mozart_client.get_battery_state.return_value = TEST_BATTERY
+    mock_mozart_client.get_beolink_self.return_value = BeolinkSelf(
+        friendly_name=TEST_FRIENDLY_NAME_4, jid=TEST_JID_4
+    )
 
     # Load entry
     mock_config_entry_a5.add_to_hass(hass)

--- a/tests/components/bang_olufsen/test_diagnostics.py
+++ b/tests/components/bang_olufsen/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Test bang_olufsen config entry diagnostics."""
 
-from mozart_api.models import BatteryState
+from mozart_api.models import BatteryState, BeolinkSelf
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
@@ -8,7 +8,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .conftest import mock_websocket_connection
-from .const import TEST_BUTTON_EVENT_ENTITY_ID, TEST_REMOTE_KEY_EVENT_ENTITY_ID
+from .const import (
+    TEST_BUTTON_EVENT_ENTITY_ID,
+    TEST_FRIENDLY_NAME_4,
+    TEST_JID_4,
+    TEST_REMOTE_KEY_EVENT_ENTITY_ID,
+)
 
 from tests.common import AsyncMock, MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -64,6 +69,9 @@ async def test_async_get_config_entry_diagnostics_with_battery(
     """Test config entry diagnostics for devices with a battery."""
     mock_mozart_client.get_battery_state.return_value = BatteryState(
         battery_level=1, state="BatteryVeryLow"
+    )
+    mock_mozart_client.get_beolink_self.return_value = BeolinkSelf(
+        friendly_name=TEST_FRIENDLY_NAME_4, jid=TEST_JID_4
     )
 
     # Load entry

--- a/tests/components/bang_olufsen/test_event.py
+++ b/tests/components/bang_olufsen/test_event.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import AsyncMock
 
-from mozart_api.models import BeoRemoteButton, ButtonEvent, PairedRemoteResponse
+from mozart_api.models import (
+    BeolinkSelf,
+    BeoRemoteButton,
+    ButtonEvent,
+    PairedRemoteResponse,
+)
 from pytest_unordered import unordered
 from syrupy.assertion import SnapshotAssertion
 
@@ -20,6 +25,10 @@ from .conftest import mock_websocket_connection
 from .const import (
     TEST_BATTERY,
     TEST_BUTTON_EVENT_ENTITY_ID,
+    TEST_FRIENDLY_NAME_3,
+    TEST_FRIENDLY_NAME_4,
+    TEST_JID_3,
+    TEST_JID_4,
     TEST_REMOTE_KEY_EVENT_ENTITY_ID,
     TEST_SERIAL_NUMBER_3,
     TEST_SERIAL_NUMBER_4,
@@ -109,6 +118,9 @@ async def test_button_event_creation_premiere(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test Bluetooth and Microphone button event entities are not created when using a Beosound Premiere."""
+    mock_mozart_client.get_beolink_self.return_value = BeolinkSelf(
+        friendly_name=TEST_FRIENDLY_NAME_3, jid=TEST_JID_3
+    )
 
     await _check_button_event_creation(
         hass,
@@ -132,6 +144,9 @@ async def test_button_event_creation_a5(
 ) -> None:
     """Test Microphone button event entity is not created when using a Beosound A5."""
     mock_mozart_client.get_battery_state.return_value = TEST_BATTERY
+    mock_mozart_client.get_beolink_self.return_value = BeolinkSelf(
+        friendly_name=TEST_FRIENDLY_NAME_4, jid=TEST_JID_4
+    )
 
     await _check_button_event_creation(
         hass,

--- a/tests/components/bang_olufsen/test_sensor.py
+++ b/tests/components/bang_olufsen/test_sensor.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
-from mozart_api.models import PairedRemote, PairedRemoteResponse
+from mozart_api.models import BeolinkSelf, PairedRemote, PairedRemoteResponse
 
 from homeassistant.components.bang_olufsen.sensor import SCAN_INTERVAL
 from homeassistant.const import STATE_UNKNOWN
@@ -13,6 +13,8 @@ from .conftest import mock_websocket_connection
 from .const import (
     TEST_BATTERY,
     TEST_BATTERY_SENSOR_ENTITY_ID,
+    TEST_FRIENDLY_NAME_4,
+    TEST_JID_4,
     TEST_REMOTE_BATTERY_LEVEL_SENSOR_ENTITY_ID,
     TEST_REMOTE_SERIAL,
 )
@@ -28,6 +30,9 @@ async def test_battery_level(
     """Test the battery level entity."""
     # Ensure battery entities are created
     mock_mozart_client.get_battery_state.return_value = TEST_BATTERY
+    mock_mozart_client.get_beolink_self.return_value = BeolinkSelf(
+        friendly_name=TEST_FRIENDLY_NAME_4, jid=TEST_JID_4
+    )
 
     # Load entry
     mock_config_entry_a5.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in https://github.com/home-assistant/core/actions/runs/25005822536/job/73229778093?pr=162263

Follow-up to #168885 and needed for #162263

The test is flaky because media-player (which updates the friendly name of the device entry) might be initialised before OR after the other platforms.
This ensures that the "updated" friendly name matches the "initial" friendly name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
