### PR TITLE
Fix Withings via_device race causing flaky test_devices

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -113,7 +113,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: WithingsConfigEntry) -> 
         hass.config_entries.async_update_entry(
             entry, data=new_data, unique_id=unique_id
         )
-
     session = async_get_clientsession(hass)
     client = WithingsClient(session=session)
     try:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -44,6 +44,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -112,6 +113,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: WithingsConfigEntry) -> 
         hass.config_entries.async_update_entry(
             entry, data=new_data, unique_id=unique_id
         )
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, str(entry.unique_id))},
+        manufacturer="Withings",
+    )
     session = async_get_clientsession(hass)
     client = WithingsClient(session=session)
     try:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -114,12 +114,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: WithingsConfigEntry) -> 
             entry, data=new_data, unique_id=unique_id
         )
 
-    device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, str(entry.unique_id))},
-        manufacturer="Withings",
-    )
     session = async_get_clientsession(hass)
     client = WithingsClient(session=session)
     try:
@@ -160,6 +154,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: WithingsConfigEntry) -> 
     for coordinator in withings_data.coordinators:
         await coordinator.async_config_entry_first_refresh()
 
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, str(entry.unique_id))},
+        manufacturer="Withings",
+    )
     entry.runtime_data = withings_data
 
     webhook_manager = WithingsWebhookManager(hass, entry)

--- a/homeassistant/components/withings/entity.py
+++ b/homeassistant/components/withings/entity.py
@@ -31,7 +31,6 @@ class WithingsEntity[_T: WithingsDataUpdateCoordinator[Any]](CoordinatorEntity[_
         self._attr_unique_id = f"withings_{coordinator.config_entry.unique_id}_{key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(coordinator.config_entry.unique_id))},
-            manufacturer="Withings",
         )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Spotted in https://github.com/home-assistant/core/actions/runs/25039807993/job/73341207391?pr=162263

Needed for #162263

The `tests/components/withings/test_init.py::test_devices` test is flaky
(~1–10% failure rate). The failure is `via_device_id is None` on the
physical scale device.

Root cause is an ordering race during sensor platform setup in
`sensor.py`:

1. `_async_device_listener()` schedules `WithingsDeviceSensor` entities
   first. These reference `via_device=(DOMAIN, unique_id)`.
2. `async_add_entities(entities)` is then scheduled for the user-level
   `WithingsEntity` sensors which actually create the hub device with
   identifier `(DOMAIN, unique_id)`.

Both calls schedule independent eager tasks and their internal awaits
interleave non-deterministically. When `async_get_or_create` is called
with `via_device=...`, the device registry resolves the parent
immediately and there is no later reconciliation: if the parent doesn't
exist yet, `via_device_id` is permanently set to `None`.

This change explicitly pre-creates the hub device in
`async_setup_entry` so the `via_device` lookup always succeeds. The
redundant `manufacturer="Withings"` is removed from `WithingsEntity`
device info since the hub device already carries that field.

Note: the device registry now reports a deprecation when `via_device`
references a non-existent device (`breaks_in_ha_version="2025.12.0"`),
so this race would become a hard failure regardless.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->