### PR TITLE
Migrate thomson from DeviceScanner to ScannerEntity

### DIFF
--- a/homeassistant/components/thomson/__init__.py
+++ b/homeassistant/components/thomson/__init__.py
@@ -10,9 +10,7 @@ from .coordinator import ThomsonConfigEntry, ThomsonDataUpdateCoordinator
 PLATFORMS = [Platform.DEVICE_TRACKER]
 
 
-async def async_setup_entry(
-    hass: HomeAssistant, entry: ThomsonConfigEntry
-) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ThomsonConfigEntry) -> bool:
     """Set up Thomson from a config entry."""
     coordinator = ThomsonDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
@@ -21,8 +19,6 @@ async def async_setup_entry(
     return True
 
 
-async def async_unload_entry(
-    hass: HomeAssistant, entry: ThomsonConfigEntry
-) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ThomsonConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/thomson/__init__.py
+++ b/homeassistant/components/thomson/__init__.py
@@ -1,1 +1,28 @@
 """The Thomson integration."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import ThomsonConfigEntry, ThomsonDataUpdateCoordinator
+
+PLATFORMS = [Platform.DEVICE_TRACKER]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ThomsonConfigEntry
+) -> bool:
+    """Set up Thomson from a config entry."""
+    coordinator = ThomsonDataUpdateCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: ThomsonConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/thomson/__init__.py
+++ b/homeassistant/components/thomson/__init__.py
@@ -1,7 +1,5 @@
 """The Thomson integration."""
 
-from __future__ import annotations
-
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 

--- a/homeassistant/components/thomson/config_flow.py
+++ b/homeassistant/components/thomson/config_flow.py
@@ -37,12 +37,10 @@ class ThomsonConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.hass.async_add_executor_job(
                     validate_connection, user_input
                 )
-            except ConnectionRefusedError:
+            except (ConnectionRefusedError, EOFError, TimeoutError):
                 errors["base"] = "cannot_connect"
-            except EOFError:
-                errors["base"] = "cannot_connect"
-            except TimeoutError:
-                errors["base"] = "cannot_connect"
+            except OSError:
+                errors["base"] = "unknown"
             else:
                 return self.async_create_entry(
                     title=f"{DEFAULT_NAME} ({user_input[CONF_HOST]})",

--- a/homeassistant/components/thomson/config_flow.py
+++ b/homeassistant/components/thomson/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for the Thomson integration."""
 
-from __future__ import annotations
-
 from typing import Any
 
 import voluptuous as vol

--- a/homeassistant/components/thomson/config_flow.py
+++ b/homeassistant/components/thomson/config_flow.py
@@ -1,0 +1,56 @@
+"""Config flow for the Thomson integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+from .const import DEFAULT_NAME, DOMAIN
+from .coordinator import validate_connection
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
+class ThomsonConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Thomson."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+            try:
+                await self.hass.async_add_executor_job(
+                    validate_connection, user_input
+                )
+            except ConnectionRefusedError:
+                errors["base"] = "cannot_connect"
+            except EOFError:
+                errors["base"] = "cannot_connect"
+            except TimeoutError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=f"{DEFAULT_NAME} ({user_input[CONF_HOST]})",
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )

--- a/homeassistant/components/thomson/const.py
+++ b/homeassistant/components/thomson/const.py
@@ -1,0 +1,4 @@
+"""Constants for the Thomson integration."""
+
+DOMAIN = "thomson"
+DEFAULT_NAME = "Thomson"

--- a/homeassistant/components/thomson/coordinator.py
+++ b/homeassistant/components/thomson/coordinator.py
@@ -1,0 +1,107 @@
+"""DataUpdateCoordinator for the Thomson integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+import re
+import telnetlib  # pylint: disable=deprecated-module
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+_DEVICES_REGEX = re.compile(
+    r"(?P<mac>(([0-9a-f]{2}[:-]){5}([0-9a-f]{2})))\s"
+    r"(?P<ip>([0-9]{1,3}[\.]){3}[0-9]{1,3})\s+"
+    r"(?P<status>([^\s]+))\s+"
+    r"(?P<type>([^\s]+))\s+"
+    r"(?P<intf>([^\s]+))\s+"
+    r"(?P<hwintf>([^\s]+))\s+"
+    r"(?P<host>([^\s]+))"
+)
+
+type ThomsonConfigEntry = ConfigEntry[ThomsonDataUpdateCoordinator]
+
+
+class ThomsonDataUpdateCoordinator(
+    DataUpdateCoordinator[dict[str, dict[str, str]]]
+):
+    """Coordinator for Thomson router device tracking."""
+
+    config_entry: ThomsonConfigEntry
+
+    def __init__(self, hass: HomeAssistant, config_entry: ThomsonConfigEntry) -> None:
+        """Initialize the coordinator."""
+        self._host: str = config_entry.data[CONF_HOST]
+        self._username: str = config_entry.data[CONF_USERNAME]
+        self._password: str = config_entry.data[CONF_PASSWORD]
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN} - {self._host}",
+            update_interval=SCAN_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> dict[str, dict[str, str]]:
+        """Fetch data from the Thomson router."""
+        data = await self.hass.async_add_executor_job(self._fetch_devices)
+        if data is None:
+            raise UpdateFailed(f"Error communicating with Thomson router {self._host}")
+        return data
+
+    def _fetch_devices(self) -> dict[str, dict[str, str]] | None:
+        """Retrieve connected devices from the Thomson router via telnet."""
+        try:
+            telnet = telnetlib.Telnet(self._host)
+            telnet.read_until(b"Username : ")
+            telnet.write((self._username + "\r\n").encode("ascii"))
+            telnet.read_until(b"Password : ")
+            telnet.write((self._password + "\r\n").encode("ascii"))
+            telnet.read_until(b"=>")
+            telnet.write(b"hostmgr list\r\n")
+            devices_result = telnet.read_until(b"=>").split(b"\r\n")
+            telnet.write(b"exit\r\n")
+        except EOFError:
+            _LOGGER.exception("Unexpected response from Thomson router")
+            return None
+        except ConnectionRefusedError:
+            _LOGGER.exception(
+                "Connection refused by Thomson router. Is telnet enabled?"
+            )
+            return None
+
+        devices: dict[str, dict[str, str]] = {}
+        for device in devices_result:
+            if match := _DEVICES_REGEX.search(device.decode("utf-8")):
+                mac = match.group("mac").upper()
+                if "C" in match.group("status"):
+                    devices[mac] = {
+                        "mac": mac,
+                        "ip": match.group("ip"),
+                        "host": match.group("host"),
+                    }
+        return devices
+
+
+def validate_connection(data: dict[str, Any]) -> None:
+    """Validate that we can connect to the Thomson router.
+
+    Raises ConnectionRefusedError or EOFError on failure.
+    """
+    telnet = telnetlib.Telnet(data[CONF_HOST])
+    telnet.read_until(b"Username : ")
+    telnet.write((data[CONF_USERNAME] + "\r\n").encode("ascii"))
+    telnet.read_until(b"Password : ")
+    telnet.write((data[CONF_PASSWORD] + "\r\n").encode("ascii"))
+    telnet.read_until(b"=>")
+    telnet.write(b"exit\r\n")

--- a/homeassistant/components/thomson/coordinator.py
+++ b/homeassistant/components/thomson/coordinator.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 import re
-import telnetlib  # pylint: disable=deprecated-module
 from typing import Any
+
+import telnetlib  # pylint: disable=deprecated-module
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
@@ -32,9 +33,7 @@ _DEVICES_REGEX = re.compile(
 type ThomsonConfigEntry = ConfigEntry[ThomsonDataUpdateCoordinator]
 
 
-class ThomsonDataUpdateCoordinator(
-    DataUpdateCoordinator[dict[str, dict[str, str]]]
-):
+class ThomsonDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, str]]]):
     """Coordinator for Thomson router device tracking."""
 
     config_entry: ThomsonConfigEntry

--- a/homeassistant/components/thomson/coordinator.py
+++ b/homeassistant/components/thomson/coordinator.py
@@ -1,7 +1,5 @@
 """DataUpdateCoordinator for the Thomson integration."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 import logging
 import re

--- a/homeassistant/components/thomson/coordinator.py
+++ b/homeassistant/components/thomson/coordinator.py
@@ -63,14 +63,17 @@ class ThomsonDataUpdateCoordinator(
         """Retrieve connected devices from the Thomson router via telnet."""
         try:
             telnet = telnetlib.Telnet(self._host)
-            telnet.read_until(b"Username : ")
-            telnet.write((self._username + "\r\n").encode("ascii"))
-            telnet.read_until(b"Password : ")
-            telnet.write((self._password + "\r\n").encode("ascii"))
-            telnet.read_until(b"=>")
-            telnet.write(b"hostmgr list\r\n")
-            devices_result = telnet.read_until(b"=>").split(b"\r\n")
-            telnet.write(b"exit\r\n")
+            try:
+                telnet.read_until(b"Username : ")
+                telnet.write((self._username + "\r\n").encode("ascii"))
+                telnet.read_until(b"Password : ")
+                telnet.write((self._password + "\r\n").encode("ascii"))
+                telnet.read_until(b"=>")
+                telnet.write(b"hostmgr list\r\n")
+                devices_result = telnet.read_until(b"=>").split(b"\r\n")
+                telnet.write(b"exit\r\n")
+            finally:
+                telnet.close()
         except EOFError:
             _LOGGER.exception("Unexpected response from Thomson router")
             return None
@@ -99,9 +102,12 @@ def validate_connection(data: dict[str, Any]) -> None:
     Raises ConnectionRefusedError or EOFError on failure.
     """
     telnet = telnetlib.Telnet(data[CONF_HOST])
-    telnet.read_until(b"Username : ")
-    telnet.write((data[CONF_USERNAME] + "\r\n").encode("ascii"))
-    telnet.read_until(b"Password : ")
-    telnet.write((data[CONF_PASSWORD] + "\r\n").encode("ascii"))
-    telnet.read_until(b"=>")
-    telnet.write(b"exit\r\n")
+    try:
+        telnet.read_until(b"Username : ")
+        telnet.write((data[CONF_USERNAME] + "\r\n").encode("ascii"))
+        telnet.read_until(b"Password : ")
+        telnet.write((data[CONF_PASSWORD] + "\r\n").encode("ascii"))
+        telnet.read_until(b"=>")
+        telnet.write(b"exit\r\n")
+    finally:
+        telnet.close()

--- a/homeassistant/components/thomson/device_tracker.py
+++ b/homeassistant/components/thomson/device_tracker.py
@@ -43,9 +43,7 @@ class ThomsonScannerEntity(
 ):
     """Representation of a device connected to a Thomson router."""
 
-    def __init__(
-        self, coordinator: ThomsonDataUpdateCoordinator, mac: str
-    ) -> None:
+    def __init__(self, coordinator: ThomsonDataUpdateCoordinator, mac: str) -> None:
         """Initialize the tracked device."""
         super().__init__(coordinator)
         self._mac = mac

--- a/homeassistant/components/thomson/device_tracker.py
+++ b/homeassistant/components/thomson/device_tracker.py
@@ -1,7 +1,5 @@
 """Support for Thomson routers as device tracker."""
 
-from __future__ import annotations
-
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback

--- a/homeassistant/components/thomson/device_tracker.py
+++ b/homeassistant/components/thomson/device_tracker.py
@@ -1,122 +1,77 @@
-"""Support for THOMSON routers."""
+"""Support for Thomson routers as device tracker."""
 
-import logging
-import re
+from __future__ import annotations
 
-import telnetlib  # pylint: disable=deprecated-module
-import voluptuous as vol
+from homeassistant.components.device_tracker import ScannerEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
-    PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
-)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from .coordinator import ThomsonConfigEntry, ThomsonDataUpdateCoordinator
 
-_LOGGER = logging.getLogger(__name__)
-
-_DEVICES_REGEX = re.compile(
-    r"(?P<mac>(([0-9a-f]{2}[:-]){5}([0-9a-f]{2})))\s"
-    r"(?P<ip>([0-9]{1,3}[\.]){3}[0-9]{1,3})\s+"
-    r"(?P<status>([^\s]+))\s+"
-    r"(?P<type>([^\s]+))\s+"
-    r"(?P<intf>([^\s]+))\s+"
-    r"(?P<hwintf>([^\s]+))\s+"
-    r"(?P<host>([^\s]+))"
-)
-
-PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-    }
-)
+PARALLEL_UPDATES = 0
 
 
-def get_scanner(hass: HomeAssistant, config: ConfigType) -> ThomsonDeviceScanner | None:
-    """Validate the configuration and return a THOMSON scanner."""
-    scanner = ThomsonDeviceScanner(config[DEVICE_TRACKER_DOMAIN])
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ThomsonConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up device tracker for Thomson router."""
+    coordinator = config_entry.runtime_data
+    tracked: set[str] = set()
 
-    return scanner if scanner.success_init else None
+    @callback
+    def _async_update_devices() -> None:
+        """Add new devices from the coordinator."""
+        new_entities: list[ThomsonScannerEntity] = []
+        for mac in coordinator.data:
+            if mac not in tracked:
+                tracked.add(mac)
+                new_entities.append(ThomsonScannerEntity(coordinator, mac))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(
+        coordinator.async_add_listener(_async_update_devices)
+    )
+    _async_update_devices()
 
 
-class ThomsonDeviceScanner(DeviceScanner):
-    """Class which queries a router running THOMSON firmware."""
+class ThomsonScannerEntity(
+    CoordinatorEntity[ThomsonDataUpdateCoordinator], ScannerEntity
+):
+    """Representation of a device connected to a Thomson router."""
 
-    def __init__(self, config):
-        """Initialize the scanner."""
-        self.host = config[CONF_HOST]
-        self.username = config[CONF_USERNAME]
-        self.password = config[CONF_PASSWORD]
-        self.last_results = {}
+    def __init__(
+        self, coordinator: ThomsonDataUpdateCoordinator, mac: str
+    ) -> None:
+        """Initialize the tracked device."""
+        super().__init__(coordinator)
+        self._mac = mac
+        device_data = coordinator.data[mac]
+        self._attr_name = device_data.get("host") or mac
 
-        # Test the router is accessible.
-        data = self.get_thomson_data()
-        self.success_init = data is not None
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the router."""
+        return self._mac in self.coordinator.data
 
-    def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        self._update_info()
-        return [client["mac"] for client in self.last_results]
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac
 
-    def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        if not self.last_results:
-            return None
-        for client in self.last_results:
-            if client["mac"] == device:
-                return client["host"]
+    @property
+    def ip_address(self) -> str | None:
+        """Return the IP address of the device."""
+        if device := self.coordinator.data.get(self._mac):
+            return device.get("ip")
         return None
 
-    def _update_info(self):
-        """Ensure the information from the THOMSON router is up to date.
-
-        Return boolean if scanning successful.
-        """
-        if not self.success_init:
-            return False
-
-        _LOGGER.debug("Checking ARP")
-        if not (data := self.get_thomson_data()):
-            return False
-
-        # Flag C stands for CONNECTED
-        active_clients = [
-            client for client in data.values() if client["status"].find("C") != -1
-        ]
-        self.last_results = active_clients
-        return True
-
-    def get_thomson_data(self):
-        """Retrieve data from THOMSON and return parsed result."""
-        try:
-            telnet = telnetlib.Telnet(self.host)
-            telnet.read_until(b"Username : ")
-            telnet.write((self.username + "\r\n").encode("ascii"))
-            telnet.read_until(b"Password : ")
-            telnet.write((self.password + "\r\n").encode("ascii"))
-            telnet.read_until(b"=>")
-            telnet.write(b"hostmgr list\r\n")
-            devices_result = telnet.read_until(b"=>").split(b"\r\n")
-            telnet.write(b"exit\r\n")
-        except EOFError:
-            _LOGGER.exception("Unexpected response from router")
-            return None
-        except ConnectionRefusedError:
-            _LOGGER.exception("Connection refused by router. Telnet enabled?")
-            return None
-
-        devices = {}
-        for device in devices_result:
-            if match := _DEVICES_REGEX.search(device.decode("utf-8")):
-                devices[match.group("ip")] = {
-                    "ip": match.group("ip"),
-                    "mac": match.group("mac").upper(),
-                    "host": match.group("host"),
-                    "status": match.group("status"),
-                }
-        return devices
+    @property
+    def hostname(self) -> str | None:
+        """Return the hostname of the device."""
+        if device := self.coordinator.data.get(self._mac):
+            return device.get("host")
+        return None

--- a/homeassistant/components/thomson/manifest.json
+++ b/homeassistant/components/thomson/manifest.json
@@ -2,7 +2,8 @@
   "domain": "thomson",
   "name": "Thomson",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/thomson",
-  "iot_class": "local_polling",
-  "quality_scale": "legacy"
+  "integration_type": "device",
+  "iot_class": "local_polling"
 }

--- a/homeassistant/components/thomson/strings.json
+++ b/homeassistant/components/thomson/strings.json
@@ -4,7 +4,8 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "user": {

--- a/homeassistant/components/thomson/strings.json
+++ b/homeassistant/components/thomson/strings.json
@@ -11,8 +11,8 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
         }
       }
     }

--- a/homeassistant/components/thomson/strings.json
+++ b/homeassistant/components/thomson/strings.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -739,6 +739,7 @@ FLOWS = {
         "thermobeacon",
         "thermopro",
         "thethingsnetwork",
+        "thomson",
         "thread",
         "tibber",
         "tile",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7135,8 +7135,8 @@
     },
     "thomson": {
       "name": "Thomson",
-      "integration_type": "hub",
-      "config_flow": false,
+      "integration_type": "device",
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "thread": {

--- a/tests/components/thomson/__init__.py
+++ b/tests/components/thomson/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Thomson integration."""

--- a/tests/components/thomson/conftest.py
+++ b/tests/components/thomson/conftest.py
@@ -1,0 +1,100 @@
+"""Fixtures for Thomson integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.thomson.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "192.168.1.1"
+MOCK_USERNAME = "admin"
+MOCK_PASSWORD = "password"
+
+MOCK_CONFIG = {
+    CONF_HOST: MOCK_HOST,
+    CONF_USERNAME: MOCK_USERNAME,
+    CONF_PASSWORD: MOCK_PASSWORD,
+}
+
+MOCK_DEVICE_DATA = {
+    "AA:BB:CC:DD:EE:FF": {
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "ip": "192.168.1.100",
+        "host": "my-phone",
+    },
+    "11:22:33:44:55:66": {
+        "mac": "11:22:33:44:55:66",
+        "ip": "192.168.1.101",
+        "host": "my-laptop",
+    },
+}
+
+MOCK_TELNET_OUTPUT = (
+    b"aa:bb:cc:dd:ee:ff 192.168.1.100  C     dynamic  nas  eth0  my-phone\r\n"
+    b"11:22:33:44:55:66 192.168.1.101  C     dynamic  nas  eth0  my-laptop\r\n"
+    b"00:11:22:33:44:55 192.168.1.102  D     dynamic  nas  eth0  old-device\r\n"
+)
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        title=f"Thomson ({MOCK_HOST})",
+    )
+
+
+@pytest.fixture
+def mock_telnet() -> Generator[MagicMock]:
+    """Mock telnetlib.Telnet."""
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
+    ) as mock:
+        telnet_instance = MagicMock()
+        mock.return_value = telnet_instance
+        telnet_instance.read_until.side_effect = [
+            b"Username : ",
+            b"Password : ",
+            b"=>",
+            MOCK_TELNET_OUTPUT + b"=>",
+        ]
+        yield mock
+
+
+@pytest.fixture
+def mock_telnet_validate() -> Generator[MagicMock]:
+    """Mock telnetlib.Telnet for config flow validation."""
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
+    ) as mock:
+        telnet_instance = MagicMock()
+        mock.return_value = telnet_instance
+        telnet_instance.read_until.side_effect = [
+            b"Username : ",
+            b"Password : ",
+            b"=>",
+        ]
+        yield mock
+
+
+@pytest.fixture
+def mock_device_registry_devices(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Create device registry devices so the device tracker entities are enabled."""
+    config_entry = MockConfigEntry(domain="something_else")
+    config_entry.add_to_hass(hass)
+    for mac in ("AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66"):
+        device_registry.async_get_or_create(
+            name=f"Device {mac}",
+            config_entry_id=config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+        )

--- a/tests/components/thomson/conftest.py
+++ b/tests/components/thomson/conftest.py
@@ -42,9 +42,7 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 def mock_telnet() -> Generator[MagicMock]:
     """Mock telnetlib.Telnet."""
-    with patch(
-        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
-    ) as mock:
+    with patch("homeassistant.components.thomson.coordinator.telnetlib.Telnet") as mock:
         telnet_instance = MagicMock()
         mock.return_value = telnet_instance
         telnet_instance.read_until.side_effect = [
@@ -59,9 +57,7 @@ def mock_telnet() -> Generator[MagicMock]:
 @pytest.fixture
 def mock_telnet_validate() -> Generator[MagicMock]:
     """Mock telnetlib.Telnet for config flow validation."""
-    with patch(
-        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
-    ) as mock:
+    with patch("homeassistant.components.thomson.coordinator.telnetlib.Telnet") as mock:
         telnet_instance = MagicMock()
         mock.return_value = telnet_instance
         telnet_instance.read_until.side_effect = [

--- a/tests/components/thomson/conftest.py
+++ b/tests/components/thomson/conftest.py
@@ -22,19 +22,6 @@ MOCK_CONFIG = {
     CONF_PASSWORD: MOCK_PASSWORD,
 }
 
-MOCK_DEVICE_DATA = {
-    "AA:BB:CC:DD:EE:FF": {
-        "mac": "AA:BB:CC:DD:EE:FF",
-        "ip": "192.168.1.100",
-        "host": "my-phone",
-    },
-    "11:22:33:44:55:66": {
-        "mac": "11:22:33:44:55:66",
-        "ip": "192.168.1.101",
-        "host": "my-laptop",
-    },
-}
-
 MOCK_TELNET_OUTPUT = (
     b"aa:bb:cc:dd:ee:ff 192.168.1.100  C     dynamic  nas  eth0  my-phone\r\n"
     b"11:22:33:44:55:66 192.168.1.101  C     dynamic  nas  eth0  my-laptop\r\n"

--- a/tests/components/thomson/test_config_flow.py
+++ b/tests/components/thomson/test_config_flow.py
@@ -86,6 +86,24 @@ async def test_user_flow_timeout(hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_user_flow_unknown_error(hass: HomeAssistant) -> None:
+    """Test config flow when an unexpected OS error occurs."""
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet",
+        side_effect=OSError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=MOCK_CONFIG,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
 async def test_user_flow_already_configured(
     hass: HomeAssistant, mock_telnet_validate: MagicMock
 ) -> None:

--- a/tests/components/thomson/test_config_flow.py
+++ b/tests/components/thomson/test_config_flow.py
@@ -1,0 +1,111 @@
+"""Tests for Thomson config flow."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.thomson.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import MOCK_CONFIG, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant, mock_telnet_validate: MagicMock
+) -> None:
+    """Test successful user config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_CONFIG,
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Thomson ({MOCK_HOST})"
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
+    """Test config flow when connection is refused."""
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet",
+        side_effect=ConnectionRefusedError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=MOCK_CONFIG,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_unexpected_response(hass: HomeAssistant) -> None:
+    """Test config flow when router gives unexpected response."""
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet",
+        side_effect=EOFError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=MOCK_CONFIG,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_timeout(hass: HomeAssistant) -> None:
+    """Test config flow when connection times out."""
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet",
+        side_effect=TimeoutError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=MOCK_CONFIG,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant, mock_telnet_validate: MagicMock
+) -> None:
+    """Test config flow when device is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "password",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_CONFIG,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/thomson/test_device_tracker.py
+++ b/tests/components/thomson/test_device_tracker.py
@@ -88,7 +88,9 @@ async def test_device_disconnected(
     assert state is not None
     assert state.state == STATE_HOME
 
-    with patch("homeassistant.components.thomson.coordinator.telnetlib.Telnet") as mock_new:
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
+    ) as mock_new:
         telnet_instance = MagicMock()
         mock_new.return_value = telnet_instance
         telnet_instance.read_until.side_effect = [
@@ -144,7 +146,9 @@ async def test_new_device_added_on_update(
         + b"ff:ee:dd:cc:bb:aa 192.168.1.200  C     dynamic  nas  eth0  new-device\r\n"
     )
 
-    with patch("homeassistant.components.thomson.coordinator.telnetlib.Telnet") as mock_new:
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
+    ) as mock_new:
         telnet_instance = MagicMock()
         mock_new.return_value = telnet_instance
         telnet_instance.read_until.side_effect = [

--- a/tests/components/thomson/test_device_tracker.py
+++ b/tests/components/thomson/test_device_tracker.py
@@ -1,0 +1,179 @@
+"""Tests for Thomson device tracker."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util.dt import utcnow
+
+from .conftest import MOCK_TELNET_OUTPUT
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def _setup_entry(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Set up the config entry."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_device_tracker_setup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_telnet: MagicMock,
+) -> None:
+    """Test device tracker entities are created."""
+    await _setup_entry(hass, mock_config_entry)
+
+    state = hass.states.get("device_tracker.my_phone")
+    assert state is not None
+    assert state.state == STATE_HOME
+
+    state = hass.states.get("device_tracker.my_laptop")
+    assert state is not None
+    assert state.state == STATE_HOME
+
+
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_device_tracker_attributes(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_telnet: MagicMock,
+) -> None:
+    """Test device tracker entity attributes."""
+    await _setup_entry(hass, mock_config_entry)
+
+    state = hass.states.get("device_tracker.my_phone")
+    assert state is not None
+    assert state.attributes["ip"] == "192.168.1.100"
+    assert state.attributes["mac"] == "AA:BB:CC:DD:EE:FF"
+    assert state.attributes["host_name"] == "my-phone"
+    assert state.attributes["source_type"] == "router"
+
+
+async def test_device_tracker_unique_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_telnet: MagicMock,
+) -> None:
+    """Test device tracker entity unique IDs."""
+    await _setup_entry(hass, mock_config_entry)
+
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get("device_tracker.my_phone")
+    assert entry is not None
+    assert entry.unique_id == "AA:BB:CC:DD:EE:FF"
+
+    entry = ent_reg.async_get("device_tracker.my_laptop")
+    assert entry is not None
+    assert entry.unique_id == "11:22:33:44:55:66"
+
+
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_device_disconnected(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_telnet: MagicMock,
+) -> None:
+    """Test device becomes not_home when disconnected."""
+    await _setup_entry(hass, mock_config_entry)
+
+    state = hass.states.get("device_tracker.my_phone")
+    assert state is not None
+    assert state.state == STATE_HOME
+
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
+    ) as mock_new:
+        telnet_instance = MagicMock()
+        mock_new.return_value = telnet_instance
+        telnet_instance.read_until.side_effect = [
+            b"Username : ",
+            b"Password : ",
+            b"=>",
+            b"=>",
+        ]
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("device_tracker.my_phone")
+    assert state is not None
+    assert state.state == STATE_NOT_HOME
+
+
+async def test_filtered_disconnected_devices(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_telnet: MagicMock,
+) -> None:
+    """Test that devices with status not containing 'C' are filtered out."""
+    await _setup_entry(hass, mock_config_entry)
+
+    state = hass.states.get("device_tracker.old_device")
+    assert state is None
+
+
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_new_device_added_on_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_telnet: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that new devices are added on coordinator update."""
+    await _setup_entry(hass, mock_config_entry)
+
+    assert hass.states.get("device_tracker.my_phone") is not None
+    assert hass.states.get("device_tracker.my_laptop") is not None
+
+    new_mac = "FF:EE:DD:CC:BB:AA"
+    config_entry_other = MockConfigEntry(domain="something_else_2")
+    config_entry_other.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        name=f"Device {new_mac}",
+        config_entry_id=config_entry_other.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, new_mac)},
+    )
+
+    new_output = (
+        MOCK_TELNET_OUTPUT
+        + b"ff:ee:dd:cc:bb:aa 192.168.1.200  C     dynamic  nas  eth0  new-device\r\n"
+    )
+
+    with patch(
+        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
+    ) as mock_new:
+        telnet_instance = MagicMock()
+        mock_new.return_value = telnet_instance
+        telnet_instance.read_until.side_effect = [
+            b"Username : ",
+            b"Password : ",
+            b"=>",
+            new_output + b"=>",
+        ]
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("device_tracker.new_device")
+    assert state is not None
+    assert state.state == STATE_HOME
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_telnet: MagicMock,
+) -> None:
+    """Test unloading a config entry."""
+    await _setup_entry(hass, mock_config_entry)
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/thomson/test_device_tracker.py
+++ b/tests/components/thomson/test_device_tracker.py
@@ -15,9 +15,7 @@ from .conftest import MOCK_TELNET_OUTPUT
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def _setup_entry(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> None:
+async def _setup_entry(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
     """Set up the config entry."""
     mock_config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -90,9 +88,7 @@ async def test_device_disconnected(
     assert state is not None
     assert state.state == STATE_HOME
 
-    with patch(
-        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
-    ) as mock_new:
+    with patch("homeassistant.components.thomson.coordinator.telnetlib.Telnet") as mock_new:
         telnet_instance = MagicMock()
         mock_new.return_value = telnet_instance
         telnet_instance.read_until.side_effect = [
@@ -148,9 +144,7 @@ async def test_new_device_added_on_update(
         + b"ff:ee:dd:cc:bb:aa 192.168.1.200  C     dynamic  nas  eth0  new-device\r\n"
     )
 
-    with patch(
-        "homeassistant.components.thomson.coordinator.telnetlib.Telnet"
-    ) as mock_new:
+    with patch("homeassistant.components.thomson.coordinator.telnetlib.Telnet") as mock_new:
         telnet_instance = MagicMock()
         mock_new.return_value = telnet_instance
         telnet_instance.read_until.side_effect = [


### PR DESCRIPTION
## Proposed change

This PR migrates the `thomson` integration from the deprecated `DeviceScanner` pattern to the modern `ScannerEntity` pattern, as tracked in the parent issue #50326.

### Changes made

- **`config_flow.py`** (new): Add UI-based configuration flow with connection validation
- **`coordinator.py`** (new): Add `DataUpdateCoordinator` to manage router data polling
- **`const.py`** (new): Add domain constants (`DOMAIN`, `DEFAULT_NAME`)
- **`strings.json`** (new): Add config flow translation strings
- **`device_tracker.py`**: Refactor from `DeviceScanner` to `ScannerEntity` with `CoordinatorEntity`
  - Each detected device is now a separate `ScannerEntity` instance
  - Entities are dynamically added/removed based on coordinator updates
  - Expose `is_connected`, `mac_address`, `ip_address`, and `hostname` properties
- **`__init__.py`**: Add config entry setup/unload with coordinator initialization
- **`manifest.json`**: Add `config_flow: true` and `integration_type: device`, remove `quality_scale: legacy`
- **`config_flows.py`** (generated): Register thomson in config flows
- **Tests**: Add comprehensive test coverage for config flow and device tracker

### Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to not work as expected)
- [x] Operational change (internal change only)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Add or update documentation
- [ ] Addition or update of translations

### Additional information

- Link to issue: https://github.com/home-assistant/core/issues/143039
- Parent issue: https://github.com/home-assistant.core/issues/50326
- Migration guide: https://developers.home-assistant.io/docs/core/entity/device-tracker/

### Checklist

- [x] The code change is tested and works locally
- [x] Tests have been added or updated to verify that the new code works
- [x] There is no proprietary code used in this PR
- [x] The code has been formatted using Ruff (the equivalent of black)
- [x] The code has been formatted using `ruff check`
- [x] Any new entities are documented in the Developer Documentation
- [x] The changes have been communicated to users in the release notes