### PR TITLE
Fix watts coordinator interrupting fast polling on hub update

### DIFF
--- a/homeassistant/components/watts/coordinator.py
+++ b/homeassistant/components/watts/coordinator.py
@@ -192,10 +192,17 @@ class WattsVisionDeviceCoordinator(DataUpdateCoordinator[WattsVisionDeviceData])
         )
 
     def _handle_hub_update(self) -> None:
-        """Handle updates from hub coordinator."""
+        """Handle updates from hub coordinator.
+
+        Update data and notify listeners without rescheduling the refresh
+        interval, so an in-flight fast-polling cycle is not interrupted.
+        """
         if self.hub_coordinator.data and self.device_id in self.hub_coordinator.data:
-            device = self.hub_coordinator.data[self.device_id]
-            self.async_set_updated_data(WattsVisionDeviceData(device=device))
+            self.data = WattsVisionDeviceData(
+                device=self.hub_coordinator.data[self.device_id]
+            )
+            self.last_update_success = True
+            self.async_update_listeners()
 
     async def _async_update_data(self) -> WattsVisionDeviceData:
         """Refresh specific device."""


### PR DESCRIPTION
## Proposed change

The Watts Vision integration uses two coordinators: a hub coordinator that polls all devices every 30 s, and per-device coordinators that drop into a 5 s fast-polling cycle for 60 s after the user changes a setpoint or HVAC mode.

When the hub coordinator finishes a refresh it notifies its listeners, and `_handle_hub_update` was forwarding the new device data through `async_set_updated_data`. That helper not only updates `self.data`, it also unschedules the device coordinator's next refresh and reschedules it relative to the hub fire time. As a result, every time the hub ticked while a fast-polling cycle was active the device coordinator's next 5 s refresh was cancelled and pushed out, dropping a fast-poll cycle.

This also caused `tests/components/watts/test_climate.py::test_fast_polling` to be flaky in CI: when the test advances the freezer past both the device's 5 s tick and the hub's 30 s tick in one go, `_async_fire_time_changed` iterates `loop._scheduled` (a heap stored as a list, so iteration order is not the firing order). If the hub timer is processed first, its refresh runs synchronously to completion (the `AsyncMock` calls don't yield with `eager_start=True`), the listener cancels the device coordinator's already-due timer, and when the loop reaches that timer it is skipped — so `get_device` is never called and the assertion fails.

The fix updates `self.data` and notifies listeners directly, leaving the device coordinator's existing refresh schedule alone so an in-flight fast-polling cycle is not interrupted.

Spotted in https://github.com/home-assistant/core/actions/runs/25044771068/job/73358299108?pr=162263 and needed for #162263.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.