### PR TITLE
Fix flaky stream test_stream_retries

### DIFF
--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -334,10 +334,12 @@ async def test_stream_retries(
         # Request stream. Enable retries which are disabled by default in tests.
         should_retry.return_value = True
         await stream.start()
+        # Capture the thread reference before yielding to the event loop, since
+        # worker_finished() may clear stream._thread once the worker exits.
+        worker_thread = stream._thread
         await open_future1
         await open_future2
-        await hass.async_add_executor_job(stream._thread.join)
-        stream._thread = None
+        await hass.async_add_executor_job(worker_thread.join)
         assert av_open.call_count == 2
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change

Fixes a race condition in `tests/components/stream/test_hls.py::test_stream_retries`.

After `_run_worker` exits the retry loop, it schedules `worker_finished()` as a task on the event loop. Once that task runs, it transitively calls `Stream._stop()` (via `remove_provider` → `stop`), which sets `stream._thread = None`. Any `await` in the test between `stream.start()` and reading `stream._thread` (here `await open_future1` / `await open_future2`) hands control back to the event loop, giving `worker_finished` a chance to run. When that happened, `await hass.async_add_executor_job(stream._thread.join)` failed with:

```
AttributeError: 'NoneType' object has no attribute 'join'
```

This was spotted in https://github.com/home-assistant/core/actions/runs/25044771068/job/73358299115?pr=162263 and is needed for #162263.

The fix captures `stream._thread` immediately after `stream.start()` and joins the captured reference. The now-redundant `stream._thread = None` line is removed; `worker_finished` already clears it, and `stop()` already handles `_thread is None`.

Verified with `pytest tests/components/stream/test_hls.py::test_stream_retries --count=50` (100/100 passing across both parametrized cases).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr