### PR TITLE
Fix flaky cloud TTS and picotts streaming tests

### DIFF
--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -274,6 +274,7 @@ async def test_get_tts_audio(
 
         # Force streaming
         await client.get(response["path"])
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     if data.get("engine_id", "").startswith("tts."):
         # Streaming

--- a/tests/components/picotts/test_tts.py
+++ b/tests/components/picotts/test_tts.py
@@ -129,6 +129,7 @@ async def test_tts_service(
             )
             == HTTPStatus.OK
         )
+        await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_get_tts_audio_subprocess_error(


### PR DESCRIPTION
## Proposed change

Wait for background tasks to complete after triggering the streaming GET in two TTS tests, so the background task that loads the streamed audio (and the ffmpeg conversion subprocess) finishes before assertions run / the test ends:

- `tests/components/cloud/test_tts.py::test_get_tts_audio`
- `tests/components/picotts/test_tts.py::test_tts_service`

In both tests the TTS audio is loaded into the cache by a hass background task. The streaming GET (`await client.get(...)` directly, or via the shared `retrieve_media` helper) only awaits response headers — the streaming background task can still be in flight when the test body finishes. Plain `async_block_till_done()` does not wait for background tasks, so the task can outlive the test and surface as teardown errors.

The cloud failure was spotted in the failing CI job for #162263:
https://github.com/home-assistant/core/actions/runs/25057100718/job/73402201821?pr=162263

Adding `await hass.async_block_till_done(wait_background_tasks=True)` after the streaming GET matches the pattern already used in `tests/components/tts/test_init.py`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: needed for #162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.