### PR TITLE
Fix nobo_hub KeyError when a zone or component is removed

### DIFF
--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -145,6 +145,11 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
     @callback
     def _read_state(self) -> None:
         """Read the current state from the hub. These are only local calls."""
+        if self._id not in self._nobo.zones:
+            # Zone removed via the Nobø app; mark unavailable.
+            self._attr_available = False
+            return
+        self._attr_available = True
         state = self._nobo.get_current_zone_mode(self._id, dt_util.now())
         self._attr_hvac_mode = HVACMode.AUTO
         self._attr_preset_mode = PRESET_NONE

--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -94,6 +94,7 @@ class NoboGlobalSelector(NoboBaseEntity, SelectEntity):
 
     @callback
     def _read_state(self) -> None:
+        """Read the current state from the hub. These are only local calls."""
         for override in self._nobo.overrides.values():
             if override["target_type"] == nobo.API.OVERRIDE_TARGET_GLOBAL:
                 self._attr_current_option = self._modes[override["mode"]]
@@ -136,6 +137,12 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
 
     @callback
     def _read_state(self) -> None:
+        """Read the current state from the hub. These are only local calls."""
+        if self._id not in self._nobo.zones:
+            # Zone removed via the Nobø app; mark unavailable.
+            self._attr_available = False
+            return
+        self._attr_available = True
         self._profiles = {
             profile["week_profile_id"]: profile["name"].replace("\xa0", " ")
             for profile in self._nobo.week_profiles.values()

--- a/homeassistant/components/nobo_hub/sensor.py
+++ b/homeassistant/components/nobo_hub/sensor.py
@@ -71,6 +71,11 @@ class NoboTemperatureSensor(NoboBaseEntity, SensorEntity):
     @callback
     def _read_state(self) -> None:
         """Read the current state from the hub. This is a local call."""
+        if self._id not in self._nobo.components:
+            # Component removed via the Nobø app; mark unavailable.
+            self._attr_available = False
+            return
+        self._attr_available = True
         value = self._nobo.get_current_component_temperature(self._id)
         if value is None:
             self._attr_native_value = None

--- a/tests/components/nobo_hub/test_climate.py
+++ b/tests/components/nobo_hub/test_climate.py
@@ -26,7 +26,7 @@ from homeassistant.components.nobo_hub.const import (
     CONF_OVERRIDE_TYPE,
     OVERRIDE_TYPE_NOW,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -184,6 +184,17 @@ async def test_set_preset_with_override_type_now(
         nobo.API.OVERRIDE_TARGET_ZONE,
         "1",
     )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_zone_removed_marks_unavailable(
+    hass: HomeAssistant,
+    mock_nobo_hub: MagicMock,
+) -> None:
+    """A zone removed via the Nobø app must not crash and goes unavailable."""
+    mock_nobo_hub.zones.pop("1")
+    await fire_hub_update(hass, mock_nobo_hub)
+    assert hass.states.get(CLIMATE_ENTITY).state == STATE_UNAVAILABLE
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/nobo_hub/test_select.py
+++ b/tests/components/nobo_hub/test_select.py
@@ -11,7 +11,7 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -136,3 +136,14 @@ async def test_week_profile_push_update(
     mock_nobo_hub.zones["1"]["week_profile_id"] = "1"
     await fire_hub_update(hass, mock_nobo_hub)
     assert hass.states.get(PROFILE_ENTITY).state == "Weekend"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_zone_removed_marks_week_profile_unavailable(
+    hass: HomeAssistant,
+    mock_nobo_hub: MagicMock,
+) -> None:
+    """A zone removed via the Nobø app must not crash and goes unavailable."""
+    mock_nobo_hub.zones.pop("1")
+    await fire_hub_update(hass, mock_nobo_hub)
+    assert hass.states.get(PROFILE_ENTITY).state == STATE_UNAVAILABLE

--- a/tests/components/nobo_hub/test_sensor.py
+++ b/tests/components/nobo_hub/test_sensor.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -55,3 +55,14 @@ async def test_temperature_push_update(
     mock_nobo_hub.get_current_component_temperature.return_value = "19.3"
     await fire_hub_update(hass, mock_nobo_hub)
     assert hass.states.get(TEMPERATURE_ENTITY).state == "19.3"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_component_removed_marks_unavailable(
+    hass: HomeAssistant,
+    mock_nobo_hub: MagicMock,
+) -> None:
+    """A component removed via the Nobø app must not crash and goes unavailable."""
+    mock_nobo_hub.components.pop("200000059091")
+    await fire_hub_update(hass, mock_nobo_hub)
+    assert hass.states.get(TEMPERATURE_ENTITY).state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removing a zone via the Nobø app causes the integration to raise `KeyError` the next time the hub pushes a state update:

```
File ".../nobo_hub/entity.py", line 34, in _handle_hub_update
    self._read_state()
File ".../nobo_hub/climate.py", line 148, in _read_state
    state = self._nobo.get_current_zone_mode(self._id, dt_util.now())
File ".../pynobo.py", line 1057, in get_zone_override_mode
    _LOGGER.debug('Current override for zone %s is %s', self.zones[zone_id]['name'], mode)
KeyError: '14'
``` 

The same crash exists for the `NoboProfileSelector` (zone id) and `NoboTemperatureSensor` (component serial) push paths.

This PR adds a guard in each platform's `_read_state` that marks the entity unavailable when its underlying zone (climate, select) or component (sensor) is no longer present in the hub's data, instead of dereferencing a missing key. Availability is restored on the next push update if the zone/component reappears.

Out of scope: dynamically adding entities for zones/components added on the hub, and removing the entity registry entries for removed ones. Those will follow as the `dynamic-devices` / `stale-devices` quality-scale work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
