### PR TITLE
Add support for Thread Integration to Display Icons for Yeelight TBRs and Fix for Amazon Echo

### DIFF
--- a/homeassistant/components/thread/discovery.py
+++ b/homeassistant/components/thread/discovery.py
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 KNOWN_BRANDS: dict[str | None, str] = {
     "Amazon": "amazon",
+    "amazon": "amazon",
     "Apple": "apple",
     "Apple Inc.": "apple",
     "Aqara": "aqara_gateway",
@@ -37,6 +38,7 @@ KNOWN_BRANDS: dict[str | None, str] = {
     "OpenThread": "openthread",
     "Samsung": "samsung",
     "SmartThings": "smartthings",
+    "Yeelight": "yeelight",
 }
 THREAD_TYPE = "_meshcop._udp.local."
 CLASS_IN = 1

--- a/tests/components/thread/test_discovery.py
+++ b/tests/components/thread/test_discovery.py
@@ -246,6 +246,66 @@ async def test_discover_routers_bad_or_missing_optional_data(
 
 
 @pytest.mark.parametrize(
+    ("vendor_name", "expected_brand"),
+    sorted(
+        (vendor_name, expected_brand)
+        for vendor_name, expected_brand in discovery.KNOWN_BRANDS.items()
+        if vendor_name is not None
+    ),
+)
+async def test_discover_routers_known_vendor_names(
+    hass: HomeAssistant,
+    mock_async_zeroconf: MagicMock,
+    vendor_name: str,
+    expected_brand: str,
+) -> None:
+    """Test discovering thread routers with known vendor names."""
+    mock_async_zeroconf.async_add_service_listener = AsyncMock()
+    mock_async_zeroconf.async_remove_service_listener = AsyncMock()
+    mock_async_zeroconf.async_get_service_info = AsyncMock()
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    router_discovered_removed = Mock()
+    thread_disovery = discovery.ThreadRouterDiscovery(
+        hass, router_discovered_removed, router_discovered_removed
+    )
+    await thread_disovery.async_start()
+    listener: discovery.ThreadRouterDiscovery.ThreadServiceListener = (
+        mock_async_zeroconf.async_add_service_listener.mock_calls[0][1][1]
+    )
+
+    data = {
+        **ROUTER_DISCOVERY_HASS,
+        "properties": {
+            **ROUTER_DISCOVERY_HASS["properties"],
+            b"vn": vendor_name.encode(),
+        },
+    }
+    mock_async_zeroconf.async_get_service_info.return_value = AsyncServiceInfo(**data)
+    listener.add_service(None, data["type_"], data["name"])
+    await hass.async_block_till_done()
+    router_discovered_removed.assert_called_once_with(
+        "aeeb2f594b570bbf",
+        discovery.ThreadRouterDiscoveryData(
+            instance_name="HomeAssistant OpenThreadBorderRouter #0BBF",
+            addresses=["192.168.0.115"],
+            border_agent_id="230c6a1ac57f6f4be262acf32e5ef52c",
+            brand=expected_brand,
+            extended_address="aeeb2f594b570bbf",
+            extended_pan_id="e60fc7c186212ce5",
+            model_name="OpenThreadBorderRouter",
+            network_name="OpenThread HC",
+            server="core-silabs-multiprotocol.local.",
+            thread_version="1.3.0",
+            unconfigured=None,
+            vendor_name=vendor_name,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
     "service",
     [
         ROUTER_DISCOVERY_HASS_MISSING_MANDATORY_DATA_XA,

--- a/tests/components/thread/test_discovery.py
+++ b/tests/components/thread/test_discovery.py
@@ -268,10 +268,10 @@ async def test_discover_routers_known_vendor_names(
     await hass.async_block_till_done()
 
     router_discovered_removed = Mock()
-    thread_disovery = discovery.ThreadRouterDiscovery(
+    thread_discovery = discovery.ThreadRouterDiscovery(
         hass, router_discovered_removed, router_discovered_removed
     )
-    await thread_disovery.async_start()
+    await thread_discovery.async_start()
     listener: discovery.ThreadRouterDiscovery.ThreadServiceListener = (
         mock_async_zeroconf.async_add_service_listener.mock_calls[0][1][1]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Amazon has changed its `vn` from `Amazon` to `amazon` since recent updates for Alexa Echo.

<img width="215" height="77" alt="Screenshot 2026-04-28 at 23 40 15" src="https://github.com/user-attachments/assets/bb6a66fa-82d1-4a7c-9215-fa17904e6b46" />

Also added an entry for the new Yeelight TBR whose `vn` is `Yeelight`.

<img width="221" height="108" alt="Screenshot 2026-04-28 at 23 40 01" src="https://github.com/user-attachments/assets/91bc7d2a-d9ac-4277-b94b-e7e66c5cb031" />

Tested locally:

<img width="1920" height="1080" alt="OTBR-Yeelight-Amazon" src="https://github.com/user-attachments/assets/16b3496b-f2eb-41e8-83f3-cd6d91315182" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
