### PR TITLE
Fix flaky mcp_server tests with Python 3.14.3

### DIFF
--- a/homeassistant/components/mcp_server/manifest.json
+++ b/homeassistant/components/mcp_server/manifest.json
@@ -3,7 +3,7 @@
   "name": "Model Context Protocol Server",
   "codeowners": ["@allenporter"],
   "config_flow": true,
-  "dependencies": ["homeassistant", "http", "conversation"],
+  "dependencies": ["http", "conversation"],
   "documentation": "https://www.home-assistant.io/integrations/mcp_server",
   "integration_type": "service",
   "iot_class": "local_push",

--- a/tests/components/mcp_server/conftest.py
+++ b/tests/components/mcp_server/conftest.py
@@ -9,8 +9,15 @@ from homeassistant.components.mcp_server.const import DOMAIN
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+async def ensure_homeassistant_loaded(hass: HomeAssistant) -> None:
+    """Override async_setup_entry."""
+    assert await async_setup_component(hass, "homeassistant", {})
 
 
 @pytest.fixture

--- a/tests/components/mcp_server/conftest.py
+++ b/tests/components/mcp_server/conftest.py
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 @pytest.fixture(autouse=True)
 async def ensure_homeassistant_loaded(hass: HomeAssistant) -> None:
-    """Override async_setup_entry."""
+    """Ensure homeassistant component is loaded."""
     assert await async_setup_component(hass, "homeassistant", {})
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alternative to #169385

Spotted in https://github.com/home-assistant/core/actions/runs/25057100718/job/73402201810?pr=162263

Needed for #162263

Under some circumstances, it seems that `conversation` can be loaded before `homeassistant` component has finished loading.

```
2026-04-28 14:14:38.268 INFO     SyncWorker_0 homeassistant.loader:loader.py:785 Loaded mcp_server from homeassistant.components.mcp_server
2026-04-28 14:14:38.270 INFO     SyncWorker_0 homeassistant.loader:loader.py:785 Loaded homeassistant from homeassistant.components.homeassistant
2026-04-28 14:14:38.271 INFO     SyncWorker_0 homeassistant.loader:loader.py:785 Loaded http from homeassistant.components.http
2026-04-28 14:14:38.272 INFO     MainThread homeassistant.setup:setup.py:393 Setting up http
2026-04-28 14:14:38.276 INFO     SyncWorker_0 homeassistant.loader:loader.py:785 Loaded conversation from homeassistant.components.conversation
2026-04-28 14:14:38.280 INFO     SyncWorker_0 homeassistant.loader:loader.py:785 Loaded intent from homeassistant.components.intent
2026-04-28 14:14:38.281 INFO     MainThread homeassistant.setup:setup.py:393 Setting up intent
2026-04-28 14:14:38.283 INFO     MainThread homeassistant.setup:setup.py:393 Setting up conversation
2026-04-28 14:14:38.284 ERROR    MainThread homeassistant.setup:setup.py:438 Error during setup of component conversation: 'homeassistant.exposed_entities'
2026-04-28 14:14:38.286 INFO     MainThread homeassistant.setup:setup.py:393 Setting up homeassistant
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
