### PR TITLE
Include matching integrations in scanned ports WS API

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -555,7 +555,17 @@ async def websocket_usb_list_serial_ports(
     except OSError as err:
         connection.send_error(msg["id"], websocket_api.ERR_UNKNOWN_ERROR, str(err))
         return
-    connection.send_result(
-        msg["id"],
-        [dataclasses.asdict(port) for port in ports],
-    )
+
+    result = []
+    for port in ports:
+        entry = dataclasses.asdict(port)
+
+        if isinstance(port, USBDevice):
+            matchers = async_get_usb_matchers_for_device(hass, port)
+            entry["matching_integrations"] = [matcher["domain"] for matcher in matchers]
+        else:
+            entry["matching_integrations"] = []
+
+        result.append(entry)
+
+    connection.send_result(msg["id"], result)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -562,7 +562,9 @@ async def websocket_usb_list_serial_ports(
 
         if isinstance(port, USBDevice):
             matchers = async_get_usb_matchers_for_device(hass, port)
-            entry["matching_integrations"] = [matcher["domain"] for matcher in matchers]
+            entry["matching_integrations"] = list(
+                dict.fromkeys(matcher["domain"] for matcher in matchers)
+            )
         else:
             entry["matching_integrations"] = []
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.selector import (
     FileSelector,
     FileSelectorConfig,
     SerialPortSelector,
+    SerialPortSelectorConfig,
 )
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -209,7 +210,15 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             {
                 vol.Required(
                     CONF_DEVICE_PATH, default=default_path
-                ): SerialPortSelector(),
+                ): SerialPortSelector(
+                    SerialPortSelectorConfig(
+                        extra_recommended_domains=[
+                            "homeassistant_yellow",
+                            "homeassistant_sky_connect",
+                            "homeassistant_connect_zbt2",
+                        ]
+                    )
+                ),
             }
         )
         return self.async_show_form(step_id="choose_serial_port", data_schema=schema)

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1771,8 +1771,10 @@ class SelectSelector(Selector[SelectSelectorConfig]):
         return [parent_schema(vol.Schema(str)(val)) for val in data]
 
 
-class SerialPortSelectorConfig(BaseSelectorConfig):
+class SerialPortSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent a serial port selector config."""
+
+    extra_recommended_domains: list[str]
 
 
 @SELECTORS.register("serial_port")
@@ -1781,7 +1783,11 @@ class SerialPortSelector(Selector[SerialPortSelectorConfig]):
 
     selector_type = "serial_port"
 
-    CONFIG_SCHEMA = make_selector_config_schema()
+    CONFIG_SCHEMA = make_selector_config_schema(
+        {
+            vol.Optional("extra_recommended_domains"): [str],
+        }
+    )
 
     def __init__(self, config: SerialPortSelectorConfig | None = None) -> None:
         """Instantiate a selector."""

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1683,7 +1683,7 @@ async def test_list_serial_ports(
     """Test listing serial ports via websocket."""
     matchers = [
         {
-            "description": "*skyconnect v1.0*",
+            "description": "*cp2102*",
             "domain": "homeassistant_sky_connect",
             "pid": "EA60",
             "vid": "10C4",
@@ -1758,7 +1758,7 @@ async def test_list_serial_ports(
             "serial_number": None,
             "manufacturer": None,
             "description": "Unknown adapter",
-            "bcd_device": 257,
+            "bcd_device": None,
             "interface_description": None,
             "interface_num": None,
             "matching_integrations": ["custom_component"],
@@ -1770,7 +1770,7 @@ async def test_list_serial_ports(
             "serial_number": None,
             "manufacturer": None,
             "description": "No matchers",
-            "bcd_device": 257,
+            "bcd_device": None,
             "interface_description": None,
             "interface_num": None,
             "matching_integrations": [],

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1169,9 +1169,7 @@ async def test_register_port_event_callback(
     mock_callback2 = Mock()
 
     # Start off with no ports
-    with (
-        patch_scanned_serial_ports(return_value=[]),
-    ):
+    with patch_scanned_serial_ports(return_value=[]):
         assert await async_setup_component(hass, DOMAIN, {"usb": {}})
 
         _cancel1 = usb.async_register_port_event_callback(hass, mock_callback1)
@@ -1264,9 +1262,7 @@ async def test_register_port_event_callback_failure(
     mock_callback2 = Mock(side_effect=RuntimeError("Failure 2"))
 
     # Start off with no ports
-    with (
-        patch_scanned_serial_ports(return_value=[]),
-    ):
+    with patch_scanned_serial_ports(return_value=[]):
         assert await async_setup_component(hass, DOMAIN, {"usb": {}})
 
         usb.async_register_port_event_callback(hass, mock_callback1)
@@ -1679,13 +1675,22 @@ async def test_removal_aborts_discovery_flows(
         assert final_flows[0]["handler"] == "test2"
 
 
+@pytest.mark.usefixtures("force_usb_polling_watcher")
 async def test_list_serial_ports(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    setup_usb: MagicMock,
 ) -> None:
     """Test listing serial ports via websocket."""
-    setup_usb.return_value = [
+    matchers = [
+        {
+            "description": "*skyconnect v1.0*",
+            "domain": "homeassistant_sky_connect",
+            "pid": "EA60",
+            "vid": "10C4",
+        },
+        {"domain": "custom_component", "vid": "DEAD", "pid": "BEEF"},
+    ]
+    mock_ports = [
         USBDevice(
             device="/dev/ttyUSB0",
             vid="10C4",
@@ -1697,6 +1702,22 @@ async def test_list_serial_ports(
             interface_description="CP2102 USB to UART Bridge",
             interface_num=0,
         ),
+        USBDevice(
+            device="/dev/ttyUSB1",
+            vid="DEAD",
+            pid="BEEF",
+            serial_number=None,
+            manufacturer=None,
+            description="Unknown adapter",
+        ),
+        USBDevice(
+            device="/dev/ttyUSB2",
+            vid="0000",
+            pid="0000",
+            serial_number=None,
+            manufacturer=None,
+            description="No matchers",
+        ),
         SerialDevice(
             device="/dev/ttyS0",
             serial_number=None,
@@ -1705,34 +1726,65 @@ async def test_list_serial_ports(
         ),
     ]
 
-    ws_client = await hass_ws_client(hass)
-    await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
-    response = await ws_client.receive_json()
+    with (
+        patch("homeassistant.components.usb.async_get_usb", return_value=matchers),
+        patch_scanned_serial_ports(return_value=mock_ports),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
+        await hass.async_block_till_done()
+
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/list_serial_ports"})
+        response = await ws_client.receive_json()
 
     assert response["success"]
-    result = response["result"]
-    assert len(result) == 2
-
-    assert result[0] == {
-        "device": "/dev/ttyUSB0",
-        "vid": "10C4",
-        "pid": "EA60",
-        "serial_number": "001234",
-        "manufacturer": "Silicon Labs",
-        "description": "CP2102 USB to UART",
-        "bcd_device": 257,
-        "interface_description": "CP2102 USB to UART Bridge",
-        "interface_num": 0,
-    }
-
-    assert result[1] == {
-        "device": "/dev/ttyS0",
-        "serial_number": None,
-        "manufacturer": None,
-        "description": "ttyS0",
-        "interface_description": None,
-        "interface_num": None,
-    }
+    assert response["result"] == [
+        {
+            "device": "/dev/ttyUSB0",
+            "vid": "10C4",
+            "pid": "EA60",
+            "serial_number": "001234",
+            "manufacturer": "Silicon Labs",
+            "description": "CP2102 USB to UART",
+            "bcd_device": 257,
+            "interface_description": "CP2102 USB to UART Bridge",
+            "interface_num": 0,
+            "matching_integrations": ["homeassistant_sky_connect"],
+        },
+        {
+            "device": "/dev/ttyUSB1",
+            "vid": "DEAD",
+            "pid": "BEEF",
+            "serial_number": None,
+            "manufacturer": None,
+            "description": "Unknown adapter",
+            "bcd_device": 257,
+            "interface_description": None,
+            "interface_num": None,
+            "matching_integrations": ["custom_component"],
+        },
+        {
+            "device": "/dev/ttyUSB2",
+            "vid": "0000",
+            "pid": "0000",
+            "serial_number": None,
+            "manufacturer": None,
+            "description": "No matchers",
+            "bcd_device": 257,
+            "interface_description": None,
+            "interface_num": None,
+            "matching_integrations": [],
+        },
+        {
+            "device": "/dev/ttyS0",
+            "serial_number": None,
+            "manufacturer": None,
+            "description": "ttyS0",
+            "interface_description": None,
+            "interface_num": None,
+            "matching_integrations": [],
+        },
+    ]
 
 
 async def test_list_serial_ports_require_admin(

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1127,6 +1127,17 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
     [
         (None, ("/dev/ttyUSB0", "/dev/ttyACM1", "COM3"), (None, 1, True)),
         ({}, ("/dev/ttyUSB0",), (None,)),
+        (
+            {
+                "extra_recommended_domains": [
+                    "homeassistant_yellow",
+                    "homeassistant_sky_connect",
+                ]
+            },
+            ("/dev/ttyUSB0",),
+            (None,),
+        ),
+        ({"extra_recommended_domains": []}, ("/dev/ttyUSB0",), (None,)),
     ],
 )
 def test_serial_port_selector_schema(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `extra_recommended_domains` to `SerialPortSelectorConfig` and `matching_integrations` to the WebSocket API response. These will allow frontend to visually highlight "recommended" ports in a port picker (those that would show up in discovery for the current integration) and to visually demote "not recommended" ports (those that are discovered by _other_ integrations).

`extra_recommended_domains` is used by ZHA to include serial ports from the Yellow, ZBT-1, and ZBT-2 integrations in its "recommended" list.

ZHA and Z-Wave have code specifically to exclude the ZWA-2 and ZBT-2 from one another. This change will allow us to do this in the frontend generically.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/51773

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
