### PR TITLE
Fix flaky gardena_bluetooth test_timeout_manufacturer_data

### DIFF
--- a/tests/components/gardena_bluetooth/test_config_flow.py
+++ b/tests/components/gardena_bluetooth/test_config_flow.py
@@ -146,6 +146,12 @@ async def test_timeout_manufacturer_data(
 
     inject_bluetooth_service_info(hass, MISSING_PRODUCT_SERVICE_INFO)
 
+    # The injected advertisement starts a bluetooth discovery flow which also
+    # calls async_get_manufacturer_data. Drain it first so it doesn't race
+    # with the user flow's own request.
+    await manufacturer_request_event.wait()
+    await scan_step()
+    await hass.async_block_till_done(wait_background_tasks=True)
     manufacturer_request_event.clear()
 
     async with asyncio.TaskGroup() as tg:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`tests/components/gardena_bluetooth/test_config_flow.py::test_timeout_manufacturer_data` is flaky and can hang the CI job, as seen in https://github.com/home-assistant/core/actions/runs/25057100718/job/73402201821?pr=162263.

`inject_bluetooth_service_info(hass, MISSING_PRODUCT_SERVICE_INFO)` triggers a background bluetooth discovery flow that also calls `async_get_manufacturer_data`. Both that flow and the user flow under test set the shared `manufacturer_request_event` on entry, so `event.wait()` returns whenever either one is reached first.

When the bluetooth discovery flow wins the race, `scan_step` advances frozen time and fires its `asyncio.timeout(15)` timer, but the user flow may not yet have registered its own timer. Because asyncio's loop time is frozen by the freezer, the user flow's timer is then never fired and `await task` hangs until the surrounding test/CI timeout.

This PR drains the bluetooth discovery flow's manufacturer data request first (wait for the event, time it out via `scan_step`, then `async_block_till_done(wait_background_tasks=True)`) before clearing the event and starting the user flow. With the discovery flow finished, only the user flow can set the event, and its timer is guaranteed to be registered before the second `scan_step` fires it.

Reproduction before the fix: `pytest tests/components/gardena_bluetooth/test_config_flow.py::test_timeout_manufacturer_data --count=200` hung within ~7 iterations.
After the fix: 1000 consecutive runs pass in ~91s with `--timeout=10`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->