### PR TITLE
Use enumerate instead of range(len()) in Duco fan speed list

### DIFF
--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -35,7 +35,7 @@ PRESET_AUTO = "auto"
 # again always round-trips to the same Duco state.
 _SPEED_LEVEL_PERCENTAGES: list[int] = [
     (i + 1) * 100 // len(ORDERED_NAMED_FAN_SPEEDS)
-    for i in range(len(ORDERED_NAMED_FAN_SPEEDS))
+    for i, _ in enumerate(ORDERED_NAMED_FAN_SPEEDS)
 ]
 
 # Maps every active Duco state (including timed MAN variants) to its


### PR DESCRIPTION
## Proposed change

Replace `range(len(ORDERED_NAMED_FAN_SPEEDS))` with `enumerate(ORDERED_NAMED_FAN_SPEEDS)` in the `_SPEED_LEVEL_PERCENTAGES` list comprehension in `homeassistant/components/duco/fan.py`.

`enumerate()` is the idiomatic Python way to iterate when an index is needed alongside the iterable. It removes a redundant call to `range(len(...))` and improves readability without changing behavior. The output of the list comprehension is identical before and after the change (verified: `[33, 66, 100]` for a 3-element input).

One-line change. No behavior change. No new dependencies.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr