### PR TITLE
iaqualink: add reconfigure flow

### DIFF
--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -13,7 +13,11 @@ from iaqualink.exception import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util.ssl import SSL_ALPN_HTTP11_HTTP2
@@ -84,12 +88,16 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle confirmation of reauthentication."""
         errors = {}
 
-        reauth_entry = self._get_reauth_entry()
+        config_entry = (
+            self._get_reconfigure_entry()
+            if self.source == SOURCE_RECONFIGURE
+            else self._get_reauth_entry()
+        )
         if user_input is not None:
             errors = await self._async_test_credentials(user_input)
             if not errors:
                 return self.async_update_reload_and_abort(
-                    reauth_entry,
+                    config_entry,
                     title=user_input[CONF_USERNAME],
                     data_updates={
                         CONF_USERNAME: user_input[CONF_USERNAME],
@@ -98,7 +106,15 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reauth_confirm",
+            step_id=(
+                "reconfigure" if self.source == SOURCE_RECONFIGURE else "reauth_confirm"
+            ),
             data_schema=CREDENTIALS_DATA_SCHEMA,
             errors=errors,
         )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        return await self.async_step_reauth_confirm(user_input)

--- a/homeassistant/components/iaqualink/quality_scale.yaml
+++ b/homeassistant/components/iaqualink/quality_scale.yaml
@@ -58,7 +58,7 @@ rules:
   entity-translations: todo
   exception-translations: todo
   icon-translations: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices: todo
 

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -3,7 +3,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -21,6 +22,18 @@
         },
         "description": "Please enter the username and password for your iAquaLink account.",
         "title": "Reauthenticate iAquaLink"
+      },
+      "reconfigure": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::iaqualink::config::step::user::data_description::password%]",
+          "username": "[%key:component::iaqualink::config::step::user::data_description::username%]"
+        },
+        "description": "Please enter the username and password for your iAquaLink account.",
+        "title": "Reconnect iAquaLink"
       },
       "user": {
         "data": {

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -20,7 +20,7 @@
           "password": "[%key:component::iaqualink::config::step::user::data_description::password%]",
           "username": "[%key:component::iaqualink::config::step::user::data_description::username%]"
         },
-        "description": "Please enter the username and password for your iAquaLink account.",
+        "description": "[%key:component::iaqualink::config::step::user::description%]",
         "title": "Reauthenticate iAquaLink"
       },
       "reconfigure": {
@@ -32,7 +32,7 @@
           "password": "[%key:component::iaqualink::config::step::user::data_description::password%]",
           "username": "[%key:component::iaqualink::config::step::user::data_description::username%]"
         },
-        "description": "Please enter the username and password for your iAquaLink account.",
+        "description": "[%key:component::iaqualink::config::step::user::description%]",
         "title": "Reconnect iAquaLink"
       },
       "user": {

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -203,6 +203,51 @@ async def test_reauth_success(hass: HomeAssistant, config_data: dict[str, str]) 
     }
 
 
+async def test_reconfigure_success(
+    hass: HomeAssistant, config_data: dict[str, str]
+) -> None:
+    """Test successful reconfiguration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=config_data[CONF_USERNAME],
+        data=config_data,
+    )
+    entry.add_to_hass(hass)
+
+    new_username = "updated@example.com"
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_reload",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: new_username, CONF_PASSWORD: "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.title == new_username
+    assert dict(entry.data) == {
+        **config_data,
+        CONF_USERNAME: new_username,
+        CONF_PASSWORD: "new_password",
+    }
+
+
 async def test_reauth_invalid_auth(
     hass: HomeAssistant, config_data: dict[str, str]
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The flow essentially triggers re-authentification.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
