### PR TITLE
Fix Acaia battery sensor going unavailable on first-session disconnect

### DIFF
--- a/homeassistant/components/acaia/sensor.py
+++ b/homeassistant/components/acaia/sensor.py
@@ -143,4 +143,4 @@ class AcaiaRestoreSensor(AcaiaEntity, RestoreSensor):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return super().available or self._restored_data is not None
+        return super().available or self.native_value is not None

--- a/tests/components/acaia/test_sensor.py
+++ b/tests/components/acaia/test_sensor.py
@@ -1,7 +1,9 @@
 """Test sensors for acaia integration."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import PERCENTAGE, Platform
@@ -12,6 +14,7 @@ from . import setup_integration
 
 from tests.common import (
     MockConfigEntry,
+    async_fire_time_changed,
     mock_restore_cache_with_extra_data,
     snapshot_platform,
 )
@@ -66,27 +69,23 @@ async def test_restore_state(
 async def test_battery_available_within_session_after_disconnect(
     hass: HomeAssistant,
     mock_scale: MagicMock,
+    freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test battery stays available on disconnect when no recorder data exists.
-    """
+    """Test battery stays available on disconnect when no restore data exists."""
     entity_id = "sensor.lunar_ddeeff_battery"
 
-    # No mock_restore_cache_with_extra_data: simulates a freshly-paired
-    # scale with no prior recorder history.
     await setup_integration(hass, mock_config_entry)
 
-    # Initial state: scale connected, battery 42 (from mock_scale fixture).
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "42"
 
-    # Simulate the scale disconnecting.
     mock_scale.connected = False
-    mock_config_entry.runtime_data.async_update_listeners()
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # Battery sensor should retain its last-known value, not go unavailable.
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "42"

--- a/tests/components/acaia/test_sensor.py
+++ b/tests/components/acaia/test_sensor.py
@@ -69,11 +69,6 @@ async def test_battery_available_within_session_after_disconnect(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test battery stays available on disconnect when no recorder data exists.
-
-    Regression test: a freshly-paired scale with no prior recorder history
-    should retain its last-known battery value when it disconnects, rather
-    than going unavailable. Before the fix, AcaiaRestoreSensor.available
-    returned False in this case because _restored_data was never populated.
     """
     entity_id = "sensor.lunar_ddeeff_battery"
 

--- a/tests/components/acaia/test_sensor.py
+++ b/tests/components/acaia/test_sensor.py
@@ -61,3 +61,37 @@ async def test_restore_state(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "65"
+
+
+async def test_battery_available_within_session_after_disconnect(
+    hass: HomeAssistant,
+    mock_scale: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test battery stays available on disconnect when no recorder data exists.
+
+    Regression test: a freshly-paired scale with no prior recorder history
+    should retain its last-known battery value when it disconnects, rather
+    than going unavailable. Before the fix, AcaiaRestoreSensor.available
+    returned False in this case because _restored_data was never populated.
+    """
+    entity_id = "sensor.lunar_ddeeff_battery"
+
+    # No mock_restore_cache_with_extra_data: simulates a freshly-paired
+    # scale with no prior recorder history.
+    await setup_integration(hass, mock_config_entry)
+
+    # Initial state: scale connected, battery 42 (from mock_scale fixture).
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "42"
+
+    # Simulate the scale disconnecting.
+    mock_scale.connected = False
+    mock_config_entry.runtime_data.async_update_listeners()
+    await hass.async_block_till_done()
+
+    # Battery sensor should retain its last-known value, not go unavailable.
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "42"


### PR DESCRIPTION
## Proposed change

Fixes a bug where the Acaia battery sensor goes `unavailable` immediately when a newly-paired scale disconnects, even though a valid battery reading was just received. The bug only affects devices in their first session before any recorder history exists; after one HA restart, behavior is correct.

`AcaiaRestoreSensor.available` previously checked `self._restored_data is not None`, but `_restored_data` is only populated once in `async_added_to_hass()` from the recorder. For a fresh device with no recorder history, `_restored_data` stays `None` for the entire session — so when the scale disconnects, `super().available` flips to `False`, and the entity goes unavailable despite having a valid `_attr_native_value` cached from `_handle_coordinator_update`.

The fix replaces the check with `self.native_value is not None`. This covers both paths: the cross-restart case (where `native_value` was populated from `_restored_data` in `async_added_to_hass`) and the within-session case (where `native_value` was populated by a live coordinator update). After a restart, behavior is identical to before — the recorder has the value, `_restored_data` populates, and `super().available` short-circuits anyway.

A regression test (`test_battery_available_within_session_after_disconnect`) is added that sets up the integration without `mock_restore_cache_with_extra_data` (simulating a fresh device), then flips `mock_scale.connected = False` and asserts the battery sensor retains its last-known value rather than going unavailable.

This PR supersedes #169395, which proposed the same one-line fix but did not include tests.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169351
- This PR supersedes: #169395
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:
- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr