### PR TITLE
Fix flaky test_alexa_config_expose_entity_prefs with Python 3.14.3

### DIFF
--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -113,7 +113,10 @@ async def test_alexa_config_expose_entity_prefs(
     conf = alexa_config.CloudAlexaConfig(
         hass, ALEXA_SCHEMA({}), "mock-user-id", cloud_prefs, cloud_stub
     )
+    assert "alexa" not in hass.config.components
     await conf.async_initialize()
+    await hass.async_block_till_done()
+    assert "alexa" in hass.config.components
 
     # an entity which is not in the entity registry can be exposed
     expose_entity(hass, "light.kitchen", True)
@@ -132,10 +135,6 @@ async def test_alexa_config_expose_entity_prefs(
     assert conf.should_expose(entity_entry5.entity_id)
 
     expose_entity(hass, entity_entry5.entity_id, None)
-    assert not conf.should_expose(entity_entry5.entity_id)
-
-    await hass.async_block_till_done()
-    assert "alexa" in hass.config.components
     assert not conf.should_expose(entity_entry5.entity_id)
 
 

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -134,7 +134,6 @@ async def test_alexa_config_expose_entity_prefs(
     expose_entity(hass, entity_entry5.entity_id, None)
     assert not conf.should_expose(entity_entry5.entity_id)
 
-    assert "alexa" not in hass.config.components
     await hass.async_block_till_done()
     assert "alexa" in hass.config.components
     assert not conf.should_expose(entity_entry5.entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Spotted in https://github.com/home-assistant/core/actions/runs/25091131329/job/73518027290?pr=162263

`tests/components/cloud/test_alexa_config.py::test_alexa_config_expose_entity_prefs` is flaky on Python 3.14.3 at the assertion:

```python
assert "alexa" not in hass.config.components
```

### Root cause

The test fixture creates `hass` with `CoreState.running`, so `hass.is_running` is `True`. When `conf.async_initialize()` calls `start.async_at_start(self.hass, on_hass_start)`, the callback is dispatched immediately via `hass.async_run_hass_job`, which creates an **eager task**.

The eager task awaits `async_setup_component("alexa", ...)`, which eventually awaits `hass.async_add_executor_job(_get_custom_components, hass)`. If the executor finishes before the coroutine reaches `await fut`, `fut.done()` is already `True` and the `await` does *not* suspend — the eager task runs straight through `hass.config.components.add("alexa")` synchronously, before control returns to the test.

On Python 3.14.3 this race is reliably lost when caches are warm: locally, `pytest --count 30` shows run 1 passing (executor cold) and runs 2–30 all failing.

### Fix

Move the `assert "alexa" not in hass.config.components` assertion to *before* `await conf.async_initialize()`, where it is deterministic — at that point `CloudAlexaConfig` has just been constructed and the eager task that sets up alexa has not yet been scheduled. The post-condition (`assert "alexa" in hass.config.components` after `async_block_till_done`) is moved up alongside it so the alexa-setup verification stays together at the top of the test, and the redundant trailing assertions are removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162263
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr