### PR TITLE
Add Axis doorbell event platform

### DIFF
--- a/homeassistant/components/axis/const.py
+++ b/homeassistant/components/axis/const.py
@@ -18,4 +18,10 @@ DEFAULT_STREAM_PROFILE = "No stream profile"
 DEFAULT_TRIGGER_TIME = 0
 DEFAULT_VIDEO_SOURCE = "No video source"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CAMERA, Platform.LIGHT, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CAMERA,
+    Platform.EVENT,
+    Platform.LIGHT,
+    Platform.SWITCH,
+]

--- a/homeassistant/components/axis/event.py
+++ b/homeassistant/components/axis/event.py
@@ -1,0 +1,76 @@
+"""Support for Axis event entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from axis.models.event import Event, EventTopic
+
+from homeassistant.components.event import (
+    DoorbellEventType,
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import AxisConfigEntry
+from .entity import AxisEventDescription, AxisEventEntity
+from .hub import AxisHub
+
+DOORBELL_MODEL = "I8116-E"
+DOORBELL_PORT = "0"
+
+
+@dataclass(frozen=True, kw_only=True)
+class AxisEventPlatformDescription(AxisEventDescription, EventEntityDescription):
+    """Axis event entity description."""
+
+
+@callback
+def doorbell_supported_fn(hub: AxisHub, event: Event) -> bool:
+    """Validate event is from the configured doorbell button input."""
+    return hub.config.model == DOORBELL_MODEL and event.id == DOORBELL_PORT
+
+
+@callback
+def doorbell_name_fn(_hub: AxisHub, _event: Event) -> str:
+    """Return the doorbell entity name."""
+    return "Doorbell"
+
+
+ENTITY_DESCRIPTIONS = (
+    AxisEventPlatformDescription(
+        key="Input port state",
+        device_class=EventDeviceClass.DOORBELL,
+        event_types=[DoorbellEventType.RING],
+        event_topic=EventTopic.PORT_INPUT,
+        name_fn=doorbell_name_fn,
+        supported_fn=doorbell_supported_fn,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: AxisConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up an Axis event platform."""
+    config_entry.runtime_data.entity_loader.register_platform(
+        async_add_entities, AxisEvent, ENTITY_DESCRIPTIONS
+    )
+
+
+class AxisEvent(AxisEventEntity, EventEntity):
+    """Representation of an Axis event entity."""
+
+    entity_description: AxisEventPlatformDescription
+
+    @callback
+    def async_event_callback(self, event: Event) -> None:
+        """Handle Axis event updates."""
+        if event.is_tripped:
+            self._trigger_event(DoorbellEventType.RING)
+            self.async_write_ha_state()

--- a/homeassistant/components/axis/event.py
+++ b/homeassistant/components/axis/event.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AxisConfigEntry
 from .entity import AxisEventDescription, AxisEventEntity
-from .hub import AxisHub
 
 DOORBELL_CONFIG = ("I8116-E", "0")
 
@@ -27,12 +26,6 @@ class AxisEventPlatformDescription(AxisEventDescription, EventEntityDescription)
     """Axis event entity description."""
 
 
-@callback
-def doorbell_supported_fn(hub: AxisHub, event: Event) -> bool:
-    """Validate event is from the configured doorbell button input."""
-    return (hub.config.model, event.id) == DOORBELL_CONFIG
-
-
 ENTITY_DESCRIPTIONS = (
     AxisEventPlatformDescription(
         key="Input port state",
@@ -40,7 +33,7 @@ ENTITY_DESCRIPTIONS = (
         event_types=[DoorbellEventType.RING],
         event_topic=EventTopic.PORT_INPUT,
         name_fn=lambda _hub, _event: "Doorbell",
-        supported_fn=doorbell_supported_fn,
+        supported_fn=lambda hub, event: (hub.config.model, event.id) == DOORBELL_CONFIG,
     ),
 )
 

--- a/homeassistant/components/axis/event.py
+++ b/homeassistant/components/axis/event.py
@@ -28,7 +28,7 @@ class AxisEventPlatformDescription(AxisEventDescription, EventEntityDescription)
 
 ENTITY_DESCRIPTIONS = (
     AxisEventPlatformDescription(
-        key="Input port state",
+        key="Doorbell",
         device_class=EventDeviceClass.DOORBELL,
         event_types=[DoorbellEventType.RING],
         event_topic=EventTopic.PORT_INPUT,

--- a/homeassistant/components/axis/event.py
+++ b/homeassistant/components/axis/event.py
@@ -34,19 +34,13 @@ def doorbell_supported_fn(hub: AxisHub, event: Event) -> bool:
     return hub.config.model == DOORBELL_MODEL and event.id == DOORBELL_PORT
 
 
-@callback
-def doorbell_name_fn(_hub: AxisHub, _event: Event) -> str:
-    """Return the doorbell entity name."""
-    return "Doorbell"
-
-
 ENTITY_DESCRIPTIONS = (
     AxisEventPlatformDescription(
         key="Input port state",
         device_class=EventDeviceClass.DOORBELL,
         event_types=[DoorbellEventType.RING],
         event_topic=EventTopic.PORT_INPUT,
-        name_fn=doorbell_name_fn,
+        name_fn=lambda _hub, _event: "Doorbell",
         supported_fn=doorbell_supported_fn,
     ),
 )

--- a/homeassistant/components/axis/event.py
+++ b/homeassistant/components/axis/event.py
@@ -19,8 +19,7 @@ from . import AxisConfigEntry
 from .entity import AxisEventDescription, AxisEventEntity
 from .hub import AxisHub
 
-DOORBELL_MODEL = "I8116-E"
-DOORBELL_PORT = "0"
+DOORBELL_CONFIG = ("I8116-E", "0")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -31,7 +30,7 @@ class AxisEventPlatformDescription(AxisEventDescription, EventEntityDescription)
 @callback
 def doorbell_supported_fn(hub: AxisHub, event: Event) -> bool:
     """Validate event is from the configured doorbell button input."""
-    return hub.config.model == DOORBELL_MODEL and event.id == DOORBELL_PORT
+    return (hub.config.model, event.id) == DOORBELL_CONFIG
 
 
 ENTITY_DESCRIPTIONS = (

--- a/tests/components/axis/test_event.py
+++ b/tests/components/axis/test_event.py
@@ -1,0 +1,93 @@
+"""Axis event platform tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.event import (
+    ATTR_EVENT_TYPE,
+    ATTR_EVENT_TYPES,
+    DOMAIN as EVENT_DOMAIN,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import ConfigEntryFactoryType, RtspEventMock
+
+
+async def test_doorbell_event_entity_created_and_triggered(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactoryType,
+    mock_rtsp_event: RtspEventMock,
+) -> None:
+    """Test doorbell event entity creation and trigger for matching model and port."""
+    with patch("homeassistant.components.axis.PLATFORMS", [Platform.EVENT]):
+        config_entry = await config_entry_factory()
+
+    config_entry.runtime_data.config.model = "I8116-E"
+
+    mock_rtsp_event(
+        topic="tns1:Device/tnsaxis:IO/Port",
+        data_type="state",
+        data_value="0",
+        operation="Initialized",
+        source_name="port",
+        source_idx="0",
+    )
+    await hass.async_block_till_done()
+
+    event_entities = hass.states.async_entity_ids(EVENT_DOMAIN)
+    assert len(event_entities) == 1
+
+    state = hass.states.get(event_entities[0])
+    assert state is not None
+    assert state.attributes[ATTR_EVENT_TYPES] == ["ring"]
+
+    mock_rtsp_event(
+        topic="tns1:Device/tnsaxis:IO/Port",
+        data_type="state",
+        data_value="1",
+        operation="Changed",
+        source_name="port",
+        source_idx="0",
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(event_entities[0])
+    assert state is not None
+    assert state.attributes[ATTR_EVENT_TYPE] == "ring"
+
+
+@pytest.mark.parametrize(
+    ("model", "topic", "source_idx"),
+    [
+        ("A1234", "tns1:Device/tnsaxis:IO/Port", "0"),
+        ("I8116-E", "tns1:Device/tnsaxis:IO/Port", "1"),
+        ("I8116-E", "tns1:Device/tnsaxis:Sensor/PIR", "0"),
+    ],
+)
+async def test_doorbell_event_entity_filtering(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactoryType,
+    mock_rtsp_event: RtspEventMock,
+    model: str,
+    topic: str,
+    source_idx: str,
+) -> None:
+    """Test doorbell event entity is filtered by model, topic and port."""
+    with patch("homeassistant.components.axis.PLATFORMS", [Platform.EVENT]):
+        config_entry = await config_entry_factory()
+
+    config_entry.runtime_data.config.model = model
+
+    mock_rtsp_event(
+        topic=topic,
+        data_type="state",
+        data_value="1",
+        operation="Initialized",
+        source_name="port",
+        source_idx=source_idx,
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids(EVENT_DOMAIN)) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add doorbell event to Axis integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45073
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
