### PR TITLE
Fix flaky test_tasks_logged_that_block_stage_2 with Python 3.14.3

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,7 +4,6 @@ import asyncio
 from collections.abc import Generator, Iterable
 import contextlib
 import glob
-import logging
 import os
 import sys
 from typing import Any
@@ -1280,14 +1279,14 @@ async def test_tasks_logged_that_block_stage_2(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we log tasks that delay stage 2 startup."""
-    done_future = hass.loop.create_future()
 
     def gen_domain_setup(domain):
         async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             async def _not_marked_background_task():
-                await done_future
+                await asyncio.sleep(0.2)
 
             hass.async_create_task(_not_marked_background_task())
+            await asyncio.sleep(0.1)
             return True
 
         return async_setup
@@ -1301,36 +1300,16 @@ async def test_tasks_logged_that_block_stage_2(
         ),
     )
 
-    wanted_messages = {
-        "Setup timed out for stage 2 waiting on",
-        "waiting on",
-        "_not_marked_background_task",
-    }
-
-    def on_message_logged(log_record: logging.LogRecord, *args):
-        for message in list(wanted_messages):
-            if message in log_record.message:
-                wanted_messages.remove(message)
-        if not done_future.done() and not wanted_messages:
-            done_future.set_result(None)
-            return
-
     with (
         patch.object(bootstrap, "STAGE_2_TIMEOUT", 0),
         patch.object(bootstrap, "COOLDOWN_TIME", 0),
-        patch.object(
-            caplog.handler,
-            "emit",
-            wraps=caplog.handler.emit,
-            side_effect=on_message_logged,
-        ),
     ):
         await bootstrap._async_set_up_integrations(hass, {"normal_integration": {}})
-        async with asyncio.timeout(2):
-            await done_future
         await hass.async_block_till_done()
 
-    assert not wanted_messages
+    assert "Setup timed out for stage 2 waiting on" in caplog.text
+    assert "waiting on" in caplog.text
+    assert "_not_marked_background_task" in caplog.text
 
 
 @pytest.mark.parametrize("load_registries", [False])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`test_tasks_logged_that_block_stage_2` was flaky with Python 3.14.3, e.g. https://github.com/home-assistant/core/actions/runs/25091559043/job/73519264798?pr=169418

The integration's `async_setup` returned `True` synchronously without yielding. With Python 3.14.3's faster asyncio, the stage 2 timer (scheduled at `loop.time() + 0` because `STAGE_2_TIMEOUT` is patched to `0`) never got a chance to fire before the body of `_async_setup_multi_components` completed. The test then hung in `await done_future` waiting for a `Setup timed out for stage 2 waiting on` log message that never came, until pytest-timeout killed it.

Mirror the working pattern of `test_tasks_logged_that_block_stage_1`: have `async_setup` `await asyncio.sleep(0.1)` so the timer reliably fires while the body is still running, and the orphan task uses `asyncio.sleep(0.2)` instead of an indefinite future. The complex `caplog.handler.emit` patching and `done_future` machinery are dropped in favor of a straightforward `caplog.text` assertion.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr