### PR TITLE
Copy unit_of_measurement onto energy inverted power sensor

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -715,6 +715,9 @@ class EnergyPowerSensor(SensorEntity):
                 self._attr_native_value = None
                 return
 
+            self._attr_native_unit_of_measurement = source_state.attributes.get(
+                ATTR_UNIT_OF_MEASUREMENT
+            )
             self._attr_native_value = value * -1
 
         elif self._is_combined:
@@ -763,13 +766,11 @@ class EnergyPowerSensor(SensorEntity):
             # Check first sensor
             if source_entry := entity_reg.async_get(self._source_sensors[0]):
                 device_id = source_entry.device_id
-                # For combined mode, always use Watts because we may have different source units; for inverted mode, copy source unit
+                # Combined mode always emits Watts because we convert
+                # heterogeneous source units internally. For inverted mode the
+                # unit is copied from the source state in _update_state.
                 if self._is_combined:
                     self._attr_native_unit_of_measurement = UnitOfPower.WATT
-                else:
-                    self._attr_native_unit_of_measurement = (
-                        source_entry.unit_of_measurement
-                    )
                 # Get source name from registry
                 source_name = source_entry.name or source_entry.original_name
             # Assign power sensor to same device as source sensor(s)

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -1427,6 +1427,92 @@ async def test_power_sensor_manager_creation(
     state = hass.states.get("sensor.battery_power_inverted")
     assert state is not None
     assert float(state.state) == -100.0
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
+
+
+async def test_power_sensor_inverted_propagates_unit(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """Test inverted power sensor copies unit from the source state."""
+    assert await async_setup_component(hass, "energy", {"energy": {}})
+    manager = await async_get_manager(hass)
+    manager.data = manager.default_preferences()
+
+    # Use a non-default unit to prove we copy from the source rather than
+    # hard-coding Watts.
+    hass.states.async_set(
+        "sensor.battery_power",
+        "1.5",
+        {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT},
+    )
+    await hass.async_block_till_done()
+
+    await manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "battery",
+                    "stat_energy_from": "sensor.battery_energy_from",
+                    "stat_energy_to": "sensor.battery_energy_to",
+                    "power_config": {
+                        "stat_rate_inverted": "sensor.battery_power",
+                    },
+                }
+            ],
+        }
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.battery_power_inverted")
+    assert state is not None
+    assert float(state.state) == -1.5
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.KILO_WATT
+
+    # Source switches to Watts — the inverted sensor should follow.
+    hass.states.async_set(
+        "sensor.battery_power",
+        "200.0",
+        {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.battery_power_inverted")
+    assert state is not None
+    assert float(state.state) == -200.0
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
+
+
+async def test_power_sensor_inverted_source_without_unit(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """Test inverted sensor reports no unit when source has none."""
+    assert await async_setup_component(hass, "energy", {"energy": {}})
+    manager = await async_get_manager(hass)
+    manager.data = manager.default_preferences()
+
+    hass.states.async_set("sensor.battery_power", "100.0")
+    await hass.async_block_till_done()
+
+    await manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "battery",
+                    "stat_energy_from": "sensor.battery_energy_from",
+                    "stat_energy_to": "sensor.battery_energy_to",
+                    "power_config": {
+                        "stat_rate_inverted": "sensor.battery_power",
+                    },
+                }
+            ],
+        }
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.battery_power_inverted")
+    assert state is not None
+    assert float(state.state) == -100.0
+    assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
 
 
 async def test_power_sensor_manager_cleanup(


### PR DESCRIPTION
## Proposed change

When the Energy dashboard's *invert* option is enabled on a battery power source, core auto-creates a `sensor.<source>_inverted` entity. Today the inverted sensor reads its unit from `RegistryEntry.unit_of_measurement`, which only holds **user overrides** — for almost every integration that field is `None`, so the inverted sensor ended up with no `unit_of_measurement` at all. The Energy graph then mis-scaled the value, and users had to work around it with `homeassistant.customize`.

This copies the unit from the source state's `ATTR_UNIT_OF_MEASUREMENT` inside `_update_state`, so it works regardless of whether the source is registry-customized and tracks unit changes on the source. Combined-mode behaviour is unchanged (still pinned to W, since it converts heterogeneous source units internally).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/frontend#30318
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr