### PR TITLE
Use all_devices in ViCare diagnostics for completeness

### DIFF
--- a/homeassistant/components/vicare/diagnostics.py
+++ b/homeassistant/components/vicare/diagnostics.py
@@ -23,7 +23,7 @@ async def async_get_config_entry_diagnostics(
         """Dump devices."""
         return [
             json.loads(device.dump_secure())
-            for device in entry.runtime_data.client.devices
+            for device in entry.runtime_data.client.all_devices
         ]
 
     return {

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -45,6 +45,7 @@ class MockPyViCare:
                     "Online",
                 )
             )
+        self.all_devices = self.devices
 
 
 class MockViCareService:

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -45,7 +45,23 @@ class MockPyViCare:
                     "Online",
                 )
             )
-        self.all_devices = self.devices
+        # Simulate a device with an unsupported deviceType that PyViCare's
+        # `devices` filter would drop but should still appear in `all_devices`
+        # (used by diagnostics).
+        self.all_devices = [
+            *self.devices,
+            PyViCareDeviceConfig(
+                MockViCareService(
+                    "installation_unsupported",
+                    "gateway_unsupported",
+                    "device_unsupported",
+                    Fixture(set(), "vicare/dummy-device-no-serial.json"),
+                ),
+                "deviceId_unsupported",
+                "unsupported_model",
+                "Online",
+            ),
+        ]
 
 
 class MockViCareService:

--- a/tests/components/vicare/snapshots/test_diagnostics.ambr
+++ b/tests/components/vicare/snapshots/test_diagnostics.ambr
@@ -4720,6 +4720,18 @@
           'type': None,
         }),
       }),
+      dict({
+        'data': list([
+        ]),
+        'device': dict({
+          'id': 'deviceId_unsupported',
+          'modelId': 'unsupported_model',
+          'roles': list([
+          ]),
+          'status': 'Online',
+          'type': None,
+        }),
+      }),
     ]),
     'entry': dict({
       'data': dict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Switch ViCare diagnostics from `client.devices` (filtered by `SUPPORTED_DEVICE_TYPES`) to `client.all_devices` (unfiltered superset).

`devices` only includes devices whose `deviceType` is in PyViCare's supported list. Devices with new/unknown `deviceType` (e.g. Vitoset Aqua with `domesticHotWater`) are silently dropped, which makes it harder to debug and add support for new device types.

`all_devices` was added in PyViCare 2.60.0 (openviess/PyViCare#750) for exactly this use case: diagnostics show every device, while entity setup keeps using the safe filtered list (no behavior change there).

This is the follow-up promised in #169401 (PyViCare 2.60.1 bump).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr