### PR TITLE
Fix flaky dsmr tests broken by Python 3.14.3 asyncio changes

### DIFF
--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -25,6 +25,9 @@ def dsmr_connection_fixture() -> Generator[tuple[MagicMock, MagicMock, MagicMock
     transport = MagicMock(spec=asyncio.Transport)
     protocol = MagicMock(spec=DSMRProtocol)
 
+    closed = asyncio.Event()
+    protocol.wait_closed = closed.wait
+
     async def connection_factory(*args, **kwargs):
         """Return mocked out Asyncio classes."""
         return (transport, protocol)
@@ -42,6 +45,7 @@ def dsmr_connection_fixture() -> Generator[tuple[MagicMock, MagicMock, MagicMock
         ),
     ):
         yield (connection_factory, transport, protocol)
+        closed.set()
 
 
 @pytest.fixture
@@ -52,6 +56,9 @@ def rfxtrx_dsmr_connection_fixture() -> Generator[
 
     transport = MagicMock(spec=asyncio.Transport)
     protocol = MagicMock(spec=RFXtrxDSMRProtocol)
+
+    closed = asyncio.Event()
+    protocol.wait_closed = closed.wait
 
     async def connection_factory(*args, **kwargs):
         """Return mocked out Asyncio classes."""
@@ -70,6 +77,7 @@ def rfxtrx_dsmr_connection_fixture() -> Generator[
         ),
     ):
         yield (connection_factory, transport, protocol)
+        closed.set()
 
 
 @pytest.fixture

--- a/tests/components/dsmr/test_diagnostics.py
+++ b/tests/components/dsmr/test_diagnostics.py
@@ -10,7 +10,6 @@ from dsmr_parser.obis_references import (
     GAS_METER_READING,
 )
 from dsmr_parser.objects import CosemObject, MBusObject, Telegram
-import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
@@ -20,9 +19,6 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
-@pytest.mark.xfail(
-    reason="Flaky due to Python 3.14.3 asyncio changes - see home-assistant/core#162263"
-)
 async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -51,9 +51,6 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, patch
 
 
-@pytest.mark.xfail(
-    reason="Flaky due to Python 3.14.3 asyncio changes - see home-assistant/core#162263"
-)
 async def test_default_setup(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Re-enables the two `dsmr` tests that were marked `@pytest.mark.xfail` in #169064 due to flakiness introduced by the Python 3.14.3 asyncio scheduling change ([#162263](https://github.com/home-assistant/core/pull/162263)):

- `tests/components/dsmr/test_sensor.py::test_default_setup`
- `tests/components/dsmr/test_diagnostics.py::test_diagnostics`

### Root cause

`MagicMock(spec=DSMRProtocol)` auto-generates an `AsyncMock` for `wait_closed()` that returns immediately when awaited. The `connect_and_reconnect` task in `homeassistant/components/dsmr/sensor.py` therefore treats the test's mocked connection as an immediate disconnect and falls through to `update_entities_telegram(None)` (line 846), which marks every entity unavailable. The Python 3.14.3 asyncio scheduling change shifted *when* the task progresses past `await reader_factory()` / `await protocol.wait_closed()` relative to the test's `await hass.async_block_till_done()` calls — so this disconnect path now runs *after* the test set state via `telegram_callback`, overwriting it with `unavailable`.

### Fix

Make `protocol.wait_closed` block on an `asyncio.Event` in `dsmr_connection_fixture` (and the rfxtrx variant), released on fixture teardown. This mirrors a real connected protocol — `wait_closed` only returns when the connection actually closes — so `connect_and_reconnect` stays parked at `await protocol.wait_closed()` for the duration of the test, exactly as it would in production.

The production code is left untouched.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169065
- This PR is related to issue: #162263, #169064
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->