### PR TITLE
Fix race in Ping device tracker device lookup

### DIFF
--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -77,6 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PingConfigEntry) -> bool
     dr.async_get(hass).async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
+        manufacturer="Ping",
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -71,6 +71,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: PingConfigEntry) -> bool
 
     entry.runtime_data = coordinator
 
+    # Ensure the device exists before forwarding to platforms, so that the
+    # device tracker (which looks up the device on init) is not racing the
+    # binary sensor / sensor platforms that create the device via DeviceInfo.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True


### PR DESCRIPTION
## Breaking change


## Proposed change

`PingDeviceTracker.__init__` looks up the Ping device by identifier and
assigns `self.device_entry`, but the device is only created when the
binary sensor / sensor entities (which use `_attr_device_info`) are
added to a platform. Since `async_forward_entry_setups` runs platforms
concurrently via `asyncio.gather` with eager tasks, ordering is
non-deterministic — when `device_tracker` runs first, the device does
not yet exist, `self.device_entry` is never set, and the entity
registry entry's `device_id` ends up `None`. This makes
`tests/components/ping/test_device_tracker.py::test_setup_and_update`
flaky (e.g. https://github.com/home-assistant/core/actions/runs/25095604857/job/73532653265).

Pre-create the device in `async_setup_entry` before forwarding to
platforms so the lookup always succeeds regardless of platform setup
ordering.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr