### PR TITLE
Remove stateclass from blebox powerConsumption sensor

### DIFF
--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -1,14 +1,16 @@
 """BleBox sensor entities."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import blebox_uniapi.sensor
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
+    StateType,
 )
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -26,9 +28,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from . import BleBoxConfigEntry
 from .entity import BleBoxEntity
+
+SCAN_INTERVAL = timedelta(seconds=5)
+
 
 SENSOR_TYPES = (
     SensorEntityDescription(
@@ -53,9 +59,10 @@ SENSOR_TYPES = (
     ),
     SensorEntityDescription(
         key="powerConsumption",
-        device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        icon="mdi:lightning-bolt",
     ),
     SensorEntityDescription(
         key="humidity",
@@ -114,6 +121,15 @@ SENSOR_TYPES = (
     ),
 )
 
+TOTAL_ENERGY_DESCRIPTION = SensorEntityDescription(
+    key="totalEnergy",
+    device_class=SensorDeviceClass.ENERGY,
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    state_class=SensorStateClass.TOTAL,
+)
+
+_MAX_ELAPSED_S = 30
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -121,11 +137,18 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox entry."""
-    entities = [
+    sensors = config_entry.runtime_data.features.get("sensors", [])
+    entities: list[BleBoxSensorEntity | BleBoxEnergySensor] = [
         BleBoxSensorEntity(feature, description)
-        for feature in config_entry.runtime_data.features.get("sensors", [])
+        for feature in sensors
         for description in SENSOR_TYPES
         if description.key == feature.device_class
+    ]
+    entities += [
+        BleBoxEnergySensor(feature, TOTAL_ENERGY_DESCRIPTION)
+        for feature in sensors
+        if feature.device_class == "activePower"
+        and feature.product.type in ("switchBox", "switchBoxD")
     ]
     async_add_entities(entities, True)
 
@@ -150,6 +173,67 @@ class BleBoxSensorEntity(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], SensorEn
     @property
     def last_reset(self) -> datetime | None:
         """Return the time when the sensor was last reset, if implemented."""
+        if self.state_class != SensorStateClass.TOTAL:
+            return None
         native_implementation = getattr(self._feature, "last_reset", None)
-
         return native_implementation or super().last_reset
+
+
+class BleBoxEnergySensor(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], RestoreSensor):
+    """Energy sensor that accumulates kWh from activePower using the trapezoidal rule."""
+
+    def __init__(
+        self,
+        feature: blebox_uniapi.sensor.BaseSensor,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the energy sensor."""
+        super().__init__(feature)
+        self.entity_description = description
+        self._attr_unique_id = f"{feature.unique_id}-totalenergy"
+        self._attr_name = f"{feature.product.name} ({feature.product.type}#totalEnergy)"
+        self._energy: float = 0.0
+        self._last_power_w: float | None = None
+        self._last_update: datetime | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore accumulated energy on restart."""
+        await super().async_added_to_hass()
+        if last_data := await self.async_get_last_sensor_data():
+            if last_data.native_value is not None:
+                self._energy = float(str(last_data.native_value))
+
+    @property
+    def native_value(self) -> StateType:
+        """Return accumulated energy in kWh."""
+        return self._energy
+
+    async def async_update(self) -> None:
+        """Accumulate energy using trapezoidal integration of activePower."""
+        await super().async_update()
+
+        power_w = self._feature.native_value
+        now = dt_util.utcnow()
+
+        if power_w is None:
+            self._last_update = now
+            self._last_power_w = None
+            return
+
+        if self._last_update is None:
+            self._last_power_w = power_w
+            self._last_update = now
+            return
+
+        elapsed_s = (now - self._last_update).total_seconds()
+
+        if elapsed_s > _MAX_ELAPSED_S:
+            self._last_power_w = power_w
+            self._last_update = now
+            return
+
+        avg_power = (self._last_power_w + power_w) / 2
+        self._energy += avg_power * elapsed_s / 3_600_000
+
+        self._last_power_w = power_w
+        self._last_update = now

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -1,5 +1,6 @@
 """BleBox sensor entities."""
 
+from contextlib import suppress
 from datetime import datetime, timedelta
 
 import blebox_uniapi.sensor
@@ -125,7 +126,7 @@ TOTAL_ENERGY_DESCRIPTION = SensorEntityDescription(
     key="totalEnergy",
     device_class=SensorDeviceClass.ENERGY,
     native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-    state_class=SensorStateClass.TOTAL_INCREASING,
+    state_class=SensorStateClass.TOTAL,
 )
 
 _MAX_ELAPSED_S = 30
@@ -201,7 +202,8 @@ class BleBoxEnergySensor(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], RestoreS
         await super().async_added_to_hass()
         if last_data := await self.async_get_last_sensor_data():
             if last_data.native_value is not None:
-                self._energy = float(str(last_data.native_value))
+                with suppress(ValueError, TypeError):
+                    self._energy = float(str(last_data.native_value))
 
     @property
     def native_value(self) -> StateType:
@@ -227,7 +229,7 @@ class BleBoxEnergySensor(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], RestoreS
 
         elapsed_s = (now - self._last_update).total_seconds()
 
-        if elapsed_s > _MAX_ELAPSED_S:
+        if elapsed_s <= 0 or elapsed_s > _MAX_ELAPSED_S:
             self._last_power_w = power_w
             self._last_update = now
             return

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -125,7 +125,7 @@ TOTAL_ENERGY_DESCRIPTION = SensorEntityDescription(
     key="totalEnergy",
     device_class=SensorDeviceClass.ENERGY,
     native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-    state_class=SensorStateClass.TOTAL,
+    state_class=SensorStateClass.TOTAL_INCREASING,
 )
 
 _MAX_ELAPSED_S = 30

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -216,8 +216,8 @@ class BleBoxEnergySensor(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], RestoreS
         now = dt_util.utcnow()
 
         if power_w is None:
-            self._last_update = now
             self._last_power_w = None
+            self._last_update = None
             return
 
         if self._last_update is None:

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -1,17 +1,14 @@
 """BleBox sensor entities."""
 
-from contextlib import suppress
 from datetime import datetime, timedelta
 
 import blebox_uniapi.sensor
 
 from homeassistant.components.sensor import (
-    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
-    StateType,
 )
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -29,7 +26,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util import dt as dt_util
 
 from . import BleBoxConfigEntry
 from .entity import BleBoxEntity
@@ -61,7 +57,6 @@ SENSOR_TYPES = (
     SensorEntityDescription(
         key="powerConsumption",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         icon="mdi:lightning-bolt",
     ),
@@ -122,15 +117,6 @@ SENSOR_TYPES = (
     ),
 )
 
-TOTAL_ENERGY_DESCRIPTION = SensorEntityDescription(
-    key="totalEnergy",
-    device_class=SensorDeviceClass.ENERGY,
-    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-    state_class=SensorStateClass.TOTAL,
-)
-
-_MAX_ELAPSED_S = 30
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -138,18 +124,11 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox entry."""
-    sensors = config_entry.runtime_data.features.get("sensors", [])
-    entities: list[BleBoxSensorEntity | BleBoxEnergySensor] = [
+    entities = [
         BleBoxSensorEntity(feature, description)
-        for feature in sensors
+        for feature in config_entry.runtime_data.features.get("sensors", [])
         for description in SENSOR_TYPES
         if description.key == feature.device_class
-    ]
-    entities += [
-        BleBoxEnergySensor(feature, TOTAL_ENERGY_DESCRIPTION)
-        for feature in sensors
-        if feature.device_class == "activePower"
-        and feature.product.type in ("switchBox", "switchBoxD")
     ]
     async_add_entities(entities, True)
 
@@ -178,64 +157,3 @@ class BleBoxSensorEntity(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], SensorEn
             return None
         native_implementation = getattr(self._feature, "last_reset", None)
         return native_implementation or super().last_reset
-
-
-class BleBoxEnergySensor(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], RestoreSensor):
-    """Energy sensor that accumulates kWh from activePower using the trapezoidal rule."""
-
-    def __init__(
-        self,
-        feature: blebox_uniapi.sensor.BaseSensor,
-        description: SensorEntityDescription,
-    ) -> None:
-        """Initialize the energy sensor."""
-        super().__init__(feature)
-        self.entity_description = description
-        self._attr_unique_id = f"{feature.unique_id}-totalenergy"
-        self._attr_name = f"{feature.product.name} ({feature.product.type}#totalEnergy)"
-        self._energy: float = 0.0
-        self._last_power_w: float | None = None
-        self._last_update: datetime | None = None
-
-    async def async_added_to_hass(self) -> None:
-        """Restore accumulated energy on restart."""
-        await super().async_added_to_hass()
-        if last_data := await self.async_get_last_sensor_data():
-            if last_data.native_value is not None:
-                with suppress(ValueError, TypeError):
-                    self._energy = float(str(last_data.native_value))
-
-    @property
-    def native_value(self) -> StateType:
-        """Return accumulated energy in kWh."""
-        return self._energy
-
-    async def async_update(self) -> None:
-        """Accumulate energy using trapezoidal integration of activePower."""
-        await super().async_update()
-
-        power_w = self._feature.native_value
-        now = dt_util.utcnow()
-
-        if power_w is None:
-            self._last_power_w = None
-            self._last_update = None
-            return
-
-        if self._last_update is None:
-            self._last_power_w = power_w
-            self._last_update = now
-            return
-
-        elapsed_s = (now - self._last_update).total_seconds()
-
-        if elapsed_s <= 0 or elapsed_s > _MAX_ELAPSED_S:
-            self._last_power_w = power_w
-            self._last_update = now
-            return
-
-        avg_power = (self._last_power_w + power_w) / 2
-        self._energy += avg_power * elapsed_s / 3_600_000
-
-        self._last_power_w = power_w
-        self._last_update = now

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -344,3 +344,35 @@ async def test_energy_sensor_restore(switchbox, hass: HomeAssistant) -> None:
     state = hass.states.get(energy_entity_id)
     delta = (500 + 500) / 2 * 5 / 3_600_000
     assert float(state.state) == pytest.approx(1.5 + delta, rel=1e-4)
+
+
+async def test_energy_sensor_none_to_numeric_transition(
+    switchbox, hass: HomeAssistant
+) -> None:
+    """Test that a None power reading followed by a numeric reading does not crash."""
+    feature_mock, power_entity_id, energy_entity_id = switchbox
+
+    t0 = utcnow()
+    t1 = t0 + timedelta(seconds=5)
+
+    feature_mock.native_value = None
+    feature_mock.async_update = AsyncMock()
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
+    ):
+        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
+
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
+    energy_entity = entities[energy_entity_id]
+
+    feature_mock.native_value = 1000.0
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t1
+    ):
+        await energy_entity.async_update()
+        energy_entity.async_write_ha_state()
+
+    state = hass.states.get(energy_entity_id)
+    assert state.state == "0.0"

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -1,29 +1,23 @@
 """Blebox sensors tests."""
 
-from datetime import timedelta
 import logging
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock
 
 import blebox_uniapi
 import pytest
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     STATE_UNKNOWN,
-    UnitOfEnergy,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
-from homeassistant.util.dt import utcnow
 
-from .conftest import async_setup_entities, async_setup_entity, mock_feature
-
-from tests.common import mock_restore_cache_with_extra_data
+from .conftest import async_setup_entity, mock_feature
 
 
 @pytest.fixture(name="airsensor")
@@ -61,27 +55,6 @@ def tempsensor_fixture():
     type(product).name = PropertyMock(return_value="My temperature sensor")
     type(product).model = PropertyMock(return_value="tempSensor")
     return (feature, "sensor.my_temperature_sensor_tempsensor_0_temperature")
-
-
-@pytest.fixture(name="switchbox")
-def switchbox_fixture():
-    """Return a switchBox activePower sensor mock (produces both power + energy entities)."""
-    feature = mock_feature(
-        "sensors",
-        blebox_uniapi.sensor.BaseSensor,
-        unique_id="BleBox-switchBox-1afe34db9437-0.activePower",
-        full_name="switchBox-0.activePower",
-        device_class="activePower",
-        unit="W",
-        native_value=None,
-    )
-    product = feature.product
-    type(product).name = PropertyMock(return_value="My switch box")
-    type(product).model = PropertyMock(return_value="switchBox")
-    type(product).type = PropertyMock(return_value="switchBox")
-    power_entity_id = "sensor.my_switch_box_switchbox_0_activepower"
-    energy_entity_id = "sensor.my_switch_box_switchbox_totalenergy"
-    return (feature, power_entity_id, energy_entity_id)
 
 
 async def test_init(
@@ -181,198 +154,3 @@ async def test_airsensor_update(airsensor, hass: HomeAssistant) -> None:
     )
 
     assert state.state == "49"
-
-
-async def test_power_consumption_state_class(hass: HomeAssistant) -> None:
-    """Test that powerConsumption sensor has MEASUREMENT state class."""
-    feature = mock_feature(
-        "sensors",
-        blebox_uniapi.sensor.BaseSensor,
-        unique_id="BleBox-switchBox-1afe34db9437-0.powerConsumption",
-        full_name="switchBox-0.powerConsumption",
-        device_class="powerConsumption",
-        unit="kWh",
-        native_value=None,
-    )
-    product = feature.product
-    type(product).name = PropertyMock(return_value="My switch box")
-    type(product).model = PropertyMock(return_value="switchBox")
-
-    entity_id = "sensor.my_switch_box_switchbox_0_powerconsumption"
-    entry = await async_setup_entity(hass, entity_id)
-    assert entry is not None
-
-    state = hass.states.get(entity_id)
-    assert state.attributes.get("state_class") == SensorStateClass.MEASUREMENT
-
-
-async def test_energy_sensor_init(switchbox, hass: HomeAssistant) -> None:
-    """Test energy sensor initial state is 0.0 with TOTAL state class."""
-    feature_mock, power_entity_id, energy_entity_id = switchbox
-
-    feature_mock.native_value = 0.0
-    await async_setup_entities(hass, [power_entity_id, energy_entity_id])
-
-    state = hass.states.get(energy_entity_id)
-    assert state is not None
-    assert state.state == "0.0"
-    assert state.attributes.get("state_class") == SensorStateClass.TOTAL
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
-
-
-async def test_energy_sensor_first_update_no_accumulation(
-    switchbox, hass: HomeAssistant
-) -> None:
-    """Test that the first update only seeds the baseline without accumulating energy."""
-    feature_mock, power_entity_id, energy_entity_id = switchbox
-
-    t0 = utcnow()
-
-    def initial_update():
-        feature_mock.native_value = 1000.0
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
-    ):
-        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
-
-    state = hass.states.get(energy_entity_id)
-    assert state.state == "0.0"
-
-
-async def test_energy_sensor_accumulates_after_second_update(
-    switchbox, hass: HomeAssistant
-) -> None:
-    """Test energy accumulation via trapezoidal rule after two consecutive polls 5s apart."""
-    feature_mock, power_entity_id, energy_entity_id = switchbox
-
-    t0 = utcnow()
-    t1 = t0 + timedelta(seconds=5)
-
-    feature_mock.native_value = 1000.0
-    feature_mock.async_update = AsyncMock()
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
-    ):
-        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
-
-    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
-    energy_entity = entities[energy_entity_id]
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t1
-    ):
-        await energy_entity.async_update()
-        energy_entity.async_write_ha_state()
-
-    state = hass.states.get(energy_entity_id)
-    expected = (1000 + 1000) / 2 * 5 / 3_600_000
-    assert float(state.state) == pytest.approx(expected, rel=1e-4)
-
-
-async def test_energy_sensor_skips_long_gap(switchbox, hass: HomeAssistant) -> None:
-    """Test that an elapsed gap > 30 s resets context without accumulating."""
-    feature_mock, power_entity_id, energy_entity_id = switchbox
-
-    t0 = utcnow()
-    t_gap = t0 + timedelta(seconds=31)
-
-    feature_mock.native_value = 1000.0
-    feature_mock.async_update = AsyncMock()
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
-    ):
-        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
-
-    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
-    energy_entity = entities[energy_entity_id]
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t_gap
-    ):
-        await energy_entity.async_update()
-        energy_entity.async_write_ha_state()
-
-    state = hass.states.get(energy_entity_id)
-    assert state.state == "0.0"
-
-
-async def test_energy_sensor_restore(switchbox, hass: HomeAssistant) -> None:
-    """Test that accumulated energy is restored after a restart."""
-    feature_mock, power_entity_id, energy_entity_id = switchbox
-
-    feature_mock.native_value = 500.0
-    feature_mock.async_update = AsyncMock()
-
-    mock_restore_cache_with_extra_data(
-        hass,
-        [
-            (
-                State(energy_entity_id, "1.5"),
-                {
-                    "native_value": "1.5",
-                    "native_unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
-                },
-            )
-        ],
-    )
-
-    t0 = utcnow()
-    t1 = t0 + timedelta(seconds=5)
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
-    ):
-        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
-
-    state = hass.states.get(energy_entity_id)
-    assert float(state.state) == pytest.approx(1.5)
-
-    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
-    energy_entity = entities[energy_entity_id]
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t1
-    ):
-        await energy_entity.async_update()
-        energy_entity.async_write_ha_state()
-
-    state = hass.states.get(energy_entity_id)
-    delta = (500 + 500) / 2 * 5 / 3_600_000
-    assert float(state.state) == pytest.approx(1.5 + delta, rel=1e-4)
-
-
-async def test_energy_sensor_none_to_numeric_transition(
-    switchbox, hass: HomeAssistant
-) -> None:
-    """Test that a None power reading followed by a numeric reading does not crash."""
-    feature_mock, power_entity_id, energy_entity_id = switchbox
-
-    t0 = utcnow()
-    t1 = t0 + timedelta(seconds=5)
-
-    feature_mock.native_value = None
-    feature_mock.async_update = AsyncMock()
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
-    ):
-        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
-
-    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
-    energy_entity = entities[energy_entity_id]
-
-    feature_mock.native_value = 1000.0
-
-    with patch(
-        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t1
-    ):
-        await energy_entity.async_update()
-        energy_entity.async_write_ha_state()
-
-    state = hass.states.get(energy_entity_id)
-    assert state.state == "0.0"

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -207,7 +207,7 @@ async def test_power_consumption_state_class(hass: HomeAssistant) -> None:
 
 
 async def test_energy_sensor_init(switchbox, hass: HomeAssistant) -> None:
-    """Test energy sensor initial state is 0.0 with TOTAL state class."""
+    """Test energy sensor initial state is 0.0 with TOTAL_INCREASING state class."""
     feature_mock, power_entity_id, energy_entity_id = switchbox
 
     feature_mock.native_value = 0.0
@@ -216,7 +216,7 @@ async def test_energy_sensor_init(switchbox, hass: HomeAssistant) -> None:
     state = hass.states.get(energy_entity_id)
     assert state is not None
     assert state.state == "0.0"
-    assert state.attributes.get("state_class") == SensorStateClass.TOTAL
+    assert state.attributes.get("state_class") == SensorStateClass.TOTAL_INCREASING
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
 
 

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -1,23 +1,29 @@
 """Blebox sensors tests."""
 
+from datetime import timedelta
 import logging
-from unittest.mock import AsyncMock, PropertyMock
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import blebox_uniapi
 import pytest
 
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     STATE_UNKNOWN,
+    UnitOfEnergy,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
+from homeassistant.util.dt import utcnow
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_entities, async_setup_entity, mock_feature
+
+from tests.common import mock_restore_cache_with_extra_data
 
 
 @pytest.fixture(name="airsensor")
@@ -55,6 +61,27 @@ def tempsensor_fixture():
     type(product).name = PropertyMock(return_value="My temperature sensor")
     type(product).model = PropertyMock(return_value="tempSensor")
     return (feature, "sensor.my_temperature_sensor_tempsensor_0_temperature")
+
+
+@pytest.fixture(name="switchbox")
+def switchbox_fixture():
+    """Return a switchBox activePower sensor mock (produces both power + energy entities)."""
+    feature = mock_feature(
+        "sensors",
+        blebox_uniapi.sensor.BaseSensor,
+        unique_id="BleBox-switchBox-1afe34db9437-0.activePower",
+        full_name="switchBox-0.activePower",
+        device_class="activePower",
+        unit="W",
+        native_value=None,
+    )
+    product = feature.product
+    type(product).name = PropertyMock(return_value="My switch box")
+    type(product).model = PropertyMock(return_value="switchBox")
+    type(product).type = PropertyMock(return_value="switchBox")
+    power_entity_id = "sensor.my_switch_box_switchbox_0_activepower"
+    energy_entity_id = "sensor.my_switch_box_switchbox_totalenergy"
+    return (feature, power_entity_id, energy_entity_id)
 
 
 async def test_init(
@@ -154,3 +181,166 @@ async def test_airsensor_update(airsensor, hass: HomeAssistant) -> None:
     )
 
     assert state.state == "49"
+
+
+async def test_power_consumption_state_class(hass: HomeAssistant) -> None:
+    """Test that powerConsumption sensor has MEASUREMENT state class."""
+    feature = mock_feature(
+        "sensors",
+        blebox_uniapi.sensor.BaseSensor,
+        unique_id="BleBox-switchBox-1afe34db9437-0.powerConsumption",
+        full_name="switchBox-0.powerConsumption",
+        device_class="powerConsumption",
+        unit="kWh",
+        native_value=None,
+    )
+    product = feature.product
+    type(product).name = PropertyMock(return_value="My switch box")
+    type(product).model = PropertyMock(return_value="switchBox")
+
+    entity_id = "sensor.my_switch_box_switchbox_0_powerconsumption"
+    entry = await async_setup_entity(hass, entity_id)
+    assert entry is not None
+
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("state_class") == SensorStateClass.MEASUREMENT
+
+
+async def test_energy_sensor_init(switchbox, hass: HomeAssistant) -> None:
+    """Test energy sensor initial state is 0.0 with TOTAL state class."""
+    feature_mock, power_entity_id, energy_entity_id = switchbox
+
+    feature_mock.native_value = 0.0
+    await async_setup_entities(hass, [power_entity_id, energy_entity_id])
+
+    state = hass.states.get(energy_entity_id)
+    assert state is not None
+    assert state.state == "0.0"
+    assert state.attributes.get("state_class") == SensorStateClass.TOTAL
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
+
+
+async def test_energy_sensor_first_update_no_accumulation(
+    switchbox, hass: HomeAssistant
+) -> None:
+    """Test that the first update only seeds the baseline without accumulating energy."""
+    feature_mock, power_entity_id, energy_entity_id = switchbox
+
+    t0 = utcnow()
+
+    def initial_update():
+        feature_mock.native_value = 1000.0
+
+    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
+    ):
+        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
+
+    state = hass.states.get(energy_entity_id)
+    assert state.state == "0.0"
+
+
+async def test_energy_sensor_accumulates_after_second_update(
+    switchbox, hass: HomeAssistant
+) -> None:
+    """Test energy accumulation via trapezoidal rule after two consecutive polls 5s apart."""
+    feature_mock, power_entity_id, energy_entity_id = switchbox
+
+    t0 = utcnow()
+    t1 = t0 + timedelta(seconds=5)
+
+    feature_mock.native_value = 1000.0
+    feature_mock.async_update = AsyncMock()
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
+    ):
+        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
+
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
+    energy_entity = entities[energy_entity_id]
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t1
+    ):
+        await energy_entity.async_update()
+        energy_entity.async_write_ha_state()
+
+    state = hass.states.get(energy_entity_id)
+    expected = (1000 + 1000) / 2 * 5 / 3_600_000
+    assert float(state.state) == pytest.approx(expected, rel=1e-4)
+
+
+async def test_energy_sensor_skips_long_gap(switchbox, hass: HomeAssistant) -> None:
+    """Test that an elapsed gap > 30 s resets context without accumulating."""
+    feature_mock, power_entity_id, energy_entity_id = switchbox
+
+    t0 = utcnow()
+    t_gap = t0 + timedelta(seconds=31)
+
+    feature_mock.native_value = 1000.0
+    feature_mock.async_update = AsyncMock()
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
+    ):
+        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
+
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
+    energy_entity = entities[energy_entity_id]
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t_gap
+    ):
+        await energy_entity.async_update()
+        energy_entity.async_write_ha_state()
+
+    state = hass.states.get(energy_entity_id)
+    assert state.state == "0.0"
+
+
+async def test_energy_sensor_restore(switchbox, hass: HomeAssistant) -> None:
+    """Test that accumulated energy is restored after a restart."""
+    feature_mock, power_entity_id, energy_entity_id = switchbox
+
+    feature_mock.native_value = 500.0
+    feature_mock.async_update = AsyncMock()
+
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(energy_entity_id, "1.5"),
+                {
+                    "native_value": "1.5",
+                    "native_unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+                },
+            )
+        ],
+    )
+
+    t0 = utcnow()
+    t1 = t0 + timedelta(seconds=5)
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t0
+    ):
+        await async_setup_entities(hass, [power_entity_id, energy_entity_id])
+
+    state = hass.states.get(energy_entity_id)
+    assert float(state.state) == pytest.approx(1.5)
+
+    entities = hass.data[DATA_DOMAIN_PLATFORM_ENTITIES][("sensor", "blebox")]
+    energy_entity = entities[energy_entity_id]
+
+    with patch(
+        "homeassistant.components.blebox.sensor.dt_util.utcnow", return_value=t1
+    ):
+        await energy_entity.async_update()
+        energy_entity.async_write_ha_state()
+
+    state = hass.states.get(energy_entity_id)
+    delta = (500 + 500) / 2 * 5 / 3_600_000
+    assert float(state.state) == pytest.approx(1.5 + delta, rel=1e-4)

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -207,7 +207,7 @@ async def test_power_consumption_state_class(hass: HomeAssistant) -> None:
 
 
 async def test_energy_sensor_init(switchbox, hass: HomeAssistant) -> None:
-    """Test energy sensor initial state is 0.0 with TOTAL_INCREASING state class."""
+    """Test energy sensor initial state is 0.0 with TOTAL state class."""
     feature_mock, power_entity_id, energy_entity_id = switchbox
 
     feature_mock.native_value = 0.0
@@ -216,7 +216,7 @@ async def test_energy_sensor_init(switchbox, hass: HomeAssistant) -> None:
     state = hass.states.get(energy_entity_id)
     assert state is not None
     assert state.state == "0.0"
-    assert state.attributes.get("state_class") == SensorStateClass.TOTAL_INCREASING
+    assert state.attributes.get("state_class") == SensorStateClass.TOTAL
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The powerConsumption sensor for switchBox and switchBoxD no longer appears in the Energy dashboard, as it only shows consumption for the last one-hour window. Users who have added it to the Energy dashboard should remove it and replace it with the new totalEnergy sensor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The powerConsumption sensor reports energy usage over a rolling one-hour window. There’s a bug in blebox_uniapi where last_reset is recalculated from datetime.now() on every API call, which causes it to drift and leads to inflated readings in the Energy dashboard.

Even if that bug is fixed, the one-hour granularity of powerConsumption still limits accuracy. 

This PR removes powerConsumption from the energy device class (it remains available as an informational sensor for last-hour usage).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
