### PR TITLE
Fix Sonos group regroup race when entity is not yet registered

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -940,12 +940,14 @@ class SonosSpeaker:
 
             for uid in group:
                 speaker = self.data.discovered.get(uid)
-                if speaker:
+                entity_id = (
+                    entity_registry.async_get_entity_id(MP_DOMAIN, DOMAIN, uid)
+                    if speaker
+                    else None
+                )
+                if speaker and entity_id:
                     self._group_members_missing.discard(uid)
                     sonos_group.append(speaker)
-                    entity_id = cast(
-                        str, entity_registry.async_get_entity_id(MP_DOMAIN, DOMAIN, uid)
-                    )
                     sonos_group_entities.append(entity_id)
                 else:
                     self._group_members_missing.add(uid)

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -137,9 +137,6 @@ async def test_device_registry_not_portable(
     assert reg_device.area_id == area_registry.async_get_area_by_name("Zone A").id
 
 
-@pytest.mark.skip(
-    reason="Flaky due to Python 3.14.3 asyncio changes - see home-assistant/core#162263"
-)
 async def test_entity_basic(
     hass: HomeAssistant,
     async_autosetup_sonos,

--- a/tests/components/sonos/test_repairs.py
+++ b/tests/components/sonos/test_repairs.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import Mock
 
-import pytest
 from soco import SoCo
 
 from homeassistant.components.sonos.const import (
@@ -19,9 +18,6 @@ from .conftest import SonosMockEvent, SonosMockSubscribe
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-@pytest.mark.skip(
-    reason="Flaky due to Python 3.14.3 asyncio changes - see home-assistant/core#162263"
-)
 async def test_subscription_repair_issues(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
@@ -44,13 +40,12 @@ async def test_subscription_repair_issues(
 
     # Ensure the issue still exists after reload
     assert await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert issue_registry.async_get_issue(DOMAIN, SUB_FAIL_ISSUE_ID)
 
     # Ensure the issue has been removed after a successful subscription callback
     variables = {"ZoneGroupState": zgs_discovery}
     event = SonosMockEvent(soco, soco.zoneGroupTopology, variables)
     sub_callback(event)
-    await hass.async_block_till_done()
-    assert not issue_registry.async_get_issue(DOMAIN, SUB_FAIL_ISSUE_ID)
     await hass.async_block_till_done(wait_background_tasks=True)
+    assert not issue_registry.async_get_issue(DOMAIN, SUB_FAIL_ISSUE_ID)

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -101,9 +101,6 @@ async def _media_play(hass: HomeAssistant, entity: str) -> None:
     )
 
 
-@pytest.mark.skip(
-    reason="Flaky due to Python 3.14.3 asyncio changes - see home-assistant/core#162263"
-)
 async def test_zgs_event_group_speakers(
     hass: HomeAssistant, sonos_setup_two_speakers: list[MockSoCo]
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Re-enables the three sonos tests skipped in #169046 and fixes the underlying race they exposed.

`SonosSpeaker.setup()` schedules a polling-driven `update_groups()` coroutine and the platform-creating `async_setup()` task at the same time. The polling task calls `_async_regroup`, which looks up the `media_player` entity ID via `async_get_entity_id`. If platform setup has not yet registered the entity, that returns `None`, and `None` was being appended directly to `sonos_group_entities` as `[None]`.

Worse, a later early-return condition (`group == [self.soco.uid] and self.sonos_group == [self] and self.sonos_group_entities`) treated `[None]` as truthy and skipped re-computing, so subsequent zone group events could not repair the state. The state then surfaced as `group_members: [None]` on the entity.

On Python 3.14.3 the asyncio executor scheduling change ([cpython#142358](https://github.com/python/cpython/pull/142358)) made `await hass.async_add_executor_job(...)` no longer yield to the loop, so the polling regroup deterministically wins the race against entity registration. This is why the three tests started failing.

Fix: in `_async_regroup`, treat a missing `entity_id` the same as a missing speaker — mark the uid as missing and return, so the next event retries. This avoids ever storing `None` in `sonos_group_entities`.

Also, `test_subscription_repair_issues` needs `wait_background_tasks=True` after reload so the new `async_subscription_failed` fires before the test invokes the success callback (otherwise it can re-create the issue after the deletion and fail the assertion).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169048
- This PR is related to issue: #169046, #162263
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr