### PR TITLE
Add timer triggers

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -194,6 +194,7 @@ _EXPERIMENTAL_TRIGGER_PLATFORMS = {
     "switch",
     "temperature",
     "text",
+    "timer",
     "todo",
     "update",
     "vacuum",

--- a/homeassistant/components/timer/icons.json
+++ b/homeassistant/components/timer/icons.json
@@ -29,5 +29,22 @@
     "start": {
       "service": "mdi:play"
     }
+  },
+  "triggers": {
+    "cancelled": {
+      "trigger": "mdi:cancel"
+    },
+    "finished": {
+      "trigger": "mdi:check"
+    },
+    "paused": {
+      "trigger": "mdi:timer-pause"
+    },
+    "restarted": {
+      "trigger": "mdi:restart"
+    },
+    "started": {
+      "trigger": "mdi:play"
+    }
   }
 }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "condition_behavior_name": "Condition passes if",
-    "condition_for_name": "For at least"
+    "condition_for_name": "For at least",
+    "trigger_behavior_name": "Trigger when",
+    "trigger_for_name": "For at least"
   },
   "conditions": {
     "is_active": {
@@ -88,6 +90,13 @@
         "all": "All",
         "any": "Any"
       }
+    },
+    "trigger_behavior": {
+      "options": {
+        "any": "Any",
+        "first": "First",
+        "last": "Last"
+      }
     }
   },
   "services": {
@@ -128,5 +137,67 @@
       "name": "Start timer"
     }
   },
-  "title": "Timer"
+  "title": "Timer",
+  "triggers": {
+    "cancelled": {
+      "description": "Triggers when one or more timers are cancelled.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::timer::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::timer::common::trigger_for_name%]"
+        }
+      },
+      "name": "Timer cancelled"
+    },
+    "finished": {
+      "description": "Triggers when one or more timers finish.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::timer::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::timer::common::trigger_for_name%]"
+        }
+      },
+      "name": "Timer finished"
+    },
+    "paused": {
+      "description": "Triggers when one or more timers are paused.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::timer::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::timer::common::trigger_for_name%]"
+        }
+      },
+      "name": "Timer paused"
+    },
+    "restarted": {
+      "description": "Triggers when one or more timers are restarted.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::timer::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::timer::common::trigger_for_name%]"
+        }
+      },
+      "name": "Timer restarted"
+    },
+    "started": {
+      "description": "Triggers when one or more timers are started.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::timer::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::timer::common::trigger_for_name%]"
+        }
+      },
+      "name": "Timer started"
+    }
+  }
 }

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -1,0 +1,32 @@
+"""Provides triggers for timers."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trigger
+
+from . import ATTR_LAST_TRANSITION, DOMAIN
+
+TRIGGERS: dict[str, type[Trigger]] = {
+    "cancelled": make_entity_target_state_trigger(
+        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "cancelled"
+    ),
+    "finished": make_entity_target_state_trigger(
+        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "finished"
+    ),
+    "paused": make_entity_target_state_trigger(
+        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "paused"
+    ),
+    "restarted": make_entity_target_state_trigger(
+        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "restarted"
+    ),
+    "started": make_entity_target_state_trigger(
+        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "started"
+    ),
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return the triggers for timers."""
+    return TRIGGERS

--- a/homeassistant/components/timer/triggers.yaml
+++ b/homeassistant/components/timer/triggers.yaml
@@ -1,0 +1,26 @@
+.trigger_common: &trigger_common
+  target:
+    entity:
+      domain: timer
+  fields:
+    behavior:
+      required: true
+      default: any
+      selector:
+        select:
+          options:
+            - first
+            - last
+            - any
+          translation_key: trigger_behavior
+    for:
+      required: true
+      default: 00:00:00
+      selector:
+        duration:
+
+cancelled: *trigger_common
+finished: *trigger_common
+paused: *trigger_common
+restarted: *trigger_common
+started: *trigger_common

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -1,0 +1,251 @@
+"""Test timer triggers."""
+
+from typing import Any
+
+import pytest
+
+from homeassistant.components.timer import (
+    ATTR_LAST_TRANSITION,
+    DOMAIN,
+    STATUS_ACTIVE,
+    STATUS_IDLE,
+    STATUS_PAUSED,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.components.common import (
+    TriggerStateDescription,
+    assert_trigger_behavior_any,
+    assert_trigger_behavior_first,
+    assert_trigger_behavior_last,
+    assert_trigger_gated_by_labs_flag,
+    assert_trigger_options_supported,
+    parametrize_target_entities,
+    parametrize_trigger_states,
+    target_entities,
+)
+
+
+@pytest.fixture
+async def target_timers(hass: HomeAssistant) -> dict[str, list[str]]:
+    """Create multiple timer entities associated with different targets."""
+    return await target_entities(hass, DOMAIN)
+
+
+@pytest.mark.parametrize(
+    "trigger_key",
+    [
+        "timer.cancelled",
+        "timer.finished",
+        "timer.paused",
+        "timer.restarted",
+        "timer.started",
+    ],
+)
+async def test_timer_triggers_gated_by_labs_flag(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, trigger_key: str
+) -> None:
+    """Test the timer triggers are gated by the labs flag."""
+    await assert_trigger_gated_by_labs_flag(hass, caplog, trigger_key)
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
+    [
+        ("timer.cancelled", {}, True, True),
+        ("timer.finished", {}, True, True),
+        ("timer.paused", {}, True, True),
+        ("timer.restarted", {}, True, True),
+        ("timer.started", {}, True, True),
+    ],
+)
+async def test_timer_trigger_options_validation(
+    hass: HomeAssistant,
+    trigger_key: str,
+    base_options: dict[str, Any] | None,
+    supports_behavior: bool,
+    supports_duration: bool,
+) -> None:
+    """Test that timer triggers support the expected options."""
+    await assert_trigger_options_supported(
+        hass,
+        trigger_key,
+        base_options,
+        supports_behavior=supports_behavior,
+        supports_duration=supports_duration,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities(DOMAIN),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="timer.cancelled",
+            target_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "cancelled"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.finished",
+            target_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "finished"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.paused",
+            target_states=[(STATUS_PAUSED, {ATTR_LAST_TRANSITION: "paused"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.restarted",
+            target_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "restarted"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.started",
+            target_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+            other_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "cancelled"})],
+        ),
+    ],
+)
+async def test_timer_trigger_behavior_any(
+    hass: HomeAssistant,
+    target_timers: dict[str, list[str]],
+    trigger_target_config: dict[str, Any],
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the timer trigger fires when any timer's last_transition changes to a specific value."""
+    await assert_trigger_behavior_any(
+        hass,
+        target_entities=target_timers,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities(DOMAIN),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="timer.cancelled",
+            target_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "cancelled"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.finished",
+            target_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "finished"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.paused",
+            target_states=[(STATUS_PAUSED, {ATTR_LAST_TRANSITION: "paused"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.restarted",
+            target_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "restarted"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.started",
+            target_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+            other_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "cancelled"})],
+        ),
+    ],
+)
+async def test_timer_trigger_behavior_first(
+    hass: HomeAssistant,
+    target_timers: dict[str, list[str]],
+    trigger_target_config: dict[str, Any],
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the timer trigger fires when the first timer's last_transition changes to a specific value."""
+    await assert_trigger_behavior_first(
+        hass,
+        target_entities=target_timers,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities(DOMAIN),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="timer.cancelled",
+            target_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "cancelled"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.finished",
+            target_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "finished"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.paused",
+            target_states=[(STATUS_PAUSED, {ATTR_LAST_TRANSITION: "paused"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.restarted",
+            target_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "restarted"})],
+            other_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+        ),
+        *parametrize_trigger_states(
+            trigger="timer.started",
+            target_states=[(STATUS_ACTIVE, {ATTR_LAST_TRANSITION: "started"})],
+            other_states=[(STATUS_IDLE, {ATTR_LAST_TRANSITION: "cancelled"})],
+        ),
+    ],
+)
+async def test_timer_trigger_behavior_last(
+    hass: HomeAssistant,
+    target_timers: dict[str, list[str]],
+    trigger_target_config: dict[str, Any],
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the timer trigger fires when the last timer's last_transition changes to a specific value."""
+    await assert_trigger_behavior_last(
+        hass,
+        target_entities=target_timers,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add most timer triggers from https://github.com/home-assistant/core/issues/158350:
  - `timer.cancelled`
  - `timer.finished`
  - `timer.paused`
  - `timer.restarted`
  - `timer.started`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes https://github.com/home-assistant/core/issues/164029
  - fixes https://github.com/home-assistant/core/issues/164030
  - fixes https://github.com/home-assistant/core/issues/164031
  - fixes https://github.com/home-assistant/core/issues/164032
  - fixes https://github.com/home-assistant/core/issues/164033
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
