### PR TITLE
Fix race in devolo Home Network device tracker device lookup

### DIFF
--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from devolo_plc_api import Device
 from devolo_plc_api.exceptions.device import DeviceNotFound
+from yarl import URL
 
 from homeassistant.components import zeroconf
 from homeassistant.const import (
@@ -17,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import (
@@ -122,6 +124,25 @@ async def async_setup_entry(
         await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data.coordinators = coordinators
+
+    # Ensure the device exists before forwarding to platforms, so that the
+    # device tracker (which looks up the device by wifi station MAC) is not
+    # racing the other platforms that create the device via DeviceInfo.
+    device_info = dr.DeviceInfo(
+        configuration_url=URL.build(scheme="http", host=device.ip),
+        identifiers={(DOMAIN, str(device.serial_number))},
+        manufacturer="devolo",
+        model=device.product,
+        model_id=device.mt_number,
+        serial_number=device.serial_number,
+        sw_version=device.firmware_version,
+    )
+    if device.mac:
+        device_info["connections"] = {(dr.CONNECTION_NETWORK_MAC, device.mac)}
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **device_info,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, platforms(device))
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`DevoloScannerEntity` inherits from `ScannerEntity`, whose
`entity_registry_enabled_default` returns `False` when the entity has a
mac address but no matching device entry. The devolo PLC device shares
its MAC with the connected wifi station used in the test, so the lookup
only succeeds once another platform (sensor/switch/etc.) has created
the device via `_attr_device_info`. Since `async_forward_entry_setups`
runs platforms concurrently via `asyncio.gather` with eager tasks, the
ordering is non-deterministic — when `device_tracker` runs first, the
device does not yet exist, the new entity registry entry is created
with `disabled_by=INTEGRATION`, and the entity has no state. This makes
`tests/components/devolo_home_network/test_device_tracker.py::test_restoring_clients`
flaky (e.g. https://github.com/home-assistant/core/actions/runs/25104865356/job/73564656777?pr=169444).

Pre-create the device in `async_setup_entry` before forwarding to
platforms so the lookup always succeeds regardless of platform setup
ordering. Same approach as #169432 for the Ping integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #169432
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr