### PR TITLE
Fix flaky portainer test_device_registry

### DIFF
--- a/tests/components/portainer/snapshots/test_init.ambr
+++ b/tests/components/portainer/snapshots/test_init.ambr
@@ -34,7 +34,7 @@
       'area_id': None,
       'config_entries': <ANY>,
       'config_entries_subentries': <ANY>,
-      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
+      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/ff31facfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
       'connections': set({
       }),
       'disabled_by': None,
@@ -44,7 +44,7 @@
       'identifiers': set({
         tuple(
           'portainer',
-          'portainer_test_entry_123_1_funny_chatelet',
+          'portainer_test_entry_123_1_dashy_dashy.1.qgza68hnz4n1qvyz3iohynx05',
         ),
       }),
       'labels': set({
@@ -52,7 +52,7 @@
       'manufacturer': 'Portainer',
       'model': 'Container',
       'model_id': None,
-      'name': 'funny_chatelet',
+      'name': 'dashy_dashy.1.qgza68hnz4n1qvyz3iohynx05',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,
@@ -92,6 +92,35 @@
       'area_id': None,
       'config_entries': <ANY>,
       'config_entries_subentries': <ANY>,
+      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'portainer',
+          'portainer_test_entry_123_1_funny_chatelet',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'Portainer',
+      'model': 'Container',
+      'model_id': None,
+      'name': 'funny_chatelet',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'sw_version': None,
+      'via_device_id': <ANY>,
+    }),
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'config_entries_subentries': <ANY>,
       'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/ee20facfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
       'connections': set({
       }),
@@ -111,6 +140,35 @@
       'model': 'Container',
       'model_id': None,
       'name': 'practical_morse',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'sw_version': None,
+      'via_device_id': <ANY>,
+    }),
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'config_entries_subentries': <ANY>,
+      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/bb97facfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'portainer',
+          'portainer_test_entry_123_1_serene_banach',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'Portainer',
+      'model': 'Container',
+      'model_id': None,
+      'name': 'serene_banach',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,
@@ -179,35 +237,6 @@
       'area_id': None,
       'config_entries': <ANY>,
       'config_entries_subentries': <ANY>,
-      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/bb97facfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': <DeviceEntryType.SERVICE: 'service'>,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'portainer',
-          'portainer_test_entry_123_1_serene_banach',
-        ),
-      }),
-      'labels': set({
-      }),
-      'manufacturer': 'Portainer',
-      'model': 'Container',
-      'model_id': None,
-      'name': 'serene_banach',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'sw_version': None,
-      'via_device_id': <ANY>,
-    }),
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'config_entries_subentries': <ANY>,
       'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/cc08facfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
       'connections': set({
       }),
@@ -237,36 +266,7 @@
       'area_id': None,
       'config_entries': <ANY>,
       'config_entries_subentries': <ANY>,
-      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/containers/ff31facfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf',
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': <DeviceEntryType.SERVICE: 'service'>,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'portainer',
-          'portainer_test_entry_123_1_dashy_dashy.1.qgza68hnz4n1qvyz3iohynx05',
-        ),
-      }),
-      'labels': set({
-      }),
-      'manufacturer': 'Portainer',
-      'model': 'Container',
-      'model_id': None,
-      'name': 'dashy_dashy.1.qgza68hnz4n1qvyz3iohynx05',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'sw_version': None,
-      'via_device_id': <ANY>,
-    }),
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'config_entries_subentries': <ANY>,
-      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/volumes/myvolume',
+      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/volumes/dashy_config',
       'connections': set({
       }),
       'disabled_by': None,
@@ -276,7 +276,7 @@
       'identifiers': set({
         tuple(
           'portainer',
-          'portainer_test_entry_123_1_volume_myvolume',
+          'portainer_test_entry_123_1_volume_dashy_config',
         ),
       }),
       'labels': set({
@@ -284,7 +284,7 @@
       'manufacturer': 'Portainer',
       'model': 'Volume',
       'model_id': None,
-      'name': 'myvolume',
+      'name': 'dashy_config',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,
@@ -324,7 +324,7 @@
       'area_id': None,
       'config_entries': <ANY>,
       'config_entries_subentries': <ANY>,
-      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/volumes/dashy_config',
+      'configuration_url': 'https://127.0.0.1:9000/#!/1/docker/volumes/myvolume',
       'connections': set({
       }),
       'disabled_by': None,
@@ -334,7 +334,7 @@
       'identifiers': set({
         tuple(
           'portainer',
-          'portainer_test_entry_123_1_volume_dashy_config',
+          'portainer_test_entry_123_1_volume_myvolume',
         ),
       }),
       'labels': set({
@@ -342,7 +342,7 @@
       'manufacturer': 'Portainer',
       'model': 'Volume',
       'model_id': None,
-      'name': 'dashy_config',
+      'name': 'myvolume',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -247,7 +247,8 @@ async def test_device_registry(
     device_entries = dr.async_entries_for_config_entry(
         device_registry, mock_config_entry.entry_id
     )
-    assert device_entries == snapshot
+    # Sort by identifier to ensure consistent order in snapshot
+    assert sorted(device_entries, key=lambda x: list(x.identifiers)[0][1]) == snapshot
 
 
 async def test_container_stack_device_links(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`tests/components/portainer/test_init.py::test_device_registry` has been observed flaking in CI (see https://github.com/home-assistant/core/actions/runs/25104865356/job/73568972731).

The portainer coordinator iterates over Python `set` objects in `_async_add_remove_endpoints` when invoking the new-device callbacks (`new_containers`, `new_volumes`, `new_stacks`). Because set iteration order depends on hash randomization, the order in which devices are registered can vary between runs, and the snapshot assertion (which compared a list against a fixed snapshot) would intermittently fail.

This PR sorts the device entries by identifier before comparing to the snapshot — the same approach already used in `tests/components/velbus/test_init.py` — and regenerates the snapshot to match. Verified by running the test 10 times under random `PYTHONHASHSEED`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->