### PR TITLE
Revert "Include indirect automation references in device view (#167719)"

### DIFF
--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -307,29 +307,6 @@ class Searcher:
             automation.automations_with_device(self.hass, device_id),
         )
 
-        # Automations referencing labels assigned to this device
-        for label_id in device_entry.labels:
-            self._add(
-                ItemType.AUTOMATION,
-                automation.automations_with_label(self.hass, label_id),
-            )
-
-        if device_entry.area_id:
-            # Automations referencing this device via its area
-            self._add(
-                ItemType.AUTOMATION,
-                automation.automations_with_area(self.hass, device_entry.area_id),
-            )
-            # Automations referencing this device via its areas floor
-            if area_entry := self._area_registry.async_get_area(device_entry.area_id):
-                if area_entry.floor_id:
-                    self._add(
-                        ItemType.AUTOMATION,
-                        automation.automations_with_floor(
-                            self.hass, area_entry.floor_id
-                        ),
-                    )
-
         # Scripts referencing this device
         self._add(ItemType.SCRIPT, script.scripts_with_device(self.hass, device_id))
 

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -603,7 +603,6 @@ async def test_search(
     assert not search(ItemType.CONFIG_ENTRY, "unknown")
     assert search(ItemType.CONFIG_ENTRY, hue_config_entry.entry_id) == {
         ItemType.AREA: {kitchen_area.id},
-        ItemType.AUTOMATION: {"automation.area", "automation.floor"},
         ItemType.DEVICE: {hue_device.id},
         ItemType.ENTITY: {
             hue_segment_1_entity.entity_id,
@@ -617,12 +616,7 @@ async def test_search(
     }
     assert search(ItemType.CONFIG_ENTRY, wled_config_entry.entry_id) == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id},
-        ItemType.AUTOMATION: {
-            "automation.floor",
-            "automation.label",
-            "automation.wled_entity",
-            "automation.wled_device",
-        },
+        ItemType.AUTOMATION: {"automation.wled_entity", "automation.wled_device"},
         ItemType.DEVICE: {wled_device.id},
         ItemType.ENTITY: {
             wled_segment_1_entity.entity_id,
@@ -638,12 +632,7 @@ async def test_search(
     assert not search(ItemType.DEVICE, "unknown")
     assert search(ItemType.DEVICE, wled_device.id) == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id},
-        ItemType.AUTOMATION: {
-            "automation.floor",
-            "automation.label",
-            "automation.wled_entity",
-            "automation.wled_device",
-        },
+        ItemType.AUTOMATION: {"automation.wled_entity", "automation.wled_device"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.ENTITY: {
             wled_segment_1_entity.entity_id,
@@ -658,7 +647,6 @@ async def test_search(
     }
     assert search(ItemType.DEVICE, hue_device.id) == {
         ItemType.AREA: {kitchen_area.id},
-        ItemType.AUTOMATION: {"automation.floor", "automation.area"},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.ENTITY: {
             hue_segment_1_entity.entity_id,
@@ -999,7 +987,6 @@ async def test_search(
     assert response["success"]
     assert response["result"] == {
         ItemType.AREA: [kitchen_area.id],
-        ItemType.AUTOMATION: unordered(["automation.area", "automation.floor"]),
         ItemType.ENTITY: unordered(
             [
                 hue_segment_1_entity.entity_id,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reverts commit 1c5e0203448245ebbd6b1ba108f1e96147799217.

- We decided we want to revert that PR as it leads to false positives with entities that aren't part of the automation targets.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/167719
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
