### PR TITLE
Move finish watering to sensor

### DIFF
--- a/homeassistant/components/gardena_bluetooth/number.py
+++ b/homeassistant/components/gardena_bluetooth/number.py
@@ -88,17 +88,6 @@ DESCRIPTIONS = (
         device_class=NumberDeviceClass.DURATION,
     ),
     GardenaBluetoothNumberEntityDescription(
-        key=AquaContourWatering.remaining_watering_time.unique_id,
-        translation_key="remaining_watering_time",
-        native_unit_of_measurement=UnitOfTime.SECONDS,
-        native_min_value=0.0,
-        native_max_value=24 * 60 * 60,
-        native_step=60.0,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        char=AquaContourWatering.remaining_watering_time,
-        device_class=NumberDeviceClass.DURATION,
-    ),
-    GardenaBluetoothNumberEntityDescription(
         key=DeviceConfiguration.rain_pause.unique_id,
         translation_key="rain_pause",
         native_unit_of_measurement=UnitOfTime.MINUTES,

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -290,8 +290,7 @@ class GardenaBluetoothRemainSensor(GardenaBluetoothEntity, SensorEntity):
         error = time - self._attr_native_value
         if abs(error.total_seconds()) > 10:
             self._attr_native_value = time
-            super()._handle_coordinator_update()
-            return
+        super()._handle_coordinator_update()
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 
 from gardena_bluetooth.const import (
     AquaContourBattery,
+    AquaContourWatering,
     Battery,
     EventHistory,
     FlowStatistics,
@@ -51,6 +52,12 @@ def _get_distance_percentage(value: int | None) -> float | None:
     if value is None:
         return None
     return value / 10
+
+
+def _get_timestamp_from_remaining_time(value: int | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.now(UTC) + timedelta(seconds=value)
 
 
 @dataclass(frozen=True)
@@ -218,7 +225,22 @@ async def async_setup_entry(
         if description.char.unique_id in coordinator.characteristics
     ]
     if Valve.remaining_open_time.unique_id in coordinator.characteristics:
-        entities.append(GardenaBluetoothRemainSensor(coordinator))
+        entities.append(
+            GardenaBluetoothRemainSensor(
+                coordinator, Valve.remaining_open_time, "remaining_open_timestamp"
+            )
+        )
+    if (
+        AquaContourWatering.remaining_watering_time.unique_id
+        in coordinator.characteristics
+    ):
+        entities.append(
+            GardenaBluetoothRemainSensor(
+                coordinator,
+                AquaContourWatering.remaining_watering_time,
+                "remaining_watering_timestamp",
+            )
+        )
     async_add_entities(entities)
 
 
@@ -245,18 +267,21 @@ class GardenaBluetoothRemainSensor(GardenaBluetoothEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_native_value: datetime | None = None
-    _attr_translation_key = "remaining_open_timestamp"
 
     def __init__(
         self,
         coordinator: GardenaBluetoothCoordinator,
+        char: Characteristic[int],
+        key: str,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, {Valve.remaining_open_time.uuid})
-        self._attr_unique_id = f"{coordinator.address}-remaining_open_timestamp"
+        super().__init__(coordinator, {char.uuid})
+        self._attr_unique_id = f"{coordinator.address}-{key}"
+        self._attr_translation_key = key
+        self._char = char
 
     def _handle_coordinator_update(self) -> None:
-        value = self.coordinator.get_cached(Valve.remaining_open_time)
+        value = self.coordinator.get_cached(self._char)
         if not value:
             self._attr_native_value = None
             super()._handle_coordinator_update()

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -54,12 +54,6 @@ def _get_distance_percentage(value: int | None) -> float | None:
     return value / 10
 
 
-def _get_timestamp_from_remaining_time(value: int | None) -> datetime | None:
-    if value is None:
-        return None
-    return datetime.now(UTC) + timedelta(seconds=value)
-
-
 @dataclass(frozen=True)
 class GardenaBluetoothSensorEntityDescription[T](SensorEntityDescription):
     """Description of entity."""

--- a/homeassistant/components/gardena_bluetooth/strings.json
+++ b/homeassistant/components/gardena_bluetooth/strings.json
@@ -134,6 +134,9 @@
       "remaining_open_timestamp": {
         "name": "Valve closing"
       },
+      "remaining_watering_timestamp": {
+        "name": "Watering finished"
+      },
       "sensor_battery_level": {
         "name": "Sensor battery"
       },

--- a/tests/components/gardena_bluetooth/snapshots/test_number.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_number.ambr
@@ -282,83 +282,7 @@
     'state': '10.0',
   })
 # ---
-# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Mock Title Remaining watering time',
-      'max': 86400,
-      'min': 0.0,
-      'mode': <NumberMode.AUTO: 'auto'>,
-      'step': 60.0,
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.mock_title_remaining_watering_time',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '100.0',
-  })
-# ---
-# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time].1
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Mock Title Remaining watering time',
-      'max': 86400,
-      'min': 0.0,
-      'mode': <NumberMode.AUTO: 'auto'>,
-      'step': 60.0,
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.mock_title_remaining_watering_time',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '10.0',
-  })
-# ---
-# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time].2
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Mock Title Remaining watering time',
-      'max': 86400,
-      'min': 0.0,
-      'mode': <NumberMode.AUTO: 'auto'>,
-      'step': 60.0,
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.mock_title_remaining_watering_time',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_setup[service_info4-98bd0d12-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_remaining_watering_time].3
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Mock Title Remaining watering time',
-      'max': 86400,
-      'min': 0.0,
-      'mode': <NumberMode.AUTO: 'auto'>,
-      'step': 60.0,
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.mock_title_remaining_watering_time',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_setup[service_info5-98bd0112-0b0e-421a-84e5-ddbf75dc6de4-raw5-number.mock_title_sector]
+# name: test_setup[service_info4-98bd0112-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_sector]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Sector',
@@ -376,7 +300,7 @@
     'state': '359.0',
   })
 # ---
-# name: test_setup[service_info5-98bd0112-0b0e-421a-84e5-ddbf75dc6de4-raw5-number.mock_title_sector].1
+# name: test_setup[service_info4-98bd0112-0b0e-421a-84e5-ddbf75dc6de4-raw4-number.mock_title_sector].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Sector',
@@ -394,7 +318,7 @@
     'state': '10.0',
   })
 # ---
-# name: test_setup[service_info6-98bd0111-0b0e-421a-84e5-ddbf75dc6de4-raw6-number.mock_title_distance]
+# name: test_setup[service_info5-98bd0111-0b0e-421a-84e5-ddbf75dc6de4-raw5-number.mock_title_distance]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Distance',
@@ -412,7 +336,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_setup[service_info6-98bd0111-0b0e-421a-84e5-ddbf75dc6de4-raw6-number.mock_title_distance].1
+# name: test_setup[service_info5-98bd0111-0b0e-421a-84e5-ddbf75dc6de4-raw5-number.mock_title_distance].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Distance',

--- a/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
@@ -433,6 +433,57 @@
     'state': '111',
   })
 # ---
+# name: test_sensors[aqua_contour][sensor.mock_title_watering_finished-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_watering_finished',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Watering finished',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Watering finished',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'remaining_watering_timestamp',
+    'unique_id': '00000000-0000-0000-0000-000000000003-remaining_watering_timestamp',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[aqua_contour][sensor.mock_title_watering_finished-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Watering finished',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_watering_finished',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-01-01T01:01:40+00:00',
+  })
+# ---
 # name: test_sensors[timer][sensor.mock_title_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/gardena_bluetooth/test_number.py
+++ b/tests/components/gardena_bluetooth/test_number.py
@@ -67,17 +67,6 @@ from tests.common import MockConfigEntry
         ),
         (
             AQUA_CONTOUR_SERVICE_INFO,
-            AquaContourWatering.remaining_watering_time.uuid,
-            [
-                AquaContourWatering.remaining_watering_time.encode(100),
-                AquaContourWatering.remaining_watering_time.encode(10),
-                CharacteristicNoAccess("Test for no access"),
-                GardenaBluetoothException("Test for errors on bluetooth"),
-            ],
-            "number.mock_title_remaining_watering_time",
-        ),
-        (
-            AQUA_CONTOUR_SERVICE_INFO,
             Spray.sector.uuid,
             [
                 Spray.sector.encode(359),
@@ -141,13 +130,6 @@ async def test_setup(
             100,
             100,
             "number.mock_title_manual_watering_time",
-        ),
-        (
-            AQUA_CONTOUR_SERVICE_INFO,
-            AquaContourWatering.remaining_watering_time,
-            100,
-            100,
-            "number.mock_title_remaining_watering_time",
         ),
     ],
 )

--- a/tests/components/gardena_bluetooth/test_sensor.py
+++ b/tests/components/gardena_bluetooth/test_sensor.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from gardena_bluetooth.const import (
     AquaContourBattery,
     AquaContourErrorCode,
+    AquaContourWatering,
     Battery,
     EventHistory,
     FlowStatistics,
@@ -96,6 +97,9 @@ async def test_setup(
                     ErrorData(
                         1, 1, datetime(2000, 1, 1), AquaContourErrorCode.FLASH_ERROR
                     )
+                ),
+                AquaContourWatering.remaining_watering_time.uuid: AquaContourWatering.remaining_watering_time.encode(
+                    100
                 ),
             },
             id="aqua_contour",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The number entity for remaining watering time has been removed (was added in current release 2026.4.0). Switch any uses to the new timestamp entity for finishing time.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The remaining watering time is not writable on aqua contour devices, and should just be represented as a timestamp sensor when the watering is going to be finished instead of as a every changing number duration entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
