### PR TITLE
Fix fritz guest WiFi QR image entity causing >10s update warnings

### DIFF
--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from io import BytesIO
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -87,6 +88,7 @@ class UpdateCoordinatorDataType(TypedDict):
 
     call_deflections: dict[int, dict]
     entity_states: dict[str, StateType | bool]
+    guest_wifi_qr_bytes: bytes | None
 
 
 class FritzConnectionCached(FritzConnection):  # type: ignore[misc]
@@ -303,6 +305,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         entity_data: UpdateCoordinatorDataType = {
             "call_deflections": {},
             "entity_states": {},
+            "guest_wifi_qr_bytes": None,
         }
         self.connection.clear_cache()
         try:
@@ -319,6 +322,10 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
                 entity_data[
                     "call_deflections"
                 ] = await self.async_update_call_deflections()
+
+            entity_data[
+                "guest_wifi_qr_bytes"
+            ] = await self.async_fetch_guest_wifi_qr_bytes()
         except FRITZ_EXCEPTIONS as ex:
             _LOGGER.debug(
                 "Reload %s due to error '%s' to ensure proper re-login",
@@ -658,6 +665,18 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
                     new_device = True
 
         await self.async_send_signal_device_update(new_device)
+
+    def _fetch_guest_wifi_qr(self) -> bytes | None:
+        """Fetch the guest WiFi QR code bytes from the FRITZ!Box."""
+        try:
+            qr_stream: BytesIO = self.fritz_guest_wifi.get_wifi_qr_code("png", border=2)
+            return qr_stream.getvalue()
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def async_fetch_guest_wifi_qr_bytes(self) -> bytes | None:
+        """Fetch the guest WiFi QR code bytes asynchronously."""
+        return await self.hass.async_add_executor_job(self._fetch_guest_wifi_qr)
 
     async def async_trigger_firmware_update(self) -> bool:
         """Trigger firmware update."""

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from io import BytesIO
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import partial
+from io import BytesIO
 import logging
 import re
 from typing import Any, TypedDict, cast

--- a/homeassistant/components/fritz/image.py
+++ b/homeassistant/components/fritz/image.py
@@ -112,6 +112,12 @@ class FritzGuestWifiQRImage(CoordinatorEntity[AvmWrapper], ImageEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self.coordinator.last_update_success:
+            self._current_qr_bytes = None
+            self._attr_image_last_updated = None
+            self.async_write_ha_state()
+            return
+
         qr_bytes = self.coordinator.data.get("guest_wifi_qr_bytes")
 
         if qr_bytes is None:

--- a/homeassistant/components/fritz/image.py
+++ b/homeassistant/components/fritz/image.py
@@ -109,6 +109,11 @@ class FritzGuestWifiQRImage(CoordinatorEntity[AvmWrapper], ImageEntity):
             self._current_qr_bytes = qr_bytes
             self._attr_image_last_updated = dt_util.utcnow()
 
+    @property
+    def available(self) -> bool:
+        """Return True; unknown image state is expressed via image_last_updated=None."""
+        return True
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/homeassistant/components/fritz/image.py
+++ b/homeassistant/components/fritz/image.py
@@ -2,25 +2,22 @@
 
 from __future__ import annotations
 
-from io import BytesIO
 import logging
-
-from requests.exceptions import RequestException
 
 from homeassistant.components.image import ImageEntity
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util, slugify
 
 from .const import DOMAIN, Platform
 from .coordinator import AvmWrapper, FritzConfigEntry
-from .entity import FritzBoxBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-# Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
 
@@ -73,13 +70,13 @@ async def async_setup_entry(
     )
 
 
-class FritzGuestWifiQRImage(FritzBoxBaseEntity, ImageEntity):
+class FritzGuestWifiQRImage(CoordinatorEntity[AvmWrapper], ImageEntity):
     """Implementation of the FritzBox guest wifi QR code image entity."""
 
     _attr_content_type = "image/png"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_has_entity_name = True
-    _attr_should_poll = True
+    _attr_should_poll = False
 
     def __init__(
         self,
@@ -91,41 +88,41 @@ class FritzGuestWifiQRImage(FritzBoxBaseEntity, ImageEntity):
         """Initialize the image entity."""
         self._attr_name = ssid
         self._attr_unique_id = f"{avm_wrapper.unique_id}-guest_wifi_qr_code"
+        self._device_name = device_friendly_name
         self._current_qr_bytes: bytes | None = None
-        super().__init__(avm_wrapper, device_friendly_name)
+        CoordinatorEntity.__init__(self, avm_wrapper)
         ImageEntity.__init__(self, hass)
 
-    def _fetch_image(self) -> bytes:
-        """Fetch the QR code from the Fritz!Box."""
-        qr_stream: BytesIO = self._avm_wrapper.fritz_guest_wifi.get_wifi_qr_code(
-            "png", border=2
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return DeviceInfo(
+            connections={(dr.CONNECTION_NETWORK_MAC, self.coordinator.mac)},
+            identifiers={(DOMAIN, self.coordinator.unique_id)},
         )
-        qr_bytes = qr_stream.getvalue()
-        _LOGGER.debug("fetched %s bytes", len(qr_bytes))
-
-        return qr_bytes
 
     async def async_added_to_hass(self) -> None:
-        """Fetch and set initial data and state."""
-        self._current_qr_bytes = await self.hass.async_add_executor_job(
-            self._fetch_image
-        )
-        self._attr_image_last_updated = dt_util.utcnow()
+        """Set initial data and register coordinator update listener."""
+        await super().async_added_to_hass()
+        qr_bytes = self.coordinator.data.get("guest_wifi_qr_bytes")
+        if qr_bytes is not None:
+            self._current_qr_bytes = qr_bytes
+            self._attr_image_last_updated = dt_util.utcnow()
 
-    async def async_update(self) -> None:
-        """Update the image entity data."""
-        try:
-            qr_bytes = await self.hass.async_add_executor_job(self._fetch_image)
-        except RequestException:
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        qr_bytes = self.coordinator.data.get("guest_wifi_qr_bytes")
+
+        if qr_bytes is None:
             self._current_qr_bytes = None
             self._attr_image_last_updated = None
             self.async_write_ha_state()
             return
 
         if self._current_qr_bytes != qr_bytes:
-            dt_now = dt_util.utcnow()
             _LOGGER.debug("qr code has changed, reset image last updated property")
-            self._attr_image_last_updated = dt_now
+            self._attr_image_last_updated = dt_util.utcnow()
             self._current_qr_bytes = qr_bytes
             self.async_write_ha_state()
 


### PR DESCRIPTION
## Proposed change

Move the guest WiFi QR code fetch from a standalone polling entity into the existing `FritzBoxTools` coordinator.

### Problem

`FritzGuestWifiQRImage` used `_attr_should_poll = True` and performed an **independent blocking HTTP request** to the FRITZ!Box on every HA polling cycle — in addition to all the requests already made by the coordinator. On slower devices (e.g. FRITZ!Box 7490) or under system load, this caused the `Update of image.fritz_box_* is taking over 10 seconds` warning to appear multiple times per day, as reported in issue #159545.

### Solution

- Add `guest_wifi_qr_bytes: bytes | None` to `UpdateCoordinatorDataType`
- Fetch the QR code bytes inside `_async_update_data` via a new `async_fetch_guest_wifi_qr_bytes` method (errors are caught and result in `None`)
- Rewrite `FritzGuestWifiQRImage` to inherit from `CoordinatorEntity[AvmWrapper]` instead of `FritzBoxBaseEntity`, with `_attr_should_poll = False`
- React to coordinator updates via `_handle_coordinator_update` — no extra HTTP request to the FRITZ!Box

The QR code only changes when the guest WiFi password changes, so fetching it as part of the normal coordinator cycle (every 30 s) is sufficient and eliminates the separate polling entirely.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)

Fixes #159545