### PR TITLE
Fix flaky Switchbot keypad vision doorbell event test

### DIFF
--- a/tests/components/switchbot/test_event.py
+++ b/tests/components/switchbot/test_event.py
@@ -1,15 +1,17 @@
 """Test the switchbot event entities."""
 
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from itertools import count
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.components.event import EventEntity
 from homeassistant.components.switchbot.const import DOMAIN
 from homeassistant.const import STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
 from . import KEYPAD_VISION_PRO_INFO
@@ -56,16 +58,15 @@ async def test_keypad_vision_pro_doorbell_event(
     mock_entry_encrypted_factory: Callable[[str], MockConfigEntry],
 ) -> None:
     """Test keypad vision pro doorbell event uses doorbell_seq for detection."""
-    triggered: list[str] = []
-    original_trigger = EventEntity._trigger_event
-
-    def _capture_trigger(
-        self: EventEntity,
-        event_type: str,
-        event_attributes: dict | None = None,
-    ) -> None:
-        triggered.append(event_type)
-        original_trigger(self, event_type, event_attributes)
+    # Make each ring's timestamp distinct so the entity's state value (which is
+    # the iso-formatted timestamp at millisecond resolution) differs between
+    # rings, ensuring state_changed fires for each. We avoid the `freezer`
+    # fixture here because it patches time.monotonic, which warps loop.time
+    # forward and causes the bluetooth manager's pre-scheduled unavailability
+    # check to fire immediately and mark the injected device unavailable.
+    timestamps = (
+        datetime(2026, 1, 1, tzinfo=UTC) + timedelta(seconds=i) for i in count()
+    )
 
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, KEYPAD_VISION_PRO_INFO)
@@ -73,52 +74,64 @@ async def test_keypad_vision_pro_doorbell_event(
     entry = mock_entry_encrypted_factory(sensor_type="keypad_vision_pro")
     entry.add_to_hass(hass)
 
+    entity_id = "event.test_name_doorbell"
+    ring_states: list[str] = []
+
+    @callback
+    def _track_ring(event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        if new_state and new_state.attributes.get("event_type") == "ring":
+            ring_states.append(new_state.state)
+
     with (
         patch(
             "homeassistant.components.switchbot.sensor.switchbot.SwitchbotKeypadVision.update",
             return_value=True,
         ),
-        patch.object(EventEntity, "_trigger_event", _capture_trigger),
+        patch(
+            "homeassistant.components.event.dt_util.utcnow",
+            side_effect=lambda: next(timestamps),
+        ),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        entity_id = "event.test_name_doorbell"
+        async_track_state_change_event(hass, entity_id, _track_ring)
+
         state = hass.states.get(entity_id)
         assert state
         assert state.state == STATE_UNKNOWN
-        assert triggered == []
 
         # First ring: seq changes from 0 → 1
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 1)
         )
         await hass.async_block_till_done()
-        assert triggered == ["ring"]
+        assert len(ring_states) == 1
 
         # Same seq repeated — no new ring event
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 1)
         )
         await hass.async_block_till_done()
-        assert triggered == ["ring"]
+        assert len(ring_states) == 1
 
         # Second ring: seq changes from 1 → 2
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 2)
         )
         await hass.async_block_till_done()
-        assert triggered == ["ring", "ring"]
+        assert len(ring_states) == 2
 
         # Seq wraps from 7 → 1 — still a ring
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 7)
         )
         await hass.async_block_till_done()
-        assert triggered == ["ring", "ring", "ring"]
+        assert len(ring_states) == 3
 
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 1)
         )
         await hass.async_block_till_done()
-        assert triggered == ["ring", "ring", "ring", "ring"]
+        assert len(ring_states) == 4

--- a/tests/components/switchbot/test_event.py
+++ b/tests/components/switchbot/test_event.py
@@ -1,13 +1,12 @@
 """Test the switchbot event entities."""
 
 from collections.abc import Callable
-from datetime import timedelta
 from unittest.mock import patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.event import EventEntity
 from homeassistant.components.switchbot.const import DOMAIN
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -55,18 +54,31 @@ def _with_doorbell_seq(
 async def test_keypad_vision_pro_doorbell_event(
     hass: HomeAssistant,
     mock_entry_encrypted_factory: Callable[[str], MockConfigEntry],
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test keypad vision pro doorbell event uses doorbell_seq for detection."""
+    triggered: list[str] = []
+    original_trigger = EventEntity._trigger_event
+
+    def _capture_trigger(
+        self: EventEntity,
+        event_type: str,
+        event_attributes: dict | None = None,
+    ) -> None:
+        triggered.append(event_type)
+        original_trigger(self, event_type, event_attributes)
+
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, KEYPAD_VISION_PRO_INFO)
 
     entry = mock_entry_encrypted_factory(sensor_type="keypad_vision_pro")
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.switchbot.sensor.switchbot.SwitchbotKeypadVision.update",
-        return_value=True,
+    with (
+        patch(
+            "homeassistant.components.switchbot.sensor.switchbot.SwitchbotKeypadVision.update",
+            return_value=True,
+        ),
+        patch.object(EventEntity, "_trigger_event", _capture_trigger),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -75,55 +87,38 @@ async def test_keypad_vision_pro_doorbell_event(
         state = hass.states.get(entity_id)
         assert state
         assert state.state == STATE_UNKNOWN
+        assert triggered == []
 
         # First ring: seq changes from 0 → 1
-        freezer.tick(timedelta(seconds=1))
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 1)
         )
         await hass.async_block_till_done()
-
-        state = hass.states.get(entity_id)
-        assert state
-        assert state.state != STATE_UNKNOWN
-        assert state.attributes["event_type"] == "ring"
-
-        first_ring_state = state.state
+        assert triggered == ["ring"]
 
         # Same seq repeated — no new ring event
-        freezer.tick(timedelta(seconds=1))
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 1)
         )
         await hass.async_block_till_done()
-
-        assert hass.states.get(entity_id).state == first_ring_state
+        assert triggered == ["ring"]
 
         # Second ring: seq changes from 1 → 2
-        freezer.tick(timedelta(seconds=1))
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 2)
         )
         await hass.async_block_till_done()
-
-        state = hass.states.get(entity_id)
-        assert state.state != first_ring_state
-        assert state.attributes["event_type"] == "ring"
+        assert triggered == ["ring", "ring"]
 
         # Seq wraps from 7 → 1 — still a ring
-        freezer.tick(timedelta(seconds=1))
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 7)
         )
         await hass.async_block_till_done()
-        third_ring_state = hass.states.get(entity_id).state
+        assert triggered == ["ring", "ring", "ring"]
 
-        freezer.tick(timedelta(seconds=1))
         inject_bluetooth_service_info(
             hass, _with_doorbell_seq(KEYPAD_VISION_PRO_INFO, 1)
         )
         await hass.async_block_till_done()
-
-        state = hass.states.get(entity_id)
-        assert state.state != third_ring_state
-        assert state.attributes["event_type"] == "ring"
+        assert triggered == ["ring", "ring", "ring", "ring"]


### PR DESCRIPTION
## Breaking change

## Proposed change

The Switchbot `test_keypad_vision_pro_doorbell_event` test is flaky on Python 3.14.4 in CI (see [failing job](https://github.com/home-assistant/core/actions/runs/25104865356/job/73564656757?pr=169444)) and reproducible locally with `--count=10`.

Root cause: the test used pytest-freezer's `freezer` fixture only to make event-entity timestamps differ between successive rings (so consecutive `state` strings could be compared). But `freezer` activates **after** the bluetooth test fixture has already scheduled timers in real monotonic time. Once freezegun patches `time.monotonic`, `loop.time()` jumps to a frozen unix-epoch value (huge), making every pre-scheduled timer (including `_async_check_unavailable`) appear past-due and fire immediately. Since `inject_bluetooth_service_info` bypasses any scanner, the address isn't in `discovered_addresses`, so the unavailable callback marks the device unavailable and the entity flips from `unknown` to `unavailable` before the assertion runs.

Fix:
- Drop the `freezer` fixture so the bluetooth scheduler keeps using real monotonic time and the device stays available.
- Listen to `state_changed` events on the bus via `async_track_state_change_event`, filtering for `event_type == "ring"`, to count ring transitions.
- Patch `dt_util.utcnow` in the event module to return monotonically increasing timestamps so consecutive rings produce distinct millisecond-precision state values, ensuring `state_changed` fires for each.

Verified locally with 100/100 passing iterations (`pytest --count=100`).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.