### PR TITLE
Add additional Moon sensor entities

### DIFF
--- a/homeassistant/components/moon/__init__.py
+++ b/homeassistant/components/moon/__init__.py
@@ -4,14 +4,20 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import PLATFORMS
+from .coordinator import MoonUpdateCoordinator
+
+type MoonConfigEntry = ConfigEntry[MoonUpdateCoordinator]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: MoonConfigEntry) -> bool:
     """Set up from a config entry."""
+    coordinator = MoonUpdateCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: MoonConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/moon/const.py
+++ b/homeassistant/components/moon/const.py
@@ -8,3 +8,23 @@ DOMAIN: Final = "moon"
 PLATFORMS: Final = [Platform.SENSOR]
 
 DEFAULT_NAME: Final = "Moon"
+
+STATE_FIRST_QUARTER: Final = "first_quarter"
+STATE_FULL_MOON: Final = "full_moon"
+STATE_LAST_QUARTER: Final = "last_quarter"
+STATE_NEW_MOON: Final = "new_moon"
+STATE_WANING_CRESCENT: Final = "waning_crescent"
+STATE_WANING_GIBBOUS: Final = "waning_gibbous"
+STATE_WAXING_CRESCENT: Final = "waxing_crescent"
+STATE_WAXING_GIBBOUS: Final = "waxing_gibbous"
+
+PHASE_OPTIONS: Final = [
+    STATE_NEW_MOON,
+    STATE_WAXING_CRESCENT,
+    STATE_FIRST_QUARTER,
+    STATE_WAXING_GIBBOUS,
+    STATE_FULL_MOON,
+    STATE_WANING_GIBBOUS,
+    STATE_LAST_QUARTER,
+    STATE_WANING_CRESCENT,
+]

--- a/homeassistant/components/moon/coordinator.py
+++ b/homeassistant/components/moon/coordinator.py
@@ -1,0 +1,152 @@
+"""Coordinate moon calculations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+import logging
+from math import degrees
+from typing import cast
+
+from astral import moon as astral_moon
+import ephem
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.sun import get_astral_location
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DOMAIN,
+    STATE_FIRST_QUARTER,
+    STATE_FULL_MOON,
+    STATE_LAST_QUARTER,
+    STATE_NEW_MOON,
+    STATE_WANING_CRESCENT,
+    STATE_WANING_GIBBOUS,
+    STATE_WAXING_CRESCENT,
+    STATE_WAXING_GIBBOUS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(minutes=5)
+
+
+@dataclass(kw_only=True, frozen=True)
+class MoonData:
+    """Calculated moon data."""
+
+    above_horizon: bool
+    phase: str
+    illumination: float
+    elevation: float
+    azimuth: float
+    next_rising: datetime | None
+    next_setting: datetime | None
+    next_transit: datetime
+    next_new_moon: datetime
+    next_first_quarter_moon: datetime
+    next_full_moon: datetime
+    next_last_quarter_moon: datetime
+
+
+class MoonUpdateCoordinator(DataUpdateCoordinator[MoonData]):
+    """Coordinate moon calculations."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+            config_entry=config_entry,
+        )
+
+    async def _async_update_data(self) -> MoonData:
+        """Fetch updated moon data."""
+        now = dt_util.utcnow()
+        local_date = dt_util.as_local(now).date()
+        location, elevation = get_astral_location(self.hass)
+
+        return await self.hass.async_add_executor_job(
+            _get_moon_data,
+            now,
+            local_date,
+            location.latitude,
+            location.longitude,
+            elevation if isinstance(elevation, (int, float)) else 0,
+        )
+
+
+def moon_phase_state(value: float) -> str:
+    """Convert Astral's moon phase value to the sensor state."""
+    if value < 0.5 or value > 27.5:
+        return STATE_NEW_MOON
+    if value < 6.5:
+        return STATE_WAXING_CRESCENT
+    if value < 7.5:
+        return STATE_FIRST_QUARTER
+    if value < 13.5:
+        return STATE_WAXING_GIBBOUS
+    if value < 14.5:
+        return STATE_FULL_MOON
+    if value < 20.5:
+        return STATE_WANING_GIBBOUS
+    if value < 21.5:
+        return STATE_LAST_QUARTER
+    return STATE_WANING_CRESCENT
+
+
+def ephem_date_to_datetime(value: ephem.Date) -> datetime:
+    """Convert an ephem date to a UTC datetime."""
+    return cast(datetime, value.datetime().replace(tzinfo=dt_util.UTC))
+
+
+def _get_next_event(
+    observer: ephem.Observer, event: Callable[[ephem.Moon], ephem.Date]
+) -> datetime | None:
+    """Safely fetch the next moon event."""
+    try:
+        return ephem_date_to_datetime(event(ephem.Moon()))
+    except ephem.AlwaysUpError, ephem.NeverUpError:
+        return None
+
+
+def _get_moon_data(
+    now: datetime,
+    local_date: date,
+    latitude: float,
+    longitude: float,
+    elevation: float,
+) -> MoonData:
+    """Calculate moon data for the configured location."""
+    observer = ephem.Observer()
+    observer.lat = str(latitude)
+    observer.lon = str(longitude)
+    observer.elevation = elevation
+    observer.date = now
+
+    current_moon = ephem.Moon(observer)
+
+    return MoonData(
+        above_horizon=float(current_moon.alt) > 0,
+        phase=moon_phase_state(astral_moon.phase(local_date)),
+        illumination=round(current_moon.phase, 1),
+        elevation=round(degrees(float(current_moon.alt)), 2),
+        azimuth=round(degrees(float(current_moon.az)), 2),
+        next_rising=_get_next_event(observer, observer.next_rising),
+        next_setting=_get_next_event(observer, observer.next_setting),
+        next_transit=ephem_date_to_datetime(observer.next_transit(ephem.Moon())),
+        next_new_moon=ephem_date_to_datetime(ephem.next_new_moon(observer.date)),
+        next_first_quarter_moon=ephem_date_to_datetime(
+            ephem.next_first_quarter_moon(observer.date)
+        ),
+        next_full_moon=ephem_date_to_datetime(ephem.next_full_moon(observer.date)),
+        next_last_quarter_moon=ephem_date_to_datetime(
+            ephem.next_last_quarter_moon(observer.date)
+        ),
+    )

--- a/homeassistant/components/moon/manifest.json
+++ b/homeassistant/components/moon/manifest.json
@@ -6,6 +6,8 @@
   "documentation": "https://www.home-assistant.io/integrations/moon",
   "integration_type": "service",
   "iot_class": "calculated",
+  "loggers": ["ephem"],
   "quality_scale": "internal",
+  "requirements": ["ephem==4.1.6"],
   "single_config_entry": true
 }

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -1,81 +1,85 @@
-"""Support for tracking the moon phases."""
+"""Support for moon sensors."""
 
 from __future__ import annotations
 
-from astral import moon
+from collections.abc import Callable
+from dataclasses import dataclass
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util import dt as dt_util
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from . import MoonConfigEntry
+from .const import DEFAULT_NAME, DOMAIN, PHASE_OPTIONS
+from .coordinator import MoonData, MoonUpdateCoordinator
 
-STATE_FIRST_QUARTER = "first_quarter"
-STATE_FULL_MOON = "full_moon"
-STATE_LAST_QUARTER = "last_quarter"
-STATE_NEW_MOON = "new_moon"
-STATE_WANING_CRESCENT = "waning_crescent"
-STATE_WANING_GIBBOUS = "waning_gibbous"
-STATE_WAXING_CRESCENT = "waxing_crescent"
-STATE_WAXING_GIBBOUS = "waxing_gibbous"
+
+@dataclass(kw_only=True, frozen=True)
+class MoonSensorEntityDescription(SensorEntityDescription):
+    """Description for a moon sensor entity."""
+
+    value_fn: Callable[[MoonData], StateType]
+
+
+SENSOR_TYPES: tuple[MoonSensorEntityDescription, ...] = (
+    MoonSensorEntityDescription(
+        key="phase",
+        device_class=SensorDeviceClass.ENUM,
+        options=PHASE_OPTIONS,
+        translation_key="phase",
+        value_fn=lambda data: data.phase,
+    ),
+)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: MoonConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the platform from config_entry."""
-    async_add_entities([MoonSensorEntity(entry)], True)
+    async_add_entities(
+        MoonSensorEntity(entry, entry.runtime_data, description)
+        for description in SENSOR_TYPES
+    )
 
 
-class MoonSensorEntity(SensorEntity):
+class MoonSensorEntity(CoordinatorEntity[MoonUpdateCoordinator], SensorEntity):
     """Representation of a Moon sensor."""
 
     _attr_has_entity_name = True
-    _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options = [
-        STATE_NEW_MOON,
-        STATE_WAXING_CRESCENT,
-        STATE_FIRST_QUARTER,
-        STATE_WAXING_GIBBOUS,
-        STATE_FULL_MOON,
-        STATE_WANING_GIBBOUS,
-        STATE_LAST_QUARTER,
-        STATE_WANING_CRESCENT,
-    ]
-    _attr_translation_key = "phase"
+    _attr_should_poll = False
+    entity_description: MoonSensorEntityDescription
 
-    def __init__(self, entry: ConfigEntry) -> None:
+    def __init__(
+        self,
+        entry: MoonConfigEntry,
+        coordinator: MoonUpdateCoordinator,
+        description: MoonSensorEntityDescription,
+    ) -> None:
         """Initialize the moon sensor."""
-        self._attr_unique_id = entry.entry_id
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_suggested_object_id = f"moon_{description.key}"
+        self._attr_unique_id = (
+            entry.entry_id
+            if description.key == "phase"
+            else f"{entry.entry_id}-{description.key}"
+        )
         self._attr_device_info = DeviceInfo(
-            name="Moon",
+            name=DEFAULT_NAME,
             identifiers={(DOMAIN, entry.entry_id)},
             entry_type=DeviceEntryType.SERVICE,
         )
 
-    async def async_update(self) -> None:
-        """Get the time and updates the states."""
-        today = dt_util.now().date()
-        state = moon.phase(today)
-
-        if state < 0.5 or state > 27.5:
-            self._attr_native_value = STATE_NEW_MOON
-        elif state < 6.5:
-            self._attr_native_value = STATE_WAXING_CRESCENT
-        elif state < 7.5:
-            self._attr_native_value = STATE_FIRST_QUARTER
-        elif state < 13.5:
-            self._attr_native_value = STATE_WAXING_GIBBOUS
-        elif state < 14.5:
-            self._attr_native_value = STATE_FULL_MOON
-        elif state < 20.5:
-            self._attr_native_value = STATE_WANING_GIBBOUS
-        elif state < 21.5:
-            self._attr_native_value = STATE_LAST_QUARTER
-        else:
-            self._attr_native_value = STATE_WANING_CRESCENT
+    @property
+    def native_value(self) -> StateType:
+        """Return the sensor value."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
+from homeassistant.const import DEGREE, PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -25,7 +28,7 @@ from .coordinator import MoonData, MoonUpdateCoordinator
 class MoonSensorEntityDescription(SensorEntityDescription):
     """Description for a moon sensor entity."""
 
-    value_fn: Callable[[MoonData], StateType]
+    value_fn: Callable[[MoonData], StateType | datetime | None]
 
 
 SENSOR_TYPES: tuple[MoonSensorEntityDescription, ...] = (
@@ -35,6 +38,84 @@ SENSOR_TYPES: tuple[MoonSensorEntityDescription, ...] = (
         options=PHASE_OPTIONS,
         translation_key="phase",
         value_fn=lambda data: data.phase,
+    ),
+    MoonSensorEntityDescription(
+        key="illumination",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        translation_key="illumination",
+        value_fn=lambda data: data.illumination,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="next_rising",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        translation_key="next_rising",
+        value_fn=lambda data: data.next_rising,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="next_setting",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        translation_key="next_setting",
+        value_fn=lambda data: data.next_setting,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="next_new_moon",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        translation_key="next_new_moon",
+        value_fn=lambda data: data.next_new_moon,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="next_first_quarter_moon",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        translation_key="next_first_quarter_moon",
+        value_fn=lambda data: data.next_first_quarter_moon,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="next_full_moon",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        translation_key="next_full_moon",
+        value_fn=lambda data: data.next_full_moon,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="next_last_quarter_moon",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        translation_key="next_last_quarter_moon",
+        value_fn=lambda data: data.next_last_quarter_moon,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="next_transit",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        translation_key="next_transit",
+        value_fn=lambda data: data.next_transit,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MoonSensorEntityDescription(
+        key="elevation",
+        native_unit_of_measurement=DEGREE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        translation_key="elevation",
+        value_fn=lambda data: data.elevation,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    MoonSensorEntityDescription(
+        key="azimuth",
+        native_unit_of_measurement=DEGREE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        translation_key="azimuth",
+        value_fn=lambda data: data.azimuth,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 )
 
@@ -80,6 +161,6 @@ class MoonSensorEntity(CoordinatorEntity[MoonUpdateCoordinator], SensorEntity):
         )
 
     @property
-    def native_value(self) -> StateType:
+    def native_value(self) -> StateType | datetime | None:
         """Return the sensor value."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/moon/strings.json
+++ b/homeassistant/components/moon/strings.json
@@ -8,6 +8,36 @@
   },
   "entity": {
     "sensor": {
+      "azimuth": {
+        "name": "Azimuth"
+      },
+      "elevation": {
+        "name": "Elevation"
+      },
+      "illumination": {
+        "name": "Illumination"
+      },
+      "next_first_quarter_moon": {
+        "name": "Next first quarter"
+      },
+      "next_full_moon": {
+        "name": "Next full moon"
+      },
+      "next_last_quarter_moon": {
+        "name": "Next last quarter"
+      },
+      "next_new_moon": {
+        "name": "Next new moon"
+      },
+      "next_rising": {
+        "name": "Next rising"
+      },
+      "next_setting": {
+        "name": "Next setting"
+      },
+      "next_transit": {
+        "name": "Next transit"
+      },
       "phase": {
         "name": "Phase",
         "state": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -924,6 +924,7 @@ enturclient==0.2.4
 # homeassistant.components.environment_canada
 env-canada==0.13.2
 
+# homeassistant.components.moon
 # homeassistant.components.season
 ephem==4.1.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -818,6 +818,7 @@ enocean-async==0.4.2
 # homeassistant.components.environment_canada
 env-canada==0.13.2
 
+# homeassistant.components.moon
 # homeassistant.components.season
 ephem==4.1.6
 

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -1,4 +1,4 @@
-"""The test for the moon sensor platform."""
+"""Tests for the moon sensor platform."""
 
 from __future__ import annotations
 
@@ -6,16 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.moon.sensor import (
-    STATE_FIRST_QUARTER,
-    STATE_FULL_MOON,
-    STATE_LAST_QUARTER,
-    STATE_NEW_MOON,
-    STATE_WANING_CRESCENT,
-    STATE_WANING_GIBBOUS,
-    STATE_WAXING_CRESCENT,
-    STATE_WAXING_GIBBOUS,
-)
+from homeassistant.components.moon.const import PHASE_OPTIONS
+from homeassistant.components.moon.coordinator import moon_phase_state
 from homeassistant.components.sensor import ATTR_OPTIONS, SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
@@ -27,29 +19,54 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("moon_value", "native_value"),
     [
-        (0, STATE_NEW_MOON),
-        (5, STATE_WAXING_CRESCENT),
-        (7, STATE_FIRST_QUARTER),
-        (12, STATE_WAXING_GIBBOUS),
-        (14.3, STATE_FULL_MOON),
-        (20.1, STATE_WANING_GIBBOUS),
-        (20.8, STATE_LAST_QUARTER),
-        (23, STATE_WANING_CRESCENT),
+        (0, "new_moon"),
+        (5, "waxing_crescent"),
+        (7, "first_quarter"),
+        (12, "waxing_gibbous"),
+        (14.3, "full_moon"),
+        (20.1, "waning_gibbous"),
+        (20.8, "last_quarter"),
+        (23, "waning_crescent"),
     ],
 )
-async def test_moon_day(
+def test_moon_phase_state(moon_value: float, native_value: str) -> None:
+    """Test moon phase mapping."""
+    assert moon_phase_state(moon_value) == native_value
+
+
+@pytest.mark.parametrize(
+    ("moon_value", "native_value"),
+    [
+        (0.4, "new_moon"),
+        (0.5, "waxing_crescent"),
+        (6.49, "waxing_crescent"),
+        (6.5, "first_quarter"),
+        (7.49, "first_quarter"),
+        (7.5, "waxing_gibbous"),
+        (13.49, "waxing_gibbous"),
+        (13.5, "full_moon"),
+        (14.49, "full_moon"),
+        (14.5, "waning_gibbous"),
+        (20.49, "waning_gibbous"),
+        (20.5, "last_quarter"),
+        (21.49, "last_quarter"),
+        (21.5, "waning_crescent"),
+        (27.5, "waning_crescent"),
+        (27.51, "new_moon"),
+    ],
+)
+async def test_moon_phase_sensor_boundary_values(
     hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     moon_value: float,
     native_value: str,
 ) -> None:
-    """Test the Moon sensor."""
+    """Test phase sensor boundary mapping against the integration."""
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.moon.sensor.moon.phase", return_value=moon_value
+        "homeassistant.components.moon.coordinator.astral_moon.phase",
+        return_value=moon_value,
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
@@ -57,18 +74,24 @@ async def test_moon_day(
     state = hass.states.get("sensor.moon_phase")
     assert state
     assert state.state == native_value
+
+
+async def test_moon_sensor(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the Moon sensor."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.moon_phase")
+    assert state
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Moon Phase"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENUM
-    assert state.attributes[ATTR_OPTIONS] == [
-        STATE_NEW_MOON,
-        STATE_WAXING_CRESCENT,
-        STATE_FIRST_QUARTER,
-        STATE_WAXING_GIBBOUS,
-        STATE_FULL_MOON,
-        STATE_WANING_GIBBOUS,
-        STATE_LAST_QUARTER,
-        STATE_WANING_CRESCENT,
-    ]
+    assert state.attributes[ATTR_OPTIONS] == PHASE_OPTIONS
 
     entry = entity_registry.async_get("sensor.moon_phase")
     assert entry

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -2,18 +2,53 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from math import degrees
 from unittest.mock import patch
 
+from astral import moon as astral_moon
+import ephem
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.moon.const import PHASE_OPTIONS
 from homeassistant.components.moon.coordinator import moon_phase_state
-from homeassistant.components.sensor import ATTR_OPTIONS, SensorDeviceClass
-from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
+from homeassistant.components.sensor import (
+    ATTR_OPTIONS,
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
+    DEGREE,
+    PERCENTAGE,
+    STATE_UNKNOWN,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
+
+
+def _to_datetime(value: ephem.Date) -> datetime:
+    """Convert an ephem date to a UTC datetime."""
+    return value.datetime().replace(tzinfo=dt_util.UTC)
+
+
+def _entity_id(
+    entity_registry: er.EntityRegistry,
+    platform: str,
+    unique_id: str,
+) -> str:
+    """Get an entity id by unique id."""
+    entity_id = entity_registry.async_get_entity_id(platform, "moon", unique_id)
+    assert entity_id is not None
+    return entity_id
 
 
 @pytest.mark.parametrize(
@@ -76,30 +111,253 @@ async def test_moon_phase_sensor_boundary_values(
     assert state.state == native_value
 
 
-async def test_moon_sensor(
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_moon_sensors(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test the Moon sensor."""
+    """Test the Moon sensors."""
+    utc_now = datetime(2026, 4, 10, 8, 0, 0, tzinfo=dt_util.UTC)
+    freezer.move_to(utc_now)
+
+    observer = ephem.Observer()
+    observer.lat = str(hass.config.latitude)
+    observer.lon = str(hass.config.longitude)
+    observer.elevation = hass.config.elevation
+    observer.date = utc_now
+    current_moon = ephem.Moon(observer)
+
+    expected_phase = moon_phase_state(astral_moon.phase(dt_util.now().date()))
+    expected_next_rising = _to_datetime(observer.next_rising(ephem.Moon()))
+    expected_next_setting = _to_datetime(observer.next_setting(ephem.Moon()))
+    expected_next_new_moon = _to_datetime(ephem.next_new_moon(observer.date))
+    expected_next_first_quarter_moon = _to_datetime(
+        ephem.next_first_quarter_moon(observer.date)
+    )
+    expected_next_full_moon = _to_datetime(ephem.next_full_moon(observer.date))
+    expected_next_last_quarter_moon = _to_datetime(
+        ephem.next_last_quarter_moon(observer.date)
+    )
+    expected_next_transit = _to_datetime(observer.next_transit(ephem.Moon()))
+    expected_elevation = degrees(float(current_moon.alt))
+    expected_azimuth = degrees(float(current_moon.az))
+
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.moon_phase")
-    assert state
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "Moon Phase"
-    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENUM
-    assert state.attributes[ATTR_OPTIONS] == PHASE_OPTIONS
+    next_first_quarter_moon_entity_id = _entity_id(
+        entity_registry,
+        "sensor",
+        f"{mock_config_entry.entry_id}-next_first_quarter_moon",
+    )
+    next_last_quarter_moon_entity_id = _entity_id(
+        entity_registry,
+        "sensor",
+        f"{mock_config_entry.entry_id}-next_last_quarter_moon",
+    )
 
-    entry = entity_registry.async_get("sensor.moon_phase")
-    assert entry
-    assert entry.unique_id == mock_config_entry.entry_id
-    assert entry.translation_key == "phase"
+    phase_state = hass.states.get("sensor.moon_phase")
+    assert phase_state
+    assert phase_state.state == expected_phase
+    assert phase_state.attributes[ATTR_FRIENDLY_NAME] == "Moon Phase"
+    assert phase_state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENUM
+    assert phase_state.attributes[ATTR_OPTIONS] == PHASE_OPTIONS
 
-    assert entry.device_id
-    device_entry = device_registry.async_get(entry.device_id)
+    illumination_state = hass.states.get("sensor.moon_illumination")
+    assert illumination_state
+    assert float(illumination_state.state) == pytest.approx(current_moon.phase, abs=0.1)
+    assert illumination_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
+
+    next_rising_state = hass.states.get("sensor.moon_next_rising")
+    assert next_rising_state
+    assert expected_next_rising.replace(microsecond=0) == dt_util.parse_datetime(
+        next_rising_state.state
+    )
+
+    next_setting_state = hass.states.get("sensor.moon_next_setting")
+    assert next_setting_state
+    assert expected_next_setting.replace(microsecond=0) == dt_util.parse_datetime(
+        next_setting_state.state
+    )
+
+    next_new_moon_state = hass.states.get("sensor.moon_next_new_moon")
+    assert next_new_moon_state
+    assert expected_next_new_moon.replace(microsecond=0) == dt_util.parse_datetime(
+        next_new_moon_state.state
+    )
+
+    next_first_quarter_moon_state = hass.states.get(next_first_quarter_moon_entity_id)
+    assert next_first_quarter_moon_state
+    assert expected_next_first_quarter_moon.replace(
+        microsecond=0
+    ) == dt_util.parse_datetime(next_first_quarter_moon_state.state)
+
+    next_full_moon_state = hass.states.get("sensor.moon_next_full_moon")
+    assert next_full_moon_state
+    assert expected_next_full_moon.replace(microsecond=0) == dt_util.parse_datetime(
+        next_full_moon_state.state
+    )
+
+    next_last_quarter_moon_state = hass.states.get(next_last_quarter_moon_entity_id)
+    assert next_last_quarter_moon_state
+    assert expected_next_last_quarter_moon.replace(
+        microsecond=0
+    ) == dt_util.parse_datetime(next_last_quarter_moon_state.state)
+
+    next_transit_state = hass.states.get("sensor.moon_next_transit")
+    assert next_transit_state
+    assert expected_next_transit.replace(microsecond=0) == dt_util.parse_datetime(
+        next_transit_state.state
+    )
+
+    elevation_state = hass.states.get("sensor.moon_elevation")
+    assert elevation_state
+    assert float(elevation_state.state) == pytest.approx(expected_elevation, abs=0.01)
+    assert elevation_state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+    assert elevation_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == DEGREE
+
+    azimuth_state = hass.states.get("sensor.moon_azimuth")
+    assert azimuth_state
+    assert float(azimuth_state.state) == pytest.approx(expected_azimuth, abs=0.01)
+    assert azimuth_state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+    assert azimuth_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == DEGREE
+
+    phase_entry = entity_registry.async_get("sensor.moon_phase")
+    assert phase_entry
+    assert phase_entry.unique_id == mock_config_entry.entry_id
+    assert phase_entry.translation_key == "phase"
+
+    illumination_entry = entity_registry.async_get("sensor.moon_illumination")
+    assert illumination_entry
+    assert illumination_entry.unique_id == f"{mock_config_entry.entry_id}-illumination"
+    assert illumination_entry.translation_key == "illumination"
+    assert illumination_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    next_rising_entry = entity_registry.async_get("sensor.moon_next_rising")
+    assert next_rising_entry
+    assert next_rising_entry.unique_id == f"{mock_config_entry.entry_id}-next_rising"
+    assert next_rising_entry.translation_key == "next_rising"
+    assert next_rising_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    next_setting_entry = entity_registry.async_get("sensor.moon_next_setting")
+    assert next_setting_entry
+    assert next_setting_entry.unique_id == f"{mock_config_entry.entry_id}-next_setting"
+    assert next_setting_entry.translation_key == "next_setting"
+    assert next_setting_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    next_new_moon_entry = entity_registry.async_get("sensor.moon_next_new_moon")
+    assert next_new_moon_entry
+    assert (
+        next_new_moon_entry.unique_id == f"{mock_config_entry.entry_id}-next_new_moon"
+    )
+    assert next_new_moon_entry.translation_key == "next_new_moon"
+    assert next_new_moon_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    next_first_quarter_moon_entry = entity_registry.async_get(
+        next_first_quarter_moon_entity_id
+    )
+    assert next_first_quarter_moon_entry
+    assert (
+        next_first_quarter_moon_entry.unique_id
+        == f"{mock_config_entry.entry_id}-next_first_quarter_moon"
+    )
+    assert next_first_quarter_moon_entry.translation_key == "next_first_quarter_moon"
+    assert next_first_quarter_moon_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    next_full_moon_entry = entity_registry.async_get("sensor.moon_next_full_moon")
+    assert next_full_moon_entry
+    assert (
+        next_full_moon_entry.unique_id == f"{mock_config_entry.entry_id}-next_full_moon"
+    )
+    assert next_full_moon_entry.translation_key == "next_full_moon"
+    assert next_full_moon_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    next_last_quarter_moon_entry = entity_registry.async_get(
+        next_last_quarter_moon_entity_id
+    )
+    assert next_last_quarter_moon_entry
+    assert (
+        next_last_quarter_moon_entry.unique_id
+        == f"{mock_config_entry.entry_id}-next_last_quarter_moon"
+    )
+    assert next_last_quarter_moon_entry.translation_key == "next_last_quarter_moon"
+    assert next_last_quarter_moon_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    next_transit_entry = entity_registry.async_get("sensor.moon_next_transit")
+    assert next_transit_entry
+    assert next_transit_entry.unique_id == f"{mock_config_entry.entry_id}-next_transit"
+    assert next_transit_entry.translation_key == "next_transit"
+    assert next_transit_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    elevation_entry = entity_registry.async_get("sensor.moon_elevation")
+    assert elevation_entry
+    assert elevation_entry.unique_id == f"{mock_config_entry.entry_id}-elevation"
+    assert elevation_entry.translation_key == "elevation"
+    assert elevation_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    azimuth_entry = entity_registry.async_get("sensor.moon_azimuth")
+    assert azimuth_entry
+    assert azimuth_entry.unique_id == f"{mock_config_entry.entry_id}-azimuth"
+    assert azimuth_entry.translation_key == "azimuth"
+    assert azimuth_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    assert phase_entry.device_id
+    device_entry = device_registry.async_get(phase_entry.device_id)
     assert device_entry
     assert device_entry.name == "Moon"
     assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
+
+
+async def test_moon_disabled_sensors_disabled_by_default(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test azimuth and elevation sensors are disabled by default."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.moon_elevation") is None
+    assert hass.states.get("sensor.moon_azimuth") is None
+
+    elevation_entry = entity_registry.async_get("sensor.moon_elevation")
+    assert elevation_entry
+    assert elevation_entry.disabled
+
+    azimuth_entry = entity_registry.async_get("sensor.moon_azimuth")
+    assert azimuth_entry
+    assert azimuth_entry.disabled
+
+
+async def test_moon_rising_setting_error_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test rising and setting sensors become unknown on observer errors."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.moon.coordinator.ephem.Observer.next_rising",
+            side_effect=ephem.AlwaysUpError,
+        ),
+        patch(
+            "homeassistant.components.moon.coordinator.ephem.Observer.next_setting",
+            side_effect=ephem.NeverUpError,
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    next_rising_state = hass.states.get("sensor.moon_next_rising")
+    assert next_rising_state
+    assert next_rising_state.state == STATE_UNKNOWN
+
+    next_setting_state = hass.states.get("sensor.moon_next_setting")
+    assert next_setting_state
+    assert next_setting_state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

- Adds additional Moon sensor entities for illumination, rise/set, transit, major phases, azimuth, and elevation.
- Keeps azimuth and elevation disabled by default.
- Adds translations and expanded sensor tests.

<img width="560" height="560" alt="image" src="https://github.com/user-attachments/assets/34548d7b-589c-445d-acc6-db83ad255dda" />


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Depends on #169514.
- Split from #168009.
- Documentation: home-assistant/home-assistant.io#45097.
- Resolves feature request: https://github.com/orgs/home-assistant/discussions/3455.
- Code for this change was generated with GPT-5.4 using Cursor.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
