### PR TITLE
Fix: Migrate also device entries to subentry in GitHub integration

### DIFF
--- a/homeassistant/components/github/__init__.py
+++ b/homeassistant/components/github/__init__.py
@@ -9,12 +9,13 @@ from aiogithubapi import GitHubAPI
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import (
     SERVER_SOFTWARE,
     async_get_clientsession,
 )
 
-from .const import CONF_REPOSITORIES, CONF_REPOSITORY, SUBENTRY_TYPE_REPOSITORY
+from .const import CONF_REPOSITORIES, CONF_REPOSITORY, DOMAIN, SUBENTRY_TYPE_REPOSITORY
 from .coordinator import GithubConfigEntry, GitHubDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -68,6 +69,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: GithubConfigEntry) -> b
 async def async_migrate_entry(hass: HomeAssistant, entry: GithubConfigEntry) -> bool:
     """Migrate old entry."""
     if entry.minor_version == 1:
+        dev_reg = dr.async_get(hass)
         # In minor version 2 we migrated repositories from entry options to
         # subentries, so we need to convert the list from
         # entry.options[CONF_REPOSITORIES] into individual subentries.
@@ -78,8 +80,13 @@ async def async_migrate_entry(hass: HomeAssistant, entry: GithubConfigEntry) -> 
                 title=repository,
                 unique_id=repository,
             )
-
             hass.config_entries.async_add_subentry(entry, subentry)
-
+            if device := dev_reg.async_get_device({(DOMAIN, repository)}):
+                dev_reg.async_update_device(
+                    device.id,
+                    remove_config_entry_id=entry.entry_id,
+                    add_config_subentry_id=subentry.subentry_id,
+                    add_config_entry_id=entry.entry_id,
+                )
         hass.config_entries.async_update_entry(entry, minor_version=2)
     return True

--- a/tests/components/github/test_init.py
+++ b/tests/components/github/test_init.py
@@ -93,7 +93,9 @@ async def test_sensor_icons(
 
 
 async def test_minor_v1_v2_migration(
-    hass: HomeAssistant, github_client: AsyncMock
+    hass: HomeAssistant,
+    github_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that we migrate minor version 1 to 2 correctly."""
     mock_config_entry = MockConfigEntry(
@@ -103,7 +105,15 @@ async def test_minor_v1_v2_migration(
         options={CONF_REPOSITORIES: ["test/repository"]},
         minor_version=1,
     )
-    await setup_integration(hass, mock_config_entry)
+    mock_config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "test/repository")},
+    )
+    assert device_entry.config_entries_subentries[mock_config_entry.entry_id] == {None}
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert mock_config_entry.options[CONF_REPOSITORIES] == ["test/repository"]
     assert mock_config_entry.minor_version == 2
@@ -112,3 +122,8 @@ async def test_minor_v1_v2_migration(
     assert subentry.data[CONF_REPOSITORY] == "test/repository"
     assert subentry.title == "test/repository"
     assert subentry.unique_id == "test/repository"
+
+    assert (device_entry := device_registry.async_get(device_entry.id))
+    assert device_entry.config_entries_subentries[mock_config_entry.entry_id] == {
+        subentry.subentry_id
+    }


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Github integration migrated to subentries but it was missed to also migrate the device entries in the device registry. This should be tagged for beta.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
