### PR TITLE
Update AI instructions for Python 3.14 forward references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,9 @@ This repository contains the core of Home Assistant, a Python 3 based home autom
 
 ## Python Syntax Notes
 
-- Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue since Home Assistant officially supports Python 3.14.
+- Home Assistant officially supports Python 3.14 as its minimum version. Do not flag syntax or features that require Python 3.14 as issues, and do not suggest workarounds for older Python versions.
+- Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue.
+- Python 3.14 evaluates annotations lazily (PEP 649). Forward references are no longer required — type hints can reference names defined later in the module without quoting them or using `from __future__ import annotations`. Do not flag unquoted forward references as issues.
 
 ## Testing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ This repository contains the core of Home Assistant, a Python 3 based home autom
 
 - Home Assistant officially supports Python 3.14 as its minimum version. Do not flag syntax or features that require Python 3.14 as issues, and do not suggest workarounds for older Python versions.
 - Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue.
-- Python 3.14 evaluates annotations lazily (PEP 649). Forward references are no longer required — type hints can reference names defined later in the module without quoting them or using `from __future__ import annotations`. Do not flag unquoted forward references as issues.
+- Python 3.14 evaluates annotations lazily (PEP 649). Forward references in annotations do not need to be quoted — annotations can reference names defined later in the module without quoting them or using `from __future__ import annotations`. Do not flag unquoted forward references in annotations as issues.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ This repository contains the core of Home Assistant, a Python 3 based home autom
 
 ## Python Syntax Notes
 
-- Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue since Home Assistant officially supports Python 3.14.
+- Home Assistant officially supports Python 3.14 as its minimum version. Do not flag syntax or features that require Python 3.14 as issues, and do not suggest workarounds for older Python versions.
+- Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue.
+- Python 3.14 evaluates annotations lazily (PEP 649). Forward references are no longer required — type hints can reference names defined later in the module without quoting them or using `from __future__ import annotations`. Do not flag unquoted forward references as issues.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repository contains the core of Home Assistant, a Python 3 based home autom
 
 - Home Assistant officially supports Python 3.14 as its minimum version. Do not flag syntax or features that require Python 3.14 as issues, and do not suggest workarounds for older Python versions.
 - Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue.
-- Python 3.14 evaluates annotations lazily (PEP 649). Forward references are no longer required — type hints can reference names defined later in the module without quoting them or using `from __future__ import annotations`. Do not flag unquoted forward references as issues.
+- Python 3.14 evaluates annotations lazily (PEP 649). Forward references in annotations do not need quotes or `from __future__ import annotations`, so do not flag unquoted forward references in annotations as issues. Some typing constructs evaluated at runtime may still require strings.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repository contains the core of Home Assistant, a Python 3 based home autom
 
 - Home Assistant officially supports Python 3.14 as its minimum version. Do not flag syntax or features that require Python 3.14 as issues, and do not suggest workarounds for older Python versions.
 - Python 3.14 explicitly allows `except TypeA, TypeB:` without parentheses. Never flag this as an issue.
-- Python 3.14 evaluates annotations lazily (PEP 649). Forward references in annotations do not need quotes or `from __future__ import annotations`, so do not flag unquoted forward references in annotations as issues. Some typing constructs evaluated at runtime may still require strings.
+- Python 3.14 evaluates annotations lazily (PEP 649). Forward references in annotations do not need to be quoted — annotations can reference names defined later in the module without quoting them or using `from __future__ import annotations`. Do not flag unquoted forward references in annotations as issues.
 
 ## Testing
 


### PR DESCRIPTION
## Proposed change

In recent pull requests I have often seen copilot raise invalid comments about the need to reorder the code and/or add quotes around type annotations and/or add `from __future__ import annotations`.
These comments were invalid and generated unnecessary noise on the pull requests.

Reference: https://peps.python.org/pep-0649/

Updates the project AI instructions ([AGENTS.md](AGENTS.md)) to clarify that Home Assistant uses Python 3.14 as its minimum supported version, and that PEP 649's lazy annotation evaluation means forward references no longer need to be quoted or use `from __future__ import annotations`.

The existing note about `except TypeA, TypeB:` is split out as a specific example, and a new general statement covers Python 3.14 syntax/features broadly. The generated `.github/copilot-instructions.md` is regenerated by the pre-commit hook.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr