### PR TITLE
Victron GX: Bug fix: parent device is mapped to the wrong device

### DIFF
--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -141,9 +141,12 @@ class Hub:
             model=device.model,
             serial_number=device.serial_number,
         )
-        # Don't set via_device for the GX device itself
-        if device.unique_id != "system_0":
-            device_info["via_device"] = (DOMAIN, f"{installation_id}_system_0")
+        # Set via_device based on parent_device relationship
+        if device.parent_device is not None:
+            device_info["via_device"] = (
+                DOMAIN,
+                f"{installation_id}_{device.parent_device.unique_id}",
+            )
         return device_info
 
     def is_device_connected(self, device_identifiers: set[tuple[str, str]]) -> bool:

--- a/tests/components/victron_gx/test_init.py
+++ b/tests/components/victron_gx/test_init.py
@@ -9,11 +9,10 @@ from victron_mqtt import (
     Hub as VictronVenusHub,
     MetricKind,
 )
-from victron_mqtt.testing import create_mocked_hub, finalize_injection, inject_message
+from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.victron_gx import async_remove_config_entry_device
 from homeassistant.components.victron_gx.const import DOMAIN
-from homeassistant.components.victron_gx.hub import Hub
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -155,26 +154,42 @@ async def test_hub_start_success(
     assert victron_hub.installation_id == MOCK_INSTALLATION_ID
 
 
-async def test_switch_output_uses_direct_parent_as_via_device() -> None:
-    """Test via_device follows the actual switch output parent device."""
-    victron_hub = await create_mocked_hub(installation_id=MOCK_INSTALLATION_ID)
-    try:
-        await inject_message(
-            victron_hub,
-            f"N/{MOCK_INSTALLATION_ID}/switch/0/SwitchableOutput/1/State",
-            '{"value": 1}',
-        )
-        await finalize_injection(victron_hub, disconnect=False)
+async def test_child_device_via_device_links_to_parent_in_registry(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test non-root device is linked to its parent device in the HA device registry."""
+    victron_hub, _mock_config_entry = init_integration
 
-        device = victron_hub.devices["switch_0_output_1"]
-        device_info = Hub._map_device_info(device, MOCK_INSTALLATION_ID)
+    # Inject a system metric first so system_0 is registered as the gateway device.
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/system/0/SystemState/State",
+        '{"value": 9}',
+    )
+    # Inject a battery metric; its parent_device resolves to system_0.
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/battery/0/Dc/0/Current",
+        '{"value": 10.5}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
 
-        assert device_info["via_device"] == (
-            DOMAIN,
-            f"{MOCK_INSTALLATION_ID}_switch_0",
-        )
-    finally:
-        await victron_hub.disconnect()
+    system_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    )
+    assert system_device is not None
+    # The GX gateway has no parent — it IS the root.
+    assert system_device.via_device_id is None
+
+    battery_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_battery_0")}
+    )
+    assert battery_device is not None
+    # Battery is a child of the GX gateway, not an orphan.
+    assert battery_device.via_device_id == system_device.id
 
 
 async def test_hub_start_authentication_error(

--- a/tests/components/victron_gx/test_init.py
+++ b/tests/components/victron_gx/test_init.py
@@ -9,10 +9,11 @@ from victron_mqtt import (
     Hub as VictronVenusHub,
     MetricKind,
 )
-from victron_mqtt.testing import finalize_injection, inject_message
+from victron_mqtt.testing import create_mocked_hub, finalize_injection, inject_message
 
 from homeassistant.components.victron_gx import async_remove_config_entry_device
 from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.components.victron_gx.hub import Hub
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -152,6 +153,28 @@ async def test_hub_start_success(
     # Verify the hub was started (integration was set up successfully)
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert victron_hub.installation_id == MOCK_INSTALLATION_ID
+
+
+async def test_switch_output_uses_direct_parent_as_via_device() -> None:
+    """Test via_device follows the actual switch output parent device."""
+    victron_hub = await create_mocked_hub(installation_id=MOCK_INSTALLATION_ID)
+    try:
+        await inject_message(
+            victron_hub,
+            f"N/{MOCK_INSTALLATION_ID}/switch/0/SwitchableOutput/1/State",
+            '{"value": 1}',
+        )
+        await finalize_injection(victron_hub, disconnect=False)
+
+        device = victron_hub.devices["switch_0_output_1"]
+        device_info = Hub._map_device_info(device, MOCK_INSTALLATION_ID)
+
+        assert device_info["via_device"] == (
+            DOMAIN,
+            f"{MOCK_INSTALLATION_ID}_switch_0",
+        )
+    finally:
+        await victron_hub.disconnect()
 
 
 async def test_hub_start_authentication_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Map each device to the right parent and not put all of them on the system device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
