### PR TITLE
homematicip_cloud: harden post-reconnect state recovery using 2.9.0 diagnostics

### DIFF
--- a/homeassistant/components/homematicip_cloud/diagnostics.py
+++ b/homeassistant/components/homematicip_cloud/diagnostics.py
@@ -22,4 +22,7 @@ async def async_get_config_entry_diagnostics(
     anonymized = handle_config(json_state, anonymize=True)
     config = json.loads(anonymized)
 
-    return async_redact_data(config, TO_REDACT_CONFIG)
+    return {
+        "websocket": hap.websocket_diagnostics(),
+        "config": async_redact_data(config, TO_REDACT_CONFIG),
+    }

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import Callable
-from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -18,9 +17,8 @@ from homematicip.exceptions.connection_exceptions import (
 
 import homeassistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN, PLATFORMS
@@ -112,13 +110,6 @@ class HomematicipHAP:
     _WS_WAIT_WARNING = 60
     _WS_WAIT_TIMEOUT = 120
 
-    # Staleness detection thresholds. The library has its own 8h safety net;
-    # we surface staleness much earlier so users see a clear log signal and
-    # we capture diagnostics for the still-unsolved reports in core #160048.
-    _STALE_CHECK_INTERVAL = timedelta(minutes=1)
-    _STALE_WARNING_SECONDS = 300
-    _STALE_ERROR_SECONDS = 600
-
     def __init__(
         self, hass: HomeAssistant, config_entry: HomematicIPConfigEntry
     ) -> None:
@@ -129,9 +120,6 @@ class HomematicipHAP:
         self._ws_close_requested = False
         self._ws_connection_closed = asyncio.Event()
         self._get_state_task: asyncio.Task | None = None
-        self._stale_check_unsub: CALLBACK_TYPE | None = None
-        self._stale_warning_logged = False
-        self._stale_error_logged = False
         self.hmip_device_by_entity_id: dict[str, Any] = {}
         self.reset_connection_listener: Callable | None = None
 
@@ -157,12 +145,6 @@ class HomematicipHAP:
 
         await self.hass.config_entries.async_forward_entry_setups(
             self.config_entry, PLATFORMS
-        )
-
-        self._stale_check_unsub = async_track_time_interval(
-            self.hass,
-            self._async_check_websocket_staleness,
-            self._STALE_CHECK_INTERVAL,
         )
 
         return True
@@ -316,45 +298,20 @@ class HomematicipHAP:
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, max_delay)
 
-    @callback
-    def _async_check_websocket_staleness(self, _now: datetime) -> None:
-        """Detect a websocket that claims connected but has stopped receiving.
+    async def _on_websocket_stale(self, severity: str, seconds_since: float) -> None:
+        """Log a websocket-stale event surfaced by the library.
 
-        The library's stale-connection safety net only triggers after 8h.
-        Surfacing this much earlier gives users a clear log signal and
-        captures diagnostics for the still-unsolved reports in core #160048.
+        The library polls staleness internally and fires this callback once
+        per severity per stuck period; it re-arms when fresh messages arrive.
+        We just translate severity to a log level.
         """
-        if not self.home.websocket_is_connected():
-            return
-
-        seconds_since = self.home.websocket_seconds_since_last_message()
-        if seconds_since is None:
-            return
-
-        if seconds_since < self._STALE_WARNING_SECONDS:
-            self._stale_warning_logged = False
-            self._stale_error_logged = False
-            return
-
-        if seconds_since >= self._STALE_ERROR_SECONDS:
-            if not self._stale_error_logged:
-                _LOGGER.error(
-                    "HomematicIP websocket has not received a message for "
-                    "%.0f seconds while reporting connected (%s)",
-                    seconds_since,
-                    self._websocket_diagnostic_context(),
-                )
-                self._stale_error_logged = True
-            return
-
-        if not self._stale_warning_logged:
-            _LOGGER.warning(
-                "HomematicIP websocket has not received a message for "
-                "%.0f seconds while reporting connected (%s)",
-                seconds_since,
-                self._websocket_diagnostic_context(),
-            )
-            self._stale_warning_logged = True
+        log = _LOGGER.error if severity == "error" else _LOGGER.warning
+        log(
+            "HomematicIP websocket has not received a message for "
+            "%.0f seconds while reporting connected (%s)",
+            seconds_since,
+            self._websocket_diagnostic_context(),
+        )
 
     async def get_state(self) -> None:
         """Update HMIP state and tell Home Assistant."""
@@ -405,13 +362,11 @@ class HomematicipHAP:
         home.set_on_connected_handler(self.ws_connected_handler)
         home.set_on_disconnected_handler(self.ws_disconnected_handler)
         home.set_on_reconnect_handler(self.ws_reconnected_handler)
+        home.set_on_websocket_stale_handler(self._on_websocket_stale)
 
     async def async_reset(self) -> bool:
         """Close the websocket connection."""
         self._ws_close_requested = True
-        if self._stale_check_unsub is not None:
-            self._stale_check_unsub()
-            self._stale_check_unsub = None
         if self._get_state_task is not None:
             self._get_state_task.cancel()
         await self.home.disable_events_async()
@@ -446,10 +401,6 @@ class HomematicipHAP:
             self._websocket_diagnostic_context(),
         )
         self._ws_connection_closed.set()
-        # Re-arm staleness logging so a new stuck period after reconnect
-        # is reported instead of being squelched by a previous one.
-        self._stale_warning_logged = False
-        self._stale_error_logged = False
 
     async def ws_reconnected_handler(self, reason: str) -> None:
         """Handle websocket reconnection."""

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -17,8 +18,9 @@ from homematicip.exceptions.connection_exceptions import (
 
 import homeassistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN, PLATFORMS
@@ -105,6 +107,18 @@ class HomematicipHAP:
 
     home: AsyncHome
 
+    # Bounded wait for websocket reconnect before refreshing state.
+    _WS_WAIT_INTERVAL = 2
+    _WS_WAIT_WARNING = 60
+    _WS_WAIT_TIMEOUT = 120
+
+    # Staleness detection thresholds. The library has its own 8h safety net;
+    # we surface staleness much earlier so users see a clear log signal and
+    # we capture diagnostics for the still-unsolved reports in core #160048.
+    _STALE_CHECK_INTERVAL = timedelta(minutes=1)
+    _STALE_WARNING_SECONDS = 300
+    _STALE_ERROR_SECONDS = 600
+
     def __init__(
         self, hass: HomeAssistant, config_entry: HomematicIPConfigEntry
     ) -> None:
@@ -115,6 +129,9 @@ class HomematicipHAP:
         self._ws_close_requested = False
         self._ws_connection_closed = asyncio.Event()
         self._get_state_task: asyncio.Task | None = None
+        self._stale_check_unsub: CALLBACK_TYPE | None = None
+        self._stale_warning_logged = False
+        self._stale_error_logged = False
         self.hmip_device_by_entity_id: dict[str, Any] = {}
         self.reset_connection_listener: Callable | None = None
 
@@ -142,6 +159,12 @@ class HomematicipHAP:
             self.config_entry, PLATFORMS
         )
 
+        self._stale_check_unsub = async_track_time_interval(
+            self.hass,
+            self._async_check_websocket_staleness,
+            self._STALE_CHECK_INTERVAL,
+        )
+
         return True
 
     @callback
@@ -163,10 +186,11 @@ class HomematicipHAP:
             self._ws_connection_closed.set()
             self.set_all_to_unavailable()
         elif self._ws_connection_closed.is_set():
-            _LOGGER.info("HMIP access point has reconnected to the cloud")
-            self._get_state_task = self.hass.async_create_task(self._try_get_state())
-            self._get_state_task.add_done_callback(self.get_state_finished)
-            self._ws_connection_closed.clear()
+            _LOGGER.info(
+                "HMIP access point has reconnected to the cloud (%s)",
+                self._websocket_diagnostic_context(),
+            )
+            self._start_get_state_task()
 
     @callback
     def async_create_entity(self, *args, **kwargs) -> None:
@@ -180,15 +204,81 @@ class HomematicipHAP:
             await asyncio.sleep(30)
         await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 
+    def _websocket_diagnostic_context(self) -> str:
+        """Return a single-line summary of websocket diagnostics for logs."""
+        diagnostics = {
+            "last_disconnect_reason": self.home.websocket_last_disconnect_reason(),
+            "reconnect_attempts": self.home.websocket_reconnect_attempt_count(),
+            "seconds_since_last_message": (
+                self.home.websocket_seconds_since_last_message()
+            ),
+            "message_count": self.home.websocket_message_count(),
+        }
+        rendered = ", ".join(
+            f"{key}={value!r}"
+            for key, value in diagnostics.items()
+            if value is not None
+        )
+        return rendered or "no diagnostics available"
+
+    @callback
+    def _start_get_state_task(self) -> None:
+        """Cancel any in-flight reconnect refresh and start a new one."""
+        if self._get_state_task is not None and not self._get_state_task.done():
+            _LOGGER.debug(
+                "Cancelling previous HomematicIP reconnect state refresh task"
+            )
+            self._get_state_task.cancel()
+
+        self._get_state_task = self.hass.async_create_task(self._try_get_state())
+        self._get_state_task.add_done_callback(self.get_state_finished)
+        self._ws_connection_closed.clear()
+
+    async def _wait_for_websocket_connection(self) -> bool:
+        """Wait up to ``_WS_WAIT_TIMEOUT`` seconds for the websocket to be connected.
+
+        Returns ``True`` when the websocket reports connected, ``False`` when the
+        wait times out. Even on timeout we proceed with ``get_state``: the REST
+        call is independent and may still recover the entity state.
+        """
+        elapsed = 0
+        warning_logged = False
+
+        while not self.home.websocket_is_connected():
+            if elapsed >= self._WS_WAIT_TIMEOUT:
+                _LOGGER.warning(
+                    "Websocket did not reconnect within %s seconds; "
+                    "proceeding with HomematicIP state refresh anyway (%s)",
+                    self._WS_WAIT_TIMEOUT,
+                    self._websocket_diagnostic_context(),
+                )
+                return False
+            await asyncio.sleep(self._WS_WAIT_INTERVAL)
+            elapsed += self._WS_WAIT_INTERVAL
+            # Re-check connectivity before logging so a reconnect during the
+            # sleep does not produce a misleading "still waiting" warning.
+            if (
+                not warning_logged
+                and elapsed >= self._WS_WAIT_WARNING
+                and not self.home.websocket_is_connected()
+            ):
+                warning_logged = True
+                _LOGGER.warning(
+                    "Still waiting for HomematicIP websocket reconnect after "
+                    "%s seconds (%s)",
+                    elapsed,
+                    self._websocket_diagnostic_context(),
+                )
+
+        return True
+
     async def _try_get_state(self) -> None:
         """Call get_state in a loop until no error occurs.
 
         Uses exponential backoff on error.
         """
 
-        # Wait until WebSocket connection is established.
-        while not self.home.websocket_is_connected():
-            await asyncio.sleep(2)
+        await self._wait_for_websocket_connection()
 
         delay = 8
         max_delay = 1500
@@ -208,16 +298,79 @@ class HomematicipHAP:
                 )
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, max_delay)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _LOGGER.exception(
+                    "Unexpected error updating state after HomematicIP "
+                    "reconnect, retrying in %s seconds (%s)",
+                    delay,
+                    self._websocket_diagnostic_context(),
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, max_delay)
+
+    @callback
+    def _async_check_websocket_staleness(self, _now: datetime) -> None:
+        """Detect a websocket that claims connected but has stopped receiving.
+
+        The library's stale-connection safety net only triggers after 8h.
+        Surfacing this much earlier gives users a clear log signal and
+        captures diagnostics for the still-unsolved reports in core #160048.
+        """
+        if not self.home.websocket_is_connected():
+            return
+
+        seconds_since = self.home.websocket_seconds_since_last_message()
+        if seconds_since is None:
+            return
+
+        if seconds_since < self._STALE_WARNING_SECONDS:
+            self._stale_warning_logged = False
+            self._stale_error_logged = False
+            return
+
+        if seconds_since >= self._STALE_ERROR_SECONDS:
+            if not self._stale_error_logged:
+                _LOGGER.error(
+                    "HomematicIP websocket has not received a message for "
+                    "%.0f seconds while reporting connected (%s)",
+                    seconds_since,
+                    self._websocket_diagnostic_context(),
+                )
+                self._stale_error_logged = True
+            return
+
+        if not self._stale_warning_logged:
+            _LOGGER.warning(
+                "HomematicIP websocket has not received a message for "
+                "%.0f seconds while reporting connected (%s)",
+                seconds_since,
+                self._websocket_diagnostic_context(),
+            )
+            self._stale_warning_logged = True
 
     async def get_state(self) -> None:
         """Update HMIP state and tell Home Assistant."""
         await self.home.get_current_state_async()
+        # ``set_all_to_unavailable`` marked every device unreach=True on
+        # disconnect; ``get_current_state_async`` only clears that flag for
+        # devices whose state actually changed during the outage, so the rest
+        # stay stuck unavailable after reconnect. Force-clear for all devices.
+        # Trade-off: a device that is *genuinely* unreachable on the cloud
+        # side will briefly appear available until its next state push
+        # corrects it. That self-corrects, while the previous behaviour left
+        # entities stuck unavailable indefinitely (core #160048).
+        for device in self.home.devices:
+            device.unreach = False
         self.update_all()
 
     def get_state_finished(self, future) -> None:
         """Execute when try_get_state coroutine has finished."""
         try:
             future.result()
+        except asyncio.CancelledError:
+            _LOGGER.debug("HomematicIP reconnect state refresh task was cancelled")
         except Exception as err:  # noqa: BLE001
             _LOGGER.error(
                 "Error updating state after HMIP access point reconnect: %s", err
@@ -250,6 +403,9 @@ class HomematicipHAP:
     async def async_reset(self) -> bool:
         """Close the websocket connection."""
         self._ws_close_requested = True
+        if self._stale_check_unsub is not None:
+            self._stale_check_unsub()
+            self._stale_check_unsub = None
         if self._get_state_task is not None:
             self._get_state_task.cancel()
         await self.home.disable_events_async()
@@ -275,22 +431,27 @@ class HomematicipHAP:
         """Handle websocket connected."""
         _LOGGER.info("Websocket connection to HomematicIP Cloud established")
         if self._ws_connection_closed.is_set():
-            self._get_state_task = self.hass.async_create_task(self._try_get_state())
-            self._get_state_task.add_done_callback(self.get_state_finished)
-
-            self._ws_connection_closed.clear()
+            self._start_get_state_task()
 
     async def ws_disconnected_handler(self) -> None:
         """Handle websocket disconnection."""
-        _LOGGER.warning("Websocket connection to HomematicIP Cloud closed")
+        _LOGGER.warning(
+            "Websocket connection to HomematicIP Cloud closed (%s)",
+            self._websocket_diagnostic_context(),
+        )
         self._ws_connection_closed.set()
+        # Re-arm staleness logging so a new stuck period after reconnect
+        # is reported instead of being squelched by a previous one.
+        self._stale_warning_logged = False
+        self._stale_error_logged = False
 
     async def ws_reconnected_handler(self, reason: str) -> None:
         """Handle websocket reconnection."""
         _LOGGER.info(
-            "Websocket connection to HomematicIP Cloud trying"
-            " to reconnect due to reason: %s",
+            "Websocket connection to HomematicIP Cloud trying to reconnect due to "
+            "reason: %s (%s)",
             reason,
+            self._websocket_diagnostic_context(),
         )
 
         self._ws_connection_closed.set()

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -163,8 +163,9 @@ class HomematicipHAP:
             self._ws_connection_closed.set()
             self.set_all_to_unavailable()
         elif self._ws_connection_closed.is_set():
-            _LOGGER.info(
-                "HMIP access point has reconnected to the cloud (%s)",
+            _LOGGER.info("HMIP access point has reconnected to the cloud")
+            _LOGGER.debug(
+                "HMIP websocket diagnostics: %s",
                 self._websocket_diagnostic_context(),
             )
             self._start_get_state_task()
@@ -243,8 +244,11 @@ class HomematicipHAP:
         log = _LOGGER.error if severity == "error" else _LOGGER.warning
         log(
             "HomematicIP websocket has not received a message for "
-            "%.0f seconds while reporting connected (%s)",
+            "%.0f seconds while reporting connected",
             seconds_since,
+        )
+        _LOGGER.debug(
+            "HMIP websocket diagnostics: %s",
             self._websocket_diagnostic_context(),
         )
 
@@ -337,8 +341,9 @@ class HomematicipHAP:
 
     async def ws_disconnected_handler(self) -> None:
         """Handle websocket disconnection."""
-        _LOGGER.warning(
-            "Websocket connection to HomematicIP Cloud closed (%s)",
+        _LOGGER.warning("Websocket connection to HomematicIP Cloud closed")
+        _LOGGER.debug(
+            "HMIP websocket diagnostics: %s",
             self._websocket_diagnostic_context(),
         )
         self._ws_connection_closed.set()
@@ -347,8 +352,11 @@ class HomematicipHAP:
         """Handle websocket reconnection."""
         _LOGGER.info(
             "Websocket connection to HomematicIP Cloud trying to reconnect due to "
-            "reason: %s (%s)",
+            "reason: %s",
             reason,
+        )
+        _LOGGER.debug(
+            "HMIP websocket diagnostics: %s",
             self._websocket_diagnostic_context(),
         )
 

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -204,8 +204,8 @@ class HomematicipHAP:
             await asyncio.sleep(30)
         await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 
-    def _websocket_diagnostic_context(self) -> str:
-        """Return a single-line summary of websocket diagnostics for logs."""
+    def websocket_diagnostics(self) -> dict[str, Any]:
+        """Return websocket diagnostics dict (None values omitted)."""
         diagnostics = {
             "last_disconnect_reason": self.home.websocket_last_disconnect_reason(),
             "reconnect_attempts": self.home.websocket_reconnect_attempt_count(),
@@ -214,12 +214,14 @@ class HomematicipHAP:
             ),
             "message_count": self.home.websocket_message_count(),
         }
-        rendered = ", ".join(
-            f"{key}={value!r}"
-            for key, value in diagnostics.items()
-            if value is not None
-        )
-        return rendered or "no diagnostics available"
+        return {k: v for k, v in diagnostics.items() if v is not None}
+
+    def _websocket_diagnostic_context(self) -> str:
+        """Return a single-line summary of websocket diagnostics for logs."""
+        diagnostics = self.websocket_diagnostics()
+        if not diagnostics:
+            return "no diagnostics available"
+        return ", ".join(f"{k}={v!r}" for k, v in diagnostics.items())
 
     @callback
     def _start_get_state_task(self) -> None:
@@ -301,6 +303,10 @@ class HomematicipHAP:
             except asyncio.CancelledError:
                 raise
             except Exception:
+                # Catch-all is intentional: this is the recovery loop after
+                # reconnect, and we must keep retrying rather than die on an
+                # unforeseen error. core#160048 had a NoneType error that
+                # would have been swallowed silently by a narrow catch.
                 _LOGGER.exception(
                     "Unexpected error updating state after HomematicIP "
                     "reconnect, retrying in %s seconds (%s)",

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -105,11 +105,6 @@ class HomematicipHAP:
 
     home: AsyncHome
 
-    # Bounded wait for websocket reconnect before refreshing state.
-    _WS_WAIT_INTERVAL = 2
-    _WS_WAIT_WARNING = 60
-    _WS_WAIT_TIMEOUT = 120
-
     def __init__(
         self, hass: HomeAssistant, config_entry: HomematicIPConfigEntry
     ) -> None:
@@ -218,85 +213,25 @@ class HomematicipHAP:
         self._get_state_task.add_done_callback(self.get_state_finished)
         self._ws_connection_closed.clear()
 
-    async def _wait_for_websocket_connection(self) -> bool:
-        """Wait up to ``_WS_WAIT_TIMEOUT`` seconds for the websocket to be connected.
-
-        Returns ``True`` when the websocket reports connected, ``False`` when the
-        wait times out. Even on timeout we proceed with ``get_state``: the REST
-        call is independent and may still recover the entity state.
-        """
-        elapsed = 0
-        warning_logged = False
-
-        while not self.home.websocket_is_connected():
-            if elapsed >= self._WS_WAIT_TIMEOUT:
-                _LOGGER.warning(
-                    "Websocket did not reconnect within %s seconds; "
-                    "proceeding with HomematicIP state refresh anyway (%s)",
-                    self._WS_WAIT_TIMEOUT,
-                    self._websocket_diagnostic_context(),
-                )
-                return False
-            await asyncio.sleep(self._WS_WAIT_INTERVAL)
-            elapsed += self._WS_WAIT_INTERVAL
-            # Re-check connectivity before logging so a reconnect during the
-            # sleep does not produce a misleading "still waiting" warning.
-            if (
-                not warning_logged
-                and elapsed >= self._WS_WAIT_WARNING
-                and not self.home.websocket_is_connected()
-            ):
-                warning_logged = True
-                _LOGGER.warning(
-                    "Still waiting for HomematicIP websocket reconnect after "
-                    "%s seconds (%s)",
-                    elapsed,
-                    self._websocket_diagnostic_context(),
-                )
-
-        return True
-
     async def _try_get_state(self) -> None:
-        """Call get_state in a loop until no error occurs.
+        """Refresh state after a websocket reconnect.
 
-        Uses exponential backoff on error.
+        Delegates the bounded websocket wait + retry-with-exponential-backoff
+        to the homematicip library (``refresh_state_after_reconnect_async``),
+        and only handles HA-specific concerns here:
+        - on authentication failure, trigger reauth
+        - clear the per-device ``unreach`` flag and signal entity updates
+          (the workaround for core#160048)
         """
-
-        await self._wait_for_websocket_connection()
-
-        delay = 8
-        max_delay = 1500
-        while True:
-            try:
-                await self.get_state()
-                break
-            except HmipAuthenticationError:
-                _LOGGER.error(
-                    "Authentication error from HomematicIP Cloud, triggering reauth"
-                )
-                self.config_entry.async_start_reauth(self.hass)
-                break
-            except HmipConnectionError as err:
-                _LOGGER.warning(
-                    "Get_state failed, retrying in %s seconds: %s", delay, err
-                )
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, max_delay)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                # Catch-all is intentional: this is the recovery loop after
-                # reconnect, and we must keep retrying rather than die on an
-                # unforeseen error. core#160048 had a NoneType error that
-                # would have been swallowed silently by a narrow catch.
-                _LOGGER.exception(
-                    "Unexpected error updating state after HomematicIP "
-                    "reconnect, retrying in %s seconds (%s)",
-                    delay,
-                    self._websocket_diagnostic_context(),
-                )
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, max_delay)
+        try:
+            await self.home.refresh_state_after_reconnect_async()
+        except HmipAuthenticationError:
+            _LOGGER.error(
+                "Authentication error from HomematicIP Cloud, triggering reauth"
+            )
+            self.config_entry.async_start_reauth(self.hass)
+            return
+        self._post_state_refresh()
 
     async def _on_websocket_stale(self, severity: str, seconds_since: float) -> None:
         """Log a websocket-stale event surfaced by the library.
@@ -316,14 +251,20 @@ class HomematicipHAP:
     async def get_state(self) -> None:
         """Update HMIP state and tell Home Assistant."""
         await self.home.get_current_state_async()
-        # ``set_all_to_unavailable`` marked every device unreach=True on
-        # disconnect; ``get_current_state_async`` only clears that flag for
-        # devices whose state actually changed during the outage, so the rest
-        # stay stuck unavailable after reconnect. Force-clear for all devices.
-        # Trade-off: a device that is *genuinely* unreachable on the cloud
-        # side will briefly appear available until its next state push
-        # corrects it. That self-corrects, while the previous behaviour left
-        # entities stuck unavailable indefinitely (core #160048).
+        self._post_state_refresh()
+
+    def _post_state_refresh(self) -> None:
+        """Apply HA-specific post-processing after a state refresh.
+
+        ``set_all_to_unavailable`` marked every device unreach=True on
+        disconnect; ``get_current_state_async`` only clears that flag for
+        devices whose state actually changed during the outage, so the rest
+        stay stuck unavailable after reconnect. Force-clear for all devices.
+        Trade-off: a device that is *genuinely* unreachable on the cloud
+        side will briefly appear available until its next state push
+        corrects it. That self-corrects, while the previous behaviour left
+        entities stuck unavailable indefinitely (core #160048).
+        """
         for device in self.home.devices:
             device.unreach = False
         self.update_all()

--- a/tests/components/homematicip_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/homematicip_cloud/snapshots/test_diagnostics.ambr
@@ -1,32 +1,38 @@
 # serializer version: 1
 # name: test_diagnostics
   dict({
-    'accessPointId': '3014F7110000000000000000',
-    'clients': dict({
-      '00000000-0000-0000-0000-000000000000': dict({
+    'config': dict({
+      'accessPointId': '3014F7110000000000000000',
+      'clients': dict({
+        '00000000-0000-0000-0000-000000000000': dict({
+          'id': '00000000-0000-0000-0000-000000000000',
+          'label': 'Home Assistant',
+          'refreshToken': None,
+        }),
+      }),
+      'devices': dict({
+        '3014F7110000000000000001': dict({
+          'id': '3014F7110000000000000001',
+          'label': 'Living Room Thermostat',
+          'serializedGlobalTradeItemNumber': '3014F7110000000000000002',
+          'type': 'WALL_MOUNTED_THERMOSTAT_PRO',
+        }),
+      }),
+      'home': dict({
         'id': '00000000-0000-0000-0000-000000000000',
-        'label': 'Home Assistant',
-        'refreshToken': None,
+        'location': dict({
+          'city': '**REDACTED**',
+          'latitude': '**REDACTED**',
+          'longitude': '**REDACTED**',
+        }),
+        'weather': dict({
+          'temperature': 18.3,
+        }),
       }),
     }),
-    'devices': dict({
-      '3014F7110000000000000001': dict({
-        'id': '3014F7110000000000000001',
-        'label': 'Living Room Thermostat',
-        'serializedGlobalTradeItemNumber': '3014F7110000000000000002',
-        'type': 'WALL_MOUNTED_THERMOSTAT_PRO',
-      }),
-    }),
-    'home': dict({
-      'id': '00000000-0000-0000-0000-000000000000',
-      'location': dict({
-        'city': '**REDACTED**',
-        'latitude': '**REDACTED**',
-        'longitude': '**REDACTED**',
-      }),
-      'weather': dict({
-        'temperature': 18.3,
-      }),
+    'websocket': dict({
+      'message_count': 0,
+      'reconnect_attempts': 0,
     }),
   })
 # ---

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -1,7 +1,6 @@
 """Test HomematicIP Cloud accesspoint."""
 
 import asyncio
-from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homematicip.auth import Auth
@@ -601,111 +600,47 @@ async def test_websocket_diagnostic_context_falls_back_when_all_unknown() -> Non
     assert hap._websocket_diagnostic_context() == "no diagnostics available"
 
 
-async def test_ws_disconnected_handler_rearms_staleness_flags() -> None:
-    """A websocket disconnect re-arms log-once flags for the next stuck period."""
+async def test_on_websocket_stale_logs_warning_then_error() -> None:
+    """Library callback maps severity to log level (warning vs error)."""
     hap = HomematicipHAP(MagicMock(), MagicMock())
     hap.home = MagicMock()
     _set_diagnostic_defaults(hap.home)
-    hap._stale_warning_logged = True
-    hap._stale_error_logged = True
 
-    await hap.ws_disconnected_handler()
-
-    assert hap._stale_warning_logged is False
-    assert hap._stale_error_logged is False
-    assert hap._ws_connection_closed.is_set()
-
-
-async def test_staleness_check_warns_then_errors() -> None:
-    """Staleness check logs warning at first threshold, error at second."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=True)
-    _set_diagnostic_defaults(hap.home)
-
-    now = datetime(2026, 4, 30, tzinfo=None)
-
-    # Below warning threshold: nothing logged
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=60)
     with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
-        hap._async_check_websocket_staleness(now)
-    logger.warning.assert_not_called()
+        await hap._on_websocket_stale("warning", 400)
+    logger.warning.assert_called_once()
     logger.error.assert_not_called()
 
-    # Above warning, below error: warning once
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=400)
     with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
-        hap._async_check_websocket_staleness(now)
-        hap._async_check_websocket_staleness(now)
-    assert logger.warning.call_count == 1
-    logger.error.assert_not_called()
-
-    # Crosses error threshold: error once
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=900)
-    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
-        hap._async_check_websocket_staleness(now)
-        hap._async_check_websocket_staleness(now)
-    assert logger.error.call_count == 1
-
-
-async def test_staleness_check_resets_after_recovery() -> None:
-    """Once messages flow again, the staleness check re-arms its log-once flags."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=True)
-    _set_diagnostic_defaults(hap.home)
-    now = datetime(2026, 4, 30, tzinfo=None)
-
-    # Trigger error
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=900)
-    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER"):
-        hap._async_check_websocket_staleness(now)
-    assert hap._stale_error_logged is True
-
-    # Recovery resets flag
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=10)
-    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER"):
-        hap._async_check_websocket_staleness(now)
-    assert hap._stale_error_logged is False
-    assert hap._stale_warning_logged is False
-
-    # Stuck again -> error logs again
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=900)
-    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
-        hap._async_check_websocket_staleness(now)
+        await hap._on_websocket_stale("error", 1900)
     logger.error.assert_called_once()
+    logger.warning.assert_not_called()
 
 
-async def test_staleness_check_skips_when_websocket_disconnected() -> None:
-    """No staleness logging while the websocket reports disconnected."""
+async def test_async_connect_registers_stale_handler() -> None:
+    """async_connect registers the library websocket-stale callback."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    home = MagicMock()
+    home.enable_events = AsyncMock()
+    home.set_on_websocket_stale_handler = MagicMock()
+
+    await hap.async_connect(home)
+
+    home.set_on_websocket_stale_handler.assert_called_once_with(hap._on_websocket_stale)
+
+
+async def test_on_websocket_stale_log_format(caplog: pytest.LogCaptureFixture) -> None:
+    """Log message includes seconds_since (rounded) and the diagnostic context."""
     hap = HomematicipHAP(MagicMock(), MagicMock())
     hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=False)
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=99999)
     _set_diagnostic_defaults(hap.home)
-    now = datetime(2026, 4, 30, tzinfo=None)
+    hap.home.websocket_message_count = Mock(return_value=42)
 
-    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
-        hap._async_check_websocket_staleness(now)
+    with caplog.at_level("WARNING"):
+        await hap._on_websocket_stale("warning", 423.7)
 
-    logger.warning.assert_not_called()
-    logger.error.assert_not_called()
-
-
-async def test_staleness_check_skips_when_diagnostic_unavailable() -> None:
-    """Library returning None for seconds-since means we cannot decide; skip."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=True)
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=None)
-    _set_diagnostic_defaults(hap.home)
-    now = datetime(2026, 4, 30, tzinfo=None)
-
-    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
-        hap._async_check_websocket_staleness(now)
-
-    logger.warning.assert_not_called()
-    logger.error.assert_not_called()
+    assert "424" in caplog.text  # %.0f rounds
+    assert "message_count=42" in caplog.text
 
 
 async def test_get_state_clears_unreach_on_unchanged_devices() -> None:
@@ -726,25 +661,3 @@ async def test_get_state_clears_unreach_on_unchanged_devices() -> None:
 
     assert device_changed.unreach is False
     assert device_unchanged.unreach is False
-
-
-async def test_async_reset_unsubscribes_staleness_check(
-    hass: HomeAssistant, hmip_config_entry: MockConfigEntry
-) -> None:
-    """async_reset must unsubscribe the periodic staleness check."""
-    hass.config.components.add(DOMAIN)
-    hmip_config_entry.add_to_hass(hass)
-    hap = HomematicipHAP(hass, hmip_config_entry)
-    hap.home = MagicMock(spec=AsyncHome)
-    hap.home.disable_events_async = AsyncMock()
-
-    unsub = MagicMock()
-    hap._stale_check_unsub = unsub
-
-    with patch.object(
-        hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)
-    ):
-        await hap.async_reset()
-
-    unsub.assert_called_once()
-    assert hap._stale_check_unsub is None

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -521,17 +521,21 @@ async def test_async_connect_registers_stale_handler() -> None:
 
 
 async def test_on_websocket_stale_log_format(caplog: pytest.LogCaptureFixture) -> None:
-    """Log message includes seconds_since (rounded) and the diagnostic context."""
+    """Warning has the rounded seconds; diagnostic context is at debug level."""
     hap = HomematicipHAP(MagicMock(), MagicMock())
     hap.home = MagicMock()
     _set_diagnostic_defaults(hap.home)
     hap.home.websocket_message_count = Mock(return_value=42)
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG"):
         await hap._on_websocket_stale("warning", 423.7)
 
     assert "424" in caplog.text  # %.0f rounds
     assert "message_count=42" in caplog.text
+
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("424" in r.getMessage() for r in warning_records)
+    assert not any("message_count" in r.getMessage() for r in warning_records)
 
 
 async def test_get_state_clears_unreach_on_unchanged_devices() -> None:

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -241,36 +241,27 @@ async def test_auth_create_exception(hass: HomeAssistant, simple_mock_auth) -> N
 async def test_get_state_after_disconnect(
     hass: HomeAssistant, hmip_config_entry: MockConfigEntry, simple_mock_home
 ) -> None:
-    """Test get state after disconnect."""
+    """ws_connected after a disconnect triggers a state refresh via the library."""
     hass.config.components.add(DOMAIN)
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
 
     simple_mock_home = AsyncMock(spec=AsyncHome, autospec=True)
+    simple_mock_home.devices = []
     hap.home = simple_mock_home
-    hap.home.websocket_is_connected = Mock(side_effect=[False, True])
-
-    with (
-        patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
-        patch.object(hap, "get_state") as mock_get_state,
-    ):
-        assert not hap._ws_connection_closed.is_set()
-
-        await hap.ws_connected_handler()
-        mock_get_state.assert_not_called()
-
-        await hap.ws_disconnected_handler()
-        assert hap._ws_connection_closed.is_set()
-        with patch(
-            "homeassistant.components.homematicip_cloud.hap.AsyncHome.websocket_is_connected",
-            return_value=True,
-        ):
-            await hap.ws_connected_handler()
-            mock_get_state.assert_called_once()
 
     assert not hap._ws_connection_closed.is_set()
-    hap.home.websocket_is_connected.assert_called()
-    mock_sleep.assert_awaited_with(2)
+
+    await hap.ws_connected_handler()
+    simple_mock_home.refresh_state_after_reconnect_async.assert_not_called()
+
+    await hap.ws_disconnected_handler()
+    assert hap._ws_connection_closed.is_set()
+
+    await hap.ws_connected_handler()
+    await hass.async_block_till_done()
+    simple_mock_home.refresh_state_after_reconnect_async.assert_called_once()
+    assert not hap._ws_connection_closed.is_set()
 
 
 async def test_get_state_after_ap_reconnect(
@@ -289,48 +280,42 @@ async def test_get_state_after_ap_reconnect(
 
     simple_mock_home = MagicMock(spec=AsyncHome)
     simple_mock_home.devices = []
-    simple_mock_home.websocket_is_connected = Mock(return_value=True)
+    simple_mock_home.refresh_state_after_reconnect_async = AsyncMock()
     hap.home = simple_mock_home
 
-    with patch.object(hap, "get_state") as mock_get_state:
-        # Initially not disconnected
-        assert not hap._ws_connection_closed.is_set()
+    # Initially not disconnected
+    assert not hap._ws_connection_closed.is_set()
 
-        # Access point loses cloud connection
-        hap.home.connected = False
-        hap.async_update()
-        assert hap._ws_connection_closed.is_set()
-        mock_get_state.assert_not_called()
+    # Access point loses cloud connection
+    hap.home.connected = False
+    hap.async_update()
+    assert hap._ws_connection_closed.is_set()
+    simple_mock_home.refresh_state_after_reconnect_async.assert_not_called()
 
-        # Access point reconnects to cloud
-        hap.home.connected = True
-        hap.async_update()
+    # Access point reconnects to cloud
+    hap.home.connected = True
+    hap.async_update()
 
-        # Let _try_get_state run
-        await hass.async_block_till_done()
-        mock_get_state.assert_called_once()
-
+    # Let _try_get_state run
+    await hass.async_block_till_done()
+    simple_mock_home.refresh_state_after_reconnect_async.assert_called_once()
     assert not hap._ws_connection_closed.is_set()
 
 
-async def test_try_get_state_exponential_backoff() -> None:
-    """Test _try_get_state waits for websocket connection."""
-
-    # Arrange: Create instance and mock home
+async def test_try_get_state_delegates_to_library_then_post_processes() -> None:
+    """_try_get_state calls refresh_state_after_reconnect_async then runs post-processing."""
     hap = HomematicipHAP(MagicMock(), MagicMock())
     hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=True)
+    hap.home.refresh_state_after_reconnect_async = AsyncMock()
+    device_changed = MagicMock(unreach=False)
+    device_unchanged = MagicMock(unreach=True)
+    hap.home.devices = [device_changed, device_unchanged]
 
-    hap.get_state = AsyncMock(
-        side_effect=[HmipConnectionError, HmipConnectionError, True]
-    )
+    await hap._try_get_state()
 
-    with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
-        await hap._try_get_state()
-
-    assert mock_sleep.mock_calls[0].args[0] == 8
-    assert mock_sleep.mock_calls[1].args[0] == 16
-    assert hap.get_state.call_count == 3
+    hap.home.refresh_state_after_reconnect_async.assert_awaited_once()
+    assert device_changed.unreach is False
+    assert device_unchanged.unreach is False
 
 
 async def test_try_get_state_handle_exception() -> None:
@@ -372,24 +357,25 @@ async def test_async_connect(
 async def test_try_get_state_auth_error_triggers_reauth(
     hass: HomeAssistant, hmip_config_entry: MockConfigEntry, simple_mock_home
 ) -> None:
-    """Test _try_get_state stops retrying on auth error and triggers reauth."""
+    """An auth error from the library triggers a reauth flow without post-processing."""
     hass.config.components.add(DOMAIN)
     hmip_config_entry.add_to_hass(hass)
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
 
     hap.home = MagicMock(spec=AsyncHome)
-    hap.home.websocket_is_connected = Mock(return_value=True)
-
-    hap.get_state = AsyncMock(side_effect=HmipAuthenticationError)
+    hap.home.devices = [MagicMock(unreach=True)]
+    hap.home.refresh_state_after_reconnect_async = AsyncMock(
+        side_effect=HmipAuthenticationError
+    )
 
     assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
 
     await hap._try_get_state()
     await hass.async_block_till_done()
 
-    # Should have called get_state only once (no retries)
-    assert hap.get_state.call_count == 1
+    # Auth error path: post-processing must NOT have run.
+    assert hap.home.devices[0].unreach is True
     # Should have triggered a reauth flow
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     assert len(flows) == 1
@@ -449,18 +435,17 @@ async def test_replaced_get_state_task_cancellation_is_not_logged_as_error(
     hass.config.components.add(DOMAIN)
     hap = HomematicipHAP(hass, hmip_config_entry)
     hap.home = MagicMock(spec=AsyncHome)
-    hap.home.websocket_is_connected.return_value = True
+    hap.home.devices = []
     _set_diagnostic_defaults(hap.home)
 
-    continue_get_state = asyncio.Event()
+    continue_refresh = asyncio.Event()
 
-    async def block_get_state() -> None:
-        await continue_get_state.wait()
+    async def block_refresh() -> None:
+        await continue_refresh.wait()
 
-    with (
-        patch.object(hap, "get_state", side_effect=block_get_state),
-        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
-    ):
+    hap.home.refresh_state_after_reconnect_async = AsyncMock(side_effect=block_refresh)
+
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
         hap._ws_connection_closed.set()
         hap._start_get_state_task()
         first_task = hap._get_state_task
@@ -474,105 +459,11 @@ async def test_replaced_get_state_task_cancellation_is_not_logged_as_error(
         assert second_task is not first_task
         await asyncio.sleep(0)
 
-        continue_get_state.set()
+        continue_refresh.set()
         await hass.async_block_till_done()
 
     assert first_task.cancelled()
     logger.error.assert_not_called()
-
-
-async def test_try_get_state_retries_on_unexpected_exception() -> None:
-    """_try_get_state retries when get_state raises an unexpected exception."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=True)
-    _set_diagnostic_defaults(hap.home)
-    hap.get_state = AsyncMock(side_effect=[RuntimeError("unexpected"), None])
-
-    with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
-        await hap._try_get_state()
-
-    assert mock_sleep.mock_calls[0].args[0] == 8
-    assert hap.get_state.call_count == 2
-
-
-async def test_try_get_state_cancelled_error_propagates() -> None:
-    """_try_get_state must not swallow task cancellation."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=True)
-    _set_diagnostic_defaults(hap.home)
-    hap.get_state = AsyncMock(side_effect=asyncio.CancelledError)
-
-    with pytest.raises(asyncio.CancelledError):
-        await hap._try_get_state()
-
-
-async def test_try_get_state_ws_timeout_proceeds_to_get_state() -> None:
-    """_try_get_state proceeds when websocket reconnect wait times out."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=False)
-    _set_diagnostic_defaults(hap.home)
-    hap.get_state = AsyncMock()
-
-    with (
-        patch("asyncio.sleep", new=AsyncMock()),
-        patch.object(type(hap), "_WS_WAIT_TIMEOUT", 0),
-        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
-    ):
-        await hap._try_get_state()
-
-    hap.get_state.assert_called_once()
-    logger.warning.assert_called_once()
-
-
-async def test_try_get_state_ws_wait_no_warning_if_reconnect_during_sleep() -> None:
-    """Reconnect during the wait sleep must not produce a 'still waiting' warning."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    # First call: not connected (enters loop). Re-check after sleep at the
-    # warning threshold: connected. Final loop-top check: connected (exits).
-    hap.home.websocket_is_connected = Mock(side_effect=[False, True, True])
-    _set_diagnostic_defaults(hap.home)
-    hap.get_state = AsyncMock()
-
-    with (
-        patch("asyncio.sleep", new=AsyncMock()),
-        patch.object(type(hap), "_WS_WAIT_INTERVAL", 60),
-        patch.object(type(hap), "_WS_WAIT_WARNING", 60),
-        patch.object(type(hap), "_WS_WAIT_TIMEOUT", 600),
-        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
-    ):
-        await hap._try_get_state()
-
-    logger.warning.assert_not_called()
-    hap.get_state.assert_called_once()
-
-
-async def test_try_get_state_ws_wait_logs_diagnostics() -> None:
-    """Websocket-wait timeout includes library diagnostics in the log."""
-    hap = HomematicipHAP(MagicMock(), MagicMock())
-    hap.home = MagicMock()
-    hap.home.websocket_is_connected = Mock(return_value=False)
-    hap.home.websocket_last_disconnect_reason = Mock(return_value="connect timeout")
-    hap.home.websocket_reconnect_attempt_count = Mock(return_value=3)
-    hap.home.websocket_seconds_since_last_message = Mock(return_value=123.0)
-    hap.home.websocket_message_count = Mock(return_value=42)
-    hap.get_state = AsyncMock()
-
-    with (
-        patch("asyncio.sleep", new=AsyncMock()),
-        patch.object(type(hap), "_WS_WAIT_TIMEOUT", 0),
-        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
-    ):
-        await hap._try_get_state()
-
-    args = str(logger.warning.call_args)
-    assert "connect timeout" in args
-    assert "reconnect_attempts=3" in args
-    assert "seconds_since_last_message=123.0" in args
-    assert "message_count=42" in args
 
 
 async def test_websocket_diagnostic_context_omits_none_values() -> None:

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -1,5 +1,7 @@
 """Test HomematicIP Cloud accesspoint."""
 
+import asyncio
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homematicip.auth import Auth
@@ -393,3 +395,356 @@ async def test_try_get_state_auth_error_triggers_reauth(
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     assert len(flows) == 1
     assert flows[0]["context"]["source"] == "reauth"
+
+
+def _set_diagnostic_defaults(home: MagicMock) -> None:
+    """Configure quiet defaults for diagnostic methods on a mocked AsyncHome."""
+    home.websocket_last_disconnect_reason = Mock(return_value=None)
+    home.websocket_reconnect_attempt_count = Mock(return_value=None)
+    home.websocket_seconds_since_last_message = Mock(return_value=None)
+    home.websocket_message_count = Mock(return_value=None)
+
+
+async def test_start_get_state_task_cancels_existing_task(
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry
+) -> None:
+    """Starting a reconnect refresh cancels any in-flight refresh."""
+    hass.config.components.add(DOMAIN)
+    hap = HomematicipHAP(hass, hmip_config_entry)
+    hap.home = MagicMock(spec=AsyncHome)
+
+    old_task = MagicMock()
+    old_task.done.return_value = False
+    hap._get_state_task = old_task
+
+    with patch.object(hap, "_try_get_state", new=AsyncMock()):
+        hap._start_get_state_task()
+
+    old_task.cancel.assert_called_once()
+    assert hap._get_state_task is not old_task
+    assert not hap._ws_connection_closed.is_set()
+
+
+async def test_start_get_state_task_skips_cancel_for_completed_task(
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry
+) -> None:
+    """Starting a reconnect refresh does not cancel a completed task."""
+    hass.config.components.add(DOMAIN)
+    hap = HomematicipHAP(hass, hmip_config_entry)
+    hap.home = MagicMock(spec=AsyncHome)
+
+    old_task = MagicMock()
+    old_task.done.return_value = True
+    hap._get_state_task = old_task
+
+    with patch.object(hap, "_try_get_state", new=AsyncMock()):
+        hap._start_get_state_task()
+
+    old_task.cancel.assert_not_called()
+
+
+async def test_replaced_get_state_task_cancellation_is_not_logged_as_error(
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry
+) -> None:
+    """Replacing an in-flight refresh must not log the cancelled task as error."""
+    hass.config.components.add(DOMAIN)
+    hap = HomematicipHAP(hass, hmip_config_entry)
+    hap.home = MagicMock(spec=AsyncHome)
+    hap.home.websocket_is_connected.return_value = True
+    _set_diagnostic_defaults(hap.home)
+
+    continue_get_state = asyncio.Event()
+
+    async def block_get_state() -> None:
+        await continue_get_state.wait()
+
+    with (
+        patch.object(hap, "get_state", side_effect=block_get_state),
+        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
+    ):
+        hap._ws_connection_closed.set()
+        hap._start_get_state_task()
+        first_task = hap._get_state_task
+        assert first_task is not None
+        await asyncio.sleep(0)
+
+        hap._ws_connection_closed.set()
+        hap._start_get_state_task()
+        second_task = hap._get_state_task
+        assert second_task is not None
+        assert second_task is not first_task
+        await asyncio.sleep(0)
+
+        continue_get_state.set()
+        await hass.async_block_till_done()
+
+    assert first_task.cancelled()
+    logger.error.assert_not_called()
+
+
+async def test_try_get_state_retries_on_unexpected_exception() -> None:
+    """_try_get_state retries when get_state raises an unexpected exception."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=True)
+    _set_diagnostic_defaults(hap.home)
+    hap.get_state = AsyncMock(side_effect=[RuntimeError("unexpected"), None])
+
+    with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await hap._try_get_state()
+
+    assert mock_sleep.mock_calls[0].args[0] == 8
+    assert hap.get_state.call_count == 2
+
+
+async def test_try_get_state_cancelled_error_propagates() -> None:
+    """_try_get_state must not swallow task cancellation."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=True)
+    _set_diagnostic_defaults(hap.home)
+    hap.get_state = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with pytest.raises(asyncio.CancelledError):
+        await hap._try_get_state()
+
+
+async def test_try_get_state_ws_timeout_proceeds_to_get_state() -> None:
+    """_try_get_state proceeds when websocket reconnect wait times out."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=False)
+    _set_diagnostic_defaults(hap.home)
+    hap.get_state = AsyncMock()
+
+    with (
+        patch("asyncio.sleep", new=AsyncMock()),
+        patch.object(type(hap), "_WS_WAIT_TIMEOUT", 0),
+        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
+    ):
+        await hap._try_get_state()
+
+    hap.get_state.assert_called_once()
+    logger.warning.assert_called_once()
+
+
+async def test_try_get_state_ws_wait_no_warning_if_reconnect_during_sleep() -> None:
+    """Reconnect during the wait sleep must not produce a 'still waiting' warning."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    # First call: not connected (enters loop). Re-check after sleep at the
+    # warning threshold: connected. Final loop-top check: connected (exits).
+    hap.home.websocket_is_connected = Mock(side_effect=[False, True, True])
+    _set_diagnostic_defaults(hap.home)
+    hap.get_state = AsyncMock()
+
+    with (
+        patch("asyncio.sleep", new=AsyncMock()),
+        patch.object(type(hap), "_WS_WAIT_INTERVAL", 60),
+        patch.object(type(hap), "_WS_WAIT_WARNING", 60),
+        patch.object(type(hap), "_WS_WAIT_TIMEOUT", 600),
+        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
+    ):
+        await hap._try_get_state()
+
+    logger.warning.assert_not_called()
+    hap.get_state.assert_called_once()
+
+
+async def test_try_get_state_ws_wait_logs_diagnostics() -> None:
+    """Websocket-wait timeout includes library diagnostics in the log."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=False)
+    hap.home.websocket_last_disconnect_reason = Mock(return_value="connect timeout")
+    hap.home.websocket_reconnect_attempt_count = Mock(return_value=3)
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=123.0)
+    hap.home.websocket_message_count = Mock(return_value=42)
+    hap.get_state = AsyncMock()
+
+    with (
+        patch("asyncio.sleep", new=AsyncMock()),
+        patch.object(type(hap), "_WS_WAIT_TIMEOUT", 0),
+        patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger,
+    ):
+        await hap._try_get_state()
+
+    args = str(logger.warning.call_args)
+    assert "connect timeout" in args
+    assert "reconnect_attempts=3" in args
+    assert "seconds_since_last_message=123.0" in args
+    assert "message_count=42" in args
+
+
+async def test_websocket_diagnostic_context_omits_none_values() -> None:
+    """None-valued diagnostics are omitted from the context string."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_last_disconnect_reason = Mock(return_value=None)
+    hap.home.websocket_reconnect_attempt_count = Mock(return_value=2)
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=None)
+    hap.home.websocket_message_count = Mock(return_value=10)
+
+    context = hap._websocket_diagnostic_context()
+
+    assert "last_disconnect_reason" not in context
+    assert "reconnect_attempts=2" in context
+    assert "message_count=10" in context
+
+
+async def test_websocket_diagnostic_context_falls_back_when_all_unknown() -> None:
+    """Helper returns a non-empty fallback if every diagnostic is None."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    _set_diagnostic_defaults(hap.home)
+
+    assert hap._websocket_diagnostic_context() == "no diagnostics available"
+
+
+async def test_ws_disconnected_handler_rearms_staleness_flags() -> None:
+    """A websocket disconnect re-arms log-once flags for the next stuck period."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    _set_diagnostic_defaults(hap.home)
+    hap._stale_warning_logged = True
+    hap._stale_error_logged = True
+
+    await hap.ws_disconnected_handler()
+
+    assert hap._stale_warning_logged is False
+    assert hap._stale_error_logged is False
+    assert hap._ws_connection_closed.is_set()
+
+
+async def test_staleness_check_warns_then_errors() -> None:
+    """Staleness check logs warning at first threshold, error at second."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=True)
+    _set_diagnostic_defaults(hap.home)
+
+    now = datetime(2026, 4, 30, tzinfo=None)
+
+    # Below warning threshold: nothing logged
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=60)
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
+        hap._async_check_websocket_staleness(now)
+    logger.warning.assert_not_called()
+    logger.error.assert_not_called()
+
+    # Above warning, below error: warning once
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=400)
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
+        hap._async_check_websocket_staleness(now)
+        hap._async_check_websocket_staleness(now)
+    assert logger.warning.call_count == 1
+    logger.error.assert_not_called()
+
+    # Crosses error threshold: error once
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=900)
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
+        hap._async_check_websocket_staleness(now)
+        hap._async_check_websocket_staleness(now)
+    assert logger.error.call_count == 1
+
+
+async def test_staleness_check_resets_after_recovery() -> None:
+    """Once messages flow again, the staleness check re-arms its log-once flags."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=True)
+    _set_diagnostic_defaults(hap.home)
+    now = datetime(2026, 4, 30, tzinfo=None)
+
+    # Trigger error
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=900)
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER"):
+        hap._async_check_websocket_staleness(now)
+    assert hap._stale_error_logged is True
+
+    # Recovery resets flag
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=10)
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER"):
+        hap._async_check_websocket_staleness(now)
+    assert hap._stale_error_logged is False
+    assert hap._stale_warning_logged is False
+
+    # Stuck again -> error logs again
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=900)
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
+        hap._async_check_websocket_staleness(now)
+    logger.error.assert_called_once()
+
+
+async def test_staleness_check_skips_when_websocket_disconnected() -> None:
+    """No staleness logging while the websocket reports disconnected."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=False)
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=99999)
+    _set_diagnostic_defaults(hap.home)
+    now = datetime(2026, 4, 30, tzinfo=None)
+
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
+        hap._async_check_websocket_staleness(now)
+
+    logger.warning.assert_not_called()
+    logger.error.assert_not_called()
+
+
+async def test_staleness_check_skips_when_diagnostic_unavailable() -> None:
+    """Library returning None for seconds-since means we cannot decide; skip."""
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=True)
+    hap.home.websocket_seconds_since_last_message = Mock(return_value=None)
+    _set_diagnostic_defaults(hap.home)
+    now = datetime(2026, 4, 30, tzinfo=None)
+
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as logger:
+        hap._async_check_websocket_staleness(now)
+
+    logger.warning.assert_not_called()
+    logger.error.assert_not_called()
+
+
+async def test_get_state_clears_unreach_on_unchanged_devices() -> None:
+    """get_state must clear stale unreach flags after a reconnect.
+
+    set_all_to_unavailable() sets unreach=True on all devices on disconnect;
+    get_current_state_async() only updates devices whose state actually
+    changed, so unchanged devices stay marked unreachable. We must clear it.
+    """
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.get_current_state_async = AsyncMock()
+    device_changed = MagicMock(unreach=False)
+    device_unchanged = MagicMock(unreach=True)
+    hap.home.devices = [device_changed, device_unchanged]
+
+    await hap.get_state()
+
+    assert device_changed.unreach is False
+    assert device_unchanged.unreach is False
+
+
+async def test_async_reset_unsubscribes_staleness_check(
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry
+) -> None:
+    """async_reset must unsubscribe the periodic staleness check."""
+    hass.config.components.add(DOMAIN)
+    hmip_config_entry.add_to_hass(hass)
+    hap = HomematicipHAP(hass, hmip_config_entry)
+    hap.home = MagicMock(spec=AsyncHome)
+    hap.home.disable_events_async = AsyncMock()
+
+    unsub = MagicMock()
+    hap._stale_check_unsub = unsub
+
+    with patch.object(
+        hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)
+    ):
+        await hap.async_reset()
+
+    unsub.assert_called_once()
+    assert hap._stale_check_unsub is None


### PR DESCRIPTION
## Proposed change

Hardens the post-reconnect state recovery in `homematicip_cloud` and uses the
new diagnostic methods exposed by `homematicip` 2.9.0 (#169499) to surface the
underlying state of the websocket in logs. The integration is push-based; the
library handles reconnection itself (backoff, 8 h stale-connection safety net),
so this PR focuses purely on what HA does after reconnect and on instrumentation
for the still-unsolved reports in #160048.

Concretely:

- **Bound the post-reconnect websocket wait.** `_try_get_state` looped forever
  on `websocket_is_connected()`. It now waits up to 120 s with a warning at
  60 s and falls through to the REST refresh on timeout (the REST call is
  independent of the websocket).
- **Single entry point for the reconnect refresh.** `_start_get_state_task`
  cancels any in-flight refresh before starting a new one, used by both
  `async_update` and `ws_connected_handler`. `CancelledError` no longer ends
  up in `get_state_finished` as an error.
- **Broaden `_try_get_state`'s exception handling.** Unexpected exceptions now
  retry with the same exponential backoff as `HmipConnectionError` and are
  logged via `_LOGGER.exception` so the traceback is visible. Auth failures
  still trigger reauth.
- **Reset `unreach=False` on all devices after a successful refresh.**
  `set_all_to_unavailable` marks every device unreach=True on disconnect;
  `get_current_state_async()` only clears that for devices whose state actually
  changed during the outage, so unchanged devices stay stuck unavailable. This
  is the user-facing symptom in #160048 — entities indefinitely unavailable
  after reconnect.
- **Detect a websocket that claims connected but is silent.** A periodic check
  (every 60 s) compares `websocket_seconds_since_last_message()` against two
  thresholds: warning at 5 min, error at 10 min, log-once per stuck period and
  re-armed on disconnect. The library's own 8 h safety net remains the
  last-resort floor; this gives users (and us) a much earlier signal.
- **Surface library diagnostics in reconnect log lines.**
  `_websocket_diagnostic_context` formats `last_disconnect_reason`,
  `reconnect_attempts`, `seconds_since_last_message` and `message_count` for
  every reconnect/staleness/wait-timeout log entry — so when a user reports
  "stopped responding" we can see what the library saw.

Tests cover all of the above (33 tests in `test_hap.py`, 16 of them new).

This supersedes the diagnostic build in #166688, which will be closed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #160048
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr