### PR TITLE
Fix stream recorder losing recording when worker exits very fast

### DIFF
--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -169,11 +169,7 @@ class RecorderOutput(StreamOutput):
                     out_file.write(chunk)
             os.remove(video_path + ".tmp")
 
-        def finish_writing(
-            segments: deque[Segment],
-            output: av.container.OutputContainer | None,
-            video_path: str,
-        ) -> None:
+        def finish_writing(segments: deque[Segment]) -> None:
             """Finish writing output."""
             # Should only have 0 or 1 segments, but loop through just in case
             while segments:
@@ -183,14 +179,14 @@ class RecorderOutput(StreamOutput):
                 return
             output.close()
             try:
-                write_transform_matrix_and_rename(video_path)
+                write_transform_matrix_and_rename(self.video_path)
             except FileNotFoundError:
                 _LOGGER.error(
                     (
                         "Error writing to '%s'. There are likely multiple recordings"
                         " writing to the same file"
                     ),
-                    video_path,
+                    self.video_path,
                 )
 
         # Write lookback segments
@@ -208,6 +204,4 @@ class RecorderOutput(StreamOutput):
                 write_segment, self._segments.popleft()
             )
         # Write remaining segments and close output
-        await self._hass.async_add_executor_job(
-            finish_writing, self._segments, output, self.video_path
-        )
+        await self._hass.async_add_executor_job(finish_writing, self._segments)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`finish_writing` in the stream recorder shadowed the enclosing closure's `output` (and `video_path`) with parameters of the same name. When `write_segment` (called inside `finish_writing`) created the output container, it did so via `nonlocal output` - which targets the closure variable, not the parameter. The subsequent `if output is None:` check then read the still-`None` local parameter, logged `Recording failed to capture anything`, and returned without closing the `.tmp` file or renaming it to the final mp4 - silently dropping the recording.

This is hit whenever the worker finishes and `cleanup()` flips `idle=True` before the `while not self.idle:` loop in `async_record` runs - i.e. when the worker exits very fast. It surfaced as flakiness in `test_record_stream_audio` (and the sibling `test_record_stream` / `test_record_stream_rotate` tests) under parallel CI load - see e.g. the `pcm_mulaw-0` failure in https://github.com/home-assistant/core/actions/runs/25149997259/job/73718853056?pr=169524.

Reproduced reliably locally with `pytest tests/components/stream/test_recorder.py --count=100 -n 8 --timeout=9` (matches the `--timeout=9` used in CI); after the fix, 1100 iterations all pass.

The fix drops the redundant `output` / `video_path` parameters so `finish_writing` reads the same closure variables that `write_segment` writes to.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr