### PR TITLE
Remove future annotations import from wemo

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -1,7 +1,5 @@
 """Support for WeMo device discovery."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Coroutine, Sequence
 from datetime import datetime
 import logging

--- a/homeassistant/components/wemo/config_flow.py
+++ b/homeassistant/components/wemo/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for Wemo."""
 
-from __future__ import annotations
-
 from dataclasses import fields
 from typing import Any, get_type_hints
 
@@ -64,11 +62,12 @@ def _schema_for_options(options: Options) -> vol.Schema:
     All values are optional. The default value is set to the current value and
     the type hint is set to the value of the field type annotation.
     """
+    type_hints = get_type_hints(type(options))
     return vol.Schema(
         {
-            vol.Optional(
-                field.name, default=getattr(options, field.name)
-            ): get_type_hints(options)[field.name]
+            vol.Optional(field.name, default=getattr(options, field.name)): type_hints[
+                field.name
+            ]
             for field in fields(options)
         }
     )

--- a/homeassistant/components/wemo/coordinator.py
+++ b/homeassistant/components/wemo/coordinator.py
@@ -1,7 +1,5 @@
 """Home Assistant wrapper for a pyWeMo device."""
 
-from __future__ import annotations
-
 import asyncio
 from dataclasses import dataclass, fields
 from datetime import timedelta

--- a/homeassistant/components/wemo/device_trigger.py
+++ b/homeassistant/components/wemo/device_trigger.py
@@ -1,7 +1,5 @@
 """Triggers for WeMo devices."""
 
-from __future__ import annotations
-
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 import voluptuous as vol
 

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -1,7 +1,5 @@
 """Classes shared among Wemo entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 import logging
 from typing import Any

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -1,7 +1,5 @@
 """Support for WeMo humidifier."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 import functools as ft
 import math

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -1,7 +1,5 @@
 """Support for Belkin WeMo lights."""
 
-from __future__ import annotations
-
 import functools as ft
 from typing import Any, cast
 

--- a/homeassistant/components/wemo/models.py
+++ b/homeassistant/components/wemo/models.py
@@ -1,7 +1,5 @@
 """Common data structures and helpers for accessing them."""
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -1,7 +1,5 @@
 """Support for power sensors in WeMo Insight devices."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import cast

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -1,7 +1,5 @@
 """Support for WeMo switches."""
 
-from __future__ import annotations
-
 from datetime import datetime, timedelta
 from typing import Any
 


### PR DESCRIPTION
## Breaking change

## Proposed change

Remove `from __future__ import annotations` from the WeMo integration following the project-wide migration to Python 3.14's PEP 649 lazy annotations. Related to #169536.

In `config_flow.py`, `get_type_hints(options)` was called on a frozen dataclass instance. Under PEP 649, that lookup no longer falls back to the class's annotations and raises `TypeError: ... does not have annotations`. Switched to `get_type_hints(type(options))`.

Part of full cleanup:
- #169527
- #169536
- #169540
- #169542
- #169547
- #169548
- #169549

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #169536
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.