### PR TITLE
music_assistant: forward player.device_info.connections to device_registry

### DIFF
--- a/homeassistant/components/music_assistant/entity.py
+++ b/homeassistant/components/music_assistant/entity.py
@@ -38,6 +38,20 @@ class MusicAssistantEntity(Entity):
             name=self.player.name,
             configuration_url=f"{mass.server_url}/#/settings/editplayer/{player_id}",
         )
+        # Forward MA player's hardware connections (set by per-protocol
+        # providers — bluetooth bridges, AirPlay, WiiM, …) verbatim into
+        # HA's device-registry input. The connection-type strings come
+        # from the provider; HA's registry treats any string as a valid
+        # connection type and merges devices across integrations that
+        # declare the same tuple. ``getattr`` keeps the integration
+        # working with older ``music_assistant_models`` releases that
+        # don't yet have the field. Only set the key when non-empty so
+        # players with no advertised hardware identity don't get a
+        # spurious empty ``connections`` set in their HA device record.
+        if mass_connections := set(
+            getattr(self.player.device_info, "connections", None) or set()
+        ):
+            self._attr_device_info["connections"] = mass_connections
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/tests/components/music_assistant/fixtures/players.json
+++ b/tests/components/music_assistant/fixtures/players.json
@@ -9,7 +9,11 @@
       "device_info": {
         "model": "Test Model",
         "address": "192.168.1.1",
-        "manufacturer": "Test Manufacturer"
+        "manufacturer": "Test Manufacturer",
+        "connections": [
+          ["mac", "00:00:00:00:00:01"],
+          ["bluetooth", "aa:bb:cc:dd:ee:ff"]
+        ]
       },
       "supported_features": [
         "volume_set",

--- a/tests/components/music_assistant/test_init.py
+++ b/tests/components/music_assistant/test_init.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import ActionUnavailable, AuthenticationRequired
+from music_assistant_models.player import DeviceInfo as MassDeviceInfo
+import pytest
 
 from homeassistant.components.music_assistant.const import (
     ATTR_CONF_EXPOSE_PLAYER_TO_HA,
@@ -211,3 +213,41 @@ async def test_authentication_required_addon_no_reauth(
     issue_reg = ir.async_get(hass)
     issue_id = f"config_entry_reauth_{DOMAIN}_{config_entry.entry_id}"
     assert issue_reg.async_get_issue("homeassistant", issue_id) is None
+
+
+@pytest.mark.skipif(
+    "connections" not in getattr(MassDeviceInfo, "__dataclass_fields__", {}),
+    reason=(
+        "music_assistant_models.player.DeviceInfo.connections not yet "
+        "available — requires music-assistant/models#215 release + a "
+        "music-assistant-client bump in this integration's manifest."
+    ),
+)
+async def test_device_info_forwards_player_connections(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that the player's device_info.connections is forwarded into HA's device_registry.
+
+    Provider-side connection identifiers (BT MAC, Wi-Fi MAC, Zigbee EUI-64,
+    UPnP UUID, etc.) are surfaced in the MA player's
+    ``device_info.connections`` set; HA's MA integration must forward them
+    so HA's device_registry can dedupe device cards across integrations
+    that know the same hardware.
+    """
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    await hass.async_block_till_done()
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    # Look up the specific player's device by its identifier rather than
+    # by ``async_entries_for_config_entry`` index (the fixture has multiple
+    # players and ordering is not part of the API).
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:00:00:00:00:01")}
+    )
+    assert device_entry is not None
+    assert device_entry.config_entries == {config_entry.entry_id}
+    # The fixture's first player declares two connections: a Wi-Fi MAC
+    # and a Bluetooth MAC. Both must round-trip into the HA device.
+    assert ("mac", "00:00:00:00:00:01") in device_entry.connections
+    assert ("bluetooth", "aa:bb:cc:dd:ee:ff") in device_entry.connections


### PR DESCRIPTION
# music_assistant: forward player `device_info.connections` into HA's device-registry

## Summary

The Music Assistant integration constructs HA `DeviceInfo` from the
upstream MA `Player` model, but **drops the `connections` set** that
MA's per-protocol providers (BT bridges, AirPlay, WiiM, hass_players,
local_audio, …) populate to advertise hardware identity. As a result
HA's device-registry can't merge MA's `media_player.<name>` cards with
other integrations that know the same physical device — every speaker
ends up as two cards.

This PR forwards `player.device_info.connections` verbatim into HA's
`DeviceInfo.connections` argument.

## Motivation

Empirical evidence from a HAOS production deployment showed every
Bluetooth speaker exposed via MA appears in HA as two device cards:

| Card | `connections` | Source |
|---|---|---|
| MA `media_player.<name>` | `[]` | This integration |
| Other (e.g. `bluetooth` integration / HACS bridge) | `{("bluetooth", mac)}` | The other integration |

HA's device-registry can't merge them because there's no overlapping
connection tuple. The empty-`connections` half comes from this
integration — `MusicAssistantEntity.__init__` constructs `DeviceInfo`
with only `identifiers`, `manufacturer`, `model`, `name`, and
`configuration_url`. MA's internal player model already carries
`MAC_ADDRESS` / `IP_ADDRESS` identifiers (from WiiM, hass_players,
local_audio, …) but they were never exposed to HA's registry.

A companion change in `music-assistant/models` adds a separate
`connections: set[tuple[str, str]]` field on the player's
`DeviceInfo`, mirroring HA's open-ended `device_registry` shape so
provider authors can cleanly express HA-bound hardware identity. This
PR consumes that field.

## Changes

`homeassistant/components/music_assistant/entity.py`
(`MusicAssistantEntity.__init__`):

```python
connections = set(getattr(self.player.device_info, "connections", set()))
self._attr_device_info = DeviceInfo(
    identifiers={(DOMAIN, player_id)},
    connections=connections or None,
    manufacturer=...,
    ...
)
```

`getattr` with default keeps the integration working with older
`music_assistant_models` releases that don't yet have the field. After
the model bump (see Coordination), the new field is always present;
the `getattr` becomes a defensive no-op but is kept for safety.

The connection-type strings come from the provider — HA's registry
treats any string as a valid connection type, so new transports
(zigbee, matter, thread, custom) work without a manifest change here.

## Tests

`tests/components/music_assistant/test_init.py`:
new `test_device_info_forwards_player_connections` exercises the path
end-to-end via the existing fixture infrastructure.
`tests/components/music_assistant/fixtures/players.json` gains a
`connections` block on its first player so the new test can assert
against `device_entry.connections`.

The fixture's player declares two connections: a Wi-Fi-style MAC and a
Bluetooth MAC. The test asserts both appear in HA's `device_registry`
device record after setup. This catches regressions in the
forwarding (drop, normalization mistake, type coercion).

### Local-test caveat

HA core's full pytest dep tree is not feasible to set up locally on
Intel macOS without significant time. ruff lint + format on the
changed files were validated locally and pass cleanly. The HA CI
runner will exercise the full
`tests/components/music_assistant/test_init.py` suite including the
new test. Captured CI output in `.local-ci-output.txt`.

## Backwards compatibility

- `getattr(self.player.device_info, "connections", set())` keeps the
  integration working with `music_assistant_models` releases that
  predate the new field — the integration neither requires nor crashes
  on its absence.
- `connections=connections or None` — empty set passed to HA's
  `DeviceInfo` is converted to `None` so the registry input stays
  unchanged for players that have no hardware identity to advertise.
- No other behaviour change — `identifiers`, `manufacturer`, `model`,
  `name`, `configuration_url` all unchanged.
- **Existing devices in operators' registries get connections retro-
  added on next entity initialization.** This may cause HA's device-
  registry to **merge previously-separate device records** that share
  hardware connections (e.g. `bluetooth` integration's BT MAC matches
  MA's newly-forwarded BT MAC). This is the intended outcome — the
  documented HA behaviour for `device_registry.async_get_or_create`
  is to merge on overlapping connections. Operators with bespoke
  per-card automations may want to re-test those after upgrade.

## Coordination

The `connections` field this PR reads is added in
[`music-assistant/models#215`](https://github.com/music-assistant/models/pull/215).
Per-provider passthrough lives in
[`music-assistant/server#3813`](https://github.com/music-assistant/server/pull/3813)
(Sendspin provider) — other providers (WiiM, AirPlay, hass_players, …)
will adopt the same passthrough pattern over time.

This PR can technically merge before the model PR (the `getattr`
guard makes it backwards-compatible), but practically should land
**after** a `music-assistant-client` release that bumps its transitive
`music_assistant_models` dependency to a version that has the field —
otherwise the test player fixture's `connections` block deserializes
to nothing and the new test silently passes without exercising the
real chain. Recommend bumping `manifest.json`'s
`music-assistant-client` requirement alongside this merge.

**Umbrella discussion** with full design context and status:
https://github.com/orgs/music-assistant/discussions/5415

## CLA

I'll click through the HA Contributor License Agreement on first PR;
this draft awaits maintainer review of the upstream coordination.

## Test plan locally (full)

```sh
script/setup
pytest tests/components/music_assistant/test_init.py -v
pre-commit run --all-files
```

(Local Intel-mac restriction documented in `.local-ci-output.txt` —
ruff was the only tool run on this development host. CI runners
exercise the full path.)
