### PR TITLE
Optimize uv cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,7 +372,7 @@ jobs:
           RUNNER_OS: ${{ runner.os }}
           RUNNER_ARCH: ${{ runner.arch }}
           PYTHON_VERSION: ${{ steps.python.outputs.python-version }}
-          HASH_FILES: ${{ hashFiles('pyproject.toml', 'requirements.txt', 'requirements_all.txt', 'requirements_test.txt') }}
+          HASH_FILES: ${{ hashFiles('requirements.txt', 'requirements_all.txt', 'requirements_test.txt') }}
         run: |
           partial_key="${RUNNER_OS}-${RUNNER_ARCH}-${PYTHON_VERSION}-uv-"
           echo "partial_key=${partial_key}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -475,7 +475,7 @@ jobs:
           ./script/check_dirty
       - name: Prune uv cache
         if: |
-          steps.cache-hit.outputs.cache-hit != 'true'
+          steps.cache-uv.outputs.cache-hit != 'true'
           && (
             success()
             || (always() && steps.create-venv.outcome == 'success'))

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -357,7 +357,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
+      - name: Restore base Python virtual environment
+        id: cache-venv
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: venv
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
+            needs.info.outputs.python_cache_key }}
       - name: Generate partial uv restore key
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         id: generate-uv-key
         env:
           RUNNER_OS: ${{ runner.os }}
@@ -367,15 +376,7 @@ jobs:
         run: |
           partial_key="${RUNNER_OS}-${RUNNER_ARCH}-${PYTHON_VERSION}-uv-"
           echo "partial_key=${partial_key}" >> $GITHUB_OUTPUT
-          echo "full_key=${partial_key}-${HASH_FILES}" >> $GITHUB_OUTPUT
-      - name: Restore base Python virtual environment
-        id: cache-venv
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: venv
-          key: >-
-            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
-            needs.info.outputs.python_cache_key }}
+          echo "full_key=${partial_key}${HASH_FILES}" >> $GITHUB_OUTPUT
       - name: Restore uv wheel cache
         if: steps.cache-venv.outputs.cache-hit != 'true'
         id: cache-uv
@@ -474,14 +475,14 @@ jobs:
           ./script/check_dirty
       - name: Prune uv cache
         if: |
-          (success() && steps.cache-venv.outputs.cache-hit != 'true')
-          || (always()
-            && steps.create-venv.outcome == 'success'
-            && steps.cache-uv.outputs.cache-matched-key == '')
+          steps.cache-hit.outputs.cache-hit != 'true'
+          && (
+            success()
+            || (always() && steps.create-venv.outcome == 'success'))
         id: prune-uv-cache
         run: |
           . venv/bin/activate
-          uv cache prune
+          uv cache prune --ci
       - name: Save uv wheel cache
         if: steps.prune-uv-cache.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -479,7 +479,9 @@ jobs:
             && steps.create-venv.outcome == 'success'
             && steps.cache-uv.outputs.cache-matched-key == '')
         id: prune-uv-cache
-        run: uv cache prune
+        run: |
+          . venv/bin/activate
+          uv cache prune
       - name: Save uv wheel cache
         if: steps.prune-uv-cache.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,6 @@ on:
 
 env:
   CACHE_VERSION: 3
-  UV_CACHE_VERSION: 1
   MYPY_CACHE_VERSION: 1
   HA_SHORT_VERSION: "2026.6"
   ADDITIONAL_PYTHON_VERSIONS: "[]"
@@ -360,10 +359,15 @@ jobs:
           check-latest: true
       - name: Generate partial uv restore key
         id: generate-uv-key
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_ARCH: ${{ runner.arch }}
+          PYTHON_VERSION: ${{ steps.python.outputs.python-version }}
+          HASH_FILES: ${{ hashFiles('pyproject.toml', 'requirements.txt', 'requirements_all.txt', 'requirements_test.txt') }}
         run: |
-          uv_version=$(cat requirements.txt | grep uv | cut -d '=' -f 3)
-          echo "version=${uv_version}" >> $GITHUB_OUTPUT
-          echo "key=uv-${UV_CACHE_VERSION}-${uv_version}-${HA_SHORT_VERSION}-$(date -u '+%Y-%m-%dT%H:%M:%s')" >> $GITHUB_OUTPUT
+          partial_key="${RUNNER_OS}-${RUNNER_ARCH}-${PYTHON_VERSION}-uv-"
+          echo "partial_key=${partial_key}" >> $GITHUB_OUTPUT
+          echo "full_key=${partial_key}-${HASH_FILES}" >> $GITHUB_OUTPUT
       - name: Restore base Python virtual environment
         id: cache-venv
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -378,13 +382,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.UV_CACHE_DIR }}
-          key: >-
-            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
-            steps.generate-uv-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-uv-${{
-            env.UV_CACHE_VERSION }}-${{ steps.generate-uv-key.outputs.version }}-${{
-            env.HA_SHORT_VERSION }}-
+          key: ${{ steps.generate-uv-key.outputs.full_key }}
+          restore-keys: ${{ steps.generate-uv-key.outputs.partial_key }}
       - name: Check if apt cache exists
         id: cache-apt-check
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -473,18 +472,20 @@ jobs:
       - name: Check dirty
         run: |
           ./script/check_dirty
-      - name: Save uv wheel cache
+      - name: Prune uv cache
         if: |
           (success() && steps.cache-venv.outputs.cache-hit != 'true')
           || (always()
             && steps.create-venv.outcome == 'success'
             && steps.cache-uv.outputs.cache-matched-key == '')
+        id: prune-uv-cache
+        run: uv cache prune
+      - name: Save uv wheel cache
+        if: steps.prune-uv-cache.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.UV_CACHE_DIR }}
-          key: >-
-            ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-${{
-            steps.generate-uv-key.outputs.key }}
+          key: ${{ steps.generate-uv-key.outputs.full_key }}
       - name: Save base Python virtual environment
         if: always() && steps.create-venv.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
Currently we store the whole UV cache in githubs action cache, which is compressed ~650MB.
On uv docs the following is specified (https://docs.astral.sh/uv/concepts/cache/#caching-in-continuous-integration):
> With uv, it turns out that it's often faster to omit pre-built wheels from the cache (and instead re-download them from the registry on each run).

And it turns out that it's true. As downloading/uploading the whole cache with compressing takes longer as just download it again from pypi.
| [Before](https://github.com/home-assistant/core/actions/runs/25134971569/job/73670919204) | [After](https://github.com/home-assistant/core/actions/runs/25166571768/job/73774305870) |
|--------|--------|
| <img width="477" height="486" alt="image" src="https://github.com/user-attachments/assets/37d73020-5f30-42cd-afd8-cb989aae2cc1" /> | <img width="481" height="441" alt="image" src="https://github.com/user-attachments/assets/af9c4fbc-063a-4e93-9ccd-33ad66e8893a" /> |
| 11+16+17 = **44s** | 1+22+2+2 = **27s** | 

As shown saving just the built wheels save us **17s** execution time but also the uploaded cache is just around ~45MB

The cache key will now be hashed from the requirements files instead of the current time as the requirements define which packages we are going to install and the cache will only change if a package will change as we pinn them.
No need to include also the HA version as the cache is still valid even if we change the HA version.
Removed also the uv cache version as it still was at 1 and a member can just go to the cache view and delete the cache if needed. It's faster than creating a PR

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
