### PR TITLE
Change MAC adresses in devolo Home Network tests

### DIFF
--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -21,7 +21,7 @@ IP_ALT = "192.0.2.2"
 
 CONNECTED_STATIONS = [
     ConnectedStationInfo(
-        mac_address="AA:BB:CC:DD:EE:FF",
+        mac_address="00:00:5E:00:53:01",
         vap_type=WIFI_VAP_MAIN_AP,
         band=WIFI_BAND_5G,
         rx_rate=87800,
@@ -48,7 +48,7 @@ DISCOVERY_INFO = ZeroconfServiceInfo(
         "FirmwareVersion": "5.6.1",
         "FirmwareDate": "2020-10-23",
         "PS": "",
-        "PlcMacAddress": "AA:BB:CC:DD:EE:FF",
+        "PlcMacAddress": "00:00:5E:00:53:00",
     },
 )
 
@@ -69,7 +69,7 @@ DISCOVERY_INFO_CHANGED = ZeroconfServiceInfo(
         "FirmwareVersion": "5.6.1",
         "FirmwareDate": "2020-10-23",
         "PS": "",
-        "PlcMacAddress": "AA:BB:CC:DD:EE:FF",
+        "PlcMacAddress": "00:00:5E:00:53:00",
     },
 )
 
@@ -103,7 +103,7 @@ GUEST_WIFI_CHANGED = WifiGuestAccessGet(
 
 NEIGHBOR_ACCESS_POINTS = [
     NeighborAPInfo(
-        mac_address="AA:BB:CC:DD:EE:FF",
+        mac_address="00:00:5E:00:53:04",
         ssid="wifi",
         band=WIFI_BAND_2G,
         channel=1,
@@ -115,19 +115,19 @@ NEIGHBOR_ACCESS_POINTS = [
 PLCNET = LogicalNetwork(
     devices=[
         {
-            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "mac_address": "00:00:5E:00:53:00",
             "attached_to_router": False,
             "topology": LOCAL,
             "user_device_name": "test1",
         },
         {
-            "mac_address": "11:22:33:44:55:66",
+            "mac_address": "00:00:5E:00:53:02",
             "attached_to_router": True,
             "topology": REMOTE,
             "user_device_name": "test2",
         },
         {
-            "mac_address": "12:34:56:78:9A:BC",
+            "mac_address": "00:00:5E:00:53:03",
             "attached_to_router": False,
             "topology": REMOTE,
             "user_device_name": "test3",
@@ -135,14 +135,14 @@ PLCNET = LogicalNetwork(
     ],
     data_rates=[
         {
-            "mac_address_from": "AA:BB:CC:DD:EE:FF",
-            "mac_address_to": "11:22:33:44:55:66",
+            "mac_address_from": "00:00:5E:00:53:00",
+            "mac_address_to": "00:00:5E:00:53:02",
             "rx_rate": 100.0,
             "tx_rate": 100.0,
         },
         {
-            "mac_address_from": "AA:BB:CC:DD:EE:FF",
-            "mac_address_to": "12:34:56:78:9A:BC",
+            "mac_address_from": "00:00:5E:00:53:00",
+            "mac_address_to": "00:00:5E:00:53:03",
             "rx_rate": 150.0,
             "tx_rate": 150.0,
         },
@@ -152,20 +152,20 @@ PLCNET = LogicalNetwork(
 PLCNET_ATTACHED = LogicalNetwork(
     devices=[
         {
-            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "mac_address": "00:00:5E:00:53:00",
             "attached_to_router": True,
         }
     ],
     data_rates=[
         {
-            "mac_address_from": "AA:BB:CC:DD:EE:FF",
-            "mac_address_to": "11:22:33:44:55:66",
+            "mac_address_from": "00:00:5E:00:53:00",
+            "mac_address_to": "00:00:5E:00:53:02",
             "rx_rate": 100.0,
             "tx_rate": 100.0,
         },
         {
-            "mac_address_from": "AA:BB:CC:DD:EE:FF",
-            "mac_address_to": "12:34:56:78:9A:BC",
+            "mac_address_from": "00:00:5E:00:53:00",
+            "mac_address_to": "00:00:5E:00:53:03",
             "rx_rate": 150.0,
             "tx_rate": 150.0,
         },

--- a/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
@@ -3,13 +3,13 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'band': '5 GHz',
-      'friendly_name': 'Mock Title AA:BB:CC:DD:EE:FF',
-      'mac': 'AA:BB:CC:DD:EE:FF',
+      'friendly_name': '00:00:5E:00:53:01',
+      'mac': '00:00:5E:00:53:01',
       'source_type': <SourceType.ROUTER: 'router'>,
       'wifi': 'Main',
     }),
     'context': <ANY>,
-    'entity_id': 'device_tracker.aa_bb_cc_dd_ee_ff',
+    'entity_id': 'device_tracker.00_00_5e_00_53_01',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/devolo_home_network/snapshots/test_init.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_init.ambr
@@ -8,7 +8,7 @@
     'connections': set({
       tuple(
         'mac',
-        'aa:bb:cc:dd:ee:ff',
+        '00:00:5e:00:53:00',
       ),
     }),
     'disabled_by': None,
@@ -43,7 +43,7 @@
     'connections': set({
       tuple(
         'mac',
-        'aa:bb:cc:dd:ee:ff',
+        '00:00:5e:00:53:00',
       ),
     }),
     'disabled_by': None,

--- a/tests/components/devolo_home_network/snapshots/test_sensor.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_sensor.ambr
@@ -254,7 +254,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'plc_rx_rate',
-    'unique_id': '1234567890_plc_rx_rate_11:22:33:44:55:66',
+    'unique_id': '1234567890_plc_rx_rate_00:00:5E:00:53:02',
     'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
   })
 # ---
@@ -309,7 +309,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'plc_rx_rate',
-    'unique_id': '1234567890_plc_rx_rate_11:22:33:44:55:66',
+    'unique_id': '1234567890_plc_rx_rate_00:00:5E:00:53:02',
     'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
   })
 # ---

--- a/tests/components/devolo_home_network/test_device_tracker.py
+++ b/tests/components/devolo_home_network/test_device_tracker.py
@@ -70,6 +70,7 @@ async def test_device_tracker(
     assert state.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_restoring_clients(
     hass: HomeAssistant,
     mock_device: MockDevice,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'm on the way to add the missing pieces for a platinum quality rating. For that, I need to have a cleaner distinction of MAC addresses used in the tests. While thinking about what to choose, I found that here is a reserved MAC range in [RFC 7042](https://datatracker.ietf.org/doc/html/rfc7042#section-2.1.1) which seems to fit perfectly because it will never be used by real devices.

While implementing them I also discovered, that test_restoring_clients just worked by accident because the fake-AP and the fake-Wi-Fi-Client had the same MAC address. This is also fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
