### PR TITLE
Fix async_unload teardown race in scripts

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -906,7 +906,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
             # Entity ID change, do not unload the script or conditions as they will
             # be reused.
             return
-        self.action_script.async_unload()
+        await self.action_script.async_unload()
         if self._condition is not None:
             self._condition.async_unload()
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -901,11 +901,12 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Remove listeners when removing automation from Home Assistant."""
         await super().async_will_remove_from_hass()
-        await self._async_disable()
         if self.registry_entry and self.registry_entry.entity_id != self.entity_id:
             # Entity ID change, do not unload the script or conditions as they will
             # be reused.
+            await self._async_disable()
             return
+        await self._async_disable(stop_actions=False)
         await self.action_script.async_unload()
         if self._condition is not None:
             self._condition.async_unload()

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -79,10 +79,9 @@ async def async_reload(hass: HomeAssistant, service_call: ServiceCall) -> None:
     existing_intents = hass.data[DOMAIN]
 
     for intent_type, conf in existing_intents.items():
-        if isinstance(conf.get(CONF_ACTION), script.Script):
-            await conf[CONF_ACTION].async_stop()
-            conf[CONF_ACTION].async_unload()
         intent.async_remove(hass, intent_type)
+        if isinstance(conf.get(CONF_ACTION), script.Script):
+            await conf[CONF_ACTION].async_unload()
 
     if not new_config or DOMAIN not in new_config:
         hass.data[DOMAIN] = {}

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -768,13 +768,13 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop script and remove service when it will be removed from HA."""
-        await self.script.async_stop()
+        self.hass.services.async_remove(DOMAIN, self._attr_unique_id)
+
         if not self.registry_entry or self.registry_entry.entity_id == self.entity_id:
             # Entity ID not changed, unload the script as it will not be reused.
             await self.script.async_unload()
-
-        # remove service
-        self.hass.services.async_remove(DOMAIN, self._attr_unique_id)
+        else:
+            await self.script.async_stop()
 
 
 @websocket_api.websocket_command({"type": "script/config", "entity_id": str})

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -770,11 +770,11 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
         """Stop script and remove service when it will be removed from HA."""
         self.hass.services.async_remove(DOMAIN, self._attr_unique_id)
 
-        if not self.registry_entry or self.registry_entry.entity_id == self.entity_id:
-            # Entity ID not changed, unload the script as it will not be reused.
-            await self.script.async_unload()
-        else:
+        if self.registry_entry and self.registry_entry.entity_id != self.entity_id:
+            # Entity ID change, do not unload the script as it will be reused.
             await self.script.async_stop()
+            return
+        await self.script.async_unload()
 
 
 @websocket_api.websocket_command({"type": "script/config", "entity_id": str})

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -771,7 +771,7 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
         await self.script.async_stop()
         if not self.registry_entry or self.registry_entry.entity_id == self.entity_id:
             # Entity ID not changed, unload the script as it will not be reused.
-            self.script.async_unload()
+            await self.script.async_unload()
 
         # remove service
         self.hass.services.async_remove(DOMAIN, self._attr_unique_id)

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -133,7 +133,7 @@ class WolSwitch(SwitchEntity):
         if self.registry_entry and self.registry_entry.entity_id != self.entity_id:
             # Entity ID change, do not unload the script as it will be reused.
             return
-        self._off_script.async_unload()
+        await self._off_script.async_unload()
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off if an off action is present."""

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -129,9 +129,9 @@ class WolSwitch(SwitchEntity):
         """Clean up script when removing from Home Assistant."""
         if self._off_script is None:
             return
-        await self._off_script.async_stop()
         if self.registry_entry and self.registry_entry.entity_id != self.entity_id:
             # Entity ID change, do not unload the script as it will be reused.
+            await self._off_script.async_stop()
             return
         await self._off_script.async_unload()
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -1077,7 +1077,7 @@ async def handle_execute_script(
         )
         return
     finally:
-        script_obj.async_unload()
+        await script_obj.async_unload()
     connection.send_result(
         msg["id"],
         {

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1918,12 +1918,12 @@ class Script:
     async def async_unload(self) -> None:
         """Unload the script, stopping any in-flight runs first.
 
-        Blocks new runs immediately, drains any in-flight runs, then cleans
+        Blocks new runs immediately, stops any in-flight runs, then cleans
         up all resources.
         """
         if self._unloaded:
             return
-        # Set the flag before draining so async_run rejects new runs.
+        # Set the flag before stopping so async_run rejects new runs.
         self._unloaded = True
         await self.async_stop()
         self._async_unload()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1521,7 +1521,7 @@ class Script:
         if self._unloaded:
             return
         try:
-            self.async_unload()
+            self._async_unload()
         except Exception:
             _LOGGER.exception("Error while unloading script")
 
@@ -1789,22 +1789,22 @@ class Script:
         started_action: Callable[..., Any] | None = None,
     ) -> ScriptRunResult | None:
         """Run script."""
-        # Prevent running an unloaded script
         if self._unloaded:
             raise RuntimeError(
                 f"Cannot run script '{self.name}' after it has been unloaded"
             )
+        if DATA_NEW_SCRIPT_RUNS_NOT_ALLOWED in self._hass.data:
+            self._log("Home Assistant is shutting down, starting script blocked")
+            return None
+        # The fences above rely on there being no await between these checks
+        # and the _runs.append below, so that setting either flag is
+        # sufficient to block new runs from being added.
 
         if context is None:
             self._log(
                 "Running script requires passing in a context", level=logging.WARNING
             )
             context = Context()
-
-        # Prevent spawning new script runs when Home Assistant is shutting down
-        if DATA_NEW_SCRIPT_RUNS_NOT_ALLOWED in self._hass.data:
-            self._log("Home Assistant is shutting down, starting script blocked")
-            return None
 
         # Prevent spawning new script runs if not allowed by script mode
         if self.is_running:
@@ -1915,7 +1915,20 @@ class Script:
             return
         await asyncio.shield(create_eager_task(self._async_stop(aws, update_state)))
 
-    def async_unload(self) -> None:
+    async def async_unload(self) -> None:
+        """Unload the script, stopping any in-flight runs first.
+
+        Blocks new runs immediately, drains any in-flight runs, then cleans
+        up all resources.
+        """
+        if self._unloaded:
+            return
+        # Set the flag before draining so async_run rejects new runs.
+        self._unloaded = True
+        await self.async_stop()
+        self._async_unload()
+
+    def _async_unload(self) -> None:
         """Unload the script, cleaning up all resources.
 
         Unloads cached conditions, and recursively unloads sub-scripts.
@@ -1937,31 +1950,31 @@ class Script:
         self._condition_cache.clear()
 
         for sub_script in self._repeat_script.values():
-            sub_script.async_unload()
+            sub_script._async_unload()  # noqa: SLF001
         self._repeat_script.clear()
 
         # Conditions in _choose_data and _if_data are the same objects as in
         # _condition_cache, so they're already unloaded above. Only unload scripts.
         for choose_data in self._choose_data.values():
             for _conditions, sub_script in choose_data["choices"]:
-                sub_script.async_unload()
+                sub_script._async_unload()  # noqa: SLF001
             if choose_data["default"] is not None:
-                choose_data["default"].async_unload()
+                choose_data["default"]._async_unload()  # noqa: SLF001
         self._choose_data.clear()
 
         for if_data in self._if_data.values():
-            if_data["if_then"].async_unload()
+            if_data["if_then"]._async_unload()  # noqa: SLF001
             if if_data["if_else"] is not None:
-                if_data["if_else"].async_unload()
+                if_data["if_else"]._async_unload()  # noqa: SLF001
         self._if_data.clear()
 
         for scripts in self._parallel_scripts.values():
             for sub_script in scripts:
-                sub_script.async_unload()
+                sub_script._async_unload()  # noqa: SLF001
         self._parallel_scripts.clear()
 
         for sub_script in self._sequence_scripts.values():
-            sub_script.async_unload()
+            sub_script._async_unload()  # noqa: SLF001
         self._sequence_scripts.clear()
 
     async def _async_get_condition(self, config: ConfigType) -> ConditionChecker:

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -294,7 +294,8 @@ async def test_remove_unloads_off_script(
         await entity.async_remove()
         await hass.async_block_till_done()
 
-    stop_mock.assert_called_once()
+    # async_stop is called explicitly and again from inside async_unload.
+    assert stop_mock.call_count == 2
     unload_mock.assert_called_once()
 
 

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -294,8 +294,7 @@ async def test_remove_unloads_off_script(
         await entity.async_remove()
         await hass.async_block_till_done()
 
-    # async_stop is called explicitly and again from inside async_unload.
-    assert stop_mock.call_count == 2
+    stop_mock.assert_called_once()
     unload_mock.assert_called_once()
 
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -7121,7 +7121,7 @@ async def test_script_del_skips_if_already_unloaded(hass: HomeAssistant) -> None
     unload_mock.assert_not_called()
 
 
-async def test_async_unload_drains_running_script(hass: HomeAssistant) -> None:
+async def test_async_unload_stops_running_script(hass: HomeAssistant) -> None:
     """Test that async_unload stops in-flight runs and unloads the script."""
     sequence = cv.SCRIPT_SCHEMA(
         [
@@ -7183,3 +7183,56 @@ async def test_async_run_raises_if_unloaded(hass: HomeAssistant) -> None:
         RuntimeError, match="Cannot run script.*after it has been unloaded"
     ):
         await script_obj.async_run(context=Context())
+
+
+async def test_async_unload_blocks_new_runs_during_stop(
+    hass: HomeAssistant,
+) -> None:
+    """Test that new runs are rejected once unload has started.
+
+    A run started after unload begins must be rejected immediately;
+    otherwise it would survive the stop and prevent cleanup.
+    """
+    sequence = cv.SCRIPT_SCHEMA([{"wait_template": "{{ false }}"}])
+    # Parallel mode so the script-mode check would not reject the second run;
+    # the only thing that should reject it is the _unloaded fence.
+    script_obj = script.Script(
+        hass, sequence, "Test Name", "test_domain", script_mode="parallel", max_runs=2
+    )
+    script_id = id(script_obj)
+
+    assert script_id in hass.data[script.DATA_SCRIPTS]
+
+    hass.async_create_task(script_obj.async_run(context=Context()))
+    await asyncio.sleep(0)
+    assert script_obj.is_running
+
+    # Gate async_stop so the test can act while unload is parked mid-stop,
+    # i.e. after _unloaded=True but before runs are stopped.
+    stop_started = asyncio.Event()
+    stop_release = asyncio.Event()
+    original_async_stop = script_obj.async_stop
+
+    async def gated_async_stop(*args: Any, **kwargs: Any) -> None:
+        stop_started.set()
+        await stop_release.wait()
+        await original_async_stop(*args, **kwargs)
+
+    script_obj.async_stop = gated_async_stop
+
+    unload_task = hass.async_create_task(script_obj.async_unload())
+    await stop_started.wait()
+
+    assert script_obj._unloaded
+    assert script_obj.is_running
+
+    with pytest.raises(
+        RuntimeError, match="Cannot run script.*after it has been unloaded"
+    ):
+        await script_obj.async_run(context=Context())
+
+    stop_release.set()
+    await unload_task
+
+    assert not script_obj.is_running
+    assert script_id not in hass.data[script.DATA_SCRIPTS]

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -6956,7 +6956,7 @@ async def test_async_unload_clears_condition_cache(hass: HomeAssistant) -> None:
     assert len(script_obj._condition_cache) == 1
     cached_cond = next(iter(script_obj._condition_cache.values()))
 
-    script_obj.async_unload()
+    await script_obj.async_unload()
 
     assert len(script_obj._condition_cache) == 0
     cached_cond.async_unload.assert_called_once()
@@ -6982,8 +6982,8 @@ async def test_async_unload_clears_repeat_scripts(hass: HomeAssistant) -> None:
     assert len(script_obj._repeat_script) == 1
     sub_script = next(iter(script_obj._repeat_script.values()))
 
-    with mock.patch.object(sub_script, "async_unload") as unload_mock:
-        script_obj.async_unload()
+    with mock.patch.object(sub_script, "_async_unload") as unload_mock:
+        await script_obj.async_unload()
 
     assert len(script_obj._repeat_script) == 0
     unload_mock.assert_called_once()
@@ -7015,10 +7015,10 @@ async def test_async_unload_clears_choose_data(hass: HomeAssistant) -> None:
     default_script = choose_data["default"]
 
     with (
-        mock.patch.object(choice_script, "async_unload") as choice_unload,
-        mock.patch.object(default_script, "async_unload") as default_unload,
+        mock.patch.object(choice_script, "_async_unload") as choice_unload,
+        mock.patch.object(default_script, "_async_unload") as default_unload,
     ):
-        script_obj.async_unload()
+        await script_obj.async_unload()
 
     assert len(script_obj._choose_data) == 0
     choice_unload.assert_called_once()
@@ -7047,10 +7047,10 @@ async def test_async_unload_clears_if_data(hass: HomeAssistant) -> None:
     else_script = if_data["if_else"]
 
     with (
-        mock.patch.object(then_script, "async_unload") as then_unload,
-        mock.patch.object(else_script, "async_unload") as else_unload,
+        mock.patch.object(then_script, "_async_unload") as then_unload,
+        mock.patch.object(else_script, "_async_unload") as else_unload,
     ):
-        script_obj.async_unload()
+        await script_obj.async_unload()
 
     assert len(script_obj._if_data) == 0
     then_unload.assert_called_once()
@@ -7079,10 +7079,10 @@ async def test_async_unload_clears_parallel_scripts(hass: HomeAssistant) -> None
     assert len(parallel_scripts) == 2
 
     with (
-        mock.patch.object(parallel_scripts[0], "async_unload") as unload_0,
-        mock.patch.object(parallel_scripts[1], "async_unload") as unload_1,
+        mock.patch.object(parallel_scripts[0], "_async_unload") as unload_0,
+        mock.patch.object(parallel_scripts[1], "_async_unload") as unload_1,
     ):
-        script_obj.async_unload()
+        await script_obj.async_unload()
 
     assert len(script_obj._parallel_scripts) == 0
     unload_0.assert_called_once()
@@ -7090,11 +7090,11 @@ async def test_async_unload_clears_parallel_scripts(hass: HomeAssistant) -> None
 
 
 async def test_script_del_calls_async_unload(hass: HomeAssistant) -> None:
-    """Test that __del__ calls async_unload if not already called."""
+    """Test that __del__ calls _async_unload if not already called."""
     sequence = cv.SCRIPT_SCHEMA([{"event": "test_event"}])
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
-    unload_mock = mock.Mock(wraps=script_obj.async_unload)
-    script_obj.async_unload = unload_mock
+    unload_mock = mock.Mock(wraps=script_obj._async_unload)
+    script_obj._async_unload = unload_mock
 
     # Pylint says we should `del script_obj`. However, that's not guaranteed
     # to immediately call __del__.
@@ -7103,14 +7103,14 @@ async def test_script_del_calls_async_unload(hass: HomeAssistant) -> None:
 
 
 async def test_script_del_skips_if_already_unloaded(hass: HomeAssistant) -> None:
-    """Test that __del__ does not call async_unload if already called."""
+    """Test that __del__ does not call _async_unload if already called."""
     sequence = cv.SCRIPT_SCHEMA([{"event": "test_event"}])
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
-    unload_mock = mock.Mock(wraps=script_obj.async_unload)
-    script_obj.async_unload = unload_mock
+    unload_mock = mock.Mock(wraps=script_obj._async_unload)
+    script_obj._async_unload = unload_mock
 
     # First call sets the flag
-    script_obj.async_unload()
+    await script_obj.async_unload()
     unload_mock.assert_called_once()
     unload_mock.reset_mock()
 
@@ -7121,8 +7121,8 @@ async def test_script_del_skips_if_already_unloaded(hass: HomeAssistant) -> None
     unload_mock.assert_not_called()
 
 
-async def test_async_unload_raises_if_running(hass: HomeAssistant) -> None:
-    """Test that async_unload raises RuntimeError if the script is running."""
+async def test_async_unload_drains_running_script(hass: HomeAssistant) -> None:
+    """Test that async_unload stops in-flight runs and unloads the script."""
     sequence = cv.SCRIPT_SCHEMA(
         [
             {"wait_template": "{{ false }}"},
@@ -7135,14 +7135,10 @@ async def test_async_unload_raises_if_running(hass: HomeAssistant) -> None:
 
     assert script_obj.is_running
 
-    with pytest.raises(RuntimeError, match="Cannot unload script"):
-        script_obj.async_unload()
+    await script_obj.async_unload()
 
-    await script_obj.async_stop()
     assert not script_obj.is_running
-
-    # Should succeed now
-    script_obj.async_unload()
+    assert script_obj._unloaded
 
 
 async def test_async_unload_removes_from_data_scripts(hass: HomeAssistant) -> None:
@@ -7153,7 +7149,7 @@ async def test_async_unload_removes_from_data_scripts(hass: HomeAssistant) -> No
     all_scripts = hass.data[script.DATA_SCRIPTS]
     assert any(s["instance"] is script_obj for s in all_scripts.values())
 
-    script_obj.async_unload()
+    await script_obj.async_unload()
 
     assert not any(s["instance"] is script_obj for s in all_scripts.values())
 
@@ -7171,7 +7167,7 @@ async def test_async_unload_non_top_level_does_not_touch_data_scripts(
     count_before = len(all_scripts)
 
     # Should not raise and should not modify DATA_SCRIPTS
-    script_obj.async_unload()
+    await script_obj.async_unload()
 
     assert len(all_scripts) == count_before
 
@@ -7181,7 +7177,7 @@ async def test_async_run_raises_if_unloaded(hass: HomeAssistant) -> None:
     sequence = cv.SCRIPT_SCHEMA([{"event": "test_event"}])
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
-    script_obj.async_unload()
+    await script_obj.async_unload()
 
     with pytest.raises(
         RuntimeError, match="Cannot run script.*after it has been unloaded"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `async_unload` teardown race in scripts.

`Script.async_unload` could race: `async_stop` snapshots `_runs` once, so a fresh `async_run()` slipping in during the await left `_runs` non-empty, raised `RuntimeError`, and leaked the script in `hass.data[DATA_SCRIPTS]`.

To fix, make `async_unload` async and set `_unloaded = True` before draining, fencing off new runs at the existing `async_run` guard.

`async_unload` was added in #169036.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
