### PR TITLE
Victron GX: button integration

### DIFF
--- a/homeassistant/components/victron_gx/__init__.py
+++ b/homeassistant/components/victron_gx/__init__.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.DEVICE_TRACKER,
     Platform.NUMBER,
     Platform.SELECT,

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -21,7 +21,7 @@ from .hub import VictronGxConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-PARALLEL_UPDATES = 0  # There is no I/O in the entity itself.
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -1,0 +1,63 @@
+"""Support for Victron GX button entities."""
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from victron_mqtt import (
+    Device as VictronVenusDevice,
+    Metric as VictronVenusMetric,
+    MetricKind,
+    WritableMetric as VictronVenusWritableMetric,
+)
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import BUTTON_PRESS_ID
+from .entity import VictronBaseEntity
+from .hub import VictronGxConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0  # There is no I/O in the entity itself.
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: VictronGxConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Victron GX button entities from a config entry."""
+    hub = config_entry.runtime_data
+
+    def on_new_metric(
+        device: VictronVenusDevice,
+        metric: VictronVenusMetric,
+        device_info: DeviceInfo,
+        installation_id: str,
+    ) -> None:
+        """Handle new button metric discovery."""
+        if TYPE_CHECKING:
+            assert isinstance(metric, VictronVenusWritableMetric)
+        async_add_entities(
+            [VictronButton(device, metric, device_info, installation_id)]
+        )
+
+    hub.register_new_metric_callback(MetricKind.BUTTON, on_new_metric)
+
+
+class VictronButton(VictronBaseEntity, ButtonEntity):
+    """Implementation of a Victron GX button entity."""
+
+    @callback
+    def _on_update_cb(self, value: Any) -> None:
+        pass
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        if TYPE_CHECKING:
+            assert isinstance(self._metric, VictronVenusWritableMetric)
+        _LOGGER.debug("Pressing button: %s", self._attr_unique_id)
+        self._metric.set(BUTTON_PRESS_ID)

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from victron_mqtt import (
     Device as VictronVenusDevice,
+    GenericOnOff,
     Metric as VictronVenusMetric,
     MetricKind,
     WritableMetric as VictronVenusWritableMetric,
@@ -15,7 +16,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import BINARY_SENSOR_ON_ID
 from .entity import VictronBaseEntity
 from .hub import VictronGxConfigEntry
 
@@ -60,5 +60,5 @@ class VictronButton(VictronBaseEntity, ButtonEntity):
         """Press the button."""
         if TYPE_CHECKING:
             assert isinstance(self._metric, VictronVenusWritableMetric)
-        _LOGGER.debug("Pressing button: %s", self._attr_unique_id)
-        self._metric.set(BINARY_SENSOR_ON_ID)
+        _LOGGER.debug("Pressing button: %s", self.unique_id)
+        self._metric.set(GenericOnOff.ON)

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -53,6 +53,7 @@ class VictronButton(VictronBaseEntity, ButtonEntity):
 
     @callback
     def _on_update_cb(self, value: Any) -> None:
+        # Buttons are stateless in HA; incoming metric updates are intentionally ignored.
         pass
 
     async def async_press(self) -> None:

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -52,7 +52,7 @@ class VictronButton(VictronBaseEntity, ButtonEntity):
     """Implementation of a Victron GX button entity."""
 
     @callback
-    def _on_update_cb(self, value: Any) -> None:
+    def _on_update_cb(self, _value: Any) -> None:
         # Buttons are stateless in HA; incoming metric updates are intentionally ignored.
         pass
 

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import BUTTON_PRESS_ID
+from .const import BINARY_SENSOR_ON_ID
 from .entity import VictronBaseEntity
 from .hub import VictronGxConfigEntry
 
@@ -61,4 +61,4 @@ class VictronButton(VictronBaseEntity, ButtonEntity):
         if TYPE_CHECKING:
             assert isinstance(self._metric, VictronVenusWritableMetric)
         _LOGGER.debug("Pressing button: %s", self._attr_unique_id)
-        self._metric.set(BUTTON_PRESS_ID)
+        self._metric.set(BINARY_SENSOR_ON_ID)

--- a/homeassistant/components/victron_gx/const.py
+++ b/homeassistant/components/victron_gx/const.py
@@ -9,6 +9,3 @@ CONF_SERIAL = "serial"
 # Binary sensor enum ids must be "on" for on and "off" for off.
 BINARY_SENSOR_ON_ID = "on"
 BINARY_SENSOR_OFF_ID = "off"
-
-# Button press value
-BUTTON_PRESS_ID = "on"

--- a/homeassistant/components/victron_gx/const.py
+++ b/homeassistant/components/victron_gx/const.py
@@ -9,3 +9,6 @@ CONF_SERIAL = "serial"
 # Binary sensor enum ids must be "on" for on and "off" for off.
 BINARY_SENSOR_ON_ID = "on"
 BINARY_SENSOR_OFF_ID = "off"
+
+# Button press value
+BUTTON_PRESS_ID = "on"

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -11,9 +11,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 # Entities that should be marked as diagnostic
-ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat"]
+ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat", "platform_device_reboot"]
 # Entities that should be disabled by default
-ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat"]
+ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat", "platform_device_reboot"]
 
 
 class VictronBaseEntity(Entity):

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -224,6 +224,11 @@
         "name": "[%key:common::state::connected%]"
       }
     },
+    "button": {
+      "platform_device_reboot": {
+        "name": "Device reboot"
+      }
+    },
     "device_tracker": {
       "gps_location": {
         "name": "[%key:common::config_flow::data::location%]"

--- a/tests/components/victron_gx/snapshots/test_button.ambr
+++ b/tests/components/victron_gx/snapshots/test_button.ambr
@@ -1,0 +1,51 @@
+# serializer version: 1
+# name: test_all_button_entities_snapshot[button.victron_venus_device_reboot-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.victron_venus_device_reboot',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Device reboot',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Device reboot',
+    'platform': 'victron_gx',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'platform_device_reboot',
+    'unique_id': '123_system_0_platform_device_reboot',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_button_entities_snapshot[button.victron_venus_device_reboot-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Victron Venus Device reboot',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.victron_venus_device_reboot',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -1,0 +1,88 @@
+"""Tests for Victron GX MQTT button entities."""
+
+from __future__ import annotations
+
+from victron_mqtt import Hub as VictronVenusHub
+from victron_mqtt.testing import finalize_injection, inject_message
+
+from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .const import MOCK_INSTALLATION_ID
+
+from tests.common import MockConfigEntry
+
+
+async def test_victron_button(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test BUTTON MetricKind - platform reboot button is created."""
+    victron_hub, mock_config_entry = init_integration
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
+        '{"value": 0}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity.entity_id == "button.victron_venus_device_reboot"
+    assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_system_0_platform_device_reboot"
+    assert entity.translation_key == "platform_device_reboot"
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == "unknown"
+
+    # Verify device info was registered correctly
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    )
+    assert device is not None
+    assert device.manufacturer == "Victron Energy"
+
+
+async def test_victron_button_press(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test button _on_update_cb and pressing it via service call."""
+    victron_hub, mock_config_entry = init_integration
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
+        '{"value": 0}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    entity_id = entities[0].entity_id
+
+    # Inject an update to exercise _on_update_cb (the pass branch)
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
+        '{"value": 1}',
+    )
+    await hass.async_block_till_done()
+
+    # Call the press service to cover press()
+    await hass.services.async_call(
+        "button", "press", {"entity_id": entity_id}, blocking=True
+    )

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -4,26 +4,29 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from victron_mqtt import Hub as VictronVenusHub, WritableMetric
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from victron_mqtt import GenericOnOff, Hub as VictronVenusHub, WritableMetric
 from victron_mqtt.testing import finalize_injection, inject_message
 
-from homeassistant.components.victron_gx.const import DOMAIN
-from homeassistant.const import EntityCategory
+from homeassistant.components.button import SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 
 from .const import MOCK_INSTALLATION_ID
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
-async def test_victron_button(
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_button_entities_snapshot(
     hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
     entity_registry: er.EntityRegistry,
-    device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test BUTTON MetricKind - platform reboot button is created."""
+    """Snapshot test for all Victron GX button entities."""
     victron_hub, mock_config_entry = init_integration
 
     await inject_message(
@@ -34,46 +37,17 @@ async def test_victron_button(
     await finalize_injection(victron_hub)
     await hass.async_block_till_done()
 
-    entities = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-
-    assert len(entities) == 1
-    entity = entities[0]
-    assert entity.entity_id == "button.victron_venus_device_reboot"
-    assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_system_0_platform_device_reboot"
-    assert entity.translation_key == "platform_device_reboot"
-    assert entity.disabled_by is er.RegistryEntryDisabler.INTEGRATION
-    assert entity.entity_category is EntityCategory.DIAGNOSTIC
-
-    # Entity is disabled by default, so state is not available
-    state = hass.states.get(entity.entity_id)
-    assert state is None
-
-    # Verify device info was registered correctly
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
-    )
-    assert device is not None
-    assert device.manufacturer == "Victron Energy"
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-async def test_victron_button_press(
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_button_press(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test button _on_update_cb and pressing it via service call."""
+    """Test pressing a Victron GX button triggers the metric write."""
     victron_hub, mock_config_entry = init_integration
-
-    # Enable the button entity before injecting so it gets a state
-    entity_registry.async_get_or_create(
-        "button",
-        DOMAIN,
-        f"{MOCK_INSTALLATION_ID}_system_0_platform_device_reboot",
-        config_entry=mock_config_entry,
-        disabled_by=None,
-    )
 
     await inject_message(
         victron_hub,
@@ -86,24 +60,14 @@ async def test_victron_button_press(
     entities = er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
-    button_entities = [e for e in entities if e.domain == "button"]
-    assert len(button_entities) == 1
-    entity_id = button_entities[0].entity_id
+    button_entity = next(e for e in entities if e.domain == "button")
 
-    # Inject an update to exercise _on_update_cb (the pass branch)
-    await inject_message(
-        victron_hub,
-        f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
-        '{"value": 1}',
-    )
-    await finalize_injection(victron_hub)
-    await hass.async_block_till_done()
-
-    # Spy on WritableMetric.set to verify the outgoing write
     with patch.object(WritableMetric, "set") as set_mock:
-        # Call the press service to cover async_press()
         await hass.services.async_call(
-            "button", "press", {"entity_id": entity_id}, blocking=True
+            "button",
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: button_entity.entity_id},
+            blocking=True,
         )
 
-        set_mock.assert_called_once_with(1)
+        set_mock.assert_called_once_with(GenericOnOff.ON)

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -6,6 +6,7 @@ from victron_mqtt import Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -37,13 +38,15 @@ async def test_victron_button(
 
     assert len(entities) == 1
     entity = entities[0]
-    assert entity.entity_id == "button.victron_venus_device_reboot"
+    assert entity.entity_id == "button.victron_venus"
     assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_system_0_platform_device_reboot"
     assert entity.translation_key == "platform_device_reboot"
+    assert entity.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert entity.entity_category is EntityCategory.DIAGNOSTIC
 
+    # Entity is disabled by default, so state is not available
     state = hass.states.get(entity.entity_id)
-    assert state is not None
-    assert state.state == "unknown"
+    assert state is None
 
     # Verify device info was registered correctly
     device = device_registry.async_get_device(
@@ -61,6 +64,15 @@ async def test_victron_button_press(
     """Test button _on_update_cb and pressing it via service call."""
     victron_hub, mock_config_entry = init_integration
 
+    # Enable the button entity before injecting so it gets a state
+    entity_registry.async_get_or_create(
+        "button",
+        DOMAIN,
+        f"{MOCK_INSTALLATION_ID}_system_0_platform_device_reboot",
+        config_entry=mock_config_entry,
+        disabled_by=None,
+    )
+
     await inject_message(
         victron_hub,
         f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
@@ -72,7 +84,8 @@ async def test_victron_button_press(
     entities = er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
-    entity_id = entities[0].entity_id
+    button_entities = [e for e in entities if e.domain == "button"]
+    entity_id = button_entities[0].entity_id
 
     # Inject an update to exercise _on_update_cb (the pass branch)
     await inject_message(
@@ -82,7 +95,7 @@ async def test_victron_button_press(
     )
     await hass.async_block_till_done()
 
-    # Call the press service to cover press()
+    # Call the press service to cover async_press()
     await hass.services.async_call(
         "button", "press", {"entity_id": entity_id}, blocking=True
     )

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -41,7 +41,7 @@ async def test_victron_button(
 
     assert len(entities) == 1
     entity = entities[0]
-    assert entity.entity_id == "button.victron_venus"
+    assert entity.entity_id == "button.victron_venus_device_reboot"
     assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_system_0_platform_device_reboot"
     assert entity.translation_key == "platform_device_reboot"
     assert entity.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import cast
+from unittest.mock import MagicMock
+
 from victron_mqtt import Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
@@ -85,6 +88,7 @@ async def test_victron_button_press(
         entity_registry, mock_config_entry.entry_id
     )
     button_entities = [e for e in entities if e.domain == "button"]
+    assert len(button_entities) == 1
     entity_id = button_entities[0].entity_id
 
     # Inject an update to exercise _on_update_cb (the pass branch)
@@ -95,7 +99,16 @@ async def test_victron_button_press(
     )
     await hass.async_block_till_done()
 
+    assert victron_hub._client is not None
+    publish_mock = cast(MagicMock, victron_hub._client.publish)
+    publish_mock.reset_mock()
+
     # Call the press service to cover async_press()
     await hass.services.async_call(
         "button", "press", {"entity_id": entity_id}, blocking=True
+    )
+
+    publish_mock.assert_called_once_with(
+        f"W/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
+        '{"value": 1}',
     )

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -81,7 +81,7 @@ async def test_victron_button_press(
         f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
         '{"value": 0}',
     )
-    await finalize_injection(victron_hub)
+    await finalize_injection(victron_hub, disconnect=False)
     await hass.async_block_till_done()
 
     entities = er.async_entries_for_config_entry(
@@ -97,6 +97,7 @@ async def test_victron_button_press(
         f"N/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
         '{"value": 1}',
     )
+    await finalize_injection(victron_hub)
     await hass.async_block_till_done()
 
     assert victron_hub._client is not None

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -106,4 +106,4 @@ async def test_victron_button_press(
             "button", "press", {"entity_id": entity_id}, blocking=True
         )
 
-        set_mock.assert_called_once()
+        set_mock.assert_called_once_with(1)

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -47,7 +47,7 @@ async def test_button_press(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test pressing a Victron GX button triggers the metric write."""
-    victron_hub, mock_config_entry = init_integration
+    victron_hub, _mock_config_entry = init_integration
 
     await inject_message(
         victron_hub,
@@ -57,10 +57,7 @@ async def test_button_press(
     await finalize_injection(victron_hub, disconnect=False)
     await hass.async_block_till_done()
 
-    entities = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-    button_entity = next(e for e in entities if e.domain == "button")
+    button_entity = entity_registry.async_get("button.victron_venus_device_reboot")
 
     with patch.object(WritableMetric, "set") as set_mock:
         await hass.services.async_call(

--- a/tests/components/victron_gx/test_button.py
+++ b/tests/components/victron_gx/test_button.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
-from victron_mqtt import Hub as VictronVenusHub
+from victron_mqtt import Hub as VictronVenusHub, WritableMetric
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.victron_gx.const import DOMAIN
@@ -100,16 +99,11 @@ async def test_victron_button_press(
     await finalize_injection(victron_hub)
     await hass.async_block_till_done()
 
-    assert victron_hub._client is not None
-    publish_mock = cast(MagicMock, victron_hub._client.publish)
-    publish_mock.reset_mock()
+    # Spy on WritableMetric.set to verify the outgoing write
+    with patch.object(WritableMetric, "set") as set_mock:
+        # Call the press service to cover async_press()
+        await hass.services.async_call(
+            "button", "press", {"entity_id": entity_id}, blocking=True
+        )
 
-    # Call the press service to cover async_press()
-    await hass.services.async_call(
-        "button", "press", {"entity_id": entity_id}, blocking=True
-    )
-
-    publish_mock.assert_called_once_with(
-        f"W/{MOCK_INSTALLATION_ID}/platform/0/Device/Reboot",
-        '{"value": 1}',
-    )
+        set_mock.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding button integration. Currently the only button is Victron GX reboot.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45120
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
