### PR TITLE
Make Wi-Fi clients own devices in devolo Home Network

### DIFF
--- a/homeassistant/components/devolo_home_network/coordinator.py
+++ b/homeassistant/components/devolo_home_network/coordinator.py
@@ -44,6 +44,8 @@ type DevoloHomeNetworkConfigEntry = ConfigEntry[DevoloHomeNetworkData]
 class DevoloDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     """Class to manage fetching data from devolo Home Network devices."""
 
+    config_entry: DevoloHomeNetworkConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -235,6 +237,16 @@ class DevoloWifiConnectedStationsGetCoordinator(
         """Fetch data from API endpoint."""
         assert self.device.device
         clients = await self.device.device.async_get_wifi_connected_station()
+
+        device_registry = dr.async_get(self.hass)
+        for client in clients:
+            device_registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                identifiers={(DOMAIN, client.mac_address)},
+                connections={(dr.CONNECTION_NETWORK_MAC, client.mac_address)},
+                name=client.mac_address,
+            )
+
         return {client.mac_address: client for client in clients}
 
 

--- a/homeassistant/components/devolo_home_network/device_tracker.py
+++ b/homeassistant/components/devolo_home_network/device_tracker.py
@@ -11,7 +11,7 @@ from homeassistant.components.device_tracker import (
 )
 from homeassistant.const import STATE_UNKNOWN, UnitOfFrequency
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -54,6 +54,7 @@ async def async_setup_entry(
     def restore_entities() -> None:
         """Restore clients that are not a part of active clients list."""
         missing = []
+        device_registry = dr.async_get(hass)
         for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
             if (
                 entity.platform == DOMAIN
@@ -65,6 +66,12 @@ async def async_setup_entry(
                 )
                 not in tracked
             ):
+                device_registry.async_get_or_create(
+                    config_entry_id=entry.entry_id,
+                    identifiers={(DOMAIN, mac_address)},
+                    connections={(dr.CONNECTION_NETWORK_MAC, mac_address)},
+                    name=mac_address,
+                )
                 missing.append(
                     DevoloScannerEntity(
                         coordinators[CONNECTED_WIFI_CLIENTS], device, mac_address
@@ -100,7 +107,6 @@ class DevoloScannerEntity(
         super().__init__(coordinator)
         self._device = device
         self._attr_mac_address = mac
-        self._attr_name = mac
 
     @property
     @override
@@ -127,6 +133,12 @@ class DevoloScannerEntity(
         """Return true if the device is connected to the network."""
         assert self.mac_address
         return self.coordinator.data.get(self.mac_address) is not None
+
+    @property
+    @override
+    def suggested_object_id(self) -> str | None:
+        """Suggest entity_id derived from the MAC address."""
+        return self.mac_address.lower().replace(":", "_") if self.mac_address else None
 
     @property
     @override

--- a/homeassistant/components/devolo_home_network/device_tracker.py
+++ b/homeassistant/components/devolo_home_network/device_tracker.py
@@ -100,6 +100,7 @@ class DevoloScannerEntity(
         super().__init__(coordinator)
         self._device = device
         self._attr_mac_address = mac
+        self._attr_name = mac
 
     @property
     @override

--- a/homeassistant/components/devolo_home_network/device_tracker.py
+++ b/homeassistant/components/devolo_home_network/device_tracker.py
@@ -75,6 +75,7 @@ async def async_setup_entry(
         async_add_entities(missing)
 
     restore_entities()
+    new_device_callback()
     entry.async_on_unload(
         coordinators[CONNECTED_WIFI_CLIENTS].async_add_listener(new_device_callback)
     )
@@ -99,7 +100,6 @@ class DevoloScannerEntity(
         super().__init__(coordinator)
         self._device = device
         self._attr_mac_address = mac
-        self._attr_name = mac
 
     @property
     @override

--- a/tests/components/devolo_home_network/mock.py
+++ b/tests/components/devolo_home_network/mock.py
@@ -93,3 +93,16 @@ class MockDeviceWrongPassword(MockDevice):
         """Bring mock in a well defined state."""
         super().__init__(ip, zeroconf_instance)
         self.device.async_uptime = AsyncMock(side_effect=DevicePasswordProtected)
+
+
+class MockAltDevice(MockDevice):
+    """Mock an alternative devolo Home Network device for tests with two devices in the same network."""
+
+    async def async_connect(
+        self, session_instance: httpx.AsyncClient | None = None
+    ) -> None:
+        """Give a mocked device the needed properties."""
+        self.mac = "00:00:5E:00:53:05"
+        self.mt_number = DISCOVERY_INFO.properties["MT"]
+        self.product = DISCOVERY_INFO.properties["Product"]
+        self.serial_number = "0987654321"

--- a/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'band': '5 GHz',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '00:00:5E:00:53:01',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '00:00:5E:00:53:01 00:00:5E:00:53:01',
       <DeviceTrackerEntityStateAttribute.IN_ZONES: 'in_zones'>: list([
         'zone.home',
       ]),

--- a/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_device_tracker.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'band': '5 GHz',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '00:00:5E:00:53:01 00:00:5E:00:53:01',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '00:00:5E:00:53:01',
       <DeviceTrackerEntityStateAttribute.IN_ZONES: 'in_zones'>: list([
         'zone.home',
       ]),

--- a/tests/components/devolo_home_network/test_device_tracker.py
+++ b/tests/components/devolo_home_network/test_device_tracker.py
@@ -1,6 +1,7 @@
 """Tests for the devolo Home Network device tracker."""
 
-from unittest.mock import AsyncMock
+from itertools import cycle
+from unittest.mock import AsyncMock, patch
 
 from devolo_plc_api.exceptions.device import DeviceUnavailable
 from freezegun.api import FrozenDateTimeFactory
@@ -12,15 +13,20 @@ from homeassistant.components.devolo_home_network.const import (
     DOMAIN,
     LONG_UPDATE_INTERVAL,
 )
-from homeassistant.const import STATE_NOT_HOME, STATE_UNAVAILABLE
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_PASSWORD,
+    STATE_NOT_HOME,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import configure_integration
-from .const import CONNECTED_STATIONS, NO_CONNECTED_STATIONS
-from .mock import MockDevice
+from .const import CONNECTED_STATIONS, DISCOVERY_INFO, IP, IP_ALT, NO_CONNECTED_STATIONS
+from .mock import MockAltDevice, MockDevice
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 STATION = CONNECTED_STATIONS[0]
 
@@ -98,3 +104,58 @@ async def test_restoring_clients(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_NOT_HOME
+
+
+async def test_multi_ap_clients_merged(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Verify a client seen by multiple APs is merged into one device."""
+    device_ap1 = MockDevice(ip=IP)
+    device_ap2 = MockAltDevice(ip=IP_ALT)
+
+    with patch(
+        "homeassistant.components.devolo_home_network.Device",
+        side_effect=cycle([device_ap1, device_ap2]),
+    ):
+        entry_ap1 = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_IP_ADDRESS: IP, CONF_PASSWORD: "test"},
+            entry_id="ap1",
+            unique_id=DISCOVERY_INFO.properties["SN"],
+        )
+        entry_ap1.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry_ap1.entry_id)
+        await hass.async_block_till_done()
+
+        entry_ap2 = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_IP_ADDRESS: IP_ALT, CONF_PASSWORD: "test"},
+            entry_id="ap2",
+            unique_id="0987654321",
+        )
+        entry_ap2.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry_ap2.entry_id)
+        await hass.async_block_till_done()
+
+    # Exactly one device for the client MAC
+    client_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, STATION.mac_address)}
+    )
+    assert client_device is not None
+    assert entry_ap1.entry_id in client_device.config_entries
+    assert entry_ap2.entry_id in client_device.config_entries
+
+    # Two scanner entities at this device, one per AP
+    entities = [
+        entity
+        for entity in entity_registry.entities.values()
+        if entity.device_id == client_device.id
+        and entity.domain == DEVICE_TRACKER_DOMAIN
+    ]
+    assert len(entities) == 2
+    assert {entity.config_entry_id for entity in entities} == {
+        entry_ap1.entry_id,
+        entry_ap2.entry_id,
+    }

--- a/tests/components/devolo_home_network/test_device_tracker.py
+++ b/tests/components/devolo_home_network/test_device_tracker.py
@@ -105,6 +105,9 @@ async def test_restoring_clients(
     assert state is not None
     assert state.state == STATE_NOT_HOME
 
+    restored_entity = entity_registry.async_get(entity_id)
+    assert restored_entity.device_id is not None
+
 
 async def test_multi_ap_clients_merged(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In order to complete the stale-devices rule, I need to treat Wi-Fi clients from the device tracker platform as own devices. This change should do the trick. I did not add the `via_device` parameter, as the clients could roam in a multi AP setup and then the parameter is not updated. With following PRs I then can make the extra attributes own entities and can make the clients removable.

As the API only knows the MAC address, I did not find a nicer way for the friendly name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
