### PR TITLE
Fix grammar and clarity in samsungtv/strings.json

### DIFF
--- a/homeassistant/components/samsungtv/strings.json
+++ b/homeassistant/components/samsungtv/strings.json
@@ -12,7 +12,7 @@
     },
     "error": {
       "auth_missing": "[%key:component::samsungtv::config::abort::auth_missing%]",
-      "invalid_host": "The host is invalid. Please try again.",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
       "invalid_pin": "The PIN is invalid. Please try again."
     },
     "flow_title": "{device}",

--- a/homeassistant/components/samsungtv/strings.json
+++ b/homeassistant/components/samsungtv/strings.json
@@ -12,13 +12,13 @@
     },
     "error": {
       "auth_missing": "[%key:component::samsungtv::config::abort::auth_missing%]",
-      "invalid_host": "Host is invalid, please try again.",
-      "invalid_pin": "PIN is invalid, please try again."
+      "invalid_host": "The host is invalid. Please try again.",
+      "invalid_pin": "The PIN is invalid. Please try again."
     },
     "flow_title": "{device}",
     "step": {
       "confirm": {
-        "description": "Do you want to set up {device}? If you never connected Home Assistant before you should see a popup on your TV asking for authorization."
+        "description": "Do you want to set up {device}? If you have never connected Home Assistant before, you should see a popup on your TV asking for authorization."
       },
       "encrypted_pairing": {
         "data": {
@@ -62,7 +62,7 @@
           "host": "The hostname or IP address of your TV.",
           "name": "The name of your TV. This will be used to identify the device in Home Assistant."
         },
-        "description": "Enter your Samsung TV information. If you never connected Home Assistant before you should see a popup on your TV asking for authorization."
+        "description": "Enter your Samsung TV information. If you have never connected Home Assistant before, you should see a popup on your TV asking for authorization."
       }
     }
   },


### PR DESCRIPTION
## Breaking change

*this PR is not a breaking change*

## Proposed change

This PR fixes a few grammar and wording issues in user-facing strings in `homeassistant/components/samsungtv/strings.json`.

- Fixed missing comma and corrected verb tense in conditional sentences ("If you never connected" -> "If you have never connected ..., you should")
- Fixed article and punctuation in error messages ("Host is invalid, please try again." -> "The host is invalid. Please try again.")

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: none
- This PR is related to issue: none
- Link to documentation pull request: none
- Link to developer documentation pull request: none
- Link to frontend pull request: none

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.