### PR TITLE
Surface IP-vs-serial connection failures as distinct errors in nobo_hub

### DIFF
--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -158,14 +158,13 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         # successful TCP connection followed by a handshake REJECT
         # (serial mismatch) returns False.
         try:
-            connected = await hub.async_connect_hub(ip_address, serial)
+            if not await hub.async_connect_hub(ip_address, serial):
+                raise NoboHubConnectError("cannot_connect")
+            return hub.hub_info["name"]
         except OSError as err:
             raise NoboHubConnectError("cannot_connect_ip") from err
-        if not connected:
-            raise NoboHubConnectError("cannot_connect")
-        name = hub.hub_info["name"]
-        await hub.close()
-        return name
+        finally:
+            await hub.close()
 
     @staticmethod
     def _format_hub(ip, serial_prefix):

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -153,7 +153,15 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         except OSError as err:
             raise NoboHubConnectError("invalid_ip") from err
         hub = nobo(serial=serial, ip=ip_address, discover=False, synchronous=False)
-        if not await hub.async_connect_hub(ip_address, serial):
+        # pynobo distinguishes the two failure modes: TCP-level errors
+        # (wrong IP, hub offline, port closed) raise OSError, while a
+        # successful TCP connection followed by a handshake REJECT
+        # (serial mismatch) returns False.
+        try:
+            connected = await hub.async_connect_hub(ip_address, serial)
+        except OSError as err:
+            raise NoboHubConnectError("cannot_connect_ip") from err
+        if not connected:
             raise NoboHubConnectError("cannot_connect")
         name = hub.hub_info["name"]
         await hub.close()

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -5,6 +5,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect - check serial number",
+      "cannot_connect_ip": "Failed to connect - check IP address",
       "invalid_ip": "Invalid IP address",
       "invalid_serial": "Invalid serial number",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, PropertyMock, patch
 
+import pytest
+
 from homeassistant import config_entries
 from homeassistant.components.nobo_hub.const import CONF_OVERRIDE_TYPE, DOMAIN
 from homeassistant.core import HomeAssistant
@@ -220,8 +222,27 @@ async def test_configure_invalid_ip_address(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "invalid_ip"}
 
 
-async def test_configure_cannot_connect(hass: HomeAssistant) -> None:
-    """Test we handle cannot connect error."""
+@pytest.mark.parametrize(
+    ("connect_outcome", "expected_error"),
+    [
+        ({"return_value": False}, "cannot_connect"),
+        ({"side_effect": ConnectionRefusedError(61, "")}, "cannot_connect_ip"),
+    ],
+    ids=["serial_mismatch", "tcp_failure"],
+)
+async def test_configure_cannot_connect(
+    hass: HomeAssistant,
+    connect_outcome: dict[str, object],
+    expected_error: str,
+) -> None:
+    """Connect failures map to distinct error keys.
+
+    pynobo's async_connect_hub returns False on a successful TCP connect
+    followed by a handshake REJECT (serial mismatch) and raises OSError
+    on TCP-level failure (wrong IP / hub offline). We surface these as
+    cannot_connect ("check serial number") and cannot_connect_ip
+    ("check IP address") respectively.
+    """
     with patch(
         "pynobo.nobo.async_discover_hubs",
         return_value=[("1.1.1.1", "123456789")],
@@ -237,16 +258,13 @@ async def test_configure_cannot_connect(hass: HomeAssistant) -> None:
         },
     )
 
-    with patch(
-        "pynobo.nobo.async_connect_hub",
-        return_value=False,
-    ) as mock_connect:
+    with patch("pynobo.nobo.async_connect_hub", **connect_outcome) as mock_connect:
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
             {"serial_suffix": "012"},
         )
         assert result3["type"] is FlowResultType.FORM
-        assert result3["errors"] == {"base": "cannot_connect"}
+        assert result3["errors"] == {"base": expected_error}
         mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Surface IP-vs-serial connection failures as distinct errors in `nobo_hub`

`pynobo`'s `async_connect_hub` raises `OSError` on TCP-level failure (wrong IP / hub offline / port closed) and returns `False` on a successful TCP connect followed by a handshake `REJECT` (serial mismatch). `_test_connection` flattened both into `"cannot_connect"` with text `"check serial number"` — misleading when the actual problem was the IP.

Adds `cannot_connect_ip` (`"Failed to connect - check IP address"`) for the `OSError` path; `cannot_connect` (unchanged text) keeps serving the serial-mismatch path. Existing translations preserved.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
