### PR TITLE
Bump zwave-js-server-python to 0.70.0

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1097,13 +1097,7 @@ async def websocket_provision_smart_start_node(
         )
         return
 
-    provisioning_info = ProvisioningEntry(
-        dsk=qr_info.dsk,
-        security_classes=qr_info.security_classes,
-        requested_security_classes=qr_info.requested_security_classes,
-        protocol=msg.get(PROTOCOL),
-        additional_properties=qr_info.additional_properties,
-    )
+    additional_properties = qr_info.additional_properties or {}
 
     device = None
     # Create an empty device if device_name is provided
@@ -1139,12 +1133,17 @@ async def websocket_provision_smart_start_node(
         dev_reg.async_update_device(
             device.id, area_id=msg.get(AREA_ID), name_by_user=device_name
         )
+        additional_properties["device_id"] = device.id
 
-        if provisioning_info.additional_properties is None:
-            provisioning_info.additional_properties = {}
-        provisioning_info.additional_properties["device_id"] = device.id
-
-    await driver.controller.async_provision_smart_start_node(provisioning_info)
+    await driver.controller.async_provision_smart_start_node(
+        ProvisioningEntry(
+            dsk=qr_info.dsk,
+            security_classes=qr_info.security_classes,
+            requested_security_classes=qr_info.requested_security_classes,
+            protocol=msg.get(PROTOCOL),
+            additional_properties=additional_properties,
+        )
+    )
     if device:
         connection.send_result(msg[ID], device.id)
     else:

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
-  "requirements": ["zwave-js-server-python==0.68.0"],
+  "requirements": ["zwave-js-server-python==0.70.0"],
   "usb": [
     {
       "known_devices": ["Aeotec Z-Stick Gen5+", "Z-WaveMe UZB"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3419,7 +3419,7 @@ zinvolt==0.4.3
 zm-py==0.5.4
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.68.0
+zwave-js-server-python==0.70.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2904,7 +2904,7 @@ zinvolt==0.4.3
 zm-py==0.5.4
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.68.0
+zwave-js-server-python==0.70.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -3519,10 +3519,8 @@ async def test_firmware_upload_view(
         )
 
         update_data = NodeFirmwareUpdateData(
-            "file", b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            "file", b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", **expected_data
         )
-        for attr, value in expected_data.items():
-            setattr(update_data, attr, value)
 
         mock_controller_cmd.assert_not_called()
         assert mock_node_cmd.call_args[0][1:3] == (multisensor_6, [update_data])

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Generator
+import dataclasses
 from ipaddress import ip_address
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -93,6 +94,13 @@ CP2652_ZIGBEE_DISCOVERY_INFO = UsbServiceInfo(
     description="cp2652",
     manufacturer="generic",
 )
+
+
+def _set_home_id(get_server_version: AsyncMock, home_id: int) -> None:
+    """Update the mocked server version's home_id (frozen dataclass)."""
+    get_server_version.return_value = dataclasses.replace(
+        get_server_version.return_value, home_id=home_id
+    )
 
 
 @pytest.fixture
@@ -1016,8 +1024,7 @@ async def test_usb_discovery_migration(
 
     assert restart_addon.call_args == call("core_zwave_js")
 
-    version_info = get_server_version.return_value
-    version_info.home_id = 3245146787
+    _set_home_id(get_server_version, 3245146787)
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
@@ -4211,7 +4218,6 @@ async def test_reconfigure_migrate_with_addon(
     device_entry_count: int,
 ) -> None:
     """Test migration flow with add-on."""
-    version_info = get_server_version.return_value
     entry = integration
     assert client.connect.call_count == 1
     assert client.driver.controller.home_id == 3245146787
@@ -4322,7 +4328,7 @@ async def test_reconfigure_migrate_with_addon(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "choose_serial_port"
 
-    version_info.home_id = 5678
+    _set_home_id(get_server_version, 5678)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], form_data
@@ -4355,7 +4361,7 @@ async def test_reconfigure_migrate_with_addon(
 
         assert entry.unique_id == "5678"
         get_server_version.side_effect = restore_server_version_side_effect
-        version_info.home_id = 3245146787
+        _set_home_id(get_server_version, 3245146787)
 
         assert result["type"] is FlowResultType.SHOW_PROGRESS
         assert result["step_id"] == "restore_nvm"
@@ -5503,7 +5509,6 @@ async def test_addon_rf_region_migrate_network(
 ) -> None:
     """Test migration flow with add-on."""
     hass.config.country = None
-    version_info = get_server_version.return_value
     entry = integration
     assert client.connect.call_count == 1
     assert client.driver.controller.home_id == 3245146787
@@ -5587,7 +5592,7 @@ async def test_addon_rf_region_migrate_network(
     with pytest.raises(InInvalid):
         data_schema.schema[CONF_USB_PATH](addon_options["device"])
 
-    version_info.home_id = 5678
+    _set_home_id(get_server_version, 5678)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -5622,7 +5627,7 @@ async def test_addon_rf_region_migrate_network(
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert entry.unique_id == "5678"
-    version_info.home_id = 3245146787
+    _set_home_id(get_server_version, 3245146787)
 
     assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "restore_nvm"


### PR DESCRIPTION
## Breaking change

With this release, you will need to update your zwave-js-server instance. You must use zwave-js-server 3.7.0 or greater (schema 47).
- If you use the Z-Wave JS add-on, you need at least version 1.3.0.
- If you use the Z-Wave JS UI Docker container, you need at least version https://github.com/zwave-js/zwave-js-ui/releases/tag/v11.16.2.
- If you run your own Docker container or some other installation method, you will need to update your zwave-js-server instance to at least 3.7.0.

## Proposed change
Bump should be a no-op for users but preps core for the next lib release which will include credential management changes

https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.69.0
https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.70.0

Diff: https://github.com/home-assistant-libs/zwave-js-server-python/compare/0.68.0...0.70.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
