### PR TITLE
Fix Duco unknown node type not re-evaluated after becoming known

### DIFF
--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -164,6 +164,7 @@ async def async_setup_entry(
     # can detect both newly added and stale (deregistered) nodes on every
     # coordinator update.
     known_nodes: set[int] = set()
+    warned_unknown_nodes: set[int] = set()
 
     @callback
     def _async_add_new_entities() -> None:
@@ -195,11 +196,21 @@ async def async_setup_entry(
                 # on every coordinator update. This allows entities to be
                 # created automatically once a firmware update or library
                 # update adds support for the device type.
-                _LOGGER.warning(
-                    "Duco node %s (%s) has an unsupported device type and will be ignored",
-                    node.node_id,
-                    node.general.name,
-                )
+                if node.node_id not in warned_unknown_nodes:
+                    _LOGGER.warning(
+                        "Duco node %s (%s) has an unsupported device type and will be "
+                        "ignored for this update; it will be retried on subsequent "
+                        "coordinator updates once its type becomes supported",
+                        node.node_id,
+                        node.general.name,
+                    )
+                    warned_unknown_nodes.add(node.node_id)
+                else:
+                    _LOGGER.debug(
+                        "Duco node %s (%s) still has an unsupported device type",
+                        node.node_id,
+                        node.general.name,
+                    )
                 continue
             known_nodes.add(node.node_id)
             new_entities.extend(

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -186,6 +186,7 @@ async def async_setup_entry(
                         remove_config_entry_id=entry.entry_id,
                     )
             known_nodes.difference_update(stale_node_ids)
+            warned_unknown_nodes.difference_update(stale_node_ids)
 
         new_entities: list[SensorEntity] = []
         for node in coordinator.data.nodes.values():
@@ -213,6 +214,7 @@ async def async_setup_entry(
                     )
                 continue
             known_nodes.add(node.node_id)
+            warned_unknown_nodes.discard(node.node_id)
             new_entities.extend(
                 DucoSensorEntity(coordinator, node, description)
                 for description in SENSOR_DESCRIPTIONS

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -167,6 +167,7 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_entities() -> None:
+        """Add new sensor entities and remove stale ones on coordinator updates."""
         # Remove devices whose nodes have disappeared from the API.
         # The firmware removes deregistered RF/wired nodes automatically.
         # BSRH box sensors that are physically unplugged from the PCB are

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -190,14 +190,18 @@ async def async_setup_entry(
         for node in coordinator.data.nodes.values():
             if node.node_id in known_nodes:
                 continue
-            known_nodes.add(node.node_id)
             if node.general.node_type == NodeType.UNKNOWN:
+                # Do not add the node to known_nodes so that it is re-evaluated
+                # on every coordinator update. This allows entities to be
+                # created automatically once a firmware update or library
+                # update adds support for the device type.
                 _LOGGER.warning(
                     "Duco node %s (%s) has an unsupported device type and will be ignored",
                     node.node_id,
                     node.general.name,
                 )
                 continue
+            known_nodes.add(node.node_id)
             new_entities.extend(
                 DucoSensorEntity(coordinator, node, description)
                 for description in SENSOR_DESCRIPTIONS

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -164,7 +164,6 @@ async def async_setup_entry(
     # can detect both newly added and stale (deregistered) nodes on every
     # coordinator update.
     known_nodes: set[int] = set()
-    warned_unknown_nodes: set[int] = set()
 
     @callback
     def _async_add_new_entities() -> None:
@@ -186,7 +185,6 @@ async def async_setup_entry(
                         remove_config_entry_id=entry.entry_id,
                     )
             known_nodes.difference_update(stale_node_ids)
-            warned_unknown_nodes.difference_update(stale_node_ids)
 
         new_entities: list[SensorEntity] = []
         for node in coordinator.data.nodes.values():
@@ -197,24 +195,14 @@ async def async_setup_entry(
                 # on every coordinator update. This allows entities to be
                 # created automatically once a firmware update or library
                 # update adds support for the device type.
-                if node.node_id not in warned_unknown_nodes:
-                    _LOGGER.warning(
-                        "Duco node %s (%s) has an unsupported device type and will be "
-                        "ignored for this update; it will be retried on subsequent "
-                        "coordinator updates once its type becomes supported",
-                        node.node_id,
-                        node.general.name,
-                    )
-                    warned_unknown_nodes.add(node.node_id)
-                else:
-                    _LOGGER.debug(
-                        "Duco node %s (%s) still has an unsupported device type",
-                        node.node_id,
-                        node.general.name,
-                    )
+                _LOGGER.debug(
+                    "Duco node %s (%s) has an unsupported device type and will be "
+                    "retried on subsequent coordinator updates",
+                    node.node_id,
+                    node.general.name,
+                )
                 continue
             known_nodes.add(node.node_id)
-            warned_unknown_nodes.discard(node.node_id)
             new_entities.extend(
                 DucoSensorEntity(coordinator, node, description)
                 for description in SENSOR_DESCRIPTIONS

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -333,6 +333,63 @@
     'state': '22.5',
   })
 # ---
+# name: test_sensor_entities_state[sensor.living-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'target_flow_level',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_target_flow_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_sensor_entities_state[sensor.living_box_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -391,57 +448,6 @@
     'state': '27.9',
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_mode_end_time-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.living_mode_end_time',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Mode end time',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': None,
-    'original_name': 'Mode end time',
-    'platform': 'duco',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'time_state_end',
-    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_end',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor_entities_state[sensor.living_mode_end_time-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Living Mode end time',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.living_mode_end_time',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_sensor_entities_state[sensor.living_signal_strength-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -497,15 +503,13 @@
     'state': '-60',
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_target_flow_level-entry]
+# name: test_sensor_entities_state[sensor.living_timestamp-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
     ]),
     'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
+    'capabilities': None,
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -513,7 +517,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.living_target_flow_level',
+    'entity_id': 'sensor.living_timestamp',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -521,37 +525,33 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Target flow level',
+    'object_id_base': 'Timestamp',
     'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Target flow level',
+    'original_name': 'Timestamp',
     'platform': 'duco',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'target_flow_level',
-    'unique_id': 'aa:bb:cc:dd:ee:ff_1_target_flow_level',
-    'unit_of_measurement': '%',
+    'translation_key': 'time_state_end',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_end',
+    'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_target_flow_level-state]
+# name: test_sensor_entities_state[sensor.living_timestamp-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Living Target flow level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'timestamp',
+      'friendly_name': 'Living Timestamp',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.living_target_flow_level',
+    'entity_id': 'sensor.living_timestamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_sensor_entities_state[sensor.living_ventilation_state-entry]

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -333,63 +333,6 @@
     'state': '22.5',
   })
 # ---
-# name: test_sensor_entities_state[sensor.living-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.living',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'duco',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'target_flow_level',
-    'unique_id': 'aa:bb:cc:dd:ee:ff_1_target_flow_level',
-    'unit_of_measurement': '%',
-  })
-# ---
-# name: test_sensor_entities_state[sensor.living-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Living',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.living',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
 # name: test_sensor_entities_state[sensor.living_box_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -448,6 +391,57 @@
     'state': '27.9',
   })
 # ---
+# name: test_sensor_entities_state[sensor.living_mode_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_mode_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mode end time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Mode end time',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_state_end',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_end',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_mode_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Living Mode end time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_mode_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_sensor_entities_state[sensor.living_signal_strength-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -503,13 +497,15 @@
     'state': '-60',
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_timestamp-entry]
+# name: test_sensor_entities_state[sensor.living_target_flow_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
     ]),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -517,7 +513,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.living_timestamp',
+    'entity_id': 'sensor.living_target_flow_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -525,33 +521,37 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Timestamp',
+    'object_id_base': 'Target flow level',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
     }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Timestamp',
+    'original_name': 'Target flow level',
     'platform': 'duco',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'time_state_end',
-    'unique_id': 'aa:bb:cc:dd:ee:ff_1_time_state_end',
-    'unit_of_measurement': None,
+    'translation_key': 'target_flow_level',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_target_flow_level',
+    'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_timestamp-state]
+# name: test_sensor_entities_state[sensor.living_target_flow_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Living Timestamp',
+      'friendly_name': 'Living Target flow level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.living_timestamp',
+    'entity_id': 'sensor.living_target_flow_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0',
   })
 # ---
 # name: test_sensor_entities_state[sensor.living_ventilation_state-entry]

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Duco sensor platform."""
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 from duco.exceptions import DucoConnectionError, DucoError
@@ -264,12 +265,16 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that a node initially reported as UNKNOWN is retried on every update.
 
     A node must not be added to known_nodes when its type is UNKNOWN, so that
     entities are created automatically once the type resolves to a supported
     value (e.g. after a firmware update or a library update).
+
+    The warning is logged only once per node; subsequent updates with an
+    UNKNOWN type emit a debug message instead to avoid log spam.
     """
     node_id = 99
 
@@ -300,15 +305,29 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
         ),
     )
 
-    # First poll: node type is UNKNOWN, no entities should be created.
+    # First poll: node type is UNKNOWN. A warning must be logged and no entities created.
     mock_duco_client.async_get_nodes.return_value = [*mock_nodes, unknown_node]
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    with caplog.at_level(logging.WARNING, logger="homeassistant.components.duco"):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert hass.states.get("sensor.future_sensor_humidity") is None
+    assert "has an unsupported device type" in caplog.text
 
-    # Second poll: the same node now reports a known type.
+    caplog.clear()
+
+    # Second poll: node is still UNKNOWN. No new warning should be emitted;
+    # only a debug message to avoid log spam.
+    with caplog.at_level(logging.WARNING, logger="homeassistant.components.duco"):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("sensor.future_sensor_humidity") is None
+    assert "has an unsupported device type" not in caplog.text
+
+    # Third poll: the same node now reports a known type. Entities must be created.
     known_node = Node(
         node_id=node_id,
         general=NodeGeneralInfo(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -274,6 +274,7 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
     sensor = NodeSensorInfo(co2=None, iaq_co2=None, rh=62.0, iaq_rh=70, temp=21.0)
 
     def _make_node(node_type: NodeType | str) -> Node:
+        """Create a Node with the given node type for use in tests."""
         return Node(
             node_id=node_id,
             general=NodeGeneralInfo(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -312,7 +312,7 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_unknown_node_warning_logged_once(
+async def test_unknown_node_logged_at_debug(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
@@ -320,7 +320,7 @@ async def test_unknown_node_warning_logged_once(
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that a WARNING for UNKNOWN nodes is emitted only once, then demoted to DEBUG."""
+    """Test that UNKNOWN nodes are logged at DEBUG level on every coordinator update."""
     unknown_node = Node(
         node_id=99,
         general=NodeGeneralInfo(
@@ -348,12 +348,11 @@ async def test_unknown_node_warning_logged_once(
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert "has an unsupported device type" in caplog.text
-    caplog.clear()
+    assert "has an unsupported device type" not in caplog.text
 
-    with caplog.at_level(logging.WARNING, logger="homeassistant.components.duco"):
+    with caplog.at_level(logging.DEBUG, logger="homeassistant.components.duco"):
         freezer.tick(SCAN_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert "has an unsupported device type" not in caplog.text
+    assert "has an unsupported device type" in caplog.text

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -255,3 +255,79 @@ async def test_unknown_node_type_logs_warning_and_creates_no_entities(
         identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_99")}
     )
     assert device is None
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a node initially reported as UNKNOWN is retried on every update.
+
+    A node must not be added to known_nodes when its type is UNKNOWN, so that
+    entities are created automatically once the type resolves to a supported
+    value (e.g. after a firmware update or a library update).
+    """
+    node_id = 99
+
+    unknown_node = Node(
+        node_id=node_id,
+        general=NodeGeneralInfo(
+            node_type=NodeType.UNKNOWN,
+            sub_type=0,
+            network_type="RF",
+            parent=1,
+            asso=1,
+            name="Future sensor",
+            identify=0,
+        ),
+        ventilation=NodeVentilationInfo(
+            state="AUTO",
+            time_state_remain=0,
+            time_state_end=0,
+            mode="-",
+            flow_lvl_tgt=None,
+        ),
+        sensor=NodeSensorInfo(
+            co2=None,
+            iaq_co2=None,
+            rh=62.0,
+            iaq_rh=70,
+            temp=21.0,
+        ),
+    )
+
+    # First poll: node type is UNKNOWN, no entities should be created.
+    mock_duco_client.async_get_nodes.return_value = [*mock_nodes, unknown_node]
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("sensor.future_sensor_humidity") is None
+
+    # Second poll: the same node now reports a known type.
+    known_node = Node(
+        node_id=node_id,
+        general=NodeGeneralInfo(
+            node_type="BSRH",
+            sub_type=0,
+            network_type="RF",
+            parent=1,
+            asso=1,
+            name="Future sensor",
+            identify=0,
+        ),
+        ventilation=unknown_node.ventilation,
+        sensor=unknown_node.sensor,
+    )
+    mock_duco_client.async_get_nodes.return_value = [*mock_nodes, known_node]
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.future_sensor_humidity")
+    assert state is not None
+    assert state.state == "62.0"

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -265,21 +265,64 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a node with UNKNOWN type is retried and gets entities once the type resolves."""
+    node_id = 99
+    ventilation = NodeVentilationInfo(
+        state="AUTO", time_state_remain=0, time_state_end=0, mode="-", flow_lvl_tgt=None
+    )
+    sensor = NodeSensorInfo(co2=None, iaq_co2=None, rh=62.0, iaq_rh=70, temp=21.0)
+
+    def _make_node(node_type: NodeType | str) -> Node:
+        return Node(
+            node_id=node_id,
+            general=NodeGeneralInfo(
+                node_type=node_type,
+                sub_type=0,
+                network_type="RF",
+                parent=1,
+                asso=1,
+                name="Future sensor",
+                identify=0,
+            ),
+            ventilation=ventilation,
+            sensor=sensor,
+        )
+
+    # First poll: UNKNOWN type — no entities created.
+    mock_duco_client.async_get_nodes.return_value = [
+        *mock_nodes,
+        _make_node(NodeType.UNKNOWN),
+    ]
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("sensor.future_sensor_humidity") is None
+
+    # Second poll: type now resolved — entities must be created.
+    mock_duco_client.async_get_nodes.return_value = [*mock_nodes, _make_node("BSRH")]
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.future_sensor_humidity")
+    assert state is not None
+    assert state.state == "62.0"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_unknown_node_warning_logged_once(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that a node initially reported as UNKNOWN is retried on every update.
-
-    A node must not be added to known_nodes when its type is UNKNOWN, so that
-    entities are created automatically once the type resolves to a supported
-    value (e.g. after a firmware update or a library update).
-
-    The warning is logged only once per node; subsequent updates with an
-    UNKNOWN type emit a debug message instead to avoid log spam.
-    """
-    node_id = 99
-
+    """Test that a WARNING for UNKNOWN nodes is emitted only once, then demoted to DEBUG."""
     unknown_node = Node(
-        node_id=node_id,
+        node_id=99,
         general=NodeGeneralInfo(
             node_type=NodeType.UNKNOWN,
             sub_type=0,
@@ -296,57 +339,21 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
             mode="-",
             flow_lvl_tgt=None,
         ),
-        sensor=NodeSensorInfo(
-            co2=None,
-            iaq_co2=None,
-            rh=62.0,
-            iaq_rh=70,
-            temp=21.0,
-        ),
+        sensor=NodeSensorInfo(co2=None, iaq_co2=None, rh=None, iaq_rh=None, temp=None),
     )
-
-    # First poll: node type is UNKNOWN. A warning must be logged and no entities created.
     mock_duco_client.async_get_nodes.return_value = [*mock_nodes, unknown_node]
+
     with caplog.at_level(logging.WARNING, logger="homeassistant.components.duco"):
         freezer.tick(SCAN_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert hass.states.get("sensor.future_sensor_humidity") is None
     assert "has an unsupported device type" in caplog.text
-
     caplog.clear()
 
-    # Second poll: node is still UNKNOWN. No new warning should be emitted;
-    # only a debug message to avoid log spam.
     with caplog.at_level(logging.WARNING, logger="homeassistant.components.duco"):
         freezer.tick(SCAN_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert hass.states.get("sensor.future_sensor_humidity") is None
     assert "has an unsupported device type" not in caplog.text
-
-    # Third poll: the same node now reports a known type. Entities must be created.
-    known_node = Node(
-        node_id=node_id,
-        general=NodeGeneralInfo(
-            node_type="BSRH",
-            sub_type=0,
-            network_type="RF",
-            parent=1,
-            asso=1,
-            name="Future sensor",
-            identify=0,
-        ),
-        ventilation=unknown_node.ventilation,
-        sensor=unknown_node.sensor,
-    )
-    mock_duco_client.async_get_nodes.return_value = [*mock_nodes, known_node]
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    state = hass.states.get("sensor.future_sensor_humidity")
-    assert state is not None
-    assert state.state == "62.0"


### PR DESCRIPTION
## Proposed change

> [!CAUTION]
> **Regression in 2026.5.0b0** — found during beta testing with a live Duco installation. The bug was introduced in #168758 (merged 2026-04-22).

When a Duco node reports `NodeType.UNKNOWN`, the previous code added the node to `known_nodes` **before** the unknown-type guard. This permanently prevented the node from being re-evaluated on subsequent coordinator updates, even after a firmware update or library update makes the type known. Restarting Home Assistant was the only workaround.

**Fix:** move `known_nodes.add(node.node_id)` to after the `NodeType.UNKNOWN` check, so unsupported nodes are retried on every coordinator update.

To prevent log spam, the warning is emitted only once per node per HA session. Subsequent coordinator updates with an UNKNOWN node type emit a `DEBUG` message instead.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: <!-- Add issue number here if applicable -->
- This PR is related to issue: <!-- Add issue number here if applicable -->
- Link to documentation pull request: <!-- Add link here if applicable -->
- Link to developer documentation pull request: <!-- Add link here if applicable -->
- Link to frontend pull request: <!-- Add link here if applicable -->

**Note for maintainers:** This fix targets `dev` but the regression is present in the 2026.5 RC branch (`rc`). A cherry-pick to `rc` would prevent 2026.5.0 from shipping with this bug.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.