### PR TITLE
Improve async_setup and async_setup_entry logic separation in hassio

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -298,7 +298,7 @@ class Analytics:
         if stored:
             self._data = AnalyticsData.from_dict(stored)
 
-        if self.supervisor:
+        if self.supervisor and not self.onboarded:
             # This may raise HassioNotReadyError if Supervisor was unreachable
             # during setup of the Supervisor integration. That will fail setup
             # of this integration. However there is no better option at this time
@@ -306,16 +306,16 @@ class Analytics:
             # setup this integration and we can't raise ConfigEntryNotReady to
             # trigger a retry from async_setup.
             supervisor_info = hassio.get_supervisor_info(self._hass)
-            if not self.onboarded:
-                # User have not configured analytics, get this setting from the supervisor
-                if supervisor_info[ATTR_DIAGNOSTICS] and not self.preferences.get(
-                    ATTR_DIAGNOSTICS, False
-                ):
-                    self._data.preferences[ATTR_DIAGNOSTICS] = True
-                elif not supervisor_info[ATTR_DIAGNOSTICS] and self.preferences.get(
-                    ATTR_DIAGNOSTICS, False
-                ):
-                    self._data.preferences[ATTR_DIAGNOSTICS] = False
+
+            # User have not configured analytics, get this setting from the supervisor
+            if supervisor_info[ATTR_DIAGNOSTICS] and not self.preferences.get(
+                ATTR_DIAGNOSTICS, False
+            ):
+                self._data.preferences[ATTR_DIAGNOSTICS] = True
+            elif not supervisor_info[ATTR_DIAGNOSTICS] and self.preferences.get(
+                ATTR_DIAGNOSTICS, False
+            ):
+                self._data.preferences[ATTR_DIAGNOSTICS] = False
 
     async def _save(self) -> None:
         """Save data."""

--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -3,6 +3,7 @@
 import asyncio
 from asyncio import timeout
 from collections.abc import Awaitable, Callable, Iterable, Mapping
+import contextlib
 from dataclasses import asdict as dataclass_asdict, dataclass, field
 from datetime import datetime
 import random
@@ -297,10 +298,14 @@ class Analytics:
         if stored:
             self._data = AnalyticsData.from_dict(stored)
 
-        if (
-            self.supervisor
-            and (supervisor_info := hassio.get_supervisor_info(self._hass)) is not None
-        ):
+        if self.supervisor:
+            # This may raise HassioNotReadyError if Supervisor was unreachable
+            # during setup of the Supervisor integration. That will fail setup
+            # of this integration. However there is no better option at this time
+            # since we need to get the diagnostic setting from Supervisor to correctly
+            # setup this integration and we can't raise ConfigEntryNotReady to
+            # trigger a retry from async_setup.
+            supervisor_info = hassio.get_supervisor_info(self._hass)
             if not self.onboarded:
                 # User have not configured analytics, get this setting from the supervisor
                 if supervisor_info[ATTR_DIAGNOSTICS] and not self.preferences.get(
@@ -344,9 +349,14 @@ class Analytics:
             await self._save()
 
         if self.supervisor:
+            # get_supervisor_info was called during setup so we can't get here
+            # if it raised. The others may raise HassioNotReadyError if only some
+            # data was successfully fetched from Supervisor
             supervisor_info = hassio.get_supervisor_info(hass)
-            operating_system_info = hassio.get_os_info(hass) or {}
-            addons_info = hassio.get_addons_info(hass) or {}
+            with contextlib.suppress(hassio.HassioNotReadyError):
+                operating_system_info = hassio.get_os_info(hass)
+            with contextlib.suppress(hassio.HassioNotReadyError):
+                addons_info = hassio.get_addons_info(hass)
 
         system_info = await async_get_system_info(hass)
         integrations = []
@@ -419,7 +429,7 @@ class Analytics:
 
                 integrations.append(integration.domain)
 
-            if addons_info is not None:
+            if addons_info:
                 supervisor_client = hassio.get_supervisor_client(hass)
                 installed_addons = await asyncio.gather(
                     *(supervisor_client.addons.addon_info(slug) for slug in addons_info)

--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -63,9 +63,14 @@ class ESPHomeDashboardManager:
         if is_hassio(self._hass):
             from homeassistant.components.hassio import get_addons_info  # noqa: PLC0415
 
-            if (addons := get_addons_info(self._hass)) is not None and info[
-                "addon_slug"
-            ] not in addons:
+            # This may raise HassioNotReadyError if Supervisor was unreachable
+            # during setup of the Supervisor integration. That will fail setup
+            # of this integration. However there is no better option at this time
+            # since we need to know if the addon is installed from Supervisor to
+            # correctly setup this integration and we can't raise ConfigEntryNotReady
+            # to trigger a retry from async_setup.
+            addons = get_addons_info(self._hass)
+            if info["addon_slug"] not in addons:
                 # The addon is not installed anymore, but it make come back
                 # so we don't want to remove the dashboard, but for now
                 # we don't want to use it.

--- a/homeassistant/components/hardkernel/__init__.py
+++ b/homeassistant/components/hardkernel/__init__.py
@@ -1,6 +1,6 @@
 """The Hardkernel integration."""
 
-from homeassistant.components.hassio import get_os_info
+from homeassistant.components.hassio import HassioNotReadyError, get_os_info
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -14,9 +14,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.async_create_task(hass.config_entries.async_remove(entry.entry_id))
         return False
 
-    if (os_info := get_os_info(hass)) is None:
-        # The hassio integration has not yet fetched data from the supervisor
-        raise ConfigEntryNotReady
+    try:
+        os_info = get_os_info(hass)
+    except HassioNotReadyError as err:
+        raise ConfigEntryNotReady from err
 
     board: str | None
     if (board := os_info.get("board")) is None or not board.startswith("odroid"):

--- a/homeassistant/components/hardkernel/hardware.py
+++ b/homeassistant/components/hardkernel/hardware.py
@@ -20,8 +20,7 @@ BOARD_NAMES = {
 @callback
 def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     """Return board info."""
-    if (os_info := get_os_info(hass)) is None:
-        raise HomeAssistantError
+    os_info = get_os_info(hass)
     board: str | None
     if (board := os_info.get("board")) is None:
         raise HomeAssistantError

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -1,5 +1,6 @@
 """Support for Hass.io."""
 
+import asyncio
 from dataclasses import replace
 from datetime import datetime
 import logging
@@ -395,21 +396,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "Failed to update Home Assistant options in Supervisor: %s", err
             )
 
-    update_hass_api_task = hass.async_create_task(
-        update_hass_api(refresh_token), eager_start=True
+    await asyncio.gather(
+        update_hass_api(refresh_token),
+        push_config(None),
+        issues.setup(),
+        async_setup_addon_panel(hass),
     )
-    push_config_task = hass.async_create_task(push_config(None), eager_start=True)
-    issues_task = hass.async_create_task(issues.setup(), eager_start=True)
-
-    # Init add-on ingress panels
-    panels_task = hass.async_create_task(
-        async_setup_addon_panel(hass), eager_start=True
-    )
-
-    await update_hass_api_task
-    await panels_task
-    await push_config_task
-    await issues_task
 
     # Setup hardware integration for the detected board type
     @callback

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -1,25 +1,16 @@
 """Support for Hass.io."""
 
-import asyncio
 from dataclasses import replace
 from datetime import datetime
 import logging
 import os
 import struct
-from typing import Any, cast
+from typing import Any
 
 from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import (
     GreenOptions,
-    HomeAssistantInfo,
     HomeAssistantOptions,
-    HostInfo,
-    InstalledAddon,
-    NetworkInfo,
-    OSInfo,
-    RootInfo,
-    StoreInfo,
-    SupervisorInfo,
     SupervisorOptions,
     YellowOptions,
 )
@@ -41,6 +32,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import Event, HassJob, HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -51,7 +43,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.issue_registry import IssueSeverity
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util.async_ import create_eager_task
 
 # config_flow, diagnostics, system_health, and entity platforms are imported to
 # ensure other dependencies that wait for hassio are not waiting
@@ -74,17 +65,12 @@ from .auth import async_setup_auth_view
 from .config import HassioConfig
 from .const import (
     ADDONS_COORDINATOR,
-    DATA_ADDONS_LIST,
     DATA_COMPONENT,
     DATA_CONFIG_STORE,
-    DATA_CORE_INFO,
-    DATA_HOST_INFO,
-    DATA_INFO,
+    DATA_HASSIO_HOST,
+    DATA_HASSIO_HTTP_CONFIG,
+    DATA_HASSIO_SUPERVISOR_USER,
     DATA_KEY_SUPERVISOR_ISSUES,
-    DATA_NETWORK_INFO,
-    DATA_OS_INFO,
-    DATA_STORE,
-    DATA_SUPERVISOR_INFO,
     DOMAIN,
     HASSIO_MAIN_UPDATE_INTERVAL,
     MAIN_COORDINATOR,
@@ -188,6 +174,61 @@ def hostname_from_addon_slug(addon_slug: str) -> str:
     return addon_slug.replace("_", "-")
 
 
+@callback
+def _check_deprecated_setup(hass: HomeAssistant) -> None:
+    """Create issues for deprecated installation types and architectures."""
+    os_info = get_os_info(hass)
+    info = get_info(hass)
+    if os_info is None or info is None:
+        return
+    is_haos = info.get("hassos") is not None
+    board = os_info.get("board")
+    arch = info.get("arch", "unknown")
+    unsupported_board = board in {"tinker", "odroid-xu4", "rpi2"}
+    unsupported_os_on_board = board in {"rpi3", "rpi4"}
+    if is_haos and (unsupported_board or unsupported_os_on_board):
+        issue_id = "deprecated_os_"
+        if unsupported_os_on_board:
+            issue_id += "aarch64"
+        elif unsupported_board:
+            issue_id += "armv7"
+        ir.async_create_issue(
+            hass,
+            "homeassistant",
+            issue_id,
+            learn_more_url=DEPRECATION_URL,
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key=issue_id,
+            translation_placeholders={
+                "installation_guide": "https://www.home-assistant.io/installation/",
+            },
+        )
+    bit32 = _is_32_bit()
+    deprecated_architecture = bit32 and not (
+        unsupported_board or unsupported_os_on_board
+    )
+    if not is_haos or deprecated_architecture:
+        issue_id = "deprecated"
+        if not is_haos:
+            issue_id += "_method"
+        if deprecated_architecture:
+            issue_id += "_architecture"
+        ir.async_create_issue(
+            hass,
+            "homeassistant",
+            issue_id,
+            learn_more_url=DEPRECATION_URL,
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key=issue_id,
+            translation_placeholders={
+                "installation_type": "OS" if is_haos else "Supervised",
+                "arch": arch,
+            },
+        )
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Hass.io component."""
     # Check local setup
@@ -201,18 +242,37 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
         return False
 
-    async_load_websocket_api(hass)
-    frontend.async_register_built_in_panel(hass, "app")
-
     host = os.environ["SUPERVISOR"]
     websession = async_get_clientsession(hass)
     hass.data[DATA_COMPONENT] = HassIO(hass.loop, websession, host)
+    hass.data[DATA_HASSIO_HOST] = host
+    hass.data[DATA_HASSIO_HTTP_CONFIG] = config.get("http", {})
+
+    async_load_websocket_api(hass)
+    hass.http.register_view(HassIOView(host, websession))
+    async_setup_services(hass)
+    async_setup_discovery_view(hass)
+    async_setup_auth_view(hass)
+    async_setup_ingress_view(hass)
+    frontend.async_register_built_in_panel(hass, "app")
+
+    discovery_flow.async_create_flow(
+        hass, DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
+    )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
     supervisor_client = get_supervisor_client(hass)
 
     try:
         await supervisor_client.supervisor.ping()
-    except SupervisorError:
-        _LOGGER.warning("Not connected with the supervisor / system too busy!")
+    except SupervisorError as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="supervisor_not_connected",
+        ) from err
 
     # Load the store
     config_store = HassioConfig(hass)
@@ -240,34 +300,43 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         refresh_token = await hass.auth.async_create_refresh_token(user)
         config_store.update(hassio_user=user.id)
 
-    hass.http.register_view(HassIOView(host, websession))
+    assert user is not None
+    hass.data[DATA_HASSIO_SUPERVISOR_USER] = user
 
-    async def update_hass_api(http_config: dict[str, Any], refresh_token: RefreshToken):
-        """Update Home Assistant API data on Hass.io."""
-        options = HomeAssistantOptions(
-            ssl=CONF_SSL_CERTIFICATE in http_config,
-            port=http_config.get(CONF_SERVER_PORT) or SERVER_PORT,
-            refresh_token=refresh_token.token,
-        )
+    # Start listening for problems with supervisor and making issues
+    hass.data[DATA_KEY_SUPERVISOR_ISSUES] = issues = SupervisorIssues(hass)
 
-        if http_config.get(CONF_SERVER_HOST) is not None:
-            options = replace(options, watchdog=False)
-            _LOGGER.warning(
-                "Found incompatible HTTP option 'server_host'. Watchdog feature"
-                " disabled"
-            )
+    async def _async_stop(hass: HomeAssistant, restart: bool) -> None:
+        """Stop or restart home assistant."""
+        if restart:
+            await supervisor_client.homeassistant.restart()
+        else:
+            await supervisor_client.homeassistant.stop()
 
-        try:
-            await supervisor_client.homeassistant.set_options(options)
-        except SupervisorError as err:
-            _LOGGER.warning(
-                "Failed to update Home Assistant options in Supervisor: %s", err
-            )
+    # Set a custom handler for the homeassistant.restart and homeassistant.stop services
+    async_set_stop_handler(hass, _async_stop)
 
-    update_hass_api_task = hass.async_create_task(
-        update_hass_api(config.get("http", {}), refresh_token), eager_start=True
+    # Set up coordinators — these can raise ConfigEntryNotReady.
+    # Register listeners only after all refreshes succeed to avoid accumulation
+    # across retries.
+    dev_reg = dr.async_get(hass)
+
+    coordinator = HassioMainDataUpdateCoordinator(hass, entry, dev_reg)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data[MAIN_COORDINATOR] = coordinator
+
+    addon_coordinator = HassioAddOnDataUpdateCoordinator(
+        hass, entry, dev_reg, coordinator.jobs
     )
+    await addon_coordinator.async_config_entry_first_refresh()
+    hass.data[ADDONS_COORDINATOR] = addon_coordinator
 
+    stats_coordinator = HassioStatsDataUpdateCoordinator(hass, entry)
+    await stats_coordinator.async_config_entry_first_refresh()
+    hass.data[STATS_COORDINATOR] = stats_coordinator
+
+    # All coordinator data is now available. Register the ongoing config listener
+    # and kick off background tasks.
     last_timezone = None
     last_country = None
 
@@ -290,100 +359,45 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             except SupervisorError as err:
                 _LOGGER.warning("Failed to update Supervisor options: %s", err)
 
-    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, push_config)
+    entry.async_on_unload(hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, push_config))
 
-    push_config_task = hass.async_create_task(push_config(None), eager_start=True)
-    # Start listening for problems with supervisor and making issues
-    hass.data[DATA_KEY_SUPERVISOR_ISSUES] = issues = SupervisorIssues(hass)
-    issues_task = hass.async_create_task(issues.setup(), eager_start=True)
+    http_config: dict[str, Any] = hass.data.get(DATA_HASSIO_HTTP_CONFIG, {})
 
-    # Register services
-    async_setup_services(hass, supervisor_client)
+    async def update_hass_api(refresh_token: RefreshToken) -> None:
+        """Update Home Assistant API data on Hass.io."""
+        options = HomeAssistantOptions(
+            ssl=CONF_SSL_CERTIFICATE in http_config,
+            port=http_config.get(CONF_SERVER_PORT) or SERVER_PORT,
+            refresh_token=refresh_token.token,
+        )
 
-    async def update_info_data(_: datetime | None = None) -> None:
-        """Update last available supervisor information."""
-        supervisor_client = get_supervisor_client(hass)
-
-        try:
-            (
-                root_info,
-                host_info,
-                store_info,
-                homeassistant_info,
-                supervisor_info,
-                os_info,
-                network_info,
-                addons_list,
-            ) = cast(
-                tuple[
-                    RootInfo,
-                    HostInfo,
-                    StoreInfo,
-                    HomeAssistantInfo,
-                    SupervisorInfo,
-                    OSInfo,
-                    NetworkInfo,
-                    list[InstalledAddon],
-                ],
-                await asyncio.gather(
-                    create_eager_task(supervisor_client.info()),
-                    create_eager_task(supervisor_client.host.info()),
-                    create_eager_task(supervisor_client.store.info()),
-                    create_eager_task(supervisor_client.homeassistant.info()),
-                    create_eager_task(supervisor_client.supervisor.info()),
-                    create_eager_task(supervisor_client.os.info()),
-                    create_eager_task(supervisor_client.network.info()),
-                    create_eager_task(supervisor_client.addons.list()),
-                ),
+        if http_config.get(CONF_SERVER_HOST) is not None:
+            options = replace(options, watchdog=False)
+            _LOGGER.warning(
+                "Found incompatible HTTP option 'server_host'. Watchdog feature"
+                " disabled"
             )
 
+        try:
+            await supervisor_client.homeassistant.set_options(options)
         except SupervisorError as err:
-            _LOGGER.warning("Can't read Supervisor data: %s", err)
-        else:
-            hass.data[DATA_INFO] = root_info
-            hass.data[DATA_HOST_INFO] = host_info
-            hass.data[DATA_STORE] = store_info
-            hass.data[DATA_CORE_INFO] = homeassistant_info
-            hass.data[DATA_SUPERVISOR_INFO] = supervisor_info
-            hass.data[DATA_OS_INFO] = os_info
-            hass.data[DATA_NETWORK_INFO] = network_info
-            hass.data[DATA_ADDONS_LIST] = addons_list
+            _LOGGER.warning(
+                "Failed to update Home Assistant options in Supervisor: %s", err
+            )
 
-    # Fetch data
-    update_info_task = hass.async_create_task(update_info_data(), eager_start=True)
-
-    async def _async_stop(hass: HomeAssistant, restart: bool) -> None:
-        """Stop or restart home assistant."""
-        if restart:
-            await supervisor_client.homeassistant.restart()
-        else:
-            await supervisor_client.homeassistant.stop()
-
-    # Set a custom handler for the homeassistant.restart and homeassistant.stop services
-    async_set_stop_handler(hass, _async_stop)
-
-    # Init discovery Hass.io feature
-    async_setup_discovery_view(hass)
-
-    # Init auth Hass.io feature
-    assert user is not None
-    async_setup_auth_view(hass, user)
-
-    # Init ingress Hass.io feature
-    async_setup_ingress_view(hass, host)
+    update_hass_api_task = hass.async_create_task(
+        update_hass_api(refresh_token), eager_start=True
+    )
+    push_config_task = hass.async_create_task(push_config(None), eager_start=True)
+    issues_task = hass.async_create_task(issues.setup(), eager_start=True)
 
     # Init add-on ingress panels
     panels_task = hass.async_create_task(
         async_setup_addon_panel(hass), eager_start=True
     )
 
-    # Make sure to await the update_info task before
-    # _async_setup_hardware_integration is called
-    # so the hardware integration can be set up
-    # and does not fallback to calling later
     await update_hass_api_task
     await panels_task
-    await update_info_task
     await push_config_task
     await issues_task
 
@@ -412,81 +426,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     _async_setup_hardware_integration()
-    discovery_flow.async_create_flow(
-        hass, DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
-    )
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up a config entry."""
-    dev_reg = dr.async_get(hass)
-
-    coordinator = HassioMainDataUpdateCoordinator(hass, entry, dev_reg)
-    await coordinator.async_config_entry_first_refresh()
-    hass.data[MAIN_COORDINATOR] = coordinator
-
-    addon_coordinator = HassioAddOnDataUpdateCoordinator(
-        hass, entry, dev_reg, coordinator.jobs
-    )
-    await addon_coordinator.async_config_entry_first_refresh()
-    hass.data[ADDONS_COORDINATOR] = addon_coordinator
-
-    stats_coordinator = HassioStatsDataUpdateCoordinator(hass, entry)
-    await stats_coordinator.async_config_entry_first_refresh()
-    hass.data[STATS_COORDINATOR] = stats_coordinator
 
     def deprecated_setup_issue() -> None:
-        os_info = get_os_info(hass)
-        info = get_info(hass)
-        if os_info is None or info is None:
-            return
-        is_haos = info.get("hassos") is not None
-        board = os_info.get("board")
-        arch = info.get("arch", "unknown")
-        unsupported_board = board in {"tinker", "odroid-xu4", "rpi2"}
-        unsupported_os_on_board = board in {"rpi3", "rpi4"}
-        if is_haos and (unsupported_board or unsupported_os_on_board):
-            issue_id = "deprecated_os_"
-            if unsupported_os_on_board:
-                issue_id += "aarch64"
-            elif unsupported_board:
-                issue_id += "armv7"
-            ir.async_create_issue(
-                hass,
-                "homeassistant",
-                issue_id,
-                learn_more_url=DEPRECATION_URL,
-                is_fixable=False,
-                severity=IssueSeverity.WARNING,
-                translation_key=issue_id,
-                translation_placeholders={
-                    "installation_guide": "https://www.home-assistant.io/installation/",
-                },
-            )
-        bit32 = _is_32_bit()
-        deprecated_architecture = bit32 and not (
-            unsupported_board or unsupported_os_on_board
-        )
-        if not is_haos or deprecated_architecture:
-            issue_id = "deprecated"
-            if not is_haos:
-                issue_id += "_method"
-            if deprecated_architecture:
-                issue_id += "_architecture"
-            ir.async_create_issue(
-                hass,
-                "homeassistant",
-                issue_id,
-                learn_more_url=DEPRECATION_URL,
-                is_fixable=False,
-                severity=IssueSeverity.WARNING,
-                translation_key=issue_id,
-                translation_placeholders={
-                    "installation_type": "OS" if is_haos else "Supervised",
-                    "arch": arch,
-                },
-            )
+        _check_deprecated_setup(hass)
         listener()
 
     listener = coordinator.async_add_listener(deprecated_setup_issue)
@@ -504,9 +446,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator: HassioMainDataUpdateCoordinator = hass.data[MAIN_COORDINATOR]
     coordinator.unload()
 
-    # Pop coordinators
+    # Pop coordinators and entry-level data
     hass.data.pop(MAIN_COORDINATOR, None)
     hass.data.pop(ADDONS_COORDINATOR, None)
     hass.data.pop(STATS_COORDINATOR, None)
+    hass.data.pop(DATA_CONFIG_STORE, None)
+    hass.data.pop(DATA_HASSIO_SUPERVISOR_USER, None)
+    hass.data.pop(DATA_KEY_SUPERVISOR_ISSUES, None)
 
     return unload_ok

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from dataclasses import replace
-from datetime import datetime
 import logging
 import os
 import struct
@@ -33,7 +32,7 @@ from homeassistant.const import (
     SERVER_PORT,
     Platform,
 )
-from homeassistant.core import Event, HassJob, HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
     config_validation as cv,
@@ -42,7 +41,6 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.issue_registry import IssueSeverity
 from homeassistant.helpers.typing import ConfigType
 
@@ -74,7 +72,6 @@ from .const import (
     DATA_HASSIO_SUPERVISOR_USER,
     DATA_KEY_SUPERVISOR_ISSUES,
     DOMAIN,
-    HASSIO_MAIN_UPDATE_INTERVAL,
     MAIN_COORDINATOR,
     STATS_COORDINATOR,
 )
@@ -96,6 +93,7 @@ from .coordinator import (
     get_supervisor_stats,
 )
 from .discovery import async_setup_discovery_view
+from .exceptions import HassioNotReadyError
 from .handler import HassIO, async_update_diagnostics, get_supervisor_client
 from .http import HassIOView
 from .ingress import async_setup_ingress_view
@@ -112,6 +110,7 @@ __all__ = [
     "AddonManager",
     "AddonState",
     "GreenOptions",
+    "HassioNotReadyError",
     "SupervisorError",
     "YellowOptions",
     "async_update_diagnostics",
@@ -181,8 +180,6 @@ def _check_deprecated_setup(hass: HomeAssistant) -> None:
     """Create issues for deprecated installation types and architectures."""
     os_info = get_os_info(hass)
     info = get_info(hass)
-    if os_info is None or info is None:
-        return
     is_haos = info.get("hassos") is not None
     board = os_info.get("board")
     arch = info.get("arch", "unknown")
@@ -416,36 +413,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Setup hardware integration for the detected board type
-    @callback
-    def _async_setup_hardware_integration(_: datetime | None = None) -> None:
-        """Set up hardware integration for the detected board type."""
-        if (os_info := get_os_info(hass)) is None:
-            # os info not yet fetched from supervisor, retry later
-            async_call_later(
-                hass,
-                HASSIO_MAIN_UPDATE_INTERVAL,
-                async_setup_hardware_integration_job,
-            )
-            return
-        if (board := os_info.get("board")) is None:
-            return
-        if (hw_integration := HARDWARE_INTEGRATIONS.get(board)) is None:
-            return
+    # This is done after the initial data refresh to ensure that the board info is available.
+    os_info = get_os_info(hass)
+    if (board := os_info.get("board")) is not None and (
+        hw_integration := HARDWARE_INTEGRATIONS.get(board)
+    ) is not None:
         discovery_flow.async_create_flow(
             hass, hw_integration, context={"source": SOURCE_SYSTEM}, data={}
         )
 
-    async_setup_hardware_integration_job = HassJob(
-        _async_setup_hardware_integration, cancel_on_shutdown=True
-    )
-
-    _async_setup_hardware_integration()
-
-    def deprecated_setup_issue() -> None:
-        _check_deprecated_setup(hass)
-        listener()
-
-    listener = coordinator.async_add_listener(deprecated_setup_issue)
+    # Check for deprecated setup and create issues if needed.
+    # This is done after the initial data refresh to ensure that the info needed is available.
+    _check_deprecated_setup(hass)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -17,7 +17,7 @@ from aiohasupervisor.models import (
 )
 
 from homeassistant.auth.const import GROUP_ID_ADMIN
-from homeassistant.auth.models import RefreshToken
+from homeassistant.auth.models import RefreshToken, User
 from homeassistant.components import frontend
 from homeassistant.components.homeassistant import async_set_stop_handler
 from homeassistant.components.homeassistant.const import DATA_STOP_HANDLER
@@ -250,12 +250,40 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DATA_HASSIO_HOST] = host
     hass.data[DATA_HASSIO_HTTP_CONFIG] = config.get("http", {})
 
+    # Load the store
+    config_store = HassioConfig(hass)
+    await config_store.load()
+    hass.data[DATA_CONFIG_STORE] = config_store
+
+    # Cache the Supervisor user. Create one if necessary
+    user: User | None = None
+    if (hassio_user := config_store.data.hassio_user) is not None:
+        user = await hass.auth.async_get_user(hassio_user)
+        if user:
+            # Migrate old Hass.io users to be admin.
+            if not user.is_admin:
+                await hass.auth.async_update_user(user, group_ids=[GROUP_ID_ADMIN])
+
+            # Migrate old name
+            if user.name == "Hass.io":
+                await hass.auth.async_update_user(user, name=HASSIO_USER_NAME)
+
+    if user is None:
+        user = await hass.auth.async_create_system_user(
+            HASSIO_USER_NAME, group_ids=[GROUP_ID_ADMIN]
+        )
+        config_store.update(hassio_user=user.id)
+
+    assert user is not None
+    hass.data[DATA_HASSIO_SUPERVISOR_USER] = user
+
     async_load_websocket_api(hass)
     hass.http.register_view(HassIOView(host, websession))
     async_setup_services(hass)
     async_setup_discovery_view(hass)
     async_setup_auth_view(hass)
     async_setup_ingress_view(hass)
+    async_setup_addon_panel(hass)
     frontend.async_register_built_in_panel(hass, "app")
 
     discovery_flow.async_create_flow(
@@ -276,34 +304,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             translation_key="supervisor_not_connected",
         ) from err
 
-    # Load the store
-    config_store = HassioConfig(hass)
-    await config_store.load()
-    hass.data[DATA_CONFIG_STORE] = config_store
-
-    refresh_token = None
-    if (hassio_user := config_store.data.hassio_user) is not None:
-        user = await hass.auth.async_get_user(hassio_user)
-        if user and user.refresh_tokens:
-            refresh_token = list(user.refresh_tokens.values())[0]
-
-            # Migrate old Hass.io users to be admin.
-            if not user.is_admin:
-                await hass.auth.async_update_user(user, group_ids=[GROUP_ID_ADMIN])
-
-            # Migrate old name
-            if user.name == "Hass.io":
-                await hass.auth.async_update_user(user, name=HASSIO_USER_NAME)
-
-    if refresh_token is None:
-        user = await hass.auth.async_create_system_user(
-            HASSIO_USER_NAME, group_ids=[GROUP_ID_ADMIN]
-        )
+    # Get or create a refresh token for the Supervisor user
+    user = hass.data[DATA_HASSIO_SUPERVISOR_USER]
+    if user.refresh_tokens:
+        refresh_token = list(user.refresh_tokens.values())[0]
+    else:
         refresh_token = await hass.auth.async_create_refresh_token(user)
-        config_store.update(hassio_user=user.id)
-
-    assert user is not None
-    hass.data[DATA_HASSIO_SUPERVISOR_USER] = user
 
     # Set up coordinators — these can raise ConfigEntryNotReady.
     # Register listeners only after all refreshes succeed to avoid accumulation
@@ -328,6 +334,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # install the stop handler now so they are never left in a partial state
     # if a coordinator refresh raises ConfigEntryNotReady.
     hass.data[DATA_KEY_SUPERVISOR_ISSUES] = issues = SupervisorIssues(hass)
+
+    def _unload_supervisor_issues() -> None:
+        if (
+            supervisor_issues := hass.data.pop(DATA_KEY_SUPERVISOR_ISSUES, None)
+        ) is not None:
+            supervisor_issues.unload()
+
+    entry.async_on_unload(_unload_supervisor_issues)
 
     async def _async_stop(hass: HomeAssistant, restart: bool) -> None:
         """Stop or restart home assistant."""
@@ -396,11 +410,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "Failed to update Home Assistant options in Supervisor: %s", err
             )
 
+    # Push initial config to Supervisor and start issues listener
     await asyncio.gather(
-        update_hass_api(refresh_token),
-        push_config(None),
-        issues.setup(),
-        async_setup_addon_panel(hass),
+        update_hass_api(refresh_token), push_config(None), issues.setup()
     )
 
     # Setup hardware integration for the detected board type
@@ -444,20 +456,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    # Unload coordinator
-    coordinator: HassioMainDataUpdateCoordinator = hass.data[MAIN_COORDINATOR]
-    coordinator.unload()
-
     # Pop coordinators and entry-level data
     hass.data.pop(MAIN_COORDINATOR, None)
     hass.data.pop(ADDONS_COORDINATOR, None)
     hass.data.pop(STATS_COORDINATOR, None)
-    hass.data.pop(DATA_CONFIG_STORE, None)
-    hass.data.pop(DATA_HASSIO_SUPERVISOR_USER, None)
-
-    if (
-        supervisor_issues := hass.data.pop(DATA_KEY_SUPERVISOR_ISSUES, None)
-    ) is not None:
-        supervisor_issues.unload()
 
     return unload_ok

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.auth.models import RefreshToken
 from homeassistant.components import frontend
 from homeassistant.components.homeassistant import async_set_stop_handler
+from homeassistant.components.homeassistant.const import DATA_STOP_HANDLER
 from homeassistant.components.http import (
     CONF_SERVER_HOST,
     CONF_SERVER_PORT,
@@ -303,19 +304,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     assert user is not None
     hass.data[DATA_HASSIO_SUPERVISOR_USER] = user
 
-    # Start listening for problems with supervisor and making issues
-    hass.data[DATA_KEY_SUPERVISOR_ISSUES] = issues = SupervisorIssues(hass)
-
-    async def _async_stop(hass: HomeAssistant, restart: bool) -> None:
-        """Stop or restart home assistant."""
-        if restart:
-            await supervisor_client.homeassistant.restart()
-        else:
-            await supervisor_client.homeassistant.stop()
-
-    # Set a custom handler for the homeassistant.restart and homeassistant.stop services
-    async_set_stop_handler(hass, _async_stop)
-
     # Set up coordinators — these can raise ConfigEntryNotReady.
     # Register listeners only after all refreshes succeed to avoid accumulation
     # across retries.
@@ -335,8 +323,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await stats_coordinator.async_config_entry_first_refresh()
     hass.data[STATS_COORDINATOR] = stats_coordinator
 
-    # All coordinator data is now available. Register the ongoing config listener
-    # and kick off background tasks.
+    # All coordinators refreshed successfully. Start the issues listener and
+    # install the stop handler now so they are never left in a partial state
+    # if a coordinator refresh raises ConfigEntryNotReady.
+    hass.data[DATA_KEY_SUPERVISOR_ISSUES] = issues = SupervisorIssues(hass)
+
+    async def _async_stop(hass: HomeAssistant, restart: bool) -> None:
+        """Stop or restart home assistant."""
+        if restart:
+            await supervisor_client.homeassistant.restart()
+        else:
+            await supervisor_client.homeassistant.stop()
+
+    # Install a custom handler for the homeassistant.restart / stop services,
+    # and restore the previous one when this entry unloads.
+    prev_stop_handler = hass.data.get(DATA_STOP_HANDLER)
+    async_set_stop_handler(hass, _async_stop)
+
+    def _restore_stop_handler() -> None:
+        if prev_stop_handler is not None:
+            async_set_stop_handler(hass, prev_stop_handler)
+        else:
+            hass.data.pop(DATA_STOP_HANDLER, None)
+
+    entry.async_on_unload(_restore_stop_handler)
     last_timezone = None
     last_country = None
 
@@ -452,6 +462,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.pop(STATS_COORDINATOR, None)
     hass.data.pop(DATA_CONFIG_STORE, None)
     hass.data.pop(DATA_HASSIO_SUPERVISOR_USER, None)
-    hass.data.pop(DATA_KEY_SUPERVISOR_ISSUES, None)
+
+    if (
+        supervisor_issues := hass.data.pop(DATA_KEY_SUPERVISOR_ISSUES, None)
+    ) is not None:
+        supervisor_issues.unload()
 
     return unload_ok

--- a/homeassistant/components/hassio/addon_panel.py
+++ b/homeassistant/components/hassio/addon_panel.py
@@ -9,27 +9,33 @@ from aiohttp import web
 
 from homeassistant.components import frontend
 from homeassistant.components.http import HomeAssistantView, require_admin
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import Event, HomeAssistant
 
 from .handler import get_supervisor_client
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_addon_panel(hass: HomeAssistant) -> None:
+def async_setup_addon_panel(hass: HomeAssistant) -> None:
     """Add-on Ingress Panel setup."""
     hassio_addon_panel = HassIOAddonPanel(hass)
     hass.http.register_view(hassio_addon_panel)
 
-    # If panels are exists
-    if not (panels := await hassio_addon_panel.get_panels()):
-        return
+    # Handle existing panels on startup
+    async def _async_panel_start_handler(event: Event) -> None:
+        """Process all existing panels on startup."""
+        # Check if there are panels to register
+        if not (panels := await hassio_addon_panel.get_panels()):
+            return
 
-    # Register available panels
-    for addon, data in panels.items():
-        if not data.enable:
-            continue
-        _register_panel(hass, addon, data)
+        # Register available panels
+        for addon, data in panels.items():
+            if not data.enable:
+                continue
+            _register_panel(hass, addon, data)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_panel_start_handler)
 
 
 class HassIOAddonPanel(HomeAssistantView):

--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -6,10 +6,13 @@ import logging
 import os
 
 from aiohttp import web
-from aiohttp.web_exceptions import HTTPNotFound, HTTPUnauthorized
+from aiohttp.web_exceptions import (
+    HTTPNotFound,
+    HTTPServiceUnavailable,
+    HTTPUnauthorized,
+)
 import voluptuous as vol
 
-from homeassistant.auth.models import User
 from homeassistant.auth.providers import homeassistant as auth_ha
 from homeassistant.components.http import KEY_HASS, KEY_HASS_USER, HomeAssistantView
 from homeassistant.components.http.const import is_supervisor_unix_socket_request
@@ -17,31 +20,31 @@ from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 
-from .const import ATTR_ADDON, ATTR_PASSWORD, ATTR_USERNAME
+from .const import ATTR_ADDON, ATTR_PASSWORD, ATTR_USERNAME, DATA_HASSIO_SUPERVISOR_USER
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @callback
-def async_setup_auth_view(hass: HomeAssistant, user: User) -> None:
+def async_setup_auth_view(hass: HomeAssistant) -> None:
     """Auth setup."""
-    hassio_auth = HassIOAuth(hass, user)
-    hassio_password_reset = HassIOPasswordReset(hass, user)
-
-    hass.http.register_view(hassio_auth)
-    hass.http.register_view(hassio_password_reset)
+    hass.http.register_view(HassIOAuth(hass))
+    hass.http.register_view(HassIOPasswordReset(hass))
 
 
 class HassIOBaseAuth(HomeAssistantView):
     """Hass.io view to handle auth requests."""
 
-    def __init__(self, hass: HomeAssistant, user: User) -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         """Initialize WebView."""
         self.hass = hass
-        self.user = user
 
     def _check_access(self, request: web.Request) -> None:
         """Check if this call is from Supervisor."""
+        user = self.hass.data.get(DATA_HASSIO_SUPERVISOR_USER)
+        if user is None:
+            raise HTTPServiceUnavailable
+
         # Requests over the Supervisor Unix socket are authenticated by the
         # http auth middleware as the Supervisor user, so the caller-IP check
         # below does not apply (and would crash, since `peername` is empty for
@@ -56,7 +59,7 @@ class HassIOBaseAuth(HomeAssistantView):
                 raise HTTPUnauthorized
 
         # Check caller token
-        if request[KEY_HASS_USER].id != self.user.id:
+        if request[KEY_HASS_USER].id != user.id:
             _LOGGER.error("Invalid auth request from %s", request[KEY_HASS_USER].name)
             raise HTTPUnauthorized
 

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.util.hass_dict import HassKey
 
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
         StoreInfo,
         SupervisorInfo,
     )
+
+    from homeassistant.auth.models import User
 
     from .config import HassioConfig
     from .coordinator import (
@@ -145,6 +147,9 @@ DATA_KEY_CORE = "core"
 DATA_KEY_HOST = "host"
 DATA_KEY_SUPERVISOR_ISSUES: HassKey[SupervisorIssues] = HassKey("supervisor_issues")
 DATA_KEY_MOUNTS = "mounts"
+DATA_HASSIO_HTTP_CONFIG: HassKey[dict[str, Any]] = HassKey("hassio_http_config")
+DATA_HASSIO_HOST: HassKey[str] = HassKey("hassio_host")
+DATA_HASSIO_SUPERVISOR_USER: HassKey[User] = HassKey("hassio_supervisor_user")
 
 PLACEHOLDER_KEY_ADDON = "addon"
 PLACEHOLDER_KEY_ADDON_INFO = "addon_info"

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -70,6 +70,7 @@ from .const import (
     UPDATE_KEY_SUPERVISOR,
     SupervisorEntityModel,
 )
+from .exceptions import HassioNotReadyError
 from .handler import get_supervisor_client
 from .jobs import SupervisorJobs
 
@@ -180,44 +181,50 @@ def _installed_addon_from_complete(info: InstalledAddonComplete) -> InstalledAdd
 
 
 @callback
-def get_info(hass: HomeAssistant) -> dict[str, Any] | None:
+def get_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return generic information from Supervisor.
 
     Async friendly.
     """
     info = hass.data.get(DATA_INFO)
-    return info.to_dict() if info is not None else None
+    if info is None:
+        raise HassioNotReadyError
+    return info.to_dict()
 
 
 @callback
-def get_host_info(hass: HomeAssistant) -> dict[str, Any] | None:
+def get_host_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return generic host information.
 
     Async friendly.
     """
     info = hass.data.get(DATA_HOST_INFO)
-    return info.to_dict() if info is not None else None
+    if info is None:
+        raise HassioNotReadyError
+    return info.to_dict()
 
 
 @callback
-def get_store(hass: HomeAssistant) -> dict[str, Any] | None:
+def get_store(hass: HomeAssistant) -> dict[str, Any]:
     """Return store information.
 
     Async friendly.
     """
     info = hass.data.get(DATA_STORE)
-    return info.to_dict() if info is not None else None
+    if info is None:
+        raise HassioNotReadyError
+    return info.to_dict()
 
 
 @callback
-def get_supervisor_info(hass: HomeAssistant) -> dict[str, Any] | None:
+def get_supervisor_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return Supervisor information.
 
     Async friendly.
     """
     info = hass.data.get(DATA_SUPERVISOR_INFO)
     if info is None:
-        return None
+        raise HassioNotReadyError
     result = info.to_dict()
     # Deprecated 2026.4.0: Folding repositories and addons into supervisor_info
     # for backwards compatibility. Can be removed after deprecation period.
@@ -229,17 +236,19 @@ def get_supervisor_info(hass: HomeAssistant) -> dict[str, Any] | None:
 
 
 @callback
-def get_network_info(hass: HomeAssistant) -> dict[str, Any] | None:
+def get_network_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return Host Network information.
 
     Async friendly.
     """
     info = hass.data.get(DATA_NETWORK_INFO)
-    return info.to_dict() if info is not None else None
+    if info is None:
+        raise HassioNotReadyError
+    return info.to_dict()
 
 
 @callback
-def get_addons_info(hass: HomeAssistant) -> dict[str, dict[str, Any] | None] | None:
+def get_addons_info(hass: HomeAssistant) -> dict[str, dict[str, Any] | None]:
     """Return Addons info.
 
     Async friendly.
@@ -248,7 +257,7 @@ def get_addons_info(hass: HomeAssistant) -> dict[str, dict[str, Any] | None] | N
         DATA_ADDONS_INFO
     )
     if addons_info is None:
-        return None
+        raise HassioNotReadyError
     # Converting these fields for compatibility as that is what was returned here.
     # We'll leave it this way as long as these component APIs continue to return
     # dictionaries. If/when we switch to using the aiohasupervisor models for everything
@@ -266,13 +275,15 @@ def get_addons_info(hass: HomeAssistant) -> dict[str, dict[str, Any] | None] | N
 
 
 @callback
-def get_addons_list(hass: HomeAssistant) -> list[dict[str, Any]] | None:
+def get_addons_list(hass: HomeAssistant) -> list[dict[str, Any]]:
     """Return list of installed addons and subset of details for each.
 
     Async friendly.
     """
     addons = hass.data.get(DATA_ADDONS_LIST)
-    return [addon.to_dict() for addon in addons] if addons is not None else None
+    if addons is None:
+        raise HassioNotReadyError
+    return [addon.to_dict() for addon in addons]
 
 
 @callback
@@ -309,23 +320,27 @@ def get_supervisor_stats(hass: HomeAssistant) -> dict[str, Any]:
 
 
 @callback
-def get_os_info(hass: HomeAssistant) -> dict[str, Any] | None:
+def get_os_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return OS information.
 
     Async friendly.
     """
     info = hass.data.get(DATA_OS_INFO)
-    return info.to_dict() if info is not None else None
+    if info is None:
+        raise HassioNotReadyError
+    return info.to_dict()
 
 
 @callback
-def get_core_info(hass: HomeAssistant) -> dict[str, Any] | None:
+def get_core_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return Home Assistant Core information from Supervisor.
 
     Async friendly.
     """
     info = hass.data.get(DATA_CORE_INFO)
-    return info.to_dict() if info is not None else None
+    if info is None:
+        raise HassioNotReadyError
+    return info.to_dict()
 
 
 @callback

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -941,8 +941,8 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[HassioMainData]):
             log_failures, raise_on_auth_failed, scheduled, raise_on_entry_error
         )
 
-    @callback
-    def unload(self) -> None:
-        """Clean up when config entry unloaded."""
+    async def async_shutdown(self) -> None:
+        """Shut down and clean up when config entry unloaded."""
+        await super().async_shutdown()
         self._dispatcher_disconnect()
         self.jobs.unload()

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -780,10 +780,7 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[HassioMainData]):
         )
         self.entry_id = config_entry.entry_id
         self.dev_reg = dev_reg
-        if info := self.hass.data.get(DATA_INFO):
-            self.is_hass_os = info.hassos is not None
-        else:
-            self.is_hass_os = False
+        self.is_hass_os = False
         self.supervisor_client = get_supervisor_client(hass)
         self.jobs = SupervisorJobs(hass)
         self._dispatcher_disconnect = async_dispatcher_connect(
@@ -843,6 +840,7 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[HassioMainData]):
             raise UpdateFailed(f"Error on Supervisor API: {err}") from err
 
         # Build clean coordinator data
+        self.is_hass_os = info.hassos is not None
         new_data = HassioMainData(
             core=core_info,
             supervisor=supervisor_info,

--- a/homeassistant/components/hassio/exceptions.py
+++ b/homeassistant/components/hassio/exceptions.py
@@ -1,0 +1,7 @@
+"""Exceptions for the Hassio integration."""
+
+from homeassistant.exceptions import HomeAssistantError
+
+
+class HassioNotReadyError(HomeAssistantError):
+    """Raised when Hassio data is not yet available."""

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.util.async_ import create_eager_task
 
-from .const import X_HASS_SOURCE, X_INGRESS_PATH
+from .const import DATA_HASSIO_HOST, X_HASS_SOURCE, X_INGRESS_PATH
 from .http import should_compress
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,8 +50,9 @@ DISABLED_TIMEOUT = ClientTimeout(total=None)
 
 
 @callback
-def async_setup_ingress_view(hass: HomeAssistant, host: str) -> None:
+def async_setup_ingress_view(hass: HomeAssistant) -> None:
     """Auth setup."""
+    host = hass.data[DATA_HASSIO_HOST]
     websession = async_get_clientsession(hass)
 
     hassio_ingress = HassIOIngress(host, websession)

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -51,7 +51,7 @@ DISABLED_TIMEOUT = ClientTimeout(total=None)
 
 @callback
 def async_setup_ingress_view(hass: HomeAssistant) -> None:
-    """Auth setup."""
+    """Set up the Hass.io ingress HTTP view."""
     host = hass.data[DATA_HASSIO_HOST]
     websession = async_get_clientsession(hass)
 

--- a/homeassistant/components/hassio/issues.py
+++ b/homeassistant/components/hassio/issues.py
@@ -1,6 +1,7 @@
 """Supervisor events monitor."""
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 import logging
@@ -180,6 +181,7 @@ class SupervisorIssues:
         self._unhealthy_reasons: set[str] = set()
         self._issues: dict[UUID, Issue] = {}
         self._supervisor_client = get_supervisor_client(hass)
+        self._disconnect: Callable[[], None] | None = None
 
     @property
     def unhealthy_reasons(self) -> set[str]:
@@ -352,9 +354,15 @@ class SupervisorIssues:
         """Create supervisor events listener."""
         await self._update()
 
-        async_dispatcher_connect(
+        self._disconnect = async_dispatcher_connect(
             self._hass, EVENT_SUPERVISOR_EVENT, self._supervisor_events_to_issues
         )
+
+    def unload(self) -> None:
+        """Remove supervisor events listener."""
+        if self._disconnect is not None:
+            self._disconnect()
+            self._disconnect = None
 
     async def _update(self, _: datetime | None = None) -> None:
         """Update issues from Supervisor resolution center."""

--- a/homeassistant/components/hassio/issues.py
+++ b/homeassistant/components/hassio/issues.py
@@ -353,7 +353,7 @@ class SupervisorIssues:
 
     async def setup(self) -> None:
         """Create supervisor events listener."""
-        await self._update()
+        await self.async_update()
 
         self._disconnect = async_dispatcher_connect(
             self._hass, EVENT_SUPERVISOR_EVENT, self._supervisor_events_to_issues
@@ -368,8 +368,15 @@ class SupervisorIssues:
             self._cancel_update_retry()
             self._cancel_update_retry = None
 
-    async def _update(self, _: datetime | None = None) -> None:
+    async def async_update(self) -> None:
         """Update issues from Supervisor resolution center."""
+        if self._cancel_update_retry:
+            self._cancel_update_retry()
+            self._cancel_update_retry = None
+        await self._update()
+
+    async def _update(self, _: datetime | None = None) -> None:
+        """Update issues from Supervisor resolution center with retry on failure."""
         try:
             data = await self._supervisor_client.resolution.info()
         except SupervisorError as err:
@@ -404,7 +411,7 @@ class SupervisorIssues:
             and event.get(ATTR_UPDATE_KEY) == UPDATE_KEY_SUPERVISOR
             and event.get(ATTR_DATA, {}).get(ATTR_STARTUP) == STARTUP_COMPLETE
         ):
-            self._hass.async_create_task(self._update())
+            self._hass.async_create_task(self.async_update())
 
         elif event[ATTR_WS_EVENT] == EVENT_HEALTH_CHANGED:
             self.unhealthy_reasons = (

--- a/homeassistant/components/hassio/issues.py
+++ b/homeassistant/components/hassio/issues.py
@@ -182,6 +182,7 @@ class SupervisorIssues:
         self._issues: dict[UUID, Issue] = {}
         self._supervisor_client = get_supervisor_client(hass)
         self._disconnect: Callable[[], None] | None = None
+        self._cancel_update_retry: Callable[[], None] | None = None
 
     @property
     def unhealthy_reasons(self) -> set[str]:
@@ -363,6 +364,9 @@ class SupervisorIssues:
         if self._disconnect is not None:
             self._disconnect()
             self._disconnect = None
+        if self._cancel_update_retry is not None:
+            self._cancel_update_retry()
+            self._cancel_update_retry = None
 
     async def _update(self, _: datetime | None = None) -> None:
         """Update issues from Supervisor resolution center."""
@@ -370,12 +374,13 @@ class SupervisorIssues:
             data = await self._supervisor_client.resolution.info()
         except SupervisorError as err:
             _LOGGER.error("Failed to update supervisor issues: %r", err)
-            async_call_later(
+            self._cancel_update_retry = async_call_later(
                 self._hass,
                 REQUEST_REFRESH_DELAY,
                 HassJob(self._update, cancel_on_shutdown=True),
             )
             return
+        self._cancel_update_retry = None
         self.unhealthy_reasons = set(data.unhealthy)
         self.unsupported_reasons = set(data.unsupported)
 

--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -51,6 +51,7 @@ from .const import (
     SupervisorEntityModel,
 )
 from .coordinator import HassioMainDataUpdateCoordinator, get_addons_info
+from .exceptions import HassioNotReadyError
 from .handler import get_supervisor_client
 
 SERVICE_ADDON_START = "addon_start"
@@ -103,7 +104,13 @@ def valid_addon(value: Any) -> str:
     value = VALID_ADDON_SLUG(value)
     hass = async_get_hass_or_none()
 
-    if hass and (addons := get_addons_info(hass)) is not None and value not in addons:
+    if not hass:
+        return value
+    try:
+        addons = get_addons_info(hass)
+    except HassioNotReadyError:
+        return value
+    if value not in addons:
         raise vol.Invalid("Not a valid app slug")
     return value
 

--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -51,6 +51,7 @@ from .const import (
     SupervisorEntityModel,
 )
 from .coordinator import HassioMainDataUpdateCoordinator, get_addons_info
+from .handler import get_supervisor_client
 
 SERVICE_ADDON_START = "addon_start"
 SERVICE_ADDON_STOP = "addon_stop"
@@ -195,10 +196,9 @@ SCHEMA_MOUNT_RELOAD = vol.Schema(
 
 
 @callback
-def async_setup_services(
-    hass: HomeAssistant, supervisor_client: SupervisorClient
-) -> None:
+def async_setup_services(hass: HomeAssistant) -> None:
     """Register the Supervisor services."""
+    supervisor_client = get_supervisor_client(hass)
     async_register_app_services(hass, supervisor_client)
     async_register_host_services(hass, supervisor_client)
     async_register_backup_restore_services(hass, supervisor_client)

--- a/homeassistant/components/hassio/strings.json
+++ b/homeassistant/components/hassio/strings.json
@@ -52,6 +52,9 @@
     },
     "mount_reload_unknown_device_id": {
       "message": "Device ID not found"
+    },
+    "supervisor_not_connected": {
+      "message": "Not connected with the supervisor / system too busy"
     }
   },
   "issues": {

--- a/homeassistant/components/hassio/system_health.py
+++ b/homeassistant/components/hassio/system_health.py
@@ -1,5 +1,6 @@
 """Provide info to system health."""
 
+from collections.abc import Callable
 import os
 from typing import Any
 
@@ -14,6 +15,7 @@ from .coordinator import (
     get_os_info,
     get_supervisor_info,
 )
+from .exceptions import HassioNotReadyError
 
 SUPERVISOR_PING = "http://{ip_address}/supervisor/ping"
 OBSERVER_URL = "http://{ip_address}:4357"
@@ -27,17 +29,30 @@ def async_register(
     register.async_register_info(system_health_info)
 
 
+def _get_supervisor_data_if_available(
+    hass: HomeAssistant, get_info_dict: Callable[[HomeAssistant], dict[str, Any]]
+) -> dict[str, Any]:
+    """Get data from supervisor if available."""
+    try:
+        return get_info_dict(hass)
+    except HassioNotReadyError:
+        return {}
+
+
 async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Get info for the info page."""
     ip_address = os.environ["SUPERVISOR"]
-    info = get_info(hass)
-    host_info = get_host_info(hass)
-    supervisor_info = get_supervisor_info(hass)
-    network_info = get_network_info(hass)
-    addons_list = get_addons_list(hass)
+    info = _get_supervisor_data_if_available(hass, get_info)
+    host_info = _get_supervisor_data_if_available(hass, get_host_info)
+    supervisor_info = _get_supervisor_data_if_available(hass, get_supervisor_info)
+    network_info = _get_supervisor_data_if_available(hass, get_network_info)
+    try:
+        addons_list = get_addons_list(hass)
+    except HassioNotReadyError:
+        addons_list = []
 
     healthy: bool | dict[str, str]
-    if supervisor_info is not None and supervisor_info.get("healthy"):
+    if supervisor_info and supervisor_info.get("healthy"):
         healthy = True
     else:
         healthy = {
@@ -46,7 +61,7 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
         }
 
     supported: bool | dict[str, str]
-    if supervisor_info is not None and supervisor_info.get("supported"):
+    if supervisor_info and supervisor_info.get("supported"):
         supported = True
     else:
         supported = {

--- a/homeassistant/components/hassio/system_health.py
+++ b/homeassistant/components/hassio/system_health.py
@@ -30,11 +30,11 @@ def async_register(
 async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Get info for the info page."""
     ip_address = os.environ["SUPERVISOR"]
-    info = get_info(hass) or {}
-    host_info = get_host_info(hass) or {}
+    info = get_info(hass)
+    host_info = get_host_info(hass)
     supervisor_info = get_supervisor_info(hass)
-    network_info = get_network_info(hass) or {}
-    addons_list = get_addons_list(hass) or []
+    network_info = get_network_info(hass)
+    addons_list = get_addons_list(hass)
 
     healthy: bool | dict[str, str]
     if supervisor_info is not None and supervisor_info.get("healthy"):
@@ -81,7 +81,7 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     }
 
     if info.get("hassos") is not None:
-        os_info = get_os_info(hass) or {}
+        os_info = get_os_info(hass)
         information["board"] = os_info.get("board")
 
     # Not using aiohasupervisor for ping call below intentionally. Given system health

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -39,6 +39,7 @@ from .const import (
     WS_TYPE_SUBSCRIBE,
 )
 from .coordinator import get_addons_list
+from .exceptions import HassioNotReadyError
 from .handler import HassioAPIError
 from .update_helper import update_addon, update_core
 
@@ -174,7 +175,20 @@ async def websocket_update_addon(
     """Websocket handler to update an addon."""
     addon_name: str | None = None
     addon_version: str | None = None
-    addons_list: list[dict[str, Any]] = get_addons_list(hass) or []
+    try:
+        addons_list: list[dict[str, Any]] = get_addons_list(hass)
+    except HassioNotReadyError:
+        _LOGGER.error(
+            "Update command received for app %s but apps list is not available",
+            msg["addon"],
+        )
+        connection.send_error(
+            msg[WS_ID],
+            code=websocket_api.ERR_UNKNOWN_ERROR,
+            message="Apps list is not available",
+        )
+        return
+
     for addon in addons_list:
         if addon[ATTR_SLUG] == msg["addon"]:
             addon_name = addon[ATTR_NAME]

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -31,7 +31,6 @@ from .const import (
     ATTR_WS_EVENT,
     DATA_COMPONENT,
     DATA_CONFIG_STORE,
-    DOMAIN,
     EVENT_SUPERVISOR_EVENT,
     WS_ID,
     WS_TYPE,
@@ -210,13 +209,9 @@ def websocket_update_config_info(
     msg: dict[str, Any],
 ) -> None:
     """Send the stored backup config."""
-    if (
-        not hass.config_entries.async_loaded_entries(DOMAIN)
-        or (config_store := hass.data.get(DATA_CONFIG_STORE)) is None
-    ):
-        connection.send_error(msg["id"], "not_loaded", "Supervisor not loaded")
-        return
-    connection.send_result(msg["id"], config_store.data.update_config.to_dict())
+    connection.send_result(
+        msg["id"], hass.data[DATA_CONFIG_STORE].data.update_config.to_dict()
+    )
 
 
 @callback
@@ -235,14 +230,10 @@ def websocket_update_config_update(
     msg: dict[str, Any],
 ) -> None:
     """Update the stored backup config."""
-    if (
-        not hass.config_entries.async_loaded_entries(DOMAIN)
-        or (config_store := hass.data.get(DATA_CONFIG_STORE)) is None
-    ):
-        connection.send_error(msg["id"], "not_loaded", "Supervisor not loaded")
-        return
     changes = dict(msg)
     changes.pop("id")
     changes.pop("type")
-    config_store.update(update_config=cast(HassioUpdateParametersDict, changes))
+    hass.data[DATA_CONFIG_STORE].update(
+        update_config=cast(HassioUpdateParametersDict, changes)
+    )
     connection.send_result(msg["id"])

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -209,9 +209,10 @@ def websocket_update_config_info(
     msg: dict[str, Any],
 ) -> None:
     """Send the stored backup config."""
-    connection.send_result(
-        msg["id"], hass.data[DATA_CONFIG_STORE].data.update_config.to_dict()
-    )
+    if (config_store := hass.data.get(DATA_CONFIG_STORE)) is None:
+        connection.send_error(msg["id"], "not_loaded", "Supervisor not loaded")
+        return
+    connection.send_result(msg["id"], config_store.data.update_config.to_dict())
 
 
 @callback
@@ -230,10 +231,11 @@ def websocket_update_config_update(
     msg: dict[str, Any],
 ) -> None:
     """Update the stored backup config."""
+    if (config_store := hass.data.get(DATA_CONFIG_STORE)) is None:
+        connection.send_error(msg["id"], "not_loaded", "Supervisor not loaded")
+        return
     changes = dict(msg)
     changes.pop("id")
     changes.pop("type")
-    hass.data[DATA_CONFIG_STORE].update(
-        update_config=cast(HassioUpdateParametersDict, changes)
-    )
+    config_store.update(update_config=cast(HassioUpdateParametersDict, changes))
     connection.send_result(msg["id"])

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -31,6 +31,7 @@ from .const import (
     ATTR_WS_EVENT,
     DATA_COMPONENT,
     DATA_CONFIG_STORE,
+    DOMAIN,
     EVENT_SUPERVISOR_EVENT,
     WS_ID,
     WS_TYPE,
@@ -209,7 +210,10 @@ def websocket_update_config_info(
     msg: dict[str, Any],
 ) -> None:
     """Send the stored backup config."""
-    if (config_store := hass.data.get(DATA_CONFIG_STORE)) is None:
+    if (
+        not hass.config_entries.async_loaded_entries(DOMAIN)
+        or (config_store := hass.data.get(DATA_CONFIG_STORE)) is None
+    ):
         connection.send_error(msg["id"], "not_loaded", "Supervisor not loaded")
         return
     connection.send_result(msg["id"], config_store.data.update_config.to_dict())
@@ -231,7 +235,10 @@ def websocket_update_config_update(
     msg: dict[str, Any],
 ) -> None:
     """Update the stored backup config."""
-    if (config_store := hass.data.get(DATA_CONFIG_STORE)) is None:
+    if (
+        not hass.config_entries.async_loaded_entries(DOMAIN)
+        or (config_store := hass.data.get(DATA_CONFIG_STORE)) is None
+    ):
         connection.send_error(msg["id"], "not_loaded", "Supervisor not loaded")
         return
     changes = dict(msg)

--- a/homeassistant/components/homeassistant_alerts/coordinator.py
+++ b/homeassistant/components/homeassistant_alerts/coordinator.py
@@ -5,7 +5,7 @@ import logging
 
 from awesomeversion import AwesomeVersion, AwesomeVersionStrategy
 
-from homeassistant.components.hassio import get_supervisor_info
+from homeassistant.components.hassio import HassioNotReadyError, get_supervisor_info
 from homeassistant.const import __version__
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -78,7 +78,9 @@ class AlertUpdateCoordinator(DataUpdateCoordinator[dict[str, IntegrationAlert]])
                         continue
 
             if self.supervisor and "supervisor" in alert:
-                if (supervisor_info := get_supervisor_info(self.hass)) is None:
+                try:
+                    supervisor_info = get_supervisor_info(self.hass)
+                except HassioNotReadyError:
                     continue
 
                 if "affected_from_version" in alert["supervisor"]:

--- a/homeassistant/components/homeassistant_green/__init__.py
+++ b/homeassistant/components/homeassistant_green/__init__.py
@@ -1,6 +1,6 @@
 """The Home Assistant Green integration."""
 
-from homeassistant.components.hassio import get_os_info
+from homeassistant.components.hassio import HassioNotReadyError, get_os_info
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -14,9 +14,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.async_create_task(hass.config_entries.async_remove(entry.entry_id))
         return False
 
-    if (os_info := get_os_info(hass)) is None:
-        # The hassio integration has not yet fetched data from the supervisor
-        raise ConfigEntryNotReady
+    try:
+        os_info = get_os_info(hass)
+    except HassioNotReadyError as err:
+        raise ConfigEntryNotReady from err
 
     board: str | None
     if (board := os_info.get("board")) is None or board != "green":

--- a/homeassistant/components/homeassistant_green/hardware.py
+++ b/homeassistant/components/homeassistant_green/hardware.py
@@ -16,8 +16,7 @@ MODEL = "green"
 @callback
 def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     """Return board info."""
-    if (os_info := get_os_info(hass)) is None:
-        raise HomeAssistantError
+    os_info = get_os_info(hass)
     board: str | None
     if (board := os_info.get("board")) is None:
         raise HomeAssistantError

--- a/homeassistant/components/homeassistant_hardware/util.py
+++ b/homeassistant/components/homeassistant_hardware/util.py
@@ -16,6 +16,7 @@ from homeassistant.components.hassio import (
     AddonError,
     AddonManager,
     AddonState,
+    HassioNotReadyError,
     get_apps_list,
 )
 from homeassistant.config_entries import ConfigEntryState
@@ -300,7 +301,11 @@ async def guess_hardware_owners(
                 )
 
     # Z2M can be provided by one of many add-ons, we match them by name
-    for app_info in get_apps_list(hass) or []:
+    try:
+        apps_list = get_apps_list(hass)
+    except HassioNotReadyError:
+        apps_list = []
+    for app_info in apps_list:
         slug = app_info.get("slug")
 
         if not isinstance(slug, str) or Z2M_ADDON_SLUG_REGEX.fullmatch(slug) is None:

--- a/homeassistant/components/homeassistant_yellow/__init__.py
+++ b/homeassistant/components/homeassistant_yellow/__init__.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 import logging
 
-from homeassistant.components.hassio import get_os_info
+from homeassistant.components.hassio import HassioNotReadyError, get_os_info
 from homeassistant.components.homeassistant_hardware.coordinator import (
     FirmwareUpdateCoordinator,
 )
@@ -58,9 +58,10 @@ async def async_setup_entry(
         hass.async_create_task(hass.config_entries.async_remove(entry.entry_id))
         return False
 
-    if (os_info := get_os_info(hass)) is None:
-        # The hassio integration has not yet fetched data from the supervisor
-        raise ConfigEntryNotReady
+    try:
+        os_info = get_os_info(hass)
+    except HassioNotReadyError as err:
+        raise ConfigEntryNotReady from err
 
     if os_info.get("board") != "yellow":
         # Not running on a Home Assistant Yellow, Home Assistant may have been migrated

--- a/homeassistant/components/homeassistant_yellow/hardware.py
+++ b/homeassistant/components/homeassistant_yellow/hardware.py
@@ -16,8 +16,7 @@ MODEL = "yellow"
 @callback
 def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     """Return board info."""
-    if (os_info := get_os_info(hass)) is None:
-        raise HomeAssistantError
+    os_info = get_os_info(hass)
     board: str | None
     if (board := os_info.get("board")) is None:
         raise HomeAssistantError

--- a/homeassistant/components/raspberry_pi/__init__.py
+++ b/homeassistant/components/raspberry_pi/__init__.py
@@ -1,6 +1,6 @@
 """The Raspberry Pi integration."""
 
-from homeassistant.components.hassio import get_os_info
+from homeassistant.components.hassio import HassioNotReadyError, get_os_info
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -14,9 +14,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.async_create_task(hass.config_entries.async_remove(entry.entry_id))
         return False
 
-    if (os_info := get_os_info(hass)) is None:
-        # The hassio integration has not yet fetched data from the supervisor
-        raise ConfigEntryNotReady
+    try:
+        os_info = get_os_info(hass)
+    except HassioNotReadyError as err:
+        raise ConfigEntryNotReady from err
 
     board: str | None
     if (board := os_info.get("board")) is None or not board.startswith("rpi"):

--- a/homeassistant/components/raspberry_pi/hardware.py
+++ b/homeassistant/components/raspberry_pi/hardware.py
@@ -35,8 +35,7 @@ MODELS = {
 @callback
 def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     """Return board info."""
-    if (os_info := get_os_info(hass)) is None:
-        raise HomeAssistantError
+    os_info = get_os_info(hass)
     board: str | None
     if (board := os_info.get("board")) is None:
         raise HomeAssistantError

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from contextlib import suppress
 from ipaddress import ip_address
+import logging
 
 from aiohttp import hdrs
 from hass_nabucasa import remote
@@ -14,6 +15,8 @@ from homeassistant.util.network import is_ip_address, is_loopback, normalize_url
 
 from . import http
 from .hassio import is_hassio
+
+_LOGGER = logging.getLogger(__name__)
 
 TYPE_URL_INTERNAL = "internal_url"
 TYPE_URL_EXTERNAL = "external_url"
@@ -180,11 +183,19 @@ def get_url(
         known_hostnames = ["localhost"]
         if is_hassio(hass):
             # Local import to avoid circular dependencies
-            from homeassistant.components.hassio import get_host_info  # noqa: PLC0415
+            from homeassistant.components.hassio import (  # noqa: PLC0415
+                HassioNotReadyError,
+                get_host_info,
+            )
 
-            if host_info := get_host_info(hass):
+            try:
+                host_info = get_host_info(hass)
                 known_hostnames.extend(
                     [host_info["hostname"], f"{host_info['hostname']}.local"]
+                )
+            except HassioNotReadyError:
+                _LOGGER.warning(
+                    "Could not retrieve Supervisor host information, list of known URLs will be incomplete"
                 )
 
         if (

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -194,7 +194,7 @@ def get_url(
                     [host_info["hostname"], f"{host_info['hostname']}.local"]
                 )
             except HassioNotReadyError:
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "Could not retrieve Supervisor host information, list of known URLs will be incomplete"
                 )
 

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -94,11 +94,17 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
         # Local import to avoid circular dependencies
         from homeassistant.components import hassio  # noqa: PLC0415
 
-        if not (info := hassio.get_info(hass)):
+        try:
+            info = hassio.get_info(hass)
+        except hassio.HassioNotReadyError:
             _LOGGER.warning("No Home Assistant Supervisor info available")
             info = {}
 
-        host = hassio.get_host_info(hass) or {}
+        try:
+            host = hassio.get_host_info(hass)
+        except hassio.HassioNotReadyError:
+            _LOGGER.warning("No Home Assistant Supervisor host info available")
+            host = {}
         info_object["supervisor"] = info.get("supervisor")
         info_object["host_os"] = host.get("operating_system")
         info_object["docker_version"] = info.get("docker")

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -277,6 +277,10 @@ async def test_send_base_with_supervisor(
             side_effect=Mock(return_value={}),
         ),
         patch(
+            "homeassistant.components.hassio.get_addons_info",
+            side_effect=Mock(return_value={}),
+        ),
+        patch(
             "homeassistant.components.analytics.analytics.is_hassio",
             side_effect=Mock(return_value=True),
         ) as is_hassio_mock,

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -893,6 +893,10 @@ def supervisor_client() -> Generator[AsyncMock]:
             return_value=supervisor_client,
         ),
         patch(
+            "homeassistant.components.hassio.services.get_supervisor_client",
+            return_value=supervisor_client,
+        ),
+        patch(
             "homeassistant.components.hassio.update_helper.get_supervisor_client",
             return_value=supervisor_client,
         ),

--- a/tests/components/hardkernel/test_hardware.py
+++ b/tests/components/hardkernel/test_hardware.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.hardkernel.const import DOMAIN
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -64,7 +64,7 @@ async def test_hardware_info(
     }
 
 
-@pytest.mark.parametrize("os_info", [None, {"board": None}, {"board": "other"}])
+@pytest.mark.parametrize("os_info", [{"board": None}, {"board": "other"}])
 async def test_hardware_info_fail(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, os_info
 ) -> None:
@@ -92,6 +92,42 @@ async def test_hardware_info_fail(
     with patch(
         "homeassistant.components.hardkernel.hardware.get_os_info",
         return_value=os_info,
+    ):
+        await client.send_json({"id": 1, "type": "hardware/info"})
+        msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["success"]
+    assert msg["result"] == {"hardware": []}
+
+
+async def test_hardware_info_not_ready(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test async_info raises HassioNotReadyError when hassio is not ready."""
+    mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={},
+        title="Hardkernel",
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.hardkernel.get_os_info",
+        return_value={"board": "odroid-n2"},
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    with patch(
+        "homeassistant.components.hardkernel.hardware.get_os_info",
+        side_effect=HassioNotReadyError,
     ):
         await client.send_json({"id": 1, "type": "hardware/info"})
         msg = await client.receive_json()

--- a/tests/components/hardkernel/test_init.py
+++ b/tests/components/hardkernel/test_init.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from homeassistant.components.hardkernel.const import DOMAIN
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -95,7 +95,7 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.hardkernel.get_os_info",
-        return_value=None,
+        side_effect=HassioNotReadyError,
     ) as mock_get_os_info:
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/hassio/test_addon_panel.py
+++ b/tests/components/hassio/test_addon_panel.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 from aiohasupervisor.models import IngressPanel
 import pytest
 
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -40,6 +41,14 @@ async def test_hassio_addon_panel_startup(
             await async_setup_component(hass, "hassio", {})
             await hass.async_block_till_done()
 
+        ingress_panels.assert_not_called()
+        mock_panel.assert_not_called()
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
         ingress_panels.assert_called_once()
         assert mock_panel.called
         mock_panel.assert_called_with(
@@ -61,12 +70,17 @@ async def test_hassio_addon_panel_api(
         ),
     }
 
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
+
     with patch(
         "homeassistant.components.hassio.addon_panel._register_panel",
     ) as mock_panel:
-        with patch.dict(os.environ, MOCK_ENVIRON):
-            await async_setup_component(hass, "hassio", {})
-            await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
 
         ingress_panels.assert_called_once()
         assert mock_panel.called
@@ -104,12 +118,17 @@ async def test_hassio_addon_panel_api_non_admin(
         "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
     }
 
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
+
     with patch(
         "homeassistant.components.hassio.addon_panel._register_panel",
     ) as mock_panel:
-        with patch.dict(os.environ, MOCK_ENVIRON):
-            await async_setup_component(hass, "hassio", {})
-            await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
 
         ingress_panels.assert_called_once()
         mock_panel.assert_called_once()
@@ -140,12 +159,17 @@ async def test_hassio_addon_panel_registration(
         ),
     }
 
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
+
     with patch(
         "homeassistant.components.hassio.addon_panel.frontend.async_register_built_in_panel"
     ) as mock_register:
-        with patch.dict(os.environ, MOCK_ENVIRON):
-            await async_setup_component(hass, "hassio", {})
-            await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
 
         # Verify that async_register_built_in_panel was called with correct arguments
         # for our test addon

--- a/tests/components/hassio/test_addon_panel.py
+++ b/tests/components/hassio/test_addon_panel.py
@@ -1,6 +1,7 @@
 """Test add-on panel."""
 
 from http import HTTPStatus
+import os
 from unittest.mock import AsyncMock, patch
 
 from aiohasupervisor.models import IngressPanel
@@ -12,17 +13,15 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockUser
 from tests.typing import ClientSessionGenerator
 
+MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
+
 
 @pytest.fixture(autouse=True)
-def mock_all(
-    supervisor_is_connected: AsyncMock,
-    homeassistant_info: AsyncMock,
-    ingress_panels: AsyncMock,
-) -> None:
+def mock_all(all_setup_requests: None) -> None:
     """Mock all setup requests."""
 
 
-@pytest.mark.usefixtures("hassio_env")
+@pytest.mark.usefixtures("supervisor_client")
 async def test_hassio_addon_panel_startup(
     hass: HomeAssistant, ingress_panels: AsyncMock
 ) -> None:
@@ -37,8 +36,9 @@ async def test_hassio_addon_panel_startup(
     with patch(
         "homeassistant.components.hassio.addon_panel._register_panel",
     ) as mock_panel:
-        await async_setup_component(hass, "hassio", {})
-        await hass.async_block_till_done()
+        with patch.dict(os.environ, MOCK_ENVIRON):
+            await async_setup_component(hass, "hassio", {})
+            await hass.async_block_till_done()
 
         ingress_panels.assert_called_once()
         assert mock_panel.called
@@ -49,7 +49,7 @@ async def test_hassio_addon_panel_startup(
         )
 
 
-@pytest.mark.usefixtures("hassio_env")
+@pytest.mark.usefixtures("supervisor_client")
 async def test_hassio_addon_panel_api(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, ingress_panels: AsyncMock
 ) -> None:
@@ -64,8 +64,9 @@ async def test_hassio_addon_panel_api(
     with patch(
         "homeassistant.components.hassio.addon_panel._register_panel",
     ) as mock_panel:
-        await async_setup_component(hass, "hassio", {})
-        await hass.async_block_till_done()
+        with patch.dict(os.environ, MOCK_ENVIRON):
+            await async_setup_component(hass, "hassio", {})
+            await hass.async_block_till_done()
 
         ingress_panels.assert_called_once()
         assert mock_panel.called
@@ -91,7 +92,7 @@ async def test_hassio_addon_panel_api(
         )
 
 
-@pytest.mark.usefixtures("hassio_env")
+@pytest.mark.usefixtures("supervisor_client")
 async def test_hassio_addon_panel_api_non_admin(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -106,8 +107,9 @@ async def test_hassio_addon_panel_api_non_admin(
     with patch(
         "homeassistant.components.hassio.addon_panel._register_panel",
     ) as mock_panel:
-        await async_setup_component(hass, "hassio", {})
-        await hass.async_block_till_done()
+        with patch.dict(os.environ, MOCK_ENVIRON):
+            await async_setup_component(hass, "hassio", {})
+            await hass.async_block_till_done()
 
         ingress_panels.assert_called_once()
         mock_panel.assert_called_once()
@@ -127,7 +129,7 @@ async def test_hassio_addon_panel_api_non_admin(
         mock_panel.assert_not_called()
 
 
-@pytest.mark.usefixtures("hassio_env")
+@pytest.mark.usefixtures("supervisor_client")
 async def test_hassio_addon_panel_registration(
     hass: HomeAssistant, ingress_panels: AsyncMock
 ) -> None:
@@ -141,8 +143,9 @@ async def test_hassio_addon_panel_registration(
     with patch(
         "homeassistant.components.hassio.addon_panel.frontend.async_register_built_in_panel"
     ) as mock_register:
-        await async_setup_component(hass, "hassio", {})
-        await hass.async_block_till_done()
+        with patch.dict(os.environ, MOCK_ENVIRON):
+            await async_setup_component(hass, "hassio", {})
+            await hass.async_block_till_done()
 
         # Verify that async_register_built_in_panel was called with correct arguments
         # for our test addon
@@ -157,7 +160,7 @@ async def test_hassio_addon_panel_registration(
         )
 
 
-@pytest.mark.usefixtures("hassio_env")
+@pytest.mark.usefixtures("supervisor_client")
 async def test_hassio_addon_panel_api_delete(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, ingress_panels: AsyncMock
 ) -> None:
@@ -165,8 +168,9 @@ async def test_hassio_addon_panel_api_delete(
     ingress_panels.return_value = {
         "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
     }
-    await async_setup_component(hass, "hassio", {})
-    await hass.async_block_till_done()
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
 
     hass_client = await hass_client()
 
@@ -178,7 +182,7 @@ async def test_hassio_addon_panel_api_delete(
         mock_remove.assert_called_once_with(hass, "test1")
 
 
-@pytest.mark.usefixtures("hassio_env")
+@pytest.mark.usefixtures("supervisor_client")
 async def test_hassio_addon_panel_api_delete_non_admin(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -189,8 +193,9 @@ async def test_hassio_addon_panel_api_delete_non_admin(
     ingress_panels.return_value = {
         "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
     }
-    await async_setup_component(hass, "hassio", {})
-    await hass.async_block_till_done()
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
 
     hass_admin_user.groups = []
     hass_client = await hass_client()

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -10,7 +10,7 @@ import pytest
 
 from homeassistant.auth.providers.homeassistant import InvalidAuth
 from homeassistant.components.hassio.auth import HassIOBaseAuth
-from homeassistant.components.hassio.const import DATA_CONFIG_STORE
+from homeassistant.components.hassio.const import DATA_HASSIO_SUPERVISOR_USER
 from homeassistant.core import HomeAssistant
 
 
@@ -187,12 +187,10 @@ async def test_check_access_unix_socket_or_missing_peername(
     expectation: AbstractContextManager,
 ) -> None:
     """Test _check_access handles Unix socket requests and missing peername."""
-    hassio_user_id = hass.data[DATA_CONFIG_STORE].data.hassio_user
-    assert hassio_user_id is not None
-    user = await hass.auth.async_get_user(hassio_user_id)
+    user = hass.data.get(DATA_HASSIO_SUPERVISOR_USER)
     assert user is not None
 
-    auth_view = HassIOBaseAuth(hass, user)
+    auth_view = HassIOBaseAuth(hass)
     request = MagicMock()
     request.transport.get_extra_info.return_value = peername
     request.__getitem__.return_value = user

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -62,7 +62,6 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.homeassistant.const import DATA_STOP_HANDLER
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -1834,13 +1833,15 @@ async def test_stop_handler_restored_on_unload(
         assert await async_setup_component(hass, "hassio", {})
         await hass.async_block_till_done()
 
-    hassio_stop_handler = hass.data[DATA_STOP_HANDLER]
-
     entry = hass.config_entries.async_entries("hassio")[0]
     await hass.config_entries.async_unload(entry.entry_id)
 
-    # After unload the hassio handler must no longer be registered.
-    assert hass.data.get(DATA_STOP_HANDLER) is not hassio_stop_handler
+    # After a stop call to core no longer calls supervisor
+    with patch.object(hass, "async_stop") as mock_stop:
+        await hass.services.async_call("homeassistant", "stop", {})
+        await hass.async_block_till_done()
+        mock_stop.assert_called_once()
+        supervisor_client.homeassistant.stop.assert_not_called()
 
 
 @pytest.mark.usefixtures("supervisor_client")

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -62,6 +62,7 @@ from homeassistant.components.homeassistant import (
     SERVICE_UPDATE_ENTITY,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
@@ -167,9 +168,26 @@ async def test_setup_api_ping(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     assert get_core_info(hass)["version_latest"] == "1.0.0"
     assert is_hassio(hass)
+
+
+async def test_setup_api_ping_fails(
+    hass: HomeAssistant, supervisor_client: AsyncMock
+) -> None:
+    """Test that a failed ping raises ConfigEntryNotReady and retries."""
+    supervisor_client.supervisor.ping.side_effect = SupervisorError
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        result = await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
+
+    # async_setup succeeds (domain registered), but the config entry is in retry
+    assert result
+    assert is_hassio(hass)
+    entry = hass.config_entries.async_entries("hassio")[0]
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_app_panel(hass: HomeAssistant) -> None:
@@ -205,7 +223,7 @@ async def test_setup_api_push_api_data(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=9999, refresh_token=ANY)
     )
@@ -221,7 +239,7 @@ async def test_setup_api_push_api_data_error(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     assert "Failed to update Home Assistant options in Supervisor: boom" in caplog.text
 
 
@@ -238,7 +256,7 @@ async def test_setup_api_push_api_data_server_host(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=9999, refresh_token=ANY, watchdog=False)
     )
@@ -256,7 +274,7 @@ async def test_setup_api_push_api_data_default(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=8123, refresh_token=ANY)
     )
@@ -333,7 +351,7 @@ async def test_setup_api_existing_hassio_user(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=8123, refresh_token=token.token)
     )
@@ -350,7 +368,7 @@ async def test_setup_core_push_config(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     supervisor_client.supervisor.set_options.assert_called_once_with(
         SupervisorOptions(timezone="testzone")
     )
@@ -375,7 +393,7 @@ async def test_setup_core_push_config_error(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     assert "Failed to update Supervisor options: boom" in caplog.text
 
 
@@ -391,7 +409,7 @@ async def test_setup_hassio_no_additional_data(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
 
 
 async def test_fail_setup_without_environ_var(hass: HomeAssistant) -> None:
@@ -403,17 +421,17 @@ async def test_fail_setup_without_environ_var(hass: HomeAssistant) -> None:
 
 async def test_warn_when_cannot_connect(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
     supervisor_is_connected: AsyncMock,
 ) -> None:
-    """Fail warn when we cannot connect."""
+    """Test that a failed ping puts the config entry in retry state."""
     supervisor_is_connected.side_effect = SupervisorError
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(hass, "hassio", {})
         assert result
 
     assert is_hassio(hass)
-    assert "Not connected with the supervisor / system too busy!" in caplog.text
+    entry = hass.config_entries.async_entries("hassio")[0]
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.usefixtures("hassio_env")
@@ -611,11 +629,8 @@ async def test_service_calls(
     "app_or_addon",
     ["app", "addon"],
 )
-async def test_invalid_service_calls(
-    hass: HomeAssistant, supervisor_is_connected: AsyncMock, app_or_addon: str
-) -> None:
+async def test_invalid_service_calls(hass: HomeAssistant, app_or_addon: str) -> None:
     """Call service with invalid input and check that it raises."""
-    supervisor_is_connected.side_effect = SupervisorError
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(hass, "hassio", {})
         await hass.async_block_till_done()
@@ -718,12 +733,12 @@ async def test_service_calls_core(
     await hass.async_block_till_done()
 
     supervisor_client.homeassistant.stop.assert_called_once_with()
-    assert len(supervisor_client.mock_calls) == 21
+    assert len(supervisor_client.mock_calls) == 9
 
     await hass.services.async_call("homeassistant", "check_config")
     await hass.async_block_till_done()
 
-    assert len(supervisor_client.mock_calls) == 21
+    assert len(supervisor_client.mock_calls) == 9
 
     with patch(
         "homeassistant.config.async_check_ha_config_file", return_value=None
@@ -733,7 +748,7 @@ async def test_service_calls_core(
         assert mock_check_config.called
 
     supervisor_client.homeassistant.restart.assert_called_once_with()
-    assert len(supervisor_client.mock_calls) == 22
+    assert len(supervisor_client.mock_calls) == 10
 
 
 @pytest.mark.parametrize(
@@ -1124,7 +1139,7 @@ async def test_setup_hardware_integration(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result
-    assert len(supervisor_client.mock_calls) == 25
+    assert len(supervisor_client.mock_calls) == 17
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -54,6 +54,7 @@ from homeassistant.components.hassio import (
 )
 from homeassistant.components.hassio.config import STORAGE_KEY
 from homeassistant.components.hassio.const import (
+    DATA_KEY_SUPERVISOR_ISSUES,
     HASSIO_MAIN_UPDATE_INTERVAL,
     REQUEST_REFRESH_DELAY,
 )
@@ -61,6 +62,7 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
+from homeassistant.components.homeassistant.const import DATA_STOP_HANDLER
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -721,24 +723,22 @@ async def test_addon_service_call_with_complex_slug(
     )
 
 
-@pytest.mark.usefixtures("hassio_env")
+@pytest.mark.usefixtures("all_setup_requests")
 async def test_service_calls_core(
     hass: HomeAssistant, supervisor_client: AsyncMock
 ) -> None:
     """Call core service and check the API calls behind that."""
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "hassio", {})
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(hass, "homeassistant", {})
+        assert await async_setup_component(hass, "hassio", {})
 
     await hass.services.async_call("homeassistant", "stop")
     await hass.async_block_till_done()
 
     supervisor_client.homeassistant.stop.assert_called_once_with()
-    assert len(supervisor_client.mock_calls) == 9
 
     await hass.services.async_call("homeassistant", "check_config")
     await hass.async_block_till_done()
-
-    assert len(supervisor_client.mock_calls) == 9
 
     with patch(
         "homeassistant.config.async_check_ha_config_file", return_value=None
@@ -748,7 +748,6 @@ async def test_service_calls_core(
         assert mock_check_config.called
 
     supervisor_client.homeassistant.restart.assert_called_once_with()
-    assert len(supervisor_client.mock_calls) == 10
 
 
 @pytest.mark.parametrize(
@@ -1822,3 +1821,44 @@ async def test_get_core_info(hass: HomeAssistant) -> None:
     assert result["version"] == "1.0.0"
     assert result["version_latest"] == "1.0.0"
     assert result["image"] == "homeassistant"
+
+
+@pytest.mark.usefixtures("all_setup_requests")
+async def test_stop_handler_restored_on_unload(
+    hass: HomeAssistant,
+    supervisor_client: AsyncMock,
+) -> None:
+    """Test that the default stop handler is restored when the hassio entry unloads."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(hass, "hassio", {})
+        await hass.async_block_till_done()
+
+    hassio_stop_handler = hass.data[DATA_STOP_HANDLER]
+
+    entry = hass.config_entries.async_entries("hassio")[0]
+    await hass.config_entries.async_unload(entry.entry_id)
+
+    # After unload the hassio handler must no longer be registered.
+    assert hass.data.get(DATA_STOP_HANDLER) is not hassio_stop_handler
+
+
+@pytest.mark.usefixtures("supervisor_client")
+async def test_supervisor_issues_not_set_on_coordinator_failure(
+    hass: HomeAssistant,
+    supervisor_is_connected: AsyncMock,
+    supervisor_root_info: AsyncMock,
+) -> None:
+    """Test DATA_KEY_SUPERVISOR_ISSUES is not populated when coordinator fails.
+
+    If a coordinator first-refresh raises ConfigEntryNotReady the issues
+    listener must not be registered, preventing accumulation across retries.
+    """
+    supervisor_root_info.side_effect = SupervisorError()
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        result = await async_setup_component(hass, "hassio", {})
+        assert result
+
+    entry = hass.config_entries.async_entries("hassio")[0]
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert DATA_KEY_SUPERVISOR_ISSUES not in hass.data

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -170,7 +170,7 @@ async def test_setup_api_ping(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     assert get_core_info(hass)["version_latest"] == "1.0.0"
     assert is_hassio(hass)
 
@@ -225,7 +225,7 @@ async def test_setup_api_push_api_data(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=9999, refresh_token=ANY)
     )
@@ -241,7 +241,7 @@ async def test_setup_api_push_api_data_error(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     assert "Failed to update Home Assistant options in Supervisor: boom" in caplog.text
 
 
@@ -258,7 +258,7 @@ async def test_setup_api_push_api_data_server_host(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=9999, refresh_token=ANY, watchdog=False)
     )
@@ -276,7 +276,7 @@ async def test_setup_api_push_api_data_default(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=8123, refresh_token=ANY)
     )
@@ -353,7 +353,7 @@ async def test_setup_api_existing_hassio_user(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
         HomeAssistantOptions(ssl=False, port=8123, refresh_token=token.token)
     )
@@ -370,7 +370,7 @@ async def test_setup_core_push_config(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     supervisor_client.supervisor.set_options.assert_called_once_with(
         SupervisorOptions(timezone="testzone")
     )
@@ -395,7 +395,7 @@ async def test_setup_core_push_config_error(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     assert "Failed to update Supervisor options: boom" in caplog.text
 
 
@@ -411,7 +411,7 @@ async def test_setup_hassio_no_additional_data(
         await hass.async_block_till_done()
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
 
 
 async def test_fail_setup_without_environ_var(hass: HomeAssistant) -> None:
@@ -1138,7 +1138,7 @@ async def test_setup_hardware_integration(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result
-    assert len(supervisor_client.mock_calls) == 17
+    assert len(supervisor_client.mock_calls) == 16
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -28,8 +28,10 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.hassio.const import DATA_HOST_INFO
+from homeassistant.components.hassio.issues import SupervisorIssues
 from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
 from .test_init import MOCK_ENVIRON
@@ -1209,3 +1211,48 @@ async def test_supervisor_issues_addon_pwned(
             "more_info_pwned": "https://www.home-assistant.io/more-info/pwned-passwords",
         },
     )
+
+
+
+async def test_supervisor_issues_unload_disconnects_listener(
+    hass: HomeAssistant,
+    supervisor_client: AsyncMock,
+    resolution_info: AsyncMock,
+) -> None:
+    """Test SupervisorIssues.unload() disconnects the EVENT_SUPERVISOR_EVENT listener.
+
+    After calling unload(), dispatching supervisor events must not trigger
+    the listener — preventing listener accumulation on config-entry reload.
+    """
+    mock_resolution_info(supervisor_client)
+    issues = SupervisorIssues(hass)
+    await issues.setup()
+
+    # While connected, a health_changed event updates unhealthy_reasons.
+    async_dispatcher_send(
+        hass,
+        "supervisor_event",
+        {
+            "event": "health_changed",
+            "data": {"healthy": False, "unhealthy_reasons": ["docker"]},
+        },
+    )
+    await hass.async_block_till_done()
+    assert "docker" in issues.unhealthy_reasons
+
+    # After unload(), the same event is silently ignored.
+    issues.unload()
+    async_dispatcher_send(
+        hass,
+        "supervisor_event",
+        {
+            "event": "health_changed",
+            "data": {"healthy": True},
+        },
+    )
+    await hass.async_block_till_done()
+    # unhealthy_reasons unchanged — listener did not fire.
+    assert "docker" in issues.unhealthy_reasons
+
+    # Calling unload() again is safe (idempotent).
+    issues.unload()

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -27,7 +27,6 @@ from aiohasupervisor.models import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.hassio.const import DATA_HOST_INFO
 from homeassistant.components.hassio.issues import SupervisorIssues
 from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
 from homeassistant.core import HomeAssistant
@@ -1099,61 +1098,6 @@ async def test_supervisor_issues_free_space(
             "more_info_free_space": "https://www.home-assistant.io/more-info/free-space",
             "storage_url": "/config/storage",
             "free_space": "1.6",
-        },
-    )
-
-
-@pytest.mark.usefixtures("all_setup_requests")
-async def test_supervisor_issues_free_space_host_info_fail(
-    hass: HomeAssistant,
-    supervisor_client: AsyncMock,
-    hass_supervisor_ws_client: WebSocketGenerator,
-    host_info: AsyncMock,
-) -> None:
-    """Test supervisor issue for too little free space remaining without host info."""
-    mock_resolution_info(supervisor_client)
-
-    result = await async_setup_component(hass, "hassio", {})
-    assert result
-
-    # Simulate host info being unavailable after setup (e.g., cached data cleared)
-    hass.data.pop(DATA_HOST_INFO, None)
-
-    client = await hass_supervisor_ws_client()
-
-    await client.send_json(
-        {
-            "id": 1,
-            "type": "supervisor/event",
-            "data": {
-                "event": "issue_changed",
-                "data": {
-                    "uuid": (issue_uuid := uuid4().hex),
-                    "type": "free_space",
-                    "context": "system",
-                    "reference": None,
-                },
-            },
-        }
-    )
-    msg = await client.receive_json()
-    assert msg["success"]
-    await hass.async_block_till_done()
-
-    await client.send_json({"id": 2, "type": "repairs/list_issues"})
-    msg = await client.receive_json()
-    assert msg["success"]
-    assert len(msg["result"]["issues"]) == 1
-    assert_issue_repair_in_list(
-        msg["result"]["issues"],
-        uuid=issue_uuid,
-        context="system",
-        type_="free_space",
-        fixable=False,
-        placeholders={
-            "more_info_free_space": "https://www.home-assistant.io/more-info/free-space",
-            "storage_url": "/config/storage",
-            "free_space": "<2",
         },
     )
 

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -27,6 +27,7 @@ from aiohasupervisor.models import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.hassio.const import DATA_HOST_INFO
 from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -1109,10 +1110,12 @@ async def test_supervisor_issues_free_space_host_info_fail(
 ) -> None:
     """Test supervisor issue for too little free space remaining without host info."""
     mock_resolution_info(supervisor_client)
-    host_info.side_effect = SupervisorError()
 
     result = await async_setup_component(hass, "hassio", {})
     assert result
+
+    # Simulate host info being unavailable after setup (e.g., cached data cleared)
+    hass.data.pop(DATA_HOST_INFO, None)
 
     client = await hass_supervisor_ws_client()
 

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -1213,7 +1213,6 @@ async def test_supervisor_issues_addon_pwned(
     )
 
 
-
 async def test_supervisor_issues_unload_disconnects_listener(
     hass: HomeAssistant,
     supervisor_client: AsyncMock,

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -27,10 +27,10 @@ from aiohasupervisor.models import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.hassio.issues import SupervisorIssues
+from homeassistant.components.hassio.const import DOMAIN
+from homeassistant.components.hassio.coordinator import get_issues_info
 from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
 from .test_init import MOCK_ENVIRON
@@ -1157,10 +1157,12 @@ async def test_supervisor_issues_addon_pwned(
     )
 
 
+@pytest.mark.usefixtures("all_setup_requests")
 async def test_supervisor_issues_unload_disconnects_listener(
     hass: HomeAssistant,
     supervisor_client: AsyncMock,
     resolution_info: AsyncMock,
+    hass_supervisor_ws_client: WebSocketGenerator,
 ) -> None:
     """Test SupervisorIssues.unload() disconnects the EVENT_SUPERVISOR_EVENT listener.
 
@@ -1168,34 +1170,52 @@ async def test_supervisor_issues_unload_disconnects_listener(
     the listener — preventing listener accumulation on config-entry reload.
     """
     mock_resolution_info(supervisor_client)
-    issues = SupervisorIssues(hass)
-    await issues.setup()
+    result = await async_setup_component(hass, "hassio", {})
+    assert result
+
+    # Get config entry
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    entry = entries[0]
+
+    # Get issues instance
+    issues = get_issues_info(hass)
+    assert issues is not None
+    assert issues.unhealthy_reasons == set()
 
     # While connected, a health_changed event updates unhealthy_reasons.
-    async_dispatcher_send(
-        hass,
-        "supervisor_event",
+    client = await hass_supervisor_ws_client()
+    await client.send_json(
         {
-            "event": "health_changed",
-            "data": {"healthy": False, "unhealthy_reasons": ["docker"]},
-        },
+            "id": 1,
+            "type": "supervisor/event",
+            "data": {
+                "event": "health_changed",
+                "data": {"healthy": False, "unhealthy_reasons": ["docker"]},
+            },
+        }
     )
+    msg = await client.receive_json()
+    assert msg["success"]
     await hass.async_block_till_done()
     assert "docker" in issues.unhealthy_reasons
 
-    # After unload(), the same event is silently ignored.
-    issues.unload()
-    async_dispatcher_send(
-        hass,
-        "supervisor_event",
+    # After config entry unload, the same event is silently ignored.
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await client.send_json(
         {
-            "event": "health_changed",
-            "data": {"healthy": True},
-        },
+            "id": 2,
+            "type": "supervisor/event",
+            "data": {
+                "event": "health_changed",
+                "data": {"healthy": True},
+            },
+        }
     )
+    msg = await client.receive_json()
+    assert msg["success"]
     await hass.async_block_till_done()
     # unhealthy_reasons unchanged — listener did not fire.
     assert "docker" in issues.unhealthy_reasons
-
-    # Calling unload() again is safe (idempotent).
-    issues.unload()

--- a/tests/components/hassio/test_system_health.py
+++ b/tests/components/hassio/test_system_health.py
@@ -327,6 +327,7 @@ async def test_hassio_system_health_with_issues(
         host_internet=None,
         supervisor_internet=False,
     )
+    hass.data[DATA_ADDONS_LIST] = []
 
     with patch.dict(os.environ, MOCK_ENVIRON):
         info = await get_system_health_info(hass, "hassio")

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -27,7 +27,6 @@ from homeassistant.components.hassio.const import (
     WS_TYPE_API,
     WS_TYPE_SUBSCRIBE,
 )
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import __version__ as HAVERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -987,31 +986,3 @@ async def test_read_update_config(
 
     await websocket_client.send_json_auto_id({"type": "hassio/update/config/info"})
     assert await websocket_client.receive_json() == snapshot
-
-
-async def test_update_config_not_loaded(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    supervisor_client: AsyncMock,
-) -> None:
-    """Test update config commands return not_loaded when entry is in SETUP_RETRY."""
-    supervisor_client.supervisor.ping.side_effect = SupervisorError
-    with patch.dict(os.environ, MOCK_ENVIRON):
-        await async_setup_component(hass, "hassio", {})
-
-    entry = hass.config_entries.async_entries("hassio")[0]
-    assert entry.state is ConfigEntryState.SETUP_RETRY
-
-    websocket_client = await hass_ws_client(hass)
-
-    await websocket_client.send_json_auto_id({"type": "hassio/update/config/info"})
-    result = await websocket_client.receive_json()
-    assert not result["success"]
-    assert result["error"]["code"] == "not_loaded"
-
-    await websocket_client.send_json_auto_id(
-        {"type": "hassio/update/config/update", "add_on_backup_before_update": True}
-    )
-    result = await websocket_client.receive_json()
-    assert not result["success"]
-    assert result["error"]["code"] == "not_loaded"

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -27,9 +27,9 @@ from homeassistant.components.hassio.const import (
     WS_TYPE_API,
     WS_TYPE_SUBSCRIBE,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import __version__ as HAVERSION
 from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -29,6 +29,7 @@ from homeassistant.components.hassio.const import (
 )
 from homeassistant.const import __version__ as HAVERSION
 from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
@@ -986,3 +987,31 @@ async def test_read_update_config(
 
     await websocket_client.send_json_auto_id({"type": "hassio/update/config/info"})
     assert await websocket_client.receive_json() == snapshot
+
+
+async def test_update_config_not_loaded(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    supervisor_client: AsyncMock,
+) -> None:
+    """Test update config commands return not_loaded when entry is in SETUP_RETRY."""
+    supervisor_client.supervisor.ping.side_effect = SupervisorError
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        await async_setup_component(hass, "hassio", {})
+
+    entry = hass.config_entries.async_entries("hassio")[0]
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+    websocket_client = await hass_ws_client(hass)
+
+    await websocket_client.send_json_auto_id({"type": "hassio/update/config/info"})
+    result = await websocket_client.receive_json()
+    assert not result["success"]
+    assert result["error"]["code"] == "not_loaded"
+
+    await websocket_client.send_json_auto_id(
+        {"type": "hassio/update/config/update", "add_on_backup_before_update": True}
+    )
+    result = await websocket_client.receive_json()
+    assert not result["success"]
+    assert result["error"]["code"] == "not_loaded"

--- a/tests/components/homeassistant_green/test_hardware.py
+++ b/tests/components/homeassistant_green/test_hardware.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.components.homeassistant_green.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -64,7 +64,7 @@ async def test_hardware_info(
     }
 
 
-@pytest.mark.parametrize("os_info", [None, {"board": None}, {"board": "other"}])
+@pytest.mark.parametrize("os_info", [{"board": None}, {"board": "other"}])
 async def test_hardware_info_fail(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, os_info
 ) -> None:
@@ -92,6 +92,42 @@ async def test_hardware_info_fail(
     with patch(
         "homeassistant.components.homeassistant_green.hardware.get_os_info",
         return_value=os_info,
+    ):
+        await client.send_json({"id": 1, "type": "hardware/info"})
+        msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["success"]
+    assert msg["result"] == {"hardware": []}
+
+
+async def test_hardware_info_not_ready(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test async_info raises HassioNotReadyError when hassio is not ready."""
+    mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Green",
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.homeassistant_green.get_os_info",
+        return_value={"board": "green"},
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_green.hardware.get_os_info",
+        side_effect=HassioNotReadyError,
     ):
         await client.send_json({"id": 1, "type": "hardware/info"})
         msg = await client.receive_json()

--- a/tests/components/homeassistant_green/test_init.py
+++ b/tests/components/homeassistant_green/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.components.homeassistant_green.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -99,7 +99,7 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.homeassistant_green.get_os_info",
-        return_value=None,
+        side_effect=HassioNotReadyError,
     ) as mock_get_os_info:
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/homeassistant_yellow/test_hardware.py
+++ b/tests/components/homeassistant_yellow/test_hardware.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.components.homeassistant_yellow.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -65,7 +65,7 @@ async def test_hardware_info(
     }
 
 
-@pytest.mark.parametrize("os_info", [None, {"board": None}, {"board": "other"}])
+@pytest.mark.parametrize("os_info", [{"board": None}, {"board": "other"}])
 @pytest.mark.usefixtures("supervisor_client")
 async def test_hardware_info_fail(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, os_info, addon_store_info
@@ -94,6 +94,43 @@ async def test_hardware_info_fail(
     with patch(
         "homeassistant.components.homeassistant_yellow.hardware.get_os_info",
         return_value=os_info,
+    ):
+        await client.send_json({"id": 1, "type": "hardware/info"})
+        msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["success"]
+    assert msg["result"] == {"hardware": []}
+
+
+@pytest.mark.usefixtures("supervisor_client")
+async def test_hardware_info_not_ready(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
+) -> None:
+    """Test async_info raises HassioNotReadyError when hassio is not ready."""
+    mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Yellow",
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.homeassistant_yellow.get_os_info",
+        return_value={"board": "yellow"},
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_yellow.hardware.get_os_info",
+        side_effect=HassioNotReadyError,
     ):
         await client.send_json({"id": 1, "type": "hardware/info"})
         msg = await client.receive_json()

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import zha
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
@@ -275,7 +275,7 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.homeassistant_yellow.get_os_info",
-        return_value=None,
+        side_effect=HassioNotReadyError,
     ) as mock_get_os_info:
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/raspberry_pi/test_hardware.py
+++ b/tests/components/raspberry_pi/test_hardware.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.components.raspberry_pi.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -65,7 +65,7 @@ async def test_hardware_info(
     }
 
 
-@pytest.mark.parametrize("os_info", [None, {"board": None}, {"board": "other"}])
+@pytest.mark.parametrize("os_info", [{"board": None}, {"board": "other"}])
 async def test_hardware_info_fail(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, os_info
 ) -> None:
@@ -94,6 +94,43 @@ async def test_hardware_info_fail(
     with patch(
         "homeassistant.components.raspberry_pi.hardware.get_os_info",
         return_value=os_info,
+    ):
+        await client.send_json({"id": 1, "type": "hardware/info"})
+        msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["success"]
+    assert msg["result"] == {"hardware": []}
+
+
+async def test_hardware_info_not_ready(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test async_info raises HassioNotReadyError when hassio is not ready."""
+    mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
+    await hass.async_block_till_done()
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={},
+        title="Raspberry Pi",
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.raspberry_pi.get_os_info",
+        return_value={"board": "rpi"},
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    with patch(
+        "homeassistant.components.raspberry_pi.hardware.get_os_info",
+        side_effect=HassioNotReadyError,
     ):
         await client.send_json({"id": 1, "type": "hardware/info"})
         msg = await client.receive_json()

--- a/tests/components/raspberry_pi/test_init.py
+++ b/tests/components/raspberry_pi/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN, HassioNotReadyError
 from homeassistant.components.raspberry_pi.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -112,7 +112,7 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.raspberry_pi.get_os_info",
-        return_value=None,
+        side_effect=HassioNotReadyError,
     ) as mock_get_os_info:
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -33,7 +33,7 @@ async def test_get_system_info_supervisor_not_available(
         patch("homeassistant.helpers.system_info.is_docker_env", return_value=True),
         patch("homeassistant.helpers.system_info.is_official_image", return_value=True),
         patch("homeassistant.helpers.hassio.is_hassio", return_value=True),
-        patch.object(hassio, "get_info", return_value=None),
+        patch.object(hassio, "get_info", side_effect=hassio.HassioNotReadyError),
         patch("homeassistant.helpers.system_info.cached_get_user", return_value="root"),
     ):
         info = await async_get_system_info(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactors the `hassio` integration to properly separate concerns between `async_setup` and `async_setup_entry`, following Home Assistant best practices.

**Before:** Most setup logic ran in `async_setup`, including coordinator startup, service registration, HTTP view registration, and auth user setup. Supervisor unavailability caused silent partial failures with no retry mechanism.

**After:**
- `async_setup` registers all static API surfaces once (websocket commands, HTTP views, services, frontend panel). These are available even while the config entry is retrying, so callers receive a meaningful error instead of a 404.
- `async_setup_entry` handles everything requiring a live supervisor connection. A failed ping now raises `ConfigEntryNotReady` with a translated error key, triggering automatic exponential-backoff retry.

Key changes:
- `auth.py`: `HassIOBaseAuth` no longer takes `User` at construction time; looks up `DATA_HASSIO_SUPERVISOR_USER` from `hass.data` at request time, returning 503 if the entry has not loaded yet
- `ingress.py`: `async_setup_ingress_view` reads host from `hass.data` instead of taking it as a parameter
- `services.py`: `async_setup_services` calls `get_supervisor_client(hass)` internally; services are now registered in `async_setup` per the `action-setup` quality scale rule
- `const.py`: adds `DATA_HASSIO_HTTP_CONFIG`, `DATA_HASSIO_HOST`, `DATA_HASSIO_SUPERVISOR_USER` `HassKey` constants
- `coordinator.py`: fixes `is_hass_os` initialization (computed from live data in `_async_update_data` instead of stale `hass.data`)
- `strings.json`: adds `supervisor_not_connected` exception translation key
- Removes redundant `update_info_data()` function (coordinator already fetches all info keys)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you will most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/168906
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, do not hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr