### PR TITLE
feat(ecovacs): add trace map image entity for mowers

### DIFF
--- a/homeassistant/components/ecovacs/image.py
+++ b/homeassistant/components/ecovacs/image.py
@@ -1,10 +1,11 @@
 """Ecovacs image entities."""
 
+from datetime import UTC, datetime
 from typing import cast
 
-from deebot_client.capabilities import CapabilityMap
+from deebot_client.capabilities import Capabilities, CapabilityMap, DeviceType
 from deebot_client.device import Device
-from deebot_client.events.map import CachedMapInfoEvent, MapChangedEvent
+from deebot_client.events.map import CachedMapInfoEvent, MapChangedEvent, MapTraceEvent
 from deebot_client.map import Map
 
 from homeassistant.components.image import ImageEntity
@@ -15,6 +16,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import EcovacsConfigEntry
 from .entity import EcovacsEntity
 
+_TRACE_MAX_POINTS = 5000
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -23,11 +26,16 @@ async def async_setup_entry(
 ) -> None:
     """Add entities for passed config_entry in HA."""
     controller = config_entry.runtime_data
-    entities = [
+    entities: list[ImageEntity] = [
         EcovacsMap(device, caps, hass)
         for device in controller.devices
         if (caps := device.capabilities.map)
     ]
+    entities.extend(
+        EcovacsMowerTraceMap(device, hass)
+        for device in controller.devices
+        if device.capabilities.device_type is DeviceType.MOWER
+    )
 
     if entities:
         async_add_entities(entities)
@@ -87,3 +95,82 @@ class EcovacsMap(
         """
         await super().async_update()
         self._map.refresh()
+
+
+class EcovacsMowerTraceMap(
+    EcovacsEntity[Capabilities],
+    ImageEntity,
+):
+    """Mower trajectory image rendered from MapTraceEvent."""
+
+    _attr_content_type = "image/svg+xml"
+
+    entity_description = EntityDescription(
+        key="trace_map",
+        translation_key="trace_map",
+    )
+
+    def __init__(self, device: Device, hass: HomeAssistant) -> None:
+        """Initialize entity."""
+        super().__init__(device, device.capabilities, hass=hass)
+        self._points: list[tuple[int, int]] = []
+        self._svg_cache: bytes | None = None
+
+    def image(self) -> bytes | None:
+        """Return bytes of image or None."""
+        if not self._points:
+            return None
+        if self._svg_cache is None:
+            self._svg_cache = self._render_svg().encode()
+        return self._svg_cache
+
+    def _render_svg(self) -> str:
+        xs = [p[0] for p in self._points]
+        ys = [p[1] for p in self._points]
+        min_x, max_x = min(xs), max(xs)
+        min_y, max_y = min(ys), max(ys)
+        padding = max(50, (max(max_x - min_x, max_y - min_y)) // 20)
+        min_x -= padding
+        max_x += padding
+        min_y -= padding
+        max_y += padding
+        width = max_x - min_x
+        height = max_y - min_y
+        # Mower coordinates use bottom-up Y; flip for SVG top-down rendering.
+        flipped = " ".join(f"{x},{max_y + min_y - y}" for x, y in self._points)
+        stroke_width = max(20, width // 200)
+        return (
+            f'<svg xmlns="http://www.w3.org/2000/svg" '
+            f'viewBox="{min_x} {min_y} {width} {height}" '
+            f'preserveAspectRatio="xMidYMid meet">'
+            f'<polyline points="{flipped}" fill="none" '
+            f'stroke="#1976d2" stroke-width="{stroke_width}" '
+            f'stroke-linejoin="round" stroke-linecap="round"/>'
+            f"</svg>"
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Set up the event listeners now that hass is ready."""
+        await super().async_added_to_hass()
+
+        async def on_trace(event: MapTraceEvent) -> None:
+            new_points: list[tuple[int, int]] = []
+            for token in event.data.split(";"):
+                token = token.strip()
+                if not token:
+                    continue
+                try:
+                    x_str, y_str = token.split(",")
+                    new_points.append((int(x_str), int(y_str)))
+                except ValueError:
+                    continue
+            if not new_points:
+                return
+            self._points.extend(new_points)
+            if len(self._points) > _TRACE_MAX_POINTS:
+                self._points = self._points[-_TRACE_MAX_POINTS:]
+            self._svg_cache = None
+            self._attr_image_last_updated = datetime.now(tz=UTC)
+            self.async_write_ha_state()
+
+        self._subscribe(MapTraceEvent, on_trace)

--- a/homeassistant/components/ecovacs/image.py
+++ b/homeassistant/components/ecovacs/image.py
@@ -7,6 +7,7 @@ from deebot_client.capabilities import Capabilities, CapabilityMap, DeviceType
 from deebot_client.device import Device
 from deebot_client.events.map import CachedMapInfoEvent, MapChangedEvent, MapTraceEvent
 from deebot_client.map import Map
+from deebot_client.mower_trace import MowerMapTrace
 
 from homeassistant.components.image import ImageEntity
 from homeassistant.core import HomeAssistant
@@ -15,8 +16,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import EcovacsConfigEntry
 from .entity import EcovacsEntity
-
-_TRACE_MAX_POINTS = 5000
 
 
 async def async_setup_entry(
@@ -113,62 +112,26 @@ class EcovacsMowerTraceMap(
     def __init__(self, device: Device, hass: HomeAssistant) -> None:
         """Initialize entity."""
         super().__init__(device, device.capabilities, hass=hass)
-        self._points: list[tuple[int, int]] = []
+        self._trace = MowerMapTrace()
         self._svg_cache: bytes | None = None
 
     def image(self) -> bytes | None:
         """Return bytes of image or None."""
-        if not self._points:
+        if not self._trace.has_points:
             return None
         if self._svg_cache is None:
-            self._svg_cache = self._render_svg().encode()
+            if (svg := self._trace.to_svg()) is None:
+                return None
+            self._svg_cache = svg.encode()
         return self._svg_cache
-
-    def _render_svg(self) -> str:
-        xs = [p[0] for p in self._points]
-        ys = [p[1] for p in self._points]
-        min_x, max_x = min(xs), max(xs)
-        min_y, max_y = min(ys), max(ys)
-        padding = max(50, (max(max_x - min_x, max_y - min_y)) // 20)
-        min_x -= padding
-        max_x += padding
-        min_y -= padding
-        max_y += padding
-        width = max_x - min_x
-        height = max_y - min_y
-        # Mower coordinates use bottom-up Y; flip for SVG top-down rendering.
-        flipped = " ".join(f"{x},{max_y + min_y - y}" for x, y in self._points)
-        stroke_width = max(20, width // 200)
-        return (
-            f'<svg xmlns="http://www.w3.org/2000/svg" '
-            f'viewBox="{min_x} {min_y} {width} {height}" '
-            f'preserveAspectRatio="xMidYMid meet">'
-            f'<polyline points="{flipped}" fill="none" '
-            f'stroke="#1976d2" stroke-width="{stroke_width}" '
-            f'stroke-linejoin="round" stroke-linecap="round"/>'
-            f"</svg>"
-        )
 
     async def async_added_to_hass(self) -> None:
         """Set up the event listeners now that hass is ready."""
         await super().async_added_to_hass()
 
         async def on_trace(event: MapTraceEvent) -> None:
-            new_points: list[tuple[int, int]] = []
-            for token in event.data.split(";"):
-                token = token.strip()
-                if not token:
-                    continue
-                try:
-                    x_str, y_str = token.split(",")
-                    new_points.append((int(x_str), int(y_str)))
-                except ValueError:
-                    continue
-            if not new_points:
+            if self._trace.add_data(event.data) == 0:
                 return
-            self._points.extend(new_points)
-            if len(self._points) > _TRACE_MAX_POINTS:
-                self._points = self._points[-_TRACE_MAX_POINTS:]
             self._svg_cache = None
             self._attr_image_last_updated = datetime.now(tz=UTC)
             self.async_write_ha_state()

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -109,6 +109,9 @@
     "image": {
       "map": {
         "name": "Map"
+      },
+      "trace_map": {
+        "name": "Trace map"
       }
     },
     "number": {

--- a/tests/components/ecovacs/test_image.py
+++ b/tests/components/ecovacs/test_image.py
@@ -4,7 +4,7 @@ from deebot_client.events.map import MapTraceEvent
 import pytest
 
 from homeassistant.components.ecovacs.controller import EcovacsController
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 
 from .util import notify_and_wait
@@ -18,25 +18,29 @@ def platforms() -> Platform | list[Platform]:
     return Platform.IMAGE
 
 
+_ENTITY_ID = "image.goat_g1_trace_map"
+
+
 @pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
 async def test_mower_trace_map_created(
     hass: HomeAssistant,
     controller: EcovacsController,
 ) -> None:
-    """A mower device exposes a trace_map image entity."""
-    entity_id = "image.goat_g1_trace_map"
-    assert (state := hass.states.get(entity_id))
-    assert state.attributes["content_type"] == "image/svg+xml"
+    """A mower device exposes a trace_map image entity in the unknown state."""
+    assert (state := hass.states.get(_ENTITY_ID))
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
-async def test_mower_trace_map_renders_svg_after_trace_event(
+async def test_mower_trace_map_state_advances_after_trace_event(
     hass: HomeAssistant,
     controller: EcovacsController,
 ) -> None:
-    """After a MapTraceEvent the entity exposes a non-empty SVG."""
-    entity_id = "image.goat_g1_trace_map"
+    """After a MapTraceEvent the entity state advances away from ``unknown``."""
     device = controller.devices[0]
+    pre = hass.states.get(_ENTITY_ID)
+    assert pre is not None
+    assert pre.state == STATE_UNKNOWN
 
     await notify_and_wait(
         hass,
@@ -44,34 +48,36 @@ async def test_mower_trace_map_renders_svg_after_trace_event(
         MapTraceEvent(start=1, total=1, data="0,0;100,200;200,400;300,600"),
     )
 
-    image_state = hass.states.get(entity_id)
-    assert image_state is not None
-    assert image_state.attributes["content_type"] == "image/svg+xml"
+    post = hass.states.get(_ENTITY_ID)
+    assert post is not None
+    assert post.state != STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
-async def test_mower_trace_map_accumulates_points_across_events(
+async def test_mower_trace_map_state_changes_on_each_event(
     hass: HomeAssistant,
     controller: EcovacsController,
 ) -> None:
-    """Successive MapTraceEvents add to the running trace."""
+    """Successive ``MapTraceEvent``s update the state timestamp each time."""
     device = controller.devices[0]
-
+    timestamps: list[str] = []
     for chunk in ("0,0;100,100", "200,200;300,300", "400,400;500,500"):
         await notify_and_wait(
             hass,
             device.events,
             MapTraceEvent(start=1, total=1, data=chunk),
         )
+        state = hass.states.get(_ENTITY_ID)
+        assert state is not None
+        timestamps.append(state.state)
 
-    image_state = hass.states.get("image.goat_g1_trace_map")
-    assert image_state is not None
-    # ``last_updated`` advances with each notification
-    assert image_state.attributes["content_type"] == "image/svg+xml"
+    # Each trace event must produce a strictly later timestamp.
+    assert timestamps == sorted(set(timestamps))
+    assert len(timestamps) == 3
 
 
 @pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
-async def test_mower_trace_map_ignores_empty_or_malformed_tokens(
+async def test_mower_trace_map_ignores_malformed_tokens(
     hass: HomeAssistant,
     controller: EcovacsController,
 ) -> None:
@@ -83,5 +89,6 @@ async def test_mower_trace_map_ignores_empty_or_malformed_tokens(
         MapTraceEvent(start=1, total=1, data="0;;100,200;not-a-pair;300,400;"),
     )
 
-    image_state = hass.states.get("image.goat_g1_trace_map")
-    assert image_state is not None
+    state = hass.states.get(_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN

--- a/tests/components/ecovacs/test_image.py
+++ b/tests/components/ecovacs/test_image.py
@@ -1,0 +1,87 @@
+"""Tests for Ecovacs image entities."""
+
+from deebot_client.events.map import MapTraceEvent
+import pytest
+
+from homeassistant.components.ecovacs.controller import EcovacsController
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .util import notify_and_wait
+
+pytestmark = [pytest.mark.usefixtures("init_integration")]
+
+
+@pytest.fixture
+def platforms() -> Platform | list[Platform]:
+    """Platforms, which should be loaded during the test."""
+    return Platform.IMAGE
+
+
+@pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
+async def test_mower_trace_map_created(
+    hass: HomeAssistant,
+    controller: EcovacsController,
+) -> None:
+    """A mower device exposes a trace_map image entity."""
+    entity_id = "image.goat_g1_trace_map"
+    assert (state := hass.states.get(entity_id))
+    assert state.attributes["content_type"] == "image/svg+xml"
+
+
+@pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
+async def test_mower_trace_map_renders_svg_after_trace_event(
+    hass: HomeAssistant,
+    controller: EcovacsController,
+) -> None:
+    """After a MapTraceEvent the entity exposes a non-empty SVG."""
+    entity_id = "image.goat_g1_trace_map"
+    device = controller.devices[0]
+
+    await notify_and_wait(
+        hass,
+        device.events,
+        MapTraceEvent(start=1, total=1, data="0,0;100,200;200,400;300,600"),
+    )
+
+    image_state = hass.states.get(entity_id)
+    assert image_state is not None
+    assert image_state.attributes["content_type"] == "image/svg+xml"
+
+
+@pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
+async def test_mower_trace_map_accumulates_points_across_events(
+    hass: HomeAssistant,
+    controller: EcovacsController,
+) -> None:
+    """Successive MapTraceEvents add to the running trace."""
+    device = controller.devices[0]
+
+    for chunk in ("0,0;100,100", "200,200;300,300", "400,400;500,500"):
+        await notify_and_wait(
+            hass,
+            device.events,
+            MapTraceEvent(start=1, total=1, data=chunk),
+        )
+
+    image_state = hass.states.get("image.goat_g1_trace_map")
+    assert image_state is not None
+    # ``last_updated`` advances with each notification
+    assert image_state.attributes["content_type"] == "image/svg+xml"
+
+
+@pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
+async def test_mower_trace_map_ignores_empty_or_malformed_tokens(
+    hass: HomeAssistant,
+    controller: EcovacsController,
+) -> None:
+    """Empty segments and the leading "0" anchor must not crash the renderer."""
+    device = controller.devices[0]
+    await notify_and_wait(
+        hass,
+        device.events,
+        MapTraceEvent(start=1, total=1, data="0;;100,200;not-a-pair;300,400;"),
+    )
+
+    image_state = hass.states.get("image.goat_g1_trace_map")
+    assert image_state is not None

--- a/tests/components/ecovacs/test_init.py
+++ b/tests/components/ecovacs/test_init.py
@@ -106,7 +106,7 @@ async def test_devices_in_dr(
     ("device_fixture", "entities"),
     [
         ("yna5x1", 27),
-        ("5xu9h3", 25),
+        ("5xu9h3", 26),
         ("123", 3),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Mower devices (Ecovacs GOAT family) don't expose a `map=` capability in their hardware definitions, so the existing `EcovacsMap` image entity is not created for them. Recent mower firmwares (observed: GOAT A1600 RTK fw 1.15.13) actively push trajectory points via `MapTraceEvent`, so the data path is mostly there — only the consumer is missing.

This PR adds a sibling `EcovacsMowerTraceMap` image entity that is created for any device whose `capabilities.device_type is MOWER`. It subscribes directly to `MapTraceEvent` on the device's event bus, accumulates points across messages, and renders an SVG polyline of the cumulative trajectory.

### Implementation notes

- Trace accumulated in memory per entity, capped at 5 000 points (FIFO drop) to bound memory.
- Y axis flipped (mower coords are bottom-up, SVG is top-down).
- `viewBox` recomputed per push from the bounding box + 5 % padding, so the trace stays visible regardless of garden size.
- `stroke-width` scales with width so the line stays visible on small and large lawns.

### Dependency on `deebot-client`

The manifest pin is **kept at the current `deebot-client==18.2.0`** even though this feature requires the `OnMapTrace` message handler that lives in [DeebotUniverse/client.py#1567](https://github.com/DeebotUniverse/client.py/pull/1567) (not yet merged/released).

**Why**: HA core's `gen_requirements_all` validator rejects `>=` constraints, and pinning to a not-yet-released version would fail. With the current pin:
- The `MapTraceEvent` import already exists in `deebot-client==18.2.0` (used by vacuums via the existing `EcovacsMap`), so the imports compile cleanly.
- For mowers, no `OnMapTrace` fires the event yet → the entity creates, never receives data, `image()` returns `None`. Silent but harmless.
- When `deebot-client` releases the version with `OnMapTrace` (likely `18.3.0`), a follow-up PR can bump the pin and the feature activates automatically — no further HA code change needed.

This is a known sequencing constraint of cross-repo features in HA core. Happy to defer merging until the upstream `deebot-client` PR lands and is released, or merge now and bump in a follow-up — whichever the codeowners prefer.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Related upstream PR (deebot-client side, lights up the data path): [DeebotUniverse/client.py#1567](https://github.com/DeebotUniverse/client.py/pull/1567).

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
      <!-- Will open a docs PR once the integration codeowners ack the approach. -->

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.
      <!-- N/A: dependency pin unchanged at deebot-client==18.2.0 (see "Dependency on deebot-client" above). -->

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
