### PR TITLE
Detect and repair missing database indexes on recorder startup

### DIFF
--- a/homeassistant/components/recorder/auto_repairs/events/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/events/schema.py
@@ -4,10 +4,12 @@ from typing import TYPE_CHECKING
 
 from ...db_schema import EventData, Events
 from ..schema import (
+    correct_db_schema_missing_indexes,
     correct_db_schema_precision,
     correct_db_schema_utf8,
     validate_db_schema_precision,
     validate_table_schema_has_correct_collation,
+    validate_table_schema_has_indexes,
     validate_table_schema_supports_utf8,
 )
 
@@ -22,6 +24,7 @@ def validate_db_schema(instance: Recorder) -> set[str]:
     ) | validate_db_schema_precision(instance, Events)
     for table in (Events, EventData):
         schema_errors |= validate_table_schema_has_correct_collation(instance, table)
+        schema_errors |= validate_table_schema_has_indexes(instance, table)
     return schema_errors
 
 
@@ -32,4 +35,5 @@ def correct_db_schema(
     """Correct issues detected by validate_db_schema."""
     for table in (Events, EventData):
         correct_db_schema_utf8(instance, table, schema_errors)
+        correct_db_schema_missing_indexes(instance, table, schema_errors)
     correct_db_schema_precision(instance, Events, schema_errors)

--- a/homeassistant/components/recorder/auto_repairs/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/schema.py
@@ -342,4 +342,12 @@ def correct_db_schema_missing_indexes(
             index_name,
             table_name,
         )
-        _create_index(instance, instance.get_session, table_name, index_name)
+        try:
+            _create_index(instance, instance.get_session, table_name, index_name)
+        except Exception:
+            _LOGGER.exception(
+                "Failed to recreate index %s on table %s"
+                " — manual deduplication may be required",
+                index_name,
+                table_name,
+            )

--- a/homeassistant/components/recorder/auto_repairs/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/schema.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Mapping
 import logging
 from typing import TYPE_CHECKING
 
+import sqlalchemy
 from sqlalchemy import MetaData, Table
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import DeclarativeBase
@@ -270,3 +271,75 @@ def correct_db_schema_precision(
             table_name,
             [f"{column} {DOUBLE_PRECISION_TYPE_SQL}" for column in precision_columns],
         )
+
+
+def validate_table_schema_has_indexes(
+    instance: Recorder,
+    table_object: type[DeclarativeBase],
+) -> set[str]:
+    """Check that the table has all indexes defined in the SQLAlchemy model.
+
+    Indexes can be silently lost during manual database migration (e.g.
+    pg_dump/pg_restore across major PostgreSQL versions) or when a migration
+    fails to create a unique index due to pre-existing duplicate rows.
+    """
+    schema_errors: set[str] = set()
+    try:
+        schema_errors = _validate_table_schema_has_indexes(instance, table_object)
+    except Exception:
+        _LOGGER.exception("Error when validating DB schema indexes")
+
+    _log_schema_errors(table_object, schema_errors)
+    return schema_errors
+
+
+def _validate_table_schema_has_indexes(
+    instance: Recorder,
+    table_object: type[DeclarativeBase],
+) -> set[str]:
+    """Check that expected indexes exist on the table."""
+    schema_errors: set[str] = set()
+    table_name = table_object.__tablename__
+    expected_indexes = {idx.name for idx in table_object.__table__.indexes}
+    if not expected_indexes:
+        return schema_errors
+
+    engine = instance.engine
+    assert engine is not None, "Engine should be set"
+    inspector = sqlalchemy.inspect(engine)
+    live_indexes = {idx["name"] for idx in inspector.get_indexes(table_name)}
+
+    for index_name in sorted(expected_indexes - live_indexes):
+        _LOGGER.error(
+            "Index %s is missing from database table %s; "
+            "this can cause severe performance degradation",
+            index_name,
+            table_name,
+        )
+        schema_errors.add(f"{table_name}.missing_index.{index_name}")
+
+    return schema_errors
+
+
+def correct_db_schema_missing_indexes(
+    instance: Recorder,
+    table_object: type[DeclarativeBase],
+    schema_errors: set[str],
+) -> None:
+    """Recreate indexes detected as missing by validate_table_schema_has_indexes."""
+    table_name = table_object.__tablename__
+    prefix = f"{table_name}.missing_index."
+    missing = {e for e in schema_errors if e.startswith(prefix)}
+    if not missing:
+        return
+
+    from ..migration import _create_index  # noqa: PLC0415
+
+    for error_key in sorted(missing):
+        index_name = error_key[len(prefix) :]
+        _LOGGER.warning(
+            "Recreating missing index %s on table %s",
+            index_name,
+            table_name,
+        )
+        _create_index(instance, instance.get_session, table_name, index_name)

--- a/homeassistant/components/recorder/auto_repairs/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/schema.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable, Mapping
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import sqlalchemy
 from sqlalchemy import MetaData, Table
@@ -300,7 +300,9 @@ def _validate_table_schema_has_indexes(
     """Check that expected indexes exist on the table."""
     schema_errors: set[str] = set()
     table_name = table_object.__tablename__
-    expected_indexes = {idx.name for idx in table_object.__table__.indexes}
+    expected_indexes = {
+        idx.name for idx in cast(Table, table_object.__table__).indexes if idx.name
+    }
     if not expected_indexes:
         return schema_errors
 

--- a/homeassistant/components/recorder/auto_repairs/states/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/states/schema.py
@@ -4,10 +4,12 @@ from typing import TYPE_CHECKING
 
 from ...db_schema import StateAttributes, States
 from ..schema import (
+    correct_db_schema_missing_indexes,
     correct_db_schema_precision,
     correct_db_schema_utf8,
     validate_db_schema_precision,
     validate_table_schema_has_correct_collation,
+    validate_table_schema_has_indexes,
     validate_table_schema_supports_utf8,
 )
 
@@ -28,6 +30,7 @@ def validate_db_schema(instance: Recorder) -> set[str]:
     schema_errors |= validate_db_schema_precision(instance, States)
     for table in (States, StateAttributes):
         schema_errors |= validate_table_schema_has_correct_collation(instance, table)
+        schema_errors |= validate_table_schema_has_indexes(instance, table)
     return schema_errors
 
 
@@ -38,4 +41,5 @@ def correct_db_schema(
     """Correct issues detected by validate_db_schema."""
     for table in (States, StateAttributes):
         correct_db_schema_utf8(instance, table, schema_errors)
+        correct_db_schema_missing_indexes(instance, table, schema_errors)
     correct_db_schema_precision(instance, States, schema_errors)

--- a/homeassistant/components/recorder/auto_repairs/statistics/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/statistics/schema.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING
 
 from ...db_schema import Statistics, StatisticsMeta, StatisticsShortTerm
 from ..schema import (
+    correct_db_schema_missing_indexes,
     correct_db_schema_precision,
     correct_db_schema_utf8,
     validate_db_schema_precision,
     validate_table_schema_has_correct_collation,
+    validate_table_schema_has_indexes,
     validate_table_schema_supports_utf8,
 )
 
@@ -30,6 +32,7 @@ def validate_db_schema(instance: Recorder) -> set[str]:
     for table in (Statistics, StatisticsShortTerm):
         schema_errors |= validate_db_schema_precision(instance, table)
         schema_errors |= validate_table_schema_has_correct_collation(instance, table)
+        schema_errors |= validate_table_schema_has_indexes(instance, table)
     if schema_errors:
         _LOGGER.debug(
             "Detected statistics schema errors: %s", ", ".join(sorted(schema_errors))
@@ -46,3 +49,4 @@ def correct_db_schema(
     for table in (Statistics, StatisticsShortTerm):
         correct_db_schema_precision(instance, table, schema_errors)
         correct_db_schema_utf8(instance, table, schema_errors)
+        correct_db_schema_missing_indexes(instance, table, schema_errors)

--- a/tests/components/recorder/auto_repairs/statistics/test_schema.py
+++ b/tests/components/recorder/auto_repairs/statistics/test_schema.py
@@ -1,6 +1,6 @@
 """The test repairing statistics schema."""
 
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 
@@ -127,4 +127,39 @@ async def test_validate_db_schema_fix_collation_issue(
     assert (
         "Updating table statistics to character set utf8mb4 and collation utf8mb4_bin"
         in caplog.text
+    )
+
+
+@pytest.mark.parametrize("enable_schema_validation", [True])
+async def test_validate_db_schema_fix_missing_index(
+    hass: HomeAssistant,
+    async_test_recorder: RecorderInstanceContextManager,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test validating and repairing a missing index on the statistics table.
+
+    Note: The test uses SQLite, the purpose is only to exercise the code.
+    """
+    with (
+        patch(
+            "homeassistant.components.recorder.auto_repairs.schema._validate_table_schema_has_indexes",
+            return_value={
+                "statistics.missing_index.ix_statistics_statistic_id_start_ts"
+            },
+        ),
+        patch(
+            "homeassistant.components.recorder.migration._create_index"
+        ) as create_index_mock,
+    ):
+        async with async_test_recorder(hass):
+            await async_wait_recording_done(hass)
+
+    assert "Schema validation failed" not in caplog.text
+    assert (
+        "Database is about to correct DB schema errors: "
+        "statistics.missing_index.ix_statistics_statistic_id_start_ts"
+        in caplog.text
+    )
+    create_index_mock.assert_any_call(
+        ANY, ANY, "statistics", "ix_statistics_statistic_id_start_ts"
     )

--- a/tests/components/recorder/auto_repairs/test_schema.py
+++ b/tests/components/recorder/auto_repairs/test_schema.py
@@ -5,13 +5,15 @@ from sqlalchemy import text
 
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.auto_repairs.schema import (
+    correct_db_schema_missing_indexes,
     correct_db_schema_precision,
     correct_db_schema_utf8,
     validate_db_schema_precision,
     validate_table_schema_has_correct_collation,
+    validate_table_schema_has_indexes,
     validate_table_schema_supports_utf8,
 )
-from homeassistant.components.recorder.db_schema import States
+from homeassistant.components.recorder.db_schema import Statistics, States
 from homeassistant.components.recorder.migration import _modify_columns
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
@@ -291,4 +293,62 @@ async def test_validate_db_schema_precision_with_unrepairable_broken_schema(
         States,
     )
     assert "Error when validating DB schema" in caplog.text
+    assert schema_errors == set()
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_validate_db_schema_missing_index_good_schema(
+    hass: HomeAssistant,
+    recorder_mock: Recorder,
+) -> None:
+    """Test validating indexes when all expected indexes exist."""
+    await async_wait_recording_done(hass)
+    schema_errors = await recorder_mock.async_add_executor_job(
+        validate_table_schema_has_indexes,
+        recorder_mock,
+        Statistics,
+    )
+    assert schema_errors == set()
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_validate_db_schema_missing_index_with_broken_schema(
+    hass: HomeAssistant,
+    recorder_mock: Recorder,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test detecting and repairing a missing index."""
+    await async_wait_recording_done(hass)
+    session_maker = recorder_mock.get_session
+
+    def _drop_index():
+        with session_scope(session=session_maker()) as session:
+            session.execute(
+                text("DROP INDEX ix_statistics_statistic_id_start_ts")
+            )
+
+    await recorder_mock.async_add_executor_job(_drop_index)
+
+    schema_errors = await recorder_mock.async_add_executor_job(
+        validate_table_schema_has_indexes,
+        recorder_mock,
+        Statistics,
+    )
+    assert schema_errors == {
+        "statistics.missing_index.ix_statistics_statistic_id_start_ts"
+    }
+    assert "ix_statistics_statistic_id_start_ts is missing" in caplog.text
+
+    await recorder_mock.async_add_executor_job(
+        correct_db_schema_missing_indexes,
+        recorder_mock,
+        Statistics,
+        schema_errors,
+    )
+
+    schema_errors = await recorder_mock.async_add_executor_job(
+        validate_table_schema_has_indexes,
+        recorder_mock,
+        Statistics,
+    )
     assert schema_errors == set()

--- a/tests/components/recorder/auto_repairs/test_schema.py
+++ b/tests/components/recorder/auto_repairs/test_schema.py
@@ -14,7 +14,7 @@ from homeassistant.components.recorder.auto_repairs.schema import (
     validate_table_schema_supports_utf8,
 )
 from homeassistant.components.recorder.db_schema import Statistics, States
-from homeassistant.components.recorder.migration import _modify_columns
+from homeassistant.components.recorder.migration import _drop_index, _modify_columns
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
 
@@ -321,13 +321,12 @@ async def test_validate_db_schema_missing_index_with_broken_schema(
     await async_wait_recording_done(hass)
     session_maker = recorder_mock.get_session
 
-    def _drop_index():
-        with session_scope(session=session_maker()) as session:
-            session.execute(
-                text("DROP INDEX ix_statistics_statistic_id_start_ts")
-            )
-
-    await recorder_mock.async_add_executor_job(_drop_index)
+    await recorder_mock.async_add_executor_job(
+        _drop_index,
+        session_maker,
+        "statistics",
+        "ix_statistics_statistic_id_start_ts",
+    )
 
     schema_errors = await recorder_mock.async_add_executor_job(
         validate_table_schema_has_indexes,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The recorder's auto-repair system validates charset, collation, and precision on startup but never checks whether expected database indexes exist. Indexes can be silently lost during:

- **Manual database migration** (e.g. `pg_dump`/`pg_restore` across major PostgreSQL versions)
- **Failed schema migration** when a unique index creation fails due to pre-existing duplicate rows (the migration logs an error but advances the schema version, leaving the index permanently missing)

**Real-world impact:** a missing `ix_statistics_statistic_id_start_ts` composite index on the `statistics` table causes the Energy dashboard's "last known statistic before timestamp" query to degrade from **~7 ms to ~38 seconds** — a **5,000x slowdown**. The correlated subquery falls back to scanning `ix_statistics_start_ts` (single column) and filtering ~458,000 rows per loop across all `statistics_meta` entries, examining ~319 million rows per query execution. Discovered on a production instance (PG18, ~5M statistics rows) after upgrading through multiple PostgreSQL major versions: the schema version was current (53) but the composite index from migration 34 was missing.

This PR adds two functions to `auto_repairs/schema.py`:

- **`validate_table_schema_has_indexes()`** — compares live database indexes (via `sqlalchemy.inspect`) against the SQLAlchemy model definitions and reports any that are missing.
- **`correct_db_schema_missing_indexes()`** — recreates missing indexes using the existing `_create_index()` infrastructure, wrapped in `try/except` so a recreation that fails (e.g. duplicate rows blocking a UNIQUE index) logs an actionable error instead of failing recorder startup.

These are wired into all three table-group validators (statistics, states, events), covering `statistics`, `statistics_short_term`, `states`, `state_attributes`, `events`, and `event_data`. On startup, if any expected index is missing, the recorder logs an error and automatically recreates it — the same self-healing pattern already used for charset/collation/precision repairs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
