### PR TITLE
Add DHCP discovery to nobo_hub

### DIFF
--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -134,13 +134,4 @@ async def async_migrate_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) ->
             entry, data=new_data, version=1, minor_version=3
         )
 
-    if entry.version == 1 and entry.minor_version < 4:
-        # MAC is populated for DHCP-discovered hubs; existing entries
-        # backfill it the next time DHCP fires for the hub.
-        new_data = dict(entry.data)
-        new_data.setdefault(CONF_MAC, None)
-        hass.config_entries.async_update_entry(
-            entry, data=new_data, version=1, minor_version=4
-        )
-
     return True

--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -6,12 +6,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_NAME,
     CONF_IP_ADDRESS,
+    CONF_MAC,
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -81,9 +83,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
     entry.runtime_data = hub
 
     device_registry = dr.async_get(hass)
+    connections: set[tuple[str, str]] = set()
+    if mac := entry.data.get(CONF_MAC):
+        connections.add((CONNECTION_NETWORK_MAC, format_mac(mac)))
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, hub.hub_serial)},
+        connections=connections,
         serial_number=hub.hub_serial,
         name=hub.hub_info[ATTR_NAME],
         manufacturer=NOBO_MANUFACTURER,
@@ -126,6 +132,15 @@ async def async_migrate_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) ->
         new_data.pop("auto_discovered", None)
         hass.config_entries.async_update_entry(
             entry, data=new_data, version=1, minor_version=3
+        )
+
+    if entry.version == 1 and entry.minor_version < 4:
+        # MAC is populated for DHCP-discovered hubs; existing entries
+        # backfill it the next time DHCP fires for the hub.
+        new_data = dict(entry.data)
+        new_data.setdefault(CONF_MAC, None)
+        hass.config_entries.async_update_entry(
+            entry, data=new_data, version=1, minor_version=4
         )
 
     return True

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -86,6 +86,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         Three paths from here:
         - Fast path: a configured entry already has this MAC stored →
           refresh its IP and abort.
+        - Device is already ignored.
         - IP+prefix match: listen for the hub's UDP broadcast (15s) to
           learn the 9-digit serial prefix. If a configured entry's
           stored IP and prefix both match the DHCP packet, backfill its
@@ -94,6 +95,18 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
           supply the 3-digit serial suffix.
         """
         self._mac = discovery_info.macaddress
+        # Fast path: a configured entry already knows this MAC. Refresh
+        # its IP and skip the broadcast wait entirely. Done before
+        # `async_set_unique_id` so an ignored entry with the same MAC
+        # doesn't block the IP refresh of an active configuration.
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data.get(CONF_MAC) == discovery_info.macaddress:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_IP_ADDRESS: discovery_info.ip},
+                    reason="already_configured",
+                )
+
         # Use the MAC as the temporary unique_id so the frontend offers an
         # "Ignore" option, and so a previously-ignored MAC correctly aborts
         # the flow here. The MAC is per-device unique (the 9-digit serial
@@ -103,19 +116,9 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(format_mac(discovery_info.macaddress))
         self._abort_if_unique_id_configured()
 
-        # Fast path: a configured entry already knows this MAC. Refresh
-        # its IP and skip the (5s) broadcast wait entirely.
-        for entry in self._async_current_entries(include_ignore=False):
-            if entry.data.get(CONF_MAC) == discovery_info.macaddress:
-                return self.async_update_reload_and_abort(
-                    entry,
-                    data_updates={CONF_IP_ADDRESS: discovery_info.ip},
-                    reason="already_configured",
-                )
-
         # Wait 15s — when DHCP fires on hub boot, the hub's broadcast
         # service comes up after the DHCPDISCOVER but typically within
-        # ~10-15s. Shorter waits miss the first post-boot broadcast.
+        # ~10s. Shorter waits may miss the first post-boot broadcast.
         discovered = await nobo.async_discover_hubs(
             ip=discovery_info.ip, autodiscover_wait=15.0
         )

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlowWithReload,
 )
-from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.const import CONF_IP_ADDRESS, CONF_MAC
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
@@ -34,12 +34,13 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Nobø Ecohub."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._discovered_hubs: dict[str, Any] | None = None
         self._hub: str | None = None
+        self._mac: str | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -80,6 +81,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         matches the prefix, just refresh its IP. Otherwise, ask the user
         for the serial suffix via the existing `selected` step.
         """
+        self._mac = discovery_info.macaddress
         # Wait 5s — real-world gaps up to ~4s have been observed.
         discovered = await nobo.async_discover_hubs(
             ip=discovery_info.ip, autodiscover_wait=5.0
@@ -89,15 +91,19 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         _, serial_prefix = next(iter(discovered))
 
         # Look for a configured entry whose full 12-digit unique_id starts
-        # with the discovered prefix and refresh its IP. Exclude ignored
-        # entries: an ignored discovery's unique_id is the 9-digit prefix,
-        # which would also match `startswith` and could shadow the real
-        # configured entry depending on iteration order.
+        # with the discovered prefix and refresh its IP (and backfill MAC
+        # for entries created before DHCP discovery existed). Exclude
+        # ignored entries: an ignored discovery's unique_id is the 9-digit
+        # prefix, which would also match `startswith` and could shadow the
+        # real configured entry depending on iteration order.
         for entry in self._async_current_entries(include_ignore=False):
             if entry.unique_id and entry.unique_id.startswith(serial_prefix):
                 return self.async_update_reload_and_abort(
                     entry,
-                    data_updates={CONF_IP_ADDRESS: discovery_info.ip},
+                    data_updates={
+                        CONF_IP_ADDRESS: discovery_info.ip,
+                        CONF_MAC: discovery_info.macaddress,
+                    },
                     reason="already_configured",
                 )
 
@@ -184,6 +190,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
             data={
                 CONF_SERIAL: serial,
                 CONF_IP_ADDRESS: ip_address,
+                CONF_MAC: self._mac,
             },
         )
 

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import NoboHubConfigEntry
 from .const import (
@@ -68,6 +69,42 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=data_schema,
         )
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery of a Nobø Ecohub.
+
+        DHCP gives us the IP and MAC; we listen for the hub's UDP broadcast
+        at that IP to get the 9-digit serial prefix. If an existing entry
+        matches the prefix, just refresh its IP. Otherwise, ask the user
+        for the serial suffix via the existing `selected` step.
+        """
+        # Wait 5s — real-world gaps up to ~4s have been observed.
+        discovered = await nobo.async_discover_hubs(
+            ip=discovery_info.ip, autodiscover_wait=5.0
+        )
+        if not discovered:
+            return self.async_abort(reason="cannot_discover")
+        _, serial_prefix = next(iter(discovered))
+
+        # Use the 9-digit serial prefix as a temporary unique_id so the
+        # frontend offers an "Ignore" option for this discovery. It is
+        # replaced with the full 12-digit serial in _create_configuration
+        # once the user supplies the suffix.
+        await self.async_set_unique_id(serial_prefix)
+
+        for entry in self._async_current_entries():
+            if entry.unique_id and entry.unique_id.startswith(serial_prefix):
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_IP_ADDRESS: discovery_info.ip},
+                    reason="already_configured",
+                )
+
+        self._discovered_hubs = {discovery_info.ip: serial_prefix}
+        self._hub = discovery_info.ip
+        return await self.async_step_selected()
 
     async def async_step_selected(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -83,7 +83,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         The unique_id is replaced with the full 12-digit serial when an
         entry is created.
 
-        Three paths from here:
+        Four paths from here:
         - Fast path: a configured entry already has this MAC stored →
           refresh its IP and abort.
         - Device is already ignored.

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_IP_ADDRESS, CONF_MAC
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
@@ -76,44 +77,70 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle DHCP discovery of a Nobø Ecohub.
 
-        DHCP gives us the IP and MAC; we listen for the hub's UDP broadcast
-        at that IP to get the 9-digit serial prefix. If an existing entry
-        matches the prefix, just refresh its IP. Otherwise, ask the user
-        for the serial suffix via the existing `selected` step.
+        The MAC from the DHCP packet is set as the flow's temporary
+        unique_id so the user can dismiss this discovery via "Ignore",
+        and so a previously-ignored hub aborts cleanly on rediscovery.
+        The unique_id is replaced with the full 12-digit serial when an
+        entry is created.
+
+        Three paths from here:
+        - Fast path: a configured entry already has this MAC stored →
+          refresh its IP and abort.
+        - IP+prefix match: listen for the hub's UDP broadcast (15s) to
+          learn the 9-digit serial prefix. If a configured entry's
+          stored IP and prefix both match the DHCP packet, backfill its
+          MAC and abort.
+        - Otherwise: route to the `selected` step so the user can
+          supply the 3-digit serial suffix.
         """
         self._mac = discovery_info.macaddress
-        # Wait 5s — real-world gaps up to ~4s have been observed.
+        # Use the MAC as the temporary unique_id so the frontend offers an
+        # "Ignore" option, and so a previously-ignored MAC correctly aborts
+        # the flow here. The MAC is per-device unique (the 9-digit serial
+        # prefix would shadow sibling hubs from the same production batch).
+        # Replaced with the full 12-digit serial in _create_configuration
+        # once the user supplies the suffix.
+        await self.async_set_unique_id(format_mac(discovery_info.macaddress))
+        self._abort_if_unique_id_configured()
+
+        # Fast path: a configured entry already knows this MAC. Refresh
+        # its IP and skip the (5s) broadcast wait entirely.
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data.get(CONF_MAC) == discovery_info.macaddress:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_IP_ADDRESS: discovery_info.ip},
+                    reason="already_configured",
+                )
+
+        # Wait 15s — when DHCP fires on hub boot, the hub's broadcast
+        # service comes up after the DHCPDISCOVER but typically within
+        # ~10-15s. Shorter waits miss the first post-boot broadcast.
         discovered = await nobo.async_discover_hubs(
-            ip=discovery_info.ip, autodiscover_wait=5.0
+            ip=discovery_info.ip, autodiscover_wait=15.0
         )
         if not discovered:
             return self.async_abort(reason="cannot_discover")
         _, serial_prefix = next(iter(discovered))
 
-        # Look for a configured entry whose full 12-digit unique_id starts
-        # with the discovered prefix and refresh its IP (and backfill MAC
-        # for entries created before DHCP discovery existed). Exclude
-        # ignored entries: an ignored discovery's unique_id is the 9-digit
-        # prefix, which would also match `startswith` and could shadow the
-        # real configured entry depending on iteration order.
+        # Fallback: a configured entry without a stored MAC (manual or
+        # user-picker entry, not yet DHCP-backfilled) is identified by
+        # both the stored IP and the 9-digit serial prefix matching the
+        # DHCP packet. Requiring IP match prevents clobbering a sibling
+        # entry from the same production batch (which shares the prefix).
+        # Pynobo's connection-failure rediscovery handles IP changes for
+        # non-DHCP-backfilled entries.
         for entry in self._async_current_entries(include_ignore=False):
-            if entry.unique_id and entry.unique_id.startswith(serial_prefix):
+            if (
+                entry.data.get(CONF_IP_ADDRESS) == discovery_info.ip
+                and entry.unique_id
+                and entry.unique_id.startswith(serial_prefix)
+            ):
                 return self.async_update_reload_and_abort(
                     entry,
-                    data_updates={
-                        CONF_IP_ADDRESS: discovery_info.ip,
-                        CONF_MAC: discovery_info.macaddress,
-                    },
+                    data_updates={CONF_MAC: discovery_info.macaddress},
                     reason="already_configured",
                 )
-
-        # Use the 9-digit serial prefix as a temporary unique_id so the
-        # frontend offers an "Ignore" option for this discovery, and so a
-        # previously-ignored prefix correctly aborts the flow here. It is
-        # replaced with the full 12-digit serial in _create_configuration
-        # once the user supplies the suffix.
-        await self.async_set_unique_id(serial_prefix)
-        self._abort_if_unique_id_configured()
 
         self._discovered_hubs = {discovery_info.ip: serial_prefix}
         self._hub = discovery_info.ip

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -88,19 +88,26 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="cannot_discover")
         _, serial_prefix = next(iter(discovered))
 
-        # Use the 9-digit serial prefix as a temporary unique_id so the
-        # frontend offers an "Ignore" option for this discovery. It is
-        # replaced with the full 12-digit serial in _create_configuration
-        # once the user supplies the suffix.
-        await self.async_set_unique_id(serial_prefix)
-
-        for entry in self._async_current_entries():
+        # Look for a configured entry whose full 12-digit unique_id starts
+        # with the discovered prefix and refresh its IP. Exclude ignored
+        # entries: an ignored discovery's unique_id is the 9-digit prefix,
+        # which would also match `startswith` and could shadow the real
+        # configured entry depending on iteration order.
+        for entry in self._async_current_entries(include_ignore=False):
             if entry.unique_id and entry.unique_id.startswith(serial_prefix):
                 return self.async_update_reload_and_abort(
                     entry,
                     data_updates={CONF_IP_ADDRESS: discovery_info.ip},
                     reason="already_configured",
                 )
+
+        # Use the 9-digit serial prefix as a temporary unique_id so the
+        # frontend offers an "Ignore" option for this discovery, and so a
+        # previously-ignored prefix correctly aborts the flow here. It is
+        # replaced with the full 12-digit serial in _create_configuration
+        # once the user supplies the suffix.
+        await self.async_set_unique_id(serial_prefix)
+        self._abort_if_unique_id_configured()
 
         self._discovered_hubs = {discovery_info.ip: serial_prefix}
         self._hub = discovery_info.ip

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -35,7 +35,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Nobø Ecohub."""
 
     VERSION = 1
-    MINOR_VERSION = 4
+    MINOR_VERSION = 3
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/homeassistant/components/nobo_hub/manifest.json
+++ b/homeassistant/components/nobo_hub/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "dhcp": [
     {
+      "hostname": "hub*",
       "macaddress": "7C8306*"
     }
   ],

--- a/homeassistant/components/nobo_hub/manifest.json
+++ b/homeassistant/components/nobo_hub/manifest.json
@@ -3,6 +3,11 @@
   "name": "Nob\u00f8 Ecohub",
   "codeowners": ["@echoromeo", "@oyvindwe"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "macaddress": "7C8306*"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/nobo_hub",
   "integration_type": "hub",
   "iot_class": "local_push",

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_discover": "Could not detect a Nobø Ecohub at the discovered IP address."
     },
     "error": {
       "cannot_connect": "Failed to connect - check serial number",

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_discover": "Could not detect a Nobø Ecohub at the discovered IP address."
     },
     "error": {

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -476,6 +476,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "000231*",
     },
     {
+        "domain": "nobo_hub",
+        "macaddress": "7C8306*",
+    },
+    {
         "domain": "nuheat",
         "hostname": "nuheat",
         "macaddress": "002338*",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -477,6 +477,7 @@ DHCP: Final[list[dict[str, str | bool]]] = [
     },
     {
         "domain": "nobo_hub",
+        "hostname": "hub*",
         "macaddress": "7C8306*",
     },
     {

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -3,7 +3,11 @@
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 from homeassistant import config_entries
-from homeassistant.components.nobo_hub.const import CONF_OVERRIDE_TYPE, DOMAIN
+from homeassistant.components.nobo_hub.const import (
+    CONF_OVERRIDE_TYPE,
+    CONF_SERIAL,
+    DOMAIN,
+)
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -24,7 +28,7 @@ async def test_configure_with_discover(
 ) -> None:
     """Test configure with discover."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value=[("1.1.1.1", "123456789")],
     ):
         result = await hass.config_entries.flow.async_init(
@@ -33,41 +37,40 @@ async def test_configure_with_discover(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            "device": "1.1.1.1",
-        },
+        {"device": "1.1.1.1"},
     )
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {}
-    assert result2["step_id"] == "selected"
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == "selected"
 
     with (
-        patch("pynobo.nobo.async_connect_hub", return_value=True) as mock_connect,
         patch(
-            "pynobo.nobo.hub_info",
+            "homeassistant.components.nobo_hub.config_flow.nobo.async_connect_hub",
+            return_value=True,
+        ) as mock_connect,
+        patch(
+            "homeassistant.components.nobo_hub.config_flow.nobo.hub_info",
             new_callable=PropertyMock,
             create=True,
             return_value={"name": "My Nobø Ecohub"},
         ),
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            {
-                "serial_suffix": "012",
-            },
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"serial_suffix": "012"},
         )
-        await hass.async_block_till_done()
 
-        assert result3["type"] is FlowResultType.CREATE_ENTRY
-        assert result3["title"] == "My Nobø Ecohub"
-        assert result3["data"] == {
-            "ip_address": "1.1.1.1",
-            "serial": "123456789012",
-        }
-        mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
-        mock_setup_entry.assert_awaited_once()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My Nobø Ecohub"
+    assert result["result"].unique_id == "123456789012"
+    assert result["data"] == {
+        CONF_IP_ADDRESS: "1.1.1.1",
+        CONF_SERIAL: "123456789012",
+    }
+    mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
+    mock_setup_entry.assert_awaited_once()
 
 
 async def test_configure_manual(
@@ -76,7 +79,7 @@ async def test_configure_manual(
 ) -> None:
     """Test manual configuration when no hubs are discovered."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value=[],
     ):
         result = await hass.config_entries.flow.async_init(
@@ -87,31 +90,34 @@ async def test_configure_manual(
         assert result["step_id"] == "manual"
 
     with (
-        patch("pynobo.nobo.async_connect_hub", return_value=True) as mock_connect,
         patch(
-            "pynobo.nobo.hub_info",
+            "homeassistant.components.nobo_hub.config_flow.nobo.async_connect_hub",
+            return_value=True,
+        ) as mock_connect,
+        patch(
+            "homeassistant.components.nobo_hub.config_flow.nobo.hub_info",
             new_callable=PropertyMock,
             create=True,
             return_value={"name": "My Nobø Ecohub"},
         ),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "serial": "123456789012",
-                "ip_address": "1.1.1.1",
+                CONF_SERIAL: "123456789012",
+                CONF_IP_ADDRESS: "1.1.1.1",
             },
         )
-        await hass.async_block_till_done()
 
-        assert result2["type"] is FlowResultType.CREATE_ENTRY
-        assert result2["title"] == "My Nobø Ecohub"
-        assert result2["data"] == {
-            "serial": "123456789012",
-            "ip_address": "1.1.1.1",
-        }
-        mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
-        mock_setup_entry.assert_awaited_once()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My Nobø Ecohub"
+    assert result["result"].unique_id == "123456789012"
+    assert result["data"] == {
+        CONF_SERIAL: "123456789012",
+        CONF_IP_ADDRESS: "1.1.1.1",
+    }
+    mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
+    mock_setup_entry.assert_awaited_once()
 
 
 async def test_configure_user_selected_manual(
@@ -120,142 +126,140 @@ async def test_configure_user_selected_manual(
 ) -> None:
     """Test configuration when user selects manual."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value=[("1.1.1.1", "123456789")],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            "device": "manual",
-        },
+        {"device": "manual"},
     )
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {}
-    assert result2["step_id"] == "manual"
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == "manual"
 
     with (
-        patch("pynobo.nobo.async_connect_hub", return_value=True) as mock_connect,
         patch(
-            "pynobo.nobo.hub_info",
+            "homeassistant.components.nobo_hub.config_flow.nobo.async_connect_hub",
+            return_value=True,
+        ) as mock_connect,
+        patch(
+            "homeassistant.components.nobo_hub.config_flow.nobo.hub_info",
             new_callable=PropertyMock,
             create=True,
             return_value={"name": "My Nobø Ecohub"},
         ),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "serial": "123456789012",
-                "ip_address": "1.1.1.1",
+                CONF_SERIAL: "123456789012",
+                CONF_IP_ADDRESS: "1.1.1.1",
             },
         )
-        await hass.async_block_till_done()
 
-        assert result2["type"] is FlowResultType.CREATE_ENTRY
-        assert result2["title"] == "My Nobø Ecohub"
-        assert result2["data"] == {
-            "serial": "123456789012",
-            "ip_address": "1.1.1.1",
-        }
-        mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
-        mock_setup_entry.assert_awaited_once()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My Nobø Ecohub"
+    assert result["result"].unique_id == "123456789012"
+    assert result["data"] == {
+        CONF_SERIAL: "123456789012",
+        CONF_IP_ADDRESS: "1.1.1.1",
+    }
+    mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
+    mock_setup_entry.assert_awaited_once()
 
 
 async def test_configure_invalid_serial_suffix(hass: HomeAssistant) -> None:
     """Test we handle invalid serial suffix error."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value=[("1.1.1.1", "123456789")],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            "device": "1.1.1.1",
-        },
+        {"device": "1.1.1.1"},
     )
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
         {"serial_suffix": "ABC"},
     )
 
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["errors"] == {"base": "invalid_serial"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_serial"}
 
 
 async def test_configure_invalid_serial_undiscovered(hass: HomeAssistant) -> None:
     """Test we handle invalid serial error."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value=[],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "manual"}
         )
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {"ip_address": "1.1.1.1", "serial": "123456789"},
+        {CONF_IP_ADDRESS: "1.1.1.1", CONF_SERIAL: "123456789"},
     )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_serial"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_serial"}
 
 
 async def test_configure_invalid_ip_address(hass: HomeAssistant) -> None:
     """Test we handle invalid ip address error."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value=[("1.1.1.1", "123456789")],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "manual"}
         )
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {"serial": "123456789012", "ip_address": "ABCD"},
+        {CONF_SERIAL: "123456789012", CONF_IP_ADDRESS: "ABCD"},
     )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_ip"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_ip"}
 
 
 async def test_configure_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value=[("1.1.1.1", "123456789")],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            "device": "1.1.1.1",
-        },
+        {"device": "1.1.1.1"},
     )
 
     with patch(
-        "pynobo.nobo.async_connect_hub",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_connect_hub",
         return_value=False,
     ) as mock_connect:
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {"serial_suffix": "012"},
         )
-        assert result3["type"] is FlowResultType.FORM
-        assert result3["errors"] == {"base": "cannot_connect"}
-        mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
 
 
 async def test_dhcp_discovery_new_hub(
@@ -264,7 +268,7 @@ async def test_dhcp_discovery_new_hub(
 ) -> None:
     """A DHCP-discovered hub routes to `selected` for the user to enter the suffix."""
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value={("192.168.1.106", "102000100")},
     ) as mock_discover:
         result = await hass.config_entries.flow.async_init(
@@ -278,24 +282,28 @@ async def test_dhcp_discovery_new_hub(
     assert result["step_id"] == "selected"
 
     with (
-        patch("pynobo.nobo.async_connect_hub", return_value=True) as mock_connect,
         patch(
-            "pynobo.nobo.hub_info",
+            "homeassistant.components.nobo_hub.config_flow.nobo.async_connect_hub",
+            return_value=True,
+        ) as mock_connect,
+        patch(
+            "homeassistant.components.nobo_hub.config_flow.nobo.hub_info",
             new_callable=PropertyMock,
             create=True,
             return_value={"name": "My Nobø Ecohub"},
         ),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"serial_suffix": "098"},
         )
-        await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["data"] == {
-        "serial": "102000100098",
-        "ip_address": "192.168.1.106",
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My Nobø Ecohub"
+    assert result["result"].unique_id == "102000100098"
+    assert result["data"] == {
+        CONF_SERIAL: "102000100098",
+        CONF_IP_ADDRESS: "192.168.1.106",
     }
     mock_connect.assert_awaited_once_with("192.168.1.106", "102000100098")
     mock_setup_entry.assert_awaited_once()
@@ -310,12 +318,12 @@ async def test_dhcp_discovery_updates_existing_ip(
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="102000100098",
-        data={"serial": "102000100098", "ip_address": "1.1.1.1"},
+        data={CONF_SERIAL: "102000100098", CONF_IP_ADDRESS: "1.1.1.1"},
     )
     config_entry.add_to_hass(hass)
 
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value={("192.168.1.106", "102000100")},
     ):
         result = await hass.config_entries.flow.async_init(
@@ -323,7 +331,6 @@ async def test_dhcp_discovery_updates_existing_ip(
             context={"source": config_entries.SOURCE_DHCP},
             data=DHCP_DISCOVERY,
         )
-        await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -351,12 +358,12 @@ async def test_dhcp_discovery_ignored_and_configured(
     configured_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="102000100098",
-        data={"serial": "102000100098", "ip_address": "1.1.1.1"},
+        data={CONF_SERIAL: "102000100098", CONF_IP_ADDRESS: "1.1.1.1"},
     )
     configured_entry.add_to_hass(hass)
 
     with patch(
-        "pynobo.nobo.async_discover_hubs",
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
         return_value={("192.168.1.106", "102000100")},
     ):
         result = await hass.config_entries.flow.async_init(
@@ -364,7 +371,6 @@ async def test_dhcp_discovery_ignored_and_configured(
             context={"source": config_entries.SOURCE_DHCP},
             data=DHCP_DISCOVERY,
         )
-        await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -373,7 +379,10 @@ async def test_dhcp_discovery_ignored_and_configured(
 
 async def test_dhcp_discovery_no_broadcast(hass: HomeAssistant) -> None:
     """DHCP at an IP that emits no Nobø broadcast aborts cleanly."""
-    with patch("pynobo.nobo.async_discover_hubs", return_value=set()):
+    with patch(
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
+        return_value=set(),
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -393,7 +402,11 @@ async def test_options_flow(
     config_entry = MockConfigEntry(
         domain="nobo_hub",
         unique_id="123456789012",
-        data={"serial": "123456789012", "ip_address": "1.1.1.1", "auto_discover": True},
+        data={
+            CONF_SERIAL: "123456789012",
+            CONF_IP_ADDRESS: "1.1.1.1",
+            "auto_discover": True,
+        },
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -4,10 +4,18 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.nobo_hub.const import CONF_OVERRIDE_TYPE, DOMAIN
+from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
+
+DHCP_DISCOVERY = DhcpServiceInfo(
+    ip="192.168.1.106",
+    macaddress="7c830602644f",
+    hostname="hubdo",
+)
 
 
 async def test_configure_with_discover(
@@ -248,6 +256,91 @@ async def test_configure_cannot_connect(hass: HomeAssistant) -> None:
         assert result3["type"] is FlowResultType.FORM
         assert result3["errors"] == {"base": "cannot_connect"}
         mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
+
+
+async def test_dhcp_discovery_new_hub(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A DHCP-discovered hub routes to `selected` for the user to enter the suffix."""
+    with patch(
+        "pynobo.nobo.async_discover_hubs",
+        return_value={("192.168.1.106", "102000100")},
+    ) as mock_discover:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+
+    mock_discover.assert_awaited_once_with(ip="192.168.1.106", autodiscover_wait=5.0)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "selected"
+
+    with (
+        patch("pynobo.nobo.async_connect_hub", return_value=True) as mock_connect,
+        patch(
+            "pynobo.nobo.hub_info",
+            new_callable=PropertyMock,
+            create=True,
+            return_value={"name": "My Nobø Ecohub"},
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"serial_suffix": "098"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {
+        "serial": "102000100098",
+        "ip_address": "192.168.1.106",
+    }
+    mock_connect.assert_awaited_once_with("192.168.1.106", "102000100098")
+    mock_setup_entry.assert_awaited_once()
+
+
+async def test_dhcp_discovery_updates_existing_ip(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_unload_entry: AsyncMock,
+) -> None:
+    """DHCP for a hub already configured updates its stored IP and aborts."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="102000100098",
+        data={"serial": "102000100098", "ip_address": "1.1.1.1"},
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "pynobo.nobo.async_discover_hubs",
+        return_value={("192.168.1.106", "102000100")},
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert config_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
+
+
+async def test_dhcp_discovery_no_broadcast(hass: HomeAssistant) -> None:
+    """DHCP at an IP that emits no Nobø broadcast aborts cleanly."""
+    with patch("pynobo.nobo.async_discover_hubs", return_value=set()):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_discover"
 
 
 async def test_options_flow(

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -487,6 +487,51 @@ async def test_dhcp_discovery_with_ignored_entry(
     assert result.get("step_id") == expected_step
 
 
+async def test_dhcp_discovery_configured_wins_over_ignored_mac(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_unload_entry: AsyncMock,
+) -> None:
+    """A configured entry's IP refresh wins over an ignored entry with the same MAC.
+
+    If both an ignored entry (unique_id = formatted MAC) and a configured
+    entry (with the MAC stored in data) exist for the same hub, the
+    configured entry's fast-path IP refresh fires before the ignored MAC
+    can abort the flow. Otherwise the ignored entry would silently block
+    every future DHCP-driven IP update for the active configuration.
+    """
+    ignored_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="7c:83:06:02:64:4f",
+        source=config_entries.SOURCE_IGNORE,
+    )
+    ignored_entry.add_to_hass(hass)
+    configured_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="102000100098",
+        data={
+            CONF_SERIAL: "102000100098",
+            CONF_IP_ADDRESS: "1.1.1.1",
+            CONF_MAC: "7c830602644f",
+        },
+    )
+    configured_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
+    ) as mock_discover:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+
+    mock_discover.assert_not_awaited()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert configured_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
+
+
 async def test_dhcp_discovery_no_broadcast(hass: HomeAssistant) -> None:
     """DHCP at an IP that emits no Nobø broadcast aborts cleanly."""
     with patch(

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -301,7 +301,7 @@ async def test_dhcp_discovery_new_hub(
             data=DHCP_DISCOVERY,
         )
 
-    mock_discover.assert_awaited_once_with(ip="192.168.1.106", autodiscover_wait=5.0)
+    mock_discover.assert_awaited_once_with(ip="192.168.1.106", autodiscover_wait=15.0)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "selected"
 
@@ -334,18 +334,51 @@ async def test_dhcp_discovery_new_hub(
     mock_setup_entry.assert_awaited_once()
 
 
-async def test_dhcp_discovery_updates_existing_ip(
+@pytest.mark.parametrize(
+    ("stored_ip", "expected_type", "expected_reason", "expected_step", "expected_mac"),
+    [
+        # Matching IP + prefix → backfill MAC, abort already_configured.
+        (
+            "192.168.1.106",
+            FlowResultType.ABORT,
+            "already_configured",
+            None,
+            "7c830602644f",
+        ),
+        # Mismatched IP (sibling hub in same production batch) → don't
+        # clobber, fall through to the selected step.
+        (
+            "192.168.1.100",
+            FlowResultType.FORM,
+            None,
+            "selected",
+            None,
+        ),
+    ],
+    ids=["matching_ip_backfills_mac", "mismatched_ip_does_not_clobber"],
+)
+async def test_dhcp_discovery_backfill_requires_ip_match(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_unload_entry: AsyncMock,
+    stored_ip: str,
+    expected_type: FlowResultType,
+    expected_reason: str | None,
+    expected_step: str | None,
+    expected_mac: str | None,
 ) -> None:
-    """DHCP for a configured hub refreshes the stored IP and backfills MAC."""
+    """MAC backfill on an entry without a stored MAC requires both IP and prefix to match.
+
+    Two hubs from the same production batch share the 9-digit serial
+    prefix but have different IPs. Requiring IP match prevents a DHCP
+    packet from one hub clobbering a sibling entry's MAC.
+    """
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="102000100098",
         data={
             CONF_SERIAL: "102000100098",
-            CONF_IP_ADDRESS: "1.1.1.1",
+            CONF_IP_ADDRESS: stored_ip,
             CONF_MAC: None,
         },
     )
@@ -361,40 +394,83 @@ async def test_dhcp_discovery_updates_existing_ip(
             data=DHCP_DISCOVERY,
         )
 
+    assert result["type"] is expected_type
+    assert result.get("reason") == expected_reason
+    assert result.get("step_id") == expected_step
+    assert config_entry.data[CONF_IP_ADDRESS] == stored_ip
+    assert config_entry.data[CONF_MAC] == expected_mac
+
+
+async def test_dhcp_discovery_skips_broadcast_when_mac_known(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_unload_entry: AsyncMock,
+) -> None:
+    """A configured entry with a stored MAC refreshes its IP without broadcasting."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="102000100098",
+        data={
+            CONF_SERIAL: "102000100098",
+            CONF_IP_ADDRESS: "1.1.1.1",
+            CONF_MAC: "7c830602644f",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
+    ) as mock_discover:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+
+    mock_discover.assert_not_awaited()
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
     assert config_entry.data[CONF_MAC] == "7c830602644f"
 
 
-async def test_dhcp_discovery_ignored_and_configured(
+@pytest.mark.parametrize(
+    ("ignored_unique_id", "expected_type", "expected_reason", "expected_step"),
+    [
+        # Same MAC: rediscovery of a previously-ignored hub aborts.
+        (
+            "7c:83:06:02:64:4f",
+            FlowResultType.ABORT,
+            "already_configured",
+            None,
+        ),
+        # Different MAC (sibling in same production batch): flow proceeds
+        # to the selected step. The 9-digit serial prefix would match,
+        # but using the MAC as unique_id prevents the false-shadowing.
+        (
+            "7c:83:06:99:99:99",
+            FlowResultType.FORM,
+            None,
+            "selected",
+        ),
+    ],
+    ids=["same_mac_aborts", "different_mac_proceeds"],
+)
+async def test_dhcp_discovery_with_ignored_entry(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_unload_entry: AsyncMock,
+    ignored_unique_id: str,
+    expected_type: FlowResultType,
+    expected_reason: str | None,
+    expected_step: str | None,
 ) -> None:
-    """A configured entry must win the IP refresh even when an ignored entry shares the prefix.
-
-    An ignored discovery's unique_id is the 9-digit prefix; the configured
-    entry's unique_id is the full 12-digit serial. Both `startswith` the
-    prefix, so iterating over all entries (including ignored) could refresh
-    the wrong one. The configured entry must always win.
-    """
+    """Ignored entries match the discovery flow by MAC, not by serial prefix."""
     ignored_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="102000100",
+        unique_id=ignored_unique_id,
         source=config_entries.SOURCE_IGNORE,
     )
     ignored_entry.add_to_hass(hass)
-    configured_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="102000100098",
-        data={
-            CONF_SERIAL: "102000100098",
-            CONF_IP_ADDRESS: "1.1.1.1",
-            CONF_MAC: None,
-        },
-    )
-    configured_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
@@ -406,10 +482,9 @@ async def test_dhcp_discovery_ignored_and_configured(
             data=DHCP_DISCOVERY,
         )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    assert configured_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
-    assert configured_entry.data[CONF_MAC] == "7c830602644f"
+    assert result["type"] is expected_type
+    assert result.get("reason") == expected_reason
+    assert result.get("step_id") == expected_step
 
 
 async def test_dhcp_discovery_no_broadcast(hass: HomeAssistant) -> None:

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -330,6 +330,47 @@ async def test_dhcp_discovery_updates_existing_ip(
     assert config_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
 
 
+async def test_dhcp_discovery_ignored_and_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_unload_entry: AsyncMock,
+) -> None:
+    """A configured entry must win the IP refresh even when an ignored entry shares the prefix.
+
+    An ignored discovery's unique_id is the 9-digit prefix; the configured
+    entry's unique_id is the full 12-digit serial. Both `startswith` the
+    prefix, so iterating over all entries (including ignored) could refresh
+    the wrong one. The configured entry must always win.
+    """
+    ignored_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="102000100",
+        source=config_entries.SOURCE_IGNORE,
+    )
+    ignored_entry.add_to_hass(hass)
+    configured_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="102000100098",
+        data={"serial": "102000100098", "ip_address": "1.1.1.1"},
+    )
+    configured_entry.add_to_hass(hass)
+
+    with patch(
+        "pynobo.nobo.async_discover_hubs",
+        return_value={("192.168.1.106", "102000100")},
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DHCP_DISCOVERY,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert configured_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
+
+
 async def test_dhcp_discovery_no_broadcast(hass: HomeAssistant) -> None:
     """DHCP at an IP that emits no Nobø broadcast aborts cleanly."""
     with patch("pynobo.nobo.async_discover_hubs", return_value=set()):

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.components.nobo_hub.const import (
     CONF_SERIAL,
     DOMAIN,
 )
-from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.const import CONF_IP_ADDRESS, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
@@ -70,6 +70,7 @@ async def test_configure_with_discover(
     assert result["data"] == {
         CONF_IP_ADDRESS: "1.1.1.1",
         CONF_SERIAL: "123456789012",
+        CONF_MAC: None,
     }
     mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
     mock_setup_entry.assert_awaited_once()
@@ -117,6 +118,7 @@ async def test_configure_manual(
     assert result["data"] == {
         CONF_SERIAL: "123456789012",
         CONF_IP_ADDRESS: "1.1.1.1",
+        CONF_MAC: None,
     }
     mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
     mock_setup_entry.assert_awaited_once()
@@ -169,6 +171,7 @@ async def test_configure_user_selected_manual(
     assert result["data"] == {
         CONF_SERIAL: "123456789012",
         CONF_IP_ADDRESS: "1.1.1.1",
+        CONF_MAC: None,
     }
     mock_connect.assert_awaited_once_with("1.1.1.1", "123456789012")
     mock_setup_entry.assert_awaited_once()
@@ -325,6 +328,7 @@ async def test_dhcp_discovery_new_hub(
     assert result["data"] == {
         CONF_SERIAL: "102000100098",
         CONF_IP_ADDRESS: "192.168.1.106",
+        CONF_MAC: "7c830602644f",
     }
     mock_connect.assert_awaited_once_with("192.168.1.106", "102000100098")
     mock_setup_entry.assert_awaited_once()
@@ -335,11 +339,15 @@ async def test_dhcp_discovery_updates_existing_ip(
     mock_setup_entry: AsyncMock,
     mock_unload_entry: AsyncMock,
 ) -> None:
-    """DHCP for a hub already configured updates its stored IP and aborts."""
+    """DHCP for a configured hub refreshes the stored IP and backfills MAC."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="102000100098",
-        data={CONF_SERIAL: "102000100098", CONF_IP_ADDRESS: "1.1.1.1"},
+        data={
+            CONF_SERIAL: "102000100098",
+            CONF_IP_ADDRESS: "1.1.1.1",
+            CONF_MAC: None,
+        },
     )
     config_entry.add_to_hass(hass)
 
@@ -356,6 +364,7 @@ async def test_dhcp_discovery_updates_existing_ip(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
+    assert config_entry.data[CONF_MAC] == "7c830602644f"
 
 
 async def test_dhcp_discovery_ignored_and_configured(
@@ -379,7 +388,11 @@ async def test_dhcp_discovery_ignored_and_configured(
     configured_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="102000100098",
-        data={CONF_SERIAL: "102000100098", CONF_IP_ADDRESS: "1.1.1.1"},
+        data={
+            CONF_SERIAL: "102000100098",
+            CONF_IP_ADDRESS: "1.1.1.1",
+            CONF_MAC: None,
+        },
     )
     configured_entry.add_to_hass(hass)
 
@@ -396,6 +409,7 @@ async def test_dhcp_discovery_ignored_and_configured(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert configured_entry.data[CONF_IP_ADDRESS] == "192.168.1.106"
+    assert configured_entry.data[CONF_MAC] == "7c830602644f"
 
 
 async def test_dhcp_discovery_no_broadcast(hass: HomeAssistant) -> None:

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -148,7 +148,7 @@ async def test_migrate_options(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.minor_version == 4
+    assert entry.minor_version == 3
     assert entry.options == expected_options
 
 
@@ -173,41 +173,12 @@ async def test_migrate_data_drops_auto_discovered(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.minor_version == 4
+    assert entry.minor_version == 3
     assert entry.data == {
         CONF_SERIAL: SERIAL,
         CONF_IP_ADDRESS: STORED_IP,
-        CONF_MAC: None,
     }
     assert entry.options == {}
-
-
-async def test_migrate_data_adds_mac_field(
-    hass: HomeAssistant,
-    mock_nobo_class: MagicMock,
-) -> None:
-    """Migrating from minor_version 3 adds the MAC field as None."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="My Eco Hub",
-        unique_id=SERIAL,
-        data={
-            CONF_SERIAL: SERIAL,
-            CONF_IP_ADDRESS: STORED_IP,
-        },
-        version=1,
-        minor_version=3,
-    )
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert entry.minor_version == 4
-    assert entry.data == {
-        CONF_SERIAL: SERIAL,
-        CONF_IP_ADDRESS: STORED_IP,
-        CONF_MAC: None,
-    }
 
 
 async def test_setup_registers_hub_device(
@@ -249,7 +220,7 @@ async def test_setup_registers_hub_device_with_mac(
             CONF_MAC: "7C8306011192",
         },
         version=1,
-        minor_version=4,
+        minor_version=3,
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.components.nobo_hub.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.const import CONF_IP_ADDRESS, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -148,7 +148,7 @@ async def test_migrate_options(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
     assert entry.options == expected_options
 
 
@@ -173,9 +173,41 @@ async def test_migrate_data_drops_auto_discovered(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.minor_version == 3
-    assert entry.data == {CONF_SERIAL: SERIAL, CONF_IP_ADDRESS: STORED_IP}
+    assert entry.minor_version == 4
+    assert entry.data == {
+        CONF_SERIAL: SERIAL,
+        CONF_IP_ADDRESS: STORED_IP,
+        CONF_MAC: None,
+    }
     assert entry.options == {}
+
+
+async def test_migrate_data_adds_mac_field(
+    hass: HomeAssistant,
+    mock_nobo_class: MagicMock,
+) -> None:
+    """Migrating from minor_version 3 adds the MAC field as None."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My Eco Hub",
+        unique_id=SERIAL,
+        data={
+            CONF_SERIAL: SERIAL,
+            CONF_IP_ADDRESS: STORED_IP,
+        },
+        version=1,
+        minor_version=3,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.minor_version == 4
+    assert entry.data == {
+        CONF_SERIAL: SERIAL,
+        CONF_IP_ADDRESS: STORED_IP,
+        CONF_MAC: None,
+    }
 
 
 async def test_setup_registers_hub_device(
@@ -198,3 +230,33 @@ async def test_setup_registers_hub_device(
     assert device.serial_number == SERIAL
     assert device.sw_version == "115"
     assert device.hw_version == "hw"
+    assert device.connections == set()
+
+
+async def test_setup_registers_hub_device_with_mac(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_nobo_class: MagicMock,
+) -> None:
+    """An entry with a stored MAC surfaces it via DeviceInfo.connections."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My Eco Hub",
+        unique_id=SERIAL,
+        data={
+            CONF_SERIAL: SERIAL,
+            CONF_IP_ADDRESS: STORED_IP,
+            CONF_MAC: "7C8306011192",
+        },
+        version=1,
+        minor_version=4,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    assert device is not None
+    assert device.connections == {
+        (dr.CONNECTION_NETWORK_MAC, "7c:83:06:01:11:92"),
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds DHCP discovery for the Nobø Ecohub via Glen Dimplex Nordic's MAC OUI (`7C:83:06:*`) plus the `Hub*` hostname prefix that the hub broadcasts in its DHCP packet.

The flow sets the hub's MAC (formatted) as the temporary `unique_id` so the frontend offers an "Ignore" option and a previously-ignored MAC aborts cleanly on rediscovery; the `unique_id` is replaced with the full 12-digit serial when the entry is created. Paths from there:

- **Fast path** — if a configured entry already has this MAC stored, refresh its IP and abort. Skips the UDP broadcast wait.
- Device is already ignored.
- **IP+prefix match** — listen 15 s for the hub's UDP broadcast to learn the 9-digit serial prefix. If a configured entry's stored IP and prefix both match the DHCP packet, backfill its MAC and abort. Requiring IP match prevents clobbering a sibling entry from the same production batch.
- Otherwise route to the existing `selected` step so the user can supply the 3-digit suffix.

The hub's MAC is stored in `entry.data` and surfaced in `DeviceInfo.connections` via `format_mac()`. Existing entries get `mac=None` from a v1.3→v1.4 minor-version migration and are backfilled the next time DHCP fires for that hub.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
