### PR TITLE
Change vacuum template config names for clean area

### DIFF
--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 from homeassistant.components.vacuum import (
     ATTR_FAN_SPEED,
     DOMAIN as VACUUM_DOMAIN,
-    SERVICE_CLEAN_AREA,
     SERVICE_CLEAN_SPOT,
     SERVICE_LOCATE,
     SERVICE_PAUSE,
@@ -60,13 +59,14 @@ from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_VACUUMS = "vacuums"
 CONF_BATTERY_LEVEL = "battery_level"
 CONF_BATTERY_LEVEL_TEMPLATE = "battery_level_template"
-CONF_FAN_SPEED_LIST = "fan_speeds"
+CONF_CLEAN_SEGMENTS = "clean_segments"
 CONF_FAN_SPEED = "fan_speed"
+CONF_FAN_SPEED_LIST = "fan_speeds"
 CONF_FAN_SPEED_TEMPLATE = "fan_speed_template"
 CONF_SEGMENTS = "segments"
+CONF_VACUUMS = "vacuums"
 
 DEFAULT_NAME = "Template Vacuum"
 
@@ -79,7 +79,7 @@ LEGACY_FIELDS = {
 }
 
 SCRIPT_FIELDS = (
-    SERVICE_CLEAN_AREA,
+    CONF_CLEAN_SEGMENTS,
     SERVICE_CLEAN_SPOT,
     SERVICE_LOCATE,
     SERVICE_PAUSE,
@@ -100,7 +100,7 @@ VACUUM_COMMON_SCHEMA = vol.Schema(
         vol.Inclusive(
             CONF_SEGMENTS,
             CLEAN_AREA_GROUP,
-            f"Options `{CONF_SEGMENTS}` and `{SERVICE_CLEAN_AREA}` must both exist",
+            f"Options `{CONF_SEGMENTS}` and `{CONF_CLEAN_SEGMENTS}` must both exist",
         ): cv.template,
         vol.Optional(SERVICE_CLEAN_SPOT): cv.SCRIPT_SCHEMA,
         vol.Optional(SERVICE_LOCATE): cv.SCRIPT_SCHEMA,
@@ -110,9 +110,9 @@ VACUUM_COMMON_SCHEMA = vol.Schema(
         vol.Required(SERVICE_START): cv.SCRIPT_SCHEMA,
         vol.Optional(SERVICE_STOP): cv.SCRIPT_SCHEMA,
         vol.Inclusive(
-            SERVICE_CLEAN_AREA,
+            CONF_CLEAN_SEGMENTS,
             CLEAN_AREA_GROUP,
-            f"Options `{CONF_SEGMENTS}` and `{SERVICE_CLEAN_AREA}` must both exist",
+            f"Options `{CONF_SEGMENTS}` and `{CONF_CLEAN_SEGMENTS}` must both exist",
         ): cv.SCRIPT_SCHEMA,
     }
 )
@@ -125,7 +125,7 @@ VACUUM_YAML_SCHEMA = vol.All(
         ).schema
     ),
     cv.key_dependency(CONF_SEGMENTS, CONF_UNIQUE_ID),
-    cv.key_dependency(SERVICE_CLEAN_AREA, CONF_UNIQUE_ID),
+    cv.key_dependency(CONF_CLEAN_SEGMENTS, CONF_UNIQUE_ID),
 )
 
 VACUUM_LEGACY_YAML_SCHEMA = vol.All(
@@ -339,7 +339,7 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
             (SERVICE_CLEAN_SPOT, VacuumEntityFeature.CLEAN_SPOT),
             (SERVICE_LOCATE, VacuumEntityFeature.LOCATE),
             (SERVICE_SET_FAN_SPEED, VacuumEntityFeature.FAN_SPEED),
-            (SERVICE_CLEAN_AREA, VacuumEntityFeature.CLEAN_AREA),
+            (CONF_CLEAN_SEGMENTS, VacuumEntityFeature.CLEAN_AREA),
         ):
             if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
@@ -367,7 +367,7 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
         if self._attr_assumed_state:
             self._attr_activity = VacuumActivity.CLEANING
             self.async_write_ha_state()
-        if script := self._action_scripts.get(SERVICE_CLEAN_AREA):
+        if script := self._action_scripts.get(CONF_CLEAN_SEGMENTS):
             await self.async_run_script(
                 script,
                 run_variables={"segment_ids": segment_ids},

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -66,7 +66,7 @@ CONF_BATTERY_LEVEL_TEMPLATE = "battery_level_template"
 CONF_FAN_SPEED_LIST = "fan_speeds"
 CONF_FAN_SPEED = "fan_speed"
 CONF_FAN_SPEED_TEMPLATE = "fan_speed_template"
-CONF_SEGMENTS_TEMPLATE = "segments_template"
+CONF_SEGMENTS = "segments"
 
 DEFAULT_NAME = "Template Vacuum"
 
@@ -98,9 +98,9 @@ VACUUM_COMMON_SCHEMA = vol.Schema(
         vol.Optional(CONF_FAN_SPEED): cv.template,
         vol.Optional(CONF_STATE): cv.template,
         vol.Inclusive(
-            CONF_SEGMENTS_TEMPLATE,
+            CONF_SEGMENTS,
             CLEAN_AREA_GROUP,
-            f"Options `{CONF_SEGMENTS_TEMPLATE}` and `{SERVICE_CLEAN_AREA}` must both exist",
+            f"Options `{CONF_SEGMENTS}` and `{SERVICE_CLEAN_AREA}` must both exist",
         ): cv.template,
         vol.Optional(SERVICE_CLEAN_SPOT): cv.SCRIPT_SCHEMA,
         vol.Optional(SERVICE_LOCATE): cv.SCRIPT_SCHEMA,
@@ -112,7 +112,7 @@ VACUUM_COMMON_SCHEMA = vol.Schema(
         vol.Inclusive(
             SERVICE_CLEAN_AREA,
             CLEAN_AREA_GROUP,
-            f"Options `{CONF_SEGMENTS_TEMPLATE}` and `{SERVICE_CLEAN_AREA}` must both exist",
+            f"Options `{CONF_SEGMENTS}` and `{SERVICE_CLEAN_AREA}` must both exist",
         ): cv.SCRIPT_SCHEMA,
     }
 )
@@ -124,7 +124,7 @@ VACUUM_YAML_SCHEMA = vol.All(
             VACUUM_DOMAIN, DEFAULT_NAME
         ).schema
     ),
-    cv.key_dependency(CONF_SEGMENTS_TEMPLATE, CONF_UNIQUE_ID),
+    cv.key_dependency(CONF_SEGMENTS, CONF_UNIQUE_ID),
     cv.key_dependency(SERVICE_CLEAN_AREA, CONF_UNIQUE_ID),
 )
 
@@ -318,9 +318,9 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
         )
 
         self.setup_template(
-            CONF_SEGMENTS_TEMPLATE,
+            CONF_SEGMENTS,
             "_segments",
-            validate_segments(self, CONF_SEGMENTS_TEMPLATE),
+            validate_segments(self, CONF_SEGMENTS),
             self._update_segments,
         )
 

--- a/tests/components/template/test_helpers.py
+++ b/tests/components/template/test_helpers.py
@@ -57,9 +57,9 @@ from homeassistant.components.template.update import (
     SCRIPT_FIELDS as UPDATE_SCRIPT_FIELDS,
 )
 from homeassistant.components.template.vacuum import (
+    CONF_CLEAN_SEGMENTS as VACUUM_CLEAN_SEGMENTS,
     LEGACY_FIELDS as VACUUM_LEGACY_FIELDS,
     SCRIPT_FIELDS as VACUUM_SCRIPT_FIELDS,
-    SERVICE_CLEAN_AREA as VACUUM_SERVICE_CLEAN_AREA,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
@@ -582,7 +582,7 @@ async def _setup_and_test_yaml_device_action(
             [
                 service
                 for service in VACUUM_SCRIPT_FIELDS
-                if service != VACUUM_SERVICE_CLEAN_AREA
+                if service != VACUUM_CLEAN_SEGMENTS
             ],
             {
                 "fan_speeds": ["low", "medium", "high"],
@@ -783,7 +783,7 @@ async def test_yaml_device_actions_modern_config(
             [
                 service
                 for service in VACUUM_SCRIPT_FIELDS
-                if service != VACUUM_SERVICE_CLEAN_AREA
+                if service != VACUUM_CLEAN_SEGMENTS
             ],
             {
                 "fan_speeds": ["low", "medium", "high"],

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -1058,7 +1058,7 @@ async def test_not_optimistic(
     [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
 @pytest.mark.usefixtures("setup_vacuum")
-async def test_clean_segments(
+async def test_clean_area(
     hass: HomeAssistant,
     calls: list[ServiceCall],
     entity_registry: er.EntityRegistry,

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -7,7 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import template, vacuum
-from homeassistant.components.template.vacuum import CONF_SEGMENTS, SERVICE_CLEAN_AREA
+from homeassistant.components.template.vacuum import CONF_CLEAN_SEGMENTS, CONF_SEGMENTS
 from homeassistant.components.vacuum import (
     ATTR_BATTERY_LEVEL,
     ATTR_FAN_SPEED,
@@ -69,7 +69,9 @@ SET_FAN_SPEED_ACTION = make_test_action(
 )
 START_ACTION = make_test_action("start")
 STOP_ACTION = make_test_action("stop")
-CLEAN_AREA_ACTION = make_test_action("clean_area", {"segment_ids": "{{ segment_ids }}"})
+CLEAN_SEGMENTS_ACTION = make_test_action(
+    "clean_segments", {"segment_ids": "{{ segment_ids }}"}
+)
 
 TEMPLATE_VACUUM_ACTIONS = {
     **START_ACTION,
@@ -1045,7 +1047,7 @@ async def test_not_optimistic(
             {
                 "unique_id": TEST_VACUUM.entity_id,
                 "start": [],
-                **CLEAN_AREA_ACTION,
+                **CLEAN_SEGMENTS_ACTION,
                 "segments": "{{ [{'id': '1', 'name': 'Livingroom'}, {'id': '2', 'name': 'Kitchen'}] }}",
             },
         )
@@ -1056,7 +1058,7 @@ async def test_not_optimistic(
     [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
 @pytest.mark.usefixtures("setup_vacuum")
-async def test_clean_area(
+async def test_clean_segments(
     hass: HomeAssistant,
     calls: list[ServiceCall],
     entity_registry: er.EntityRegistry,
@@ -1076,7 +1078,7 @@ async def test_clean_area(
 
     await common.async_clean_area(hass, ["area_1"], TEST_VACUUM.entity_id)
     await hass.async_block_till_done()
-    assert_action(TEST_VACUUM, calls, 1, "clean_area", segment_ids=["1", "2"])
+    assert_action(TEST_VACUUM, calls, 1, "clean_segments", segment_ids=["1", "2"])
 
     state = hass.states.get(TEST_VACUUM.entity_id)
     assert state is not None
@@ -1090,7 +1092,7 @@ async def test_clean_area(
             1,
             {
                 "start": [],
-                **CLEAN_AREA_ACTION,
+                **CLEAN_SEGMENTS_ACTION,
             },
         )
     ],
@@ -1145,7 +1147,7 @@ async def test_get_segments(
             1,
             {
                 "start": [],
-                **CLEAN_AREA_ACTION,
+                **CLEAN_SEGMENTS_ACTION,
             },
         )
     ],
@@ -1228,7 +1230,7 @@ async def test_invalid_segments(
             {
                 "unique_id": TEST_VACUUM.entity_id,
                 "start": [],
-                **CLEAN_AREA_ACTION,
+                **CLEAN_SEGMENTS_ACTION,
                 "segments": "{{ [ {'id': '1', 'name': 'Kitchen'}, {'id': '2', 'name': states('sensor.test_attribute')}] }}",
             },
         )
@@ -1268,7 +1270,7 @@ async def test_raise_segments_changed_issue(
     [
         (
             {**START_ACTION},
-            f"Options `{CONF_SEGMENTS}` and `{SERVICE_CLEAN_AREA}` must both exist",
+            f"Options `{CONF_SEGMENTS}` and `{CONF_CLEAN_SEGMENTS}` must both exist",
         ),
     ],
 )
@@ -1283,7 +1285,7 @@ async def test_raise_segments_changed_issue(
         ),
         (
             0,
-            {**CLEAN_AREA_ACTION},
+            {**CLEAN_SEGMENTS_ACTION},
         ),
     ],
 )
@@ -1309,7 +1311,7 @@ async def test_segments_part_config(
     [
         {
             **START_ACTION,
-            **CLEAN_AREA_ACTION,
+            **CLEAN_SEGMENTS_ACTION,
             "segments": "{{ [{'id': '1', 'name': 'Kitchen'}] }}",
         },
     ],

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -7,10 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import template, vacuum
-from homeassistant.components.template.vacuum import (
-    CONF_SEGMENTS_TEMPLATE,
-    SERVICE_CLEAN_AREA,
-)
+from homeassistant.components.template.vacuum import CONF_SEGMENTS, SERVICE_CLEAN_AREA
 from homeassistant.components.vacuum import (
     ATTR_BATTERY_LEVEL,
     ATTR_FAN_SPEED,
@@ -1049,7 +1046,7 @@ async def test_not_optimistic(
                 "unique_id": TEST_VACUUM.entity_id,
                 "start": [],
                 **CLEAN_AREA_ACTION,
-                "segments_template": "{{ [{'id': '1', 'name': 'Livingroom'}, {'id': '2', 'name': 'Kitchen'}] }}",
+                "segments": "{{ [{'id': '1', 'name': 'Livingroom'}, {'id': '2', 'name': 'Kitchen'}] }}",
             },
         )
     ],
@@ -1108,7 +1105,7 @@ async def test_clean_area(
         (
             {
                 "unique_id": TEST_VACUUM.entity_id,
-                "segments_template": "{{ ["
+                "segments": "{{ ["
                 "{'id': '1', 'name': 'Kitchen'}, "
                 "{'id': '2', 'name': 'Bedroom', 'group': 'Upstairs'}"
                 "] }}",
@@ -1163,46 +1160,46 @@ async def test_get_segments(
         (
             {
                 "unique_id": TEST_VACUUM.entity_id,
-                "segments_template": "{{ [ {'id': '1'} ] }}",
+                "segments": "{{ [ {'id': '1'} ] }}",
             },
             "expected dictionary with keys id, name and optional group and string values",
         ),
         (
             {
                 "unique_id": TEST_VACUUM.entity_id,
-                "segments_template": "{{ [ {'name': 'kitchen'} ] }}",
+                "segments": "{{ [ {'name': 'kitchen'} ] }}",
             },
             "expected dictionary with keys id, name and optional group and string values",
         ),
         (
             {
                 "unique_id": TEST_VACUUM.entity_id,
-                "segments_template": "{{ [ {} ] }}",
+                "segments": "{{ [ {} ] }}",
             },
             "expected dictionary with keys id, name and optional group and string values",
         ),
         (
             {
                 "unique_id": TEST_VACUUM.entity_id,
-                "segments_template": "{{ [ {'id': '1', 'name': 'Kitchen', 'extra_key': 'value'} ] }}",
+                "segments": "{{ [ {'id': '1', 'name': 'Kitchen', 'extra_key': 'value'} ] }}",
             },
             "expected dictionary with keys id, name and optional group and string values",
         ),
         (
-            {"unique_id": TEST_VACUUM.entity_id, "segments_template": "{{ [[]] }}"},
+            {"unique_id": TEST_VACUUM.entity_id, "segments": "{{ [[]] }}"},
             "expected dictionary with keys id, name and optional group and string values",
         ),
         (
             {
                 "unique_id": TEST_VACUUM.entity_id,
-                "segments_template": "{{ [ {'id': '1', 'name': 'Kitchen'}, [] ] }}",
+                "segments": "{{ [ {'id': '1', 'name': 'Kitchen'}, [] ] }}",
             },
             "expected dictionary with keys id, name and optional group and string values",
         ),
     ],
 )
 @pytest.mark.usefixtures("setup_test_vacuum_with_extra_config")
-async def test_invalid_segments_template(
+async def test_invalid_segments(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog_setup_text,
@@ -1232,7 +1229,7 @@ async def test_invalid_segments_template(
                 "unique_id": TEST_VACUUM.entity_id,
                 "start": [],
                 **CLEAN_AREA_ACTION,
-                "segments_template": "{{ [ {'id': '1', 'name': 'Kitchen'}, {'id': '2', 'name': states('sensor.test_attribute')}] }}",
+                "segments": "{{ [ {'id': '1', 'name': 'Kitchen'}, {'id': '2', 'name': states('sensor.test_attribute')}] }}",
             },
         )
     ],
@@ -1271,7 +1268,7 @@ async def test_raise_segments_changed_issue(
     [
         (
             {**START_ACTION},
-            f"Options `{CONF_SEGMENTS_TEMPLATE}` and `{SERVICE_CLEAN_AREA}` must both exist",
+            f"Options `{CONF_SEGMENTS}` and `{SERVICE_CLEAN_AREA}` must both exist",
         ),
     ],
 )
@@ -1281,7 +1278,7 @@ async def test_raise_segments_changed_issue(
         (
             0,
             {
-                "segments_template": "{{ [{'id': '1', 'name': 'Kitchen'}] }}",
+                "segments": "{{ [{'id': '1', 'name': 'Kitchen'}] }}",
             },
         ),
         (
@@ -1313,7 +1310,7 @@ async def test_segments_part_config(
         {
             **START_ACTION,
             **CLEAN_AREA_ACTION,
-            "segments_template": "{{ [{'id': '1', 'name': 'Kitchen'}] }}",
+            "segments": "{{ [{'id': '1', 'name': 'Kitchen'}] }}",
         },
     ],
 )
@@ -1323,7 +1320,7 @@ async def test_segments_part_config(
         (
             0,
             {},
-            f'key "{CONF_SEGMENTS_TEMPLATE}" requires key "{CONF_UNIQUE_ID}" to exist',
+            f'key "{CONF_SEGMENTS}" requires key "{CONF_UNIQUE_ID}" to exist',
         ),
         (1, {"unique_id": TEST_VACUUM.entity_id}, ""),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The vacuum template config names have changed. Technically a breaking change, but as the feature was introduced in this beta, no stable users are affected.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The vacuum template config names have changed to make them consistent:
- clean_area -> clean_segments
- segments_template -> segments

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45129
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
