### PR TITLE
Set subscription identifier to allow matching duplicate payloads with overlapping subscriptions

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1043,7 +1043,7 @@ class MQTT:
         subscribe_chain = chunked_or_all(
             pending_subscriptions.items(), MAX_SUBSCRIBES_PER_CALL
         )
-        if self.is_mqttv5 and pending_subscriptions:
+        if self.supports_subscriptions_identifiers and pending_subscriptions:
             bulk_properties = mqtt.Properties(packetType=mqtt.PacketTypes.SUBSCRIBE)  # type: ignore[no-untyped-call]
             bulk_properties.SubscriptionIdentifier = 1
         else:
@@ -1052,7 +1052,7 @@ class MQTT:
         self._pending_subscriptions = {}
 
         for topic, qos in pending_wildcard_subscriptions.items():
-            if self.is_mqttv5:
+            if self.supports_subscriptions_identifiers:
                 properties = mqtt.Properties(packetType=mqtt.PacketTypes.SUBSCRIBE)  # type: ignore[no-untyped-call]
                 properties.SubscriptionIdentifier = self._registered_subscriptions[
                     topic

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1217,7 +1217,7 @@ class MQTT:
 
     @lru_cache(None)  # pylint: disable=method-cache-max-size-none
     def _matching_subscriptions(
-        self, topic: str, identifiers: tuple[int,] | None
+        self, topic: str, identifiers: tuple[int, ...] | None
     ) -> list[Subscription]:
         subscriptions: list[Subscription] = []
         if topic in self._simple_subscriptions:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1028,8 +1028,6 @@ class MQTT:
         #
         # Since we do not know if a published value is retained we need to
         # (re)subscribe, to ensure retained messages are replayed
-        import paho.mqtt.client as mqtt  # noqa: PLC0415
-
         if not self._pending_subscriptions:
             return
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -439,7 +439,7 @@ class MQTT:
     _mqttc: AsyncMQTTClient
     _last_subscribe: float
     _mqtt_data: MqttData
-    supports_subscriptions_identifiers: bool = False
+    _supports_subscription_identifiers: bool = False
 
     def __init__(
         self, hass: HomeAssistant, config_entry: ConfigEntry, conf: ConfigType
@@ -1043,7 +1043,7 @@ class MQTT:
         subscribe_chain = chunked_or_all(
             pending_subscriptions.items(), MAX_SUBSCRIBES_PER_CALL
         )
-        if self.supports_subscriptions_identifiers and pending_subscriptions:
+        if self._supports_subscription_identifiers and pending_subscriptions:
             bulk_properties = mqtt.Properties(packetType=mqtt.PacketTypes.SUBSCRIBE)  # type: ignore[no-untyped-call]
             bulk_properties.SubscriptionIdentifier = 1
         else:
@@ -1052,7 +1052,7 @@ class MQTT:
         self._pending_subscriptions = {}
 
         for topic, qos in pending_wildcard_subscriptions.items():
-            if self.supports_subscriptions_identifiers:
+            if self._supports_subscription_identifiers:
                 properties = mqtt.Properties(packetType=mqtt.PacketTypes.SUBSCRIBE)  # type: ignore[no-untyped-call]
                 properties.SubscriptionIdentifier = self._registered_subscriptions[
                     topic
@@ -1168,11 +1168,11 @@ class MQTT:
                     "Please use a supported MQTT broker; got broker properties: %s",
                     properties,
                 )
-                self.supports_subscriptions_identifiers = False
+                self._supports_subscription_identifiers = False
             else:
-                self.supports_subscriptions_identifiers = True
+                self._supports_subscription_identifiers = True
         else:
-            self.supports_subscriptions_identifiers = False
+            self._supports_subscription_identifiers = False
 
         if reason_code.is_failure:
             # 24: Continue authentication
@@ -1267,7 +1267,7 @@ class MQTT:
         self, _mqttc: mqtt.Client, _userdata: None, msg: mqtt.MQTTMessage
     ) -> None:
         identifiers: tuple[int, ...] | None = None
-        if self.supports_subscriptions_identifiers:
+        if self._supports_subscription_identifiers:
             # It is possible we have multiple messages if there
             # are overlapping wildcard subscriptions.
             # So we assigned all wildcard subscriptions with a

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -481,7 +481,6 @@ class MQTT:
 
         self._max_qos: defaultdict[str, int] = defaultdict(int)  # topic, max qos
         self._pending_subscriptions: dict[str, int] = {}  # topic, qos
-        self._registered_subscriptions: dict[str, int] = {}  # topic, subscription_id
         self._unsubscribe_debouncer = EnsureJobAfterCooldown(
             UNSUBSCRIBE_COOLDOWN, self._async_perform_unsubscribes
         )
@@ -856,8 +855,8 @@ class MQTT:
     ) -> None:
         """Restore tracked subscriptions after reload."""
         for subscription in subscriptions:
-            self._registered_subscriptions[subscription.topic] = (
-                subscription.subscription_id
+            self._mqtt_data.subscription_id_generator.restore(
+                subscription.subscription_id, subscription.topic
             )
             self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()
@@ -966,11 +965,9 @@ class MQTT:
 
         if is_simple_match:
             subscription_id = 1
-        elif topic in self._registered_subscriptions:
-            subscription_id = self._registered_subscriptions[topic]
         else:
-            subscription_id = self._registered_subscriptions[topic] = (
-                self._mqtt_data.subscription_id_generator.generate()
+            subscription_id = self._mqtt_data.subscription_id_generator.get_or_generate(
+                topic
             )
 
         subscription = Subscription(
@@ -1054,9 +1051,9 @@ class MQTT:
         for topic, qos in pending_wildcard_subscriptions.items():
             if self._supports_subscription_identifiers:
                 properties = mqtt.Properties(packetType=mqtt.PacketTypes.SUBSCRIBE)  # type: ignore[no-untyped-call]
-                properties.SubscriptionIdentifier = self._registered_subscriptions[
-                    topic
-                ]
+                properties.SubscriptionIdentifier = (
+                    self._mqtt_data.subscription_id_generator.get_subscription_id(topic)
+                )
             else:
                 properties = None
 
@@ -1115,9 +1112,7 @@ class MQTT:
 
         # Remove stored subscription identifiers for topics that were just unsubscribed
         for topic in topics:
-            self._mqtt_data.subscription_id_generator.release(
-                self._registered_subscriptions.pop(topic, None)
-            )
+            self._mqtt_data.subscription_id_generator.release(topic)
 
     async def _async_resubscribe_and_publish_birth_message(
         self, birth_message: PublishMessage

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1243,15 +1243,9 @@ class MQTT:
     ) -> list[Subscription]:
         subscriptions: list[Subscription] = []
         if topic in self._simple_subscriptions:
-            simple_subscriptions_for_topic = self._simple_subscriptions[topic]
-            if identifiers is None:
-                subscriptions.extend(simple_subscriptions_for_topic)
-            else:
-                subscriptions.extend(
-                    subscription
-                    for subscription in simple_subscriptions_for_topic
-                    if subscription.subscription_id in identifiers
-                )
+            # The subscription identifier is always 1 for simple subscriptions,
+            # so there is no need to check for the subscription identifier
+            subscriptions.extend(self._simple_subscriptions[topic])
         subscriptions.extend(
             subscription
             for subscription in self._wildcard_subscriptions
@@ -1273,9 +1267,10 @@ class MQTT:
             # So we assigned all wildcard subscriptions with a
             # unique SubscriptionIdentifier. Simple subscriptions are assigned
             # with SubscriptionIdentifier 1.
-            if msg.properties is not None and hasattr(
-                msg.properties, "SubscriptionIdentifier"
-            ):
+            if TYPE_CHECKING:
+                assert msg.properties is not None
+                assert hasattr(msg.properties, "SubscriptionIdentifier")
+            with contextlib.suppress(AttributeError):
                 identifiers = tuple(msg.properties.SubscriptionIdentifier)
         try:
             # msg.topic is a property that decodes the topic to a string

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -994,15 +994,15 @@ class MQTT:
             del self._retained_topics[subscription]
         # Only unsubscribe if currently connected
         if self.connected:
-            self._async_unsubscribe(subscription.topic)
+            self._async_unsubscribe(subscription.topic, subscription.subscription_id)
 
     @callback
-    def _async_unsubscribe(self, topic: str) -> None:
+    def _async_unsubscribe(self, topic: str, subscription_id: int) -> None:
         """Unsubscribe from a topic."""
         if self.is_active_subscription(topic):
             if self._max_qos[topic] == 0:
                 return
-            subs = self._matching_subscriptions(topic)
+            subs = self._matching_subscriptions(topic, (subscription_id,))
             self._max_qos[topic] = max(sub.qos for sub in subs)
             # Other subscriptions on topic remaining - don't unsubscribe.
             return
@@ -1215,16 +1215,27 @@ class MQTT:
         )
 
     @lru_cache(None)  # pylint: disable=method-cache-max-size-none
-    def _matching_subscriptions(self, topic: str) -> list[Subscription]:
+    def _matching_subscriptions(
+        self, topic: str, identifiers: tuple[int,] | None
+    ) -> list[Subscription]:
         subscriptions: list[Subscription] = []
         if topic in self._simple_subscriptions:
-            subscriptions.extend(self._simple_subscriptions[topic])
+            simple_subscriptions_for_topic = self._simple_subscriptions[topic]
+            if identifiers is None:
+                subscriptions.extend(simple_subscriptions_for_topic)
+            else:
+                subscriptions.extend(
+                    subscription
+                    for subscription in simple_subscriptions_for_topic
+                    if subscription.subscription_id in identifiers
+                )
         subscriptions.extend(
             subscription
             for subscription in self._wildcard_subscriptions
             # mypy doesn't know that complex_matcher is always set when
             # is_simple_match is False
             if subscription.complex_matcher(topic)  # type: ignore[misc]
+            and (identifiers is None or subscription.subscription_id in identifiers)
         )
         return subscriptions
 
@@ -1232,7 +1243,7 @@ class MQTT:
     def _async_mqtt_on_message(
         self, _mqttc: mqtt.Client, _userdata: None, msg: mqtt.MQTTMessage
     ) -> None:
-        identifiers: list[int] | None = None
+        identifiers: tuple[int,] | None = None
         if self.is_mqttv5:
             # It is possible we have multiple messages if there
             # are overlapping wildcard subscriptions.
@@ -1242,7 +1253,7 @@ class MQTT:
             if msg.properties is not None and hasattr(
                 msg.properties, "SubscriptionIdentifier"
             ):
-                identifiers = msg.properties.SubscriptionIdentifier
+                identifiers = tuple(msg.properties.SubscriptionIdentifier)
         try:
             # msg.topic is a property that decodes the topic to a string
             # every time it is accessed. Save the result to avoid
@@ -1268,11 +1279,7 @@ class MQTT:
         )
         msg_cache_by_subscription_topic: dict[str, ReceiveMessage] = {}
 
-        for subscription in [
-            subscription
-            for subscription in self._matching_subscriptions(topic)
-            if identifiers is None or subscription.subscription_id in identifiers
-        ]:
+        for subscription in self._matching_subscriptions(topic, identifiers):
             if msg.retain:
                 retained_topics = self._retained_topics[subscription]
                 # Skip if the subscription already received a retained message

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -439,6 +439,7 @@ class MQTT:
     _mqttc: AsyncMQTTClient
     _last_subscribe: float
     _mqtt_data: MqttData
+    supports_subscriptions_identifiers: bool = False
 
     def __init__(
         self, hass: HomeAssistant, config_entry: ConfigEntry, conf: ConfigType
@@ -1150,6 +1151,27 @@ class MQTT:
         Resubscribe to all topics we were subscribed to and publish birth
         message.
         """
+        if self.is_mqttv5:
+            # Check if the server explicitly disabled Subscription Identifiers
+            if (
+                properties is not None
+                and hasattr(properties, "SubscriptionIdentifierAvailable")
+                and properties.SubscriptionIdentifierAvailable == 0
+            ):
+                _LOGGER.warning(
+                    "Your MQTT broker reports it does not support "
+                    "Subscription Identifiers, see "
+                    "https://docs.oasis-open.org/"
+                    "mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901092. "
+                    "Please use a supported MQTT broker; got broker properties: %s",
+                    properties,
+                )
+                self.supports_subscriptions_identifiers = False
+            else:
+                self.supports_subscriptions_identifiers = True
+        else:
+            self.supports_subscriptions_identifiers = False
+
         if reason_code.is_failure:
             # 24: Continue authentication
             # 25: Re-authenticate
@@ -1243,7 +1265,7 @@ class MQTT:
         self, _mqttc: mqtt.Client, _userdata: None, msg: mqtt.MQTTMessage
     ) -> None:
         identifiers: tuple[int,] | None = None
-        if self.is_mqttv5:
+        if self.supports_subscriptions_identifiers:
             # It is possible we have multiple messages if there
             # are overlapping wildcard subscriptions.
             # So we assigned all wildcard subscriptions with a

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1242,9 +1242,11 @@ class MQTT:
         self, topic: str, identifiers: tuple[int, ...] | None
     ) -> list[Subscription]:
         subscriptions: list[Subscription] = []
-        if topic in self._simple_subscriptions:
+        if topic in self._simple_subscriptions and (
+            identifiers is None or 1 in identifiers
+        ):
             # The subscription identifier is always 1 for simple subscriptions,
-            # so there is no need to check for the subscription identifier
+            # so only include them when no identifiers are provided or 1 matches.
             subscriptions.extend(self._simple_subscriptions[topic])
         subscriptions.extend(
             subscription

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -855,6 +855,9 @@ class MQTT:
     ) -> None:
         """Restore tracked subscriptions after reload."""
         for subscription in subscriptions:
+            self._registered_subscriptions[subscription.topic] = (
+                subscription.subscription_id
+            )
             self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -110,7 +110,6 @@ TIMEOUT_ACK = 10
 SUBSCRIBE_TIMEOUT = 10
 RECONNECT_INTERVAL_SECONDS = 10
 
-MAX_WILDCARD_SUBSCRIBES_PER_CALL = 1
 MAX_SUBSCRIBES_PER_CALL = 500
 MAX_UNSUBSCRIBES_PER_CALL = 500
 
@@ -331,8 +330,9 @@ class Subscription:
     is_simple_match: bool
     complex_matcher: Callable[[str], bool] | None
     job: HassJob[[ReceiveMessage], Coroutine[Any, Any, None] | None]
-    qos: int = 0
-    encoding: str | None = "utf-8"
+    qos: int
+    encoding: str | None
+    subscription_id: int
 
 
 class MqttClientSetup:
@@ -480,6 +480,7 @@ class MQTT:
 
         self._max_qos: defaultdict[str, int] = defaultdict(int)  # topic, max qos
         self._pending_subscriptions: dict[str, int] = {}  # topic, qos
+        self._registered_subscriptions: dict[str, int] = {}  # topic, subscription_id
         self._unsubscribe_debouncer = EnsureJobAfterCooldown(
             UNSUBSCRIBE_COOLDOWN, self._async_perform_unsubscribes
         )
@@ -959,7 +960,19 @@ class MQTT:
         is_simple_match = not ("+" in topic or "#" in topic)
         matcher = None if is_simple_match else _matcher_for_topic(topic)
 
-        subscription = Subscription(topic, is_simple_match, matcher, job, qos, encoding)
+        if is_simple_match:
+            subscription_id = 1
+        elif topic in self._registered_subscriptions:
+            subscription_id = self._registered_subscriptions[topic]
+        else:
+            subscription_id = self._registered_subscriptions[topic] = (
+                self._mqtt_data.subscription_id_generator.generate()
+            )
+
+        subscription = Subscription(
+            topic, is_simple_match, matcher, job, qos, encoding, subscription_id
+        )
+
         self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()
 
@@ -1012,33 +1025,61 @@ class MQTT:
         #
         # Since we do not know if a published value is retained we need to
         # (re)subscribe, to ensure retained messages are replayed
+        import paho.mqtt.client as mqtt  # noqa: PLC0415
 
         if not self._pending_subscriptions:
             return
 
         # Split out the wildcard subscriptions, we subscribe to them one by one
+        debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         pending_subscriptions: dict[str, int] = self._pending_subscriptions
         pending_wildcard_subscriptions = {
             subscription.topic: pending_subscriptions.pop(subscription.topic)
             for subscription in self._wildcard_subscriptions
             if subscription.topic in pending_subscriptions
         }
+        subscribe_chain = chunked_or_all(
+            pending_subscriptions.items(), MAX_SUBSCRIBES_PER_CALL
+        )
+        if self.is_mqttv5 and pending_subscriptions:
+            bulk_properties = mqtt.Properties(packetType=mqtt.PacketTypes.SUBSCRIBE)  # type: ignore[no-untyped-call]
+            bulk_properties.SubscriptionIdentifier = 1
+        else:
+            bulk_properties = None
 
         self._pending_subscriptions = {}
 
-        debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
+        for topic, qos in pending_wildcard_subscriptions.items():
+            if self.is_mqttv5:
+                properties = mqtt.Properties(packetType=mqtt.PacketTypes.SUBSCRIBE)  # type: ignore[no-untyped-call]
+                properties.SubscriptionIdentifier = self._registered_subscriptions[
+                    topic
+                ]
+            else:
+                properties = None
 
-        for chunk in chain(
-            chunked_or_all(
-                pending_wildcard_subscriptions.items(), MAX_WILDCARD_SUBSCRIBES_PER_CALL
-            ),
-            chunked_or_all(pending_subscriptions.items(), MAX_SUBSCRIBES_PER_CALL),
-        ):
+            result, mid = self._mqttc.subscribe(topic, qos, properties=properties)
+            if debug_enabled:
+                _LOGGER.debug(
+                    "Subscribing with mid: %s to topic %s with qos: %s and properties: %s",
+                    mid,
+                    topic,
+                    qos,
+                    properties,
+                )
+            self._last_subscribe = time.monotonic()
+
+            await self._async_wait_for_mid_or_raise(mid, result)
+            async_dispatcher_send(
+                self.hass, MQTT_PROCESSED_SUBSCRIPTIONS, [(topic, qos)]
+            )
+
+        for chunk in subscribe_chain:
             chunk_list = list(chunk)
             if not chunk_list:
                 continue
 
-            result, mid = self._mqttc.subscribe(chunk_list)
+            result, mid = self._mqttc.subscribe(chunk_list, properties=bulk_properties)
 
             if debug_enabled:
                 _LOGGER.debug(
@@ -1068,6 +1109,10 @@ class MQTT:
                 )
 
             await self._async_wait_for_mid_or_raise(mid, result)
+
+        # Flush subscription identifiers if they are available
+        for topic in topics:
+            self._registered_subscriptions.pop(topic, None)
 
     async def _async_resubscribe_and_publish_birth_message(
         self, birth_message: PublishMessage
@@ -1184,6 +1229,17 @@ class MQTT:
     def _async_mqtt_on_message(
         self, _mqttc: mqtt.Client, _userdata: None, msg: mqtt.MQTTMessage
     ) -> None:
+        identifiers: list[int] | None = None
+        if self.is_mqttv5:
+            # It is possible we have multiple messages if there
+            # are overlapping wildcard subscriptions.
+            # So we assigned all wildcard subscriptions with a
+            # unique SubscriptionIdentifier. Simple subscriptions are assigned
+            # with SubscriptionIdentifier 1.
+            if msg.properties is not None and hasattr(
+                msg.properties, "SubscriptionIdentifier"
+            ):
+                identifiers = msg.properties.SubscriptionIdentifier
         try:
             # msg.topic is a property that decodes the topic to a string
             # every time it is accessed. Save the result to avoid
@@ -1200,16 +1256,20 @@ class MQTT:
             )
             return
         _LOGGER.debug(
-            "Received%s message on %s (qos=%s): %s",
+            "Received%s message on %s (qos=%s) IDs=%s: %s",
             " retained" if msg.retain else "",
             topic,
             msg.qos,
+            identifiers,
             msg.payload[0:8192],
         )
-        subscriptions = self._matching_subscriptions(topic)
         msg_cache_by_subscription_topic: dict[str, ReceiveMessage] = {}
 
-        for subscription in subscriptions:
+        for subscription in [
+            subscription
+            for subscription in self._matching_subscriptions(topic)
+            if identifiers is None or subscription.subscription_id in identifiers
+        ]:
             if msg.retain:
                 retained_topics = self._retained_topics[subscription]
                 # Skip if the subscription already received a retained message

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1064,7 +1064,8 @@ class MQTT:
             result, mid = self._mqttc.subscribe(topic, qos, properties=properties)
             if debug_enabled:
                 _LOGGER.debug(
-                    "Subscribing with mid: %s to topic %s with qos: %s and properties: %s",
+                    "Subscribing with mid: %s to topic %s "
+                    "with qos: %s and properties: %s",
                     mid,
                     topic,
                     qos,

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1266,7 +1266,7 @@ class MQTT:
     def _async_mqtt_on_message(
         self, _mqttc: mqtt.Client, _userdata: None, msg: mqtt.MQTTMessage
     ) -> None:
-        identifiers: tuple[int,] | None = None
+        identifiers: tuple[int, ...] | None = None
         if self.supports_subscriptions_identifiers:
             # It is possible we have multiple messages if there
             # are overlapping wildcard subscriptions.

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1115,7 +1115,9 @@ class MQTT:
 
         # Remove stored subscription identifiers for topics that were just unsubscribed
         for topic in topics:
-            self._registered_subscriptions.pop(topic, None)
+            self._mqtt_data.subscription_id_generator.release(
+                self._registered_subscriptions.pop(topic, None)
+            )
 
     async def _async_resubscribe_and_publish_birth_message(
         self, birth_message: PublishMessage

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1112,7 +1112,7 @@ class MQTT:
 
             await self._async_wait_for_mid_or_raise(mid, result)
 
-        # Flush subscription identifiers if they are available
+        # Remove stored subscription identifiers for topics that were just unsubscribed
         for topic in topics:
             self._registered_subscriptions.pop(topic, None)
 
@@ -1143,7 +1143,7 @@ class MQTT:
         _userdata: None,
         _connect_flags: mqtt.ConnectFlags,
         reason_code: mqtt.ReasonCode,
-        _properties: mqtt.Properties | None = None,
+        properties: mqtt.Properties | None = None,
     ) -> None:
         """On connect callback.
 

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -13,7 +13,11 @@ from paho.mqtt.client import MQTTMessage
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, Platform
 from homeassistant.core import CALLBACK_TYPE, callback
-from homeassistant.exceptions import ServiceValidationError, TemplateError
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceValidationError,
+    TemplateError,
+)
 from homeassistant.helpers import template
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.service_info.mqtt import ReceivePayloadType
@@ -42,10 +46,20 @@ class PayloadSentinel(StrEnum):
     DEFAULT = "default"
 
 
+MAX_28BIT: int = 268435455
+
+
 class SubscriptionID:
     """ID generator for wildcard subscriptions."""
 
-    _id: int = 1
+    _next_id: int = 2
+    _used_ids: set[int]
+    _available_ids: set[int]
+
+    def __init__(self) -> None:
+        """Initialize the Subscription Identifier generator."""
+        self._used_ids = set()
+        self._available_ids = set()
 
     def generate(self) -> int:
         """Generate a new subscription ID.
@@ -54,8 +68,28 @@ class SubscriptionID:
         ID 1 is used for non wildcard topics.
         Generator starts at ID 2.
         """
-        self._id = self._id + 1
-        return self._id
+        if self._available_ids:
+            subscription_id = self._available_ids.pop()
+            self._used_ids.add(subscription_id)
+            return subscription_id
+
+        subscription_id = self._next_id
+        self._used_ids.add(self._next_id)
+        if self._next_id > MAX_28BIT:
+            raise HomeAssistantError(
+                "MQTT Subscription ID limit reached. "
+                "Cannot generate more IDs to subscribe",
+                translation_domain=DOMAIN,
+                translation_key="mqtt_max_subscription_id_reached",
+            )
+        self._next_id += 1
+        return subscription_id
+
+    def release(self, subscription_id: int | None) -> None:
+        """Release a Subscription Identifier to allow reuse."""
+        if subscription_id and subscription_id in self._used_ids:
+            self._used_ids.remove(subscription_id)
+            self._available_ids.add(subscription_id)
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -55,19 +55,16 @@ class SubscriptionID:
     _next_id: int = 2
     _used_ids: set[int]
     _available_ids: set[int]
+    _registered_subscriptions: dict[str, int]  # topic, subscription_id
 
     def __init__(self) -> None:
         """Initialize the Subscription Identifier generator."""
         self._used_ids = set()
         self._available_ids = set()
+        self._registered_subscriptions = {}
 
-    def generate(self) -> int:
-        """Generate a new subscription ID.
-
-        ID 0 is reserved.
-        ID 1 is used for non wildcard topics.
-        Generator starts at ID 2.
-        """
+    def _generate(self, topic: str) -> int:
+        """Generate a new subscription ID."""
         if self._available_ids:
             subscription_id = self._available_ids.pop()
             self._used_ids.add(subscription_id)
@@ -83,13 +80,41 @@ class SubscriptionID:
             )
         self._used_ids.add(subscription_id)
         self._next_id += 1
+        self._registered_subscriptions[topic] = subscription_id
         return subscription_id
 
-    def release(self, subscription_id: int | None) -> None:
+    def get_subscription_id(self, topic: str) -> int:
+        """Get a registered subscription ID."""
+        return self._registered_subscriptions[topic]
+
+    def get_or_generate(self, topic: str) -> int:
+        """Get an existing or generate a new subscription ID.
+
+        ID 0 is reserved.
+        ID 1 is used for non wildcard topics.
+        Generator starts at ID 2.
+        """
+        if topic in self._registered_subscriptions:
+            return self._registered_subscriptions[topic]
+        return self._generate(topic)
+
+    def release(self, topic: str) -> None:
         """Release a Subscription Identifier to allow reuse."""
-        if subscription_id and subscription_id in self._used_ids:
+        if (
+            (subscription_id := self._registered_subscriptions.pop(topic, None))
+            is not None
+            and subscription_id
+            and subscription_id in self._used_ids
+        ):
             self._used_ids.remove(subscription_id)
             self._available_ids.add(subscription_id)
+
+    def restore(self, subscription_id: int | None, topic: str) -> None:
+        """Restore a subscription."""
+        if subscription_id is None:
+            return
+        self._registered_subscriptions[topic] = subscription_id
+        self._used_ids.add(subscription_id)
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -42,6 +42,22 @@ class PayloadSentinel(StrEnum):
     DEFAULT = "default"
 
 
+class SubscriptionID:
+    """ID generator for wildcard subscriptions."""
+
+    _id: int = 1
+
+    def generate(self) -> int:
+        """Generate a new subscription ID.
+
+        ID 0 is reserved.
+        ID 1 is used for non wildcard topics.
+        Generator starts at ID 2.
+        """
+        self._id = self._id + 1
+        return self._id
+
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_THIS = "this"
@@ -428,6 +444,7 @@ class MqttData:
     state_write_requests: EntityTopicState = field(default_factory=EntityTopicState)
     subscriptions_to_restore: set[Subscription] = field(default_factory=set)
     tags: dict[str, dict[str, MQTTTagScanner]] = field(default_factory=dict)
+    subscription_id_generator: SubscriptionID = field(default_factory=SubscriptionID)
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -74,14 +74,14 @@ class SubscriptionID:
             return subscription_id
 
         subscription_id = self._next_id
-        self._used_ids.add(self._next_id)
-        if self._next_id > MAX_28BIT:
+        if subscription_id > MAX_28BIT:
             raise HomeAssistantError(
                 "MQTT Subscription ID limit reached. "
                 "Cannot generate more IDs to subscribe",
                 translation_domain=DOMAIN,
                 translation_key="mqtt_max_subscription_id_reached",
             )
+        self._used_ids.add(subscription_id)
         self._next_id += 1
         return subscription_id
 

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -1099,6 +1099,9 @@
     "mqtt_broker_error": {
       "message": "Error talking to MQTT: {error_message}."
     },
+    "mqtt_max_subscription_id_reached": {
+      "message": "MQTT Subscription ID limit reached. Cannot generate more IDs to subscribe."
+    },
     "mqtt_message_expiry_interval_not_supported": {
       "message": "Publishing to topic {topic} with a Message Expiry Interval is not supported for protocol version {protocol}."
     },

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,7 +23,7 @@ import os
 import pathlib
 import time
 from types import FrameType, ModuleType
-from typing import Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Any, Literal, NoReturn
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.test_utils import unused_port as get_test_instance_port
@@ -121,6 +121,9 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 from .testing_config.custom_components.test_constant_deprecation import (
     import_deprecated_constant,
 )
+
+if TYPE_CHECKING:
+    import paho.mqtt.client as mqtt
 
 __all__ = [
     "async_get_device_automation_capabilities",
@@ -452,6 +455,7 @@ def async_fire_mqtt_message(
     payload: bytes | str,
     qos: int = 0,
     retain: bool = False,
+    properties: mqtt.Properties | None = None,
 ) -> None:
     """Fire the MQTT message."""
     from homeassistant.components.mqtt import MqttData  # noqa: PLC0415
@@ -464,6 +468,7 @@ def async_fire_mqtt_message(
     msg.qos = qos
     msg.retain = retain
     msg.timestamp = time.monotonic()
+    msg.properties = properties
 
     mqtt_data: MqttData = hass.data["mqtt"]
     assert mqtt_data.client

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1374,7 +1374,7 @@ async def test_logs_error_if_broker_does_not_support_subscription_identifiers(
     caplog: pytest.LogCaptureFixture,
     setup_with_birth_msg_client_mock: MqttMockPahoClient,
 ) -> None:
-    """Test for setup failure if connection to broker is missing."""
+    """Test logging an error if the broker reports Subscription Identifiers are disabled."""
     mqtt_client_mock = setup_with_birth_msg_client_mock
     mqtt_client_mock.on_disconnect(Mock(), None, None, MockMqttReasonCode())
     properties = paho_mqtt.Properties(paho_mqtt.PacketTypes.CONNACK)

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -2588,3 +2588,44 @@ async def test_overlapping_subscriptions_only_processed_once(
             await hass.async_block_till_done()
         # Each sensor should receive one update, so we should have 3 state write calls
         assert len(mock_async_ha_write_state.mock_calls) == 3
+
+
+async def test_subscriptions_id_generation(hass: HomeAssistant) -> None:
+    """Test subscription identifier generation."""
+
+    generator = mqtt.models.SubscriptionID()
+    # Mock we are past the last subscriptions
+    generator._next_id = mqtt.models.MAX_28BIT - 2
+    new_id_1 = generator.generate()
+    assert new_id_1 == mqtt.models.MAX_28BIT - 2
+    new_id_2 = generator.generate()
+    assert new_id_2 == mqtt.models.MAX_28BIT - 1
+    new_id_3 = generator.generate()
+    assert new_id_3 == mqtt.models.MAX_28BIT
+    with pytest.raises(HomeAssistantError) as exc:
+        generator.generate()
+    assert exc.value.translation_domain == mqtt.DOMAIN
+    assert exc.value.translation_key == "mqtt_max_subscription_id_reached"
+
+    generator.release(new_id_2)
+    new_id_4 = generator.generate()
+    # Check we reused the ID
+    assert new_id_4 == mqtt.models.MAX_28BIT - 1
+
+    with pytest.raises(HomeAssistantError) as exc:
+        generator.generate()
+    assert exc.value.translation_domain == mqtt.DOMAIN
+    assert exc.value.translation_key == "mqtt_max_subscription_id_reached"
+
+    generator.release(new_id_1)
+    generator.release(new_id_3)
+
+    new_id_5 = generator.generate()
+    new_id_6 = generator.generate()
+
+    assert {new_id_5, new_id_6} == {new_id_1, new_id_3}
+
+    with pytest.raises(HomeAssistantError) as exc:
+        generator.generate()
+    assert exc.value.translation_domain == mqtt.DOMAIN
+    assert exc.value.translation_key == "mqtt_max_subscription_id_reached"

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import timedelta
+import json
 import socket
 import ssl
 import time
@@ -1104,16 +1105,16 @@ async def test_unsubscribe_race(
     # We allow either calls [subscribe, unsubscribe, subscribe], [subscribe, subscribe] or
     # when both subscriptions were combined [subscribe]
     expected_calls_1 = [
-        call.subscribe([("test/state", 0)]),
+        call.subscribe([("test/state", 0)], properties=None),
         call.unsubscribe("test/state"),
-        call.subscribe([("test/state", 0)]),
+        call.subscribe([("test/state", 0)], properties=None),
     ]
     expected_calls_2 = [
-        call.subscribe([("test/state", 0)]),
-        call.subscribe([("test/state", 0)]),
+        call.subscribe([("test/state", 0)], properties=None),
+        call.subscribe([("test/state", 0)], properties=None),
     ]
     expected_calls_3 = [
-        call.subscribe([("test/state", 0)]),
+        call.subscribe([("test/state", 0)], properties=None),
     ]
     assert mqtt_client_mock.mock_calls in (
         expected_calls_1,
@@ -1181,7 +1182,7 @@ async def test_restore_all_active_subscriptions_on_reconnect(
 
     # the subscription with the highest QoS should survive
     expected = [
-        call([("test/state", 2)]),
+        call([("test/state", 2)], properties=None),
     ]
     assert mqtt_client_mock.subscribe.mock_calls == expected
 
@@ -1195,7 +1196,7 @@ async def test_restore_all_active_subscriptions_on_reconnect(
     # wait for cooldown
     await mock_debouncer.wait()
 
-    expected.append(call([("test/state", 1)]))
+    expected.append(call([("test/state", 1)], properties=None))
     for expected_call in expected:
         assert mqtt_client_mock.subscribe.hass_call(expected_call)
 
@@ -1387,7 +1388,7 @@ async def test_subscribe_error(
     mqtt_client_mock = setup_with_birth_msg_client_mock
     mqtt_client_mock.reset_mock()
     # simulate client is not connected error before subscribing
-    mqtt_client_mock.subscribe.side_effect = lambda *args: (4, None)
+    mqtt_client_mock.subscribe.side_effect = lambda *args, **kwargs: (4, 0)
     await mqtt.async_subscribe(hass, "some-topic", record_calls)
     while mqtt_client_mock.subscribe.call_count == 0:
         await hass.async_block_till_done()
@@ -2384,3 +2385,89 @@ async def test_loop_write_failure(
 
     # Cleanup. Server is closed earlier already.
     client.close()
+
+
+@pytest.mark.parametrize(
+    ("mqtt_config_entry_data", "mqtt_config_entry_options"),
+    [
+        (
+            {
+                mqtt.CONF_BROKER: "mock-broker",
+                CONF_PROTOCOL: "5",
+            },
+            ENTRY_DEFAULT_BIRTH_MESSAGE,
+        ),
+    ],
+    ids=["v5"],
+)
+async def test_overlapping_subscriptions_only_processed_once(
+    hass: HomeAssistant,
+    setup_with_birth_msg_client_mock: MqttMockPahoClient,
+) -> None:
+    """Test message are only processed once per subscription in case of overlap.
+
+    Overlapping subscriptions are only supported with MQTTv5
+    """
+    mqtt_client_mock = setup_with_birth_msg_client_mock
+    assert mqtt_client_mock.connect.call_count == 1
+
+    mock_subscribe: MagicMock = mqtt_client_mock.subscribe
+    mock_subscribe.reset_mock()
+
+    # We create 3 sensors:
+    # - 2 with an overlapping wildcard subscription
+    # - 1 with an overlapping simple subscription
+    config1 = json.dumps(
+        {
+            "name": "test1",
+            "default_entity_id": "sensor.test1",
+            "unique_id": "test1_veryunique",
+            "state_topic": "test/+/status",
+        }
+    )
+    config2 = json.dumps(
+        {
+            "name": "test2",
+            "default_entity_id": "sensor.test2",
+            "unique_id": "test2_veryunique",
+            "state_topic": "test/#",
+        }
+    )
+    config3 = json.dumps(
+        {
+            "name": "test3",
+            "default_entity_id": "sensor.test3",
+            "unique_id": "test3_veryunique",
+            "state_topic": "test/bla/status",
+        }
+    )
+
+    async_fire_mqtt_message(hass, "homeassistant/sensor/config1/config", config1)
+    async_fire_mqtt_message(hass, "homeassistant/sensor/config2/config", config2)
+    async_fire_mqtt_message(hass, "homeassistant/sensor/config3/config", config3)
+    while len(mock_subscribe.mock_calls) < 3:
+        await hass.async_block_till_done()
+
+    message_identifiers = [
+        mock_call[2]["properties"].SubscriptionIdentifier[0]
+        for mock_call in mock_subscribe.mock_calls
+    ]
+
+    assert hass.states.get("sensor.test1") is not None
+    assert hass.states.get("sensor.test2") is not None
+    assert hass.states.get("sensor.test3") is not None
+
+    with patch(
+        "homeassistant.components.mqtt.entity.MqttEntity.async_write_ha_state"
+    ) as mock_async_ha_write_state:
+        # Simulate the broker sends a publish message at topic "test/bla/status"
+        # That matches all three subscriptions
+        for message_identifier in message_identifiers:
+            properties = paho_mqtt.Properties(paho_mqtt.PacketTypes.SUBSCRIBE)
+            properties.SubscriptionIdentifier = message_identifier
+            async_fire_mqtt_message(
+                hass, "test/bla/status", "bla", properties=properties
+            )
+            await hass.async_block_till_done()
+        # Each sensor should receive one update, so we should have 3 state write calls
+        assert len(mock_async_ha_write_state.mock_calls) == 3

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1088,6 +1088,7 @@ async def test_not_calling_subscribe_when_unsubscribed_within_cooldown(
             CONF_PROTOCOL: "5",
         },
     ],
+    ids=["v3.1", "v3.1.1", "v5"],
 )
 async def test_unsubscribe_race(
     hass: HomeAssistant,
@@ -1159,7 +1160,7 @@ async def test_unsubscribe_race(
             CONF_PROTOCOL: "5",
         },
     ],
-    ids=["v3.1", "v3.3.1", "5"],
+    ids=["v3.1", "v3.1.1", "v5"],
 )
 @pytest.mark.parametrize("mqtt_config_entry_options", [ENTRY_DEFAULT_BIRTH_MESSAGE])
 async def test_wildcard_unsubscribe_race(

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1367,6 +1367,29 @@ async def test_logs_error_if_no_connect_broker(
 
 
 @pytest.mark.parametrize(
+    "mqtt_config_entry_data", [{mqtt.CONF_BROKER: "mock-broker", CONF_PROTOCOL: "5"}]
+)
+async def test_logs_error_if_broker_does_not_support_subscription_identifiers(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    setup_with_birth_msg_client_mock: MqttMockPahoClient,
+) -> None:
+    """Test for setup failure if connection to broker is missing."""
+    mqtt_client_mock = setup_with_birth_msg_client_mock
+    mqtt_client_mock.on_disconnect(Mock(), None, None, MockMqttReasonCode())
+    properties = paho_mqtt.Properties(paho_mqtt.PacketTypes.CONNACK)
+    properties.SubscriptionIdentifierAvailable = 0
+    mqtt_client_mock.on_connect(Mock(), None, None, MockMqttReasonCode(), properties)
+    await hass.async_block_till_done()
+    assert (
+        "Your MQTT broker reports it does not support Subscription Identifiers, see "
+        "https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901092. "
+        "Please use a supported MQTT broker; got broker properties: "
+        "[SubscriptionIdentifierAvailable : 0]" in caplog.text
+    )
+
+
+@pytest.mark.parametrize(
     "reason_code",
     [
         MockMqttReasonCode(

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1482,7 +1482,7 @@ async def test_subscribe_error(
     mqtt_client_mock = setup_with_birth_msg_client_mock
     mqtt_client_mock.reset_mock()
     # simulate client is not connected error before subscribing
-    mqtt_client_mock.subscribe.side_effect = lambda *args, **kwargs: (4, 0)
+    mqtt_client_mock.subscribe.side_effect = lambda *args, **kwargs: (4, None)
     await mqtt.async_subscribe(hass, "some-topic", record_calls)
     while mqtt_client_mock.subscribe.call_count == 0:
         await hass.async_block_till_done()

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1072,12 +1072,32 @@ async def test_not_calling_subscribe_when_unsubscribed_within_cooldown(
     assert not mqtt_client_mock.subscribe.called
 
 
+@pytest.mark.parametrize(
+    "mqtt_config_entry_data",
+    [
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            CONF_PROTOCOL: "3.1",
+        },
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            CONF_PROTOCOL: "3.1.1",
+        },
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            CONF_PROTOCOL: "5",
+        },
+    ],
+)
 async def test_unsubscribe_race(
     hass: HomeAssistant,
     mock_debouncer: asyncio.Event,
     setup_with_birth_msg_client_mock: MqttMockPahoClient,
 ) -> None:
-    """Test not calling unsubscribe() when other subscribers are active."""
+    """Test not calling unsubscribe() when other subscribers are active.
+
+    Testing with simple topics.
+    """
     mqtt_client_mock = setup_with_birth_msg_client_mock
     calls_a: list[ReceiveMessage] = []
     calls_b: list[ReceiveMessage] = []
@@ -1105,16 +1125,89 @@ async def test_unsubscribe_race(
     # We allow either calls [subscribe, unsubscribe, subscribe], [subscribe, subscribe] or
     # when both subscriptions were combined [subscribe]
     expected_calls_1 = [
-        call.subscribe([("test/state", 0)], properties=None),
+        call.subscribe([("test/state", 0)], properties=ANY),
         call.unsubscribe("test/state"),
-        call.subscribe([("test/state", 0)], properties=None),
+        call.subscribe([("test/state", 0)], properties=ANY),
     ]
     expected_calls_2 = [
-        call.subscribe([("test/state", 0)], properties=None),
-        call.subscribe([("test/state", 0)], properties=None),
+        call.subscribe([("test/state", 0)], properties=ANY),
+        call.subscribe([("test/state", 0)], properties=ANY),
     ]
     expected_calls_3 = [
-        call.subscribe([("test/state", 0)], properties=None),
+        call.subscribe([("test/state", 0)], properties=ANY),
+    ]
+    assert mqtt_client_mock.mock_calls in (
+        expected_calls_1,
+        expected_calls_2,
+        expected_calls_3,
+    )
+
+
+@pytest.mark.parametrize(
+    "mqtt_config_entry_data",
+    [
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            CONF_PROTOCOL: "3.1",
+        },
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            CONF_PROTOCOL: "3.1.1",
+        },
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            CONF_PROTOCOL: "5",
+        },
+    ],
+    ids=["v3.1", "v3.3.1", "5"],
+)
+@pytest.mark.parametrize("mqtt_config_entry_options", [ENTRY_DEFAULT_BIRTH_MESSAGE])
+async def test_wildcard_unsubscribe_race(
+    hass: HomeAssistant,
+    mock_debouncer: asyncio.Event,
+    setup_with_birth_msg_client_mock: MqttMockPahoClient,
+) -> None:
+    """Test not calling unsubscribe() when other subscribers are active.
+
+    Testing with wildcard topics.
+    """
+    mqtt_client_mock = setup_with_birth_msg_client_mock
+    calls_a: list[ReceiveMessage] = []
+    calls_b: list[ReceiveMessage] = []
+
+    @callback
+    def _callback_a(msg: ReceiveMessage) -> None:
+        calls_a.append(msg)
+
+    @callback
+    def _callback_b(msg: ReceiveMessage) -> None:
+        calls_b.append(msg)
+
+    mqtt_client_mock.reset_mock()
+
+    mock_debouncer.clear()
+    unsub = await mqtt.async_subscribe(hass, "test/#", _callback_a)
+    unsub()
+    await mqtt.async_subscribe(hass, "test/#", _callback_b)
+    await mock_debouncer.wait()
+
+    async_fire_mqtt_message(hass, "test/state", "online")
+    assert not calls_a
+    assert calls_b
+
+    # We allow either calls [subscribe, unsubscribe, subscribe], [subscribe, subscribe] or
+    # when both subscriptions were combined [subscribe]
+    expected_calls_1 = [
+        call.subscribe("test/#", 0, properties=ANY),
+        call.unsubscribe("test/#"),
+        call.subscribe("test/#", 0, properties=ANY),
+    ]
+    expected_calls_2 = [
+        call.subscribe("test/#", 0, properties=ANY),
+        call.subscribe("test/#", 0, ANY),
+    ]
+    expected_calls_3 = [
+        call.subscribe("test/#", 0, properties=ANY),
     ]
     assert mqtt_client_mock.mock_calls in (
         expected_calls_1,
@@ -2404,7 +2497,7 @@ async def test_overlapping_subscriptions_only_processed_once(
     hass: HomeAssistant,
     setup_with_birth_msg_client_mock: MqttMockPahoClient,
 ) -> None:
-    """Test message are only processed once per subscription in case of overlap.
+    """Test messages are only processed once per subscription in case of overlap.
 
     Overlapping subscriptions are only supported with MQTTv5
     """

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1204,7 +1204,7 @@ async def test_wildcard_unsubscribe_race(
     ]
     expected_calls_2 = [
         call.subscribe("test/#", 0, properties=ANY),
-        call.subscribe("test/#", 0, ANY),
+        call.subscribe("test/#", 0, properties=ANY),
     ]
     expected_calls_3 = [
         call.subscribe("test/#", 0, properties=ANY),

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -2596,36 +2596,36 @@ async def test_subscriptions_id_generation(hass: HomeAssistant) -> None:
     generator = mqtt.models.SubscriptionID()
     # Mock we are past the last subscriptions
     generator._next_id = mqtt.models.MAX_28BIT - 2
-    new_id_1 = generator.generate()
+    new_id_1 = generator.get_or_generate("test1/#")
     assert new_id_1 == mqtt.models.MAX_28BIT - 2
-    new_id_2 = generator.generate()
+    new_id_2 = generator.get_or_generate("test2/#")
     assert new_id_2 == mqtt.models.MAX_28BIT - 1
-    new_id_3 = generator.generate()
+    new_id_3 = generator.get_or_generate("test3/#")
     assert new_id_3 == mqtt.models.MAX_28BIT
     with pytest.raises(HomeAssistantError) as exc:
-        generator.generate()
+        generator.get_or_generate("test4/#")
     assert exc.value.translation_domain == mqtt.DOMAIN
     assert exc.value.translation_key == "mqtt_max_subscription_id_reached"
 
-    generator.release(new_id_2)
-    new_id_4 = generator.generate()
+    generator.release("test2/#")
+    new_id_4 = generator.get_or_generate("test4/#")
     # Check we reused the ID
     assert new_id_4 == mqtt.models.MAX_28BIT - 1
 
     with pytest.raises(HomeAssistantError) as exc:
-        generator.generate()
+        generator.get_or_generate("test5/#")
     assert exc.value.translation_domain == mqtt.DOMAIN
     assert exc.value.translation_key == "mqtt_max_subscription_id_reached"
 
-    generator.release(new_id_1)
-    generator.release(new_id_3)
+    generator.release("test1/#")
+    generator.release("test3/#")
 
-    new_id_5 = generator.generate()
-    new_id_6 = generator.generate()
+    new_id_5 = generator.get_or_generate("test5/#")
+    new_id_6 = generator.get_or_generate("test6/#")
 
     assert {new_id_5, new_id_6} == {new_id_1, new_id_3}
 
     with pytest.raises(HomeAssistantError) as exc:
-        generator.generate()
+        generator.get_or_generate("test7/#")
     assert exc.value.translation_domain == mqtt.DOMAIN
     assert exc.value.translation_key == "mqtt_max_subscription_id_reached"

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -2557,7 +2557,7 @@ async def test_overlapping_subscriptions_only_processed_once(
         # Simulate the broker sends a publish message at topic "test/bla/status"
         # That matches all three subscriptions
         for message_identifier in message_identifiers:
-            properties = paho_mqtt.Properties(paho_mqtt.PacketTypes.SUBSCRIBE)
+            properties = paho_mqtt.Properties(paho_mqtt.PacketTypes.PUBLISH)
             properties.SubscriptionIdentifier = message_identifier
             async_fire_mqtt_message(
                 hass, "test/bla/status", "bla", properties=properties

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1071,7 +1071,7 @@ def mqtt_client_mock(hass: HomeAssistant) -> Generator[MqttMockPahoClient]:
             )
             return FakeInfo(mid)
 
-        def _subscribe(topic, qos=0):
+        def _subscribe(topic_or_list, qos=0, **kwargs):
             mid = get_mid()
             hass.loop.call_soon(
                 mock_client.on_subscribe, Mock(), 0, mid, [MockMqttReasonCode()], None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set subscription identifier to allow matching duplicate payloads with overlapping subscriptions.

This feature works with MQTT v5 only.

### Background

When there are overlapping subscriptions, the MQTT broker might send the same message for all matching subscription. This is an issue for MQTT protocol version 3.1 and 3.1.1. MQTT protocol version 5 allows matching subscriptions with the incoming messages using identifiers to resolve duplicate messages.

The standard behavior of the MQTT integration is that it will try to match the topics of incoming messages based on its known subscriptions. Since version 2.1.0 of Mosquitto, [the default setting `allow_duplicate_messages` has been changed from `false` to `true`](https://mosquitto.org/blog/2026/01/version-2-1-0-released/). But this is causing compatibility issues with the MQTT integration.

Overlapping subscriptions are caused when wildcard subscriptions or a simple subscription trigger the same message.
For example, the subscriptions `test/bla/status`, `test/+/status` and `test/#` match with a message published at topic `test/bla/status`. With protocol version 3.1 or 3.1.1, it is possible the broker sends 3 messages, one for each match. But there is no way to link the incoming message to the subscription.
With protocol version 5, an identifier is assigned to each subscription which allows to process each message for its own subscription.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168379
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45143
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
