### PR TITLE
Bump indevolt-api to 1.7.1

### DIFF
--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -10,7 +10,6 @@ from indevolt_api import (
     IndevoltConfig,
     IndevoltEnergyMode,
     IndevoltRealtimeAction,
-    TimeOutException,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -78,7 +77,7 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Fetch device info once on boot."""
         try:
             config_data = await self.api.get_config()
-        except TimeOutException as err:
+        except TimeoutError as err:
             raise ConfigEntryNotReady(
                 f"Device config retrieval timed out: {err}"
             ) from err
@@ -94,14 +93,14 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         try:
             return await self.api.fetch_data(sensor_keys)
-        except TimeOutException as err:
+        except TimeoutError as err:
             raise UpdateFailed(f"Device update timed out: {err}") from err
 
     async def async_push_data(self, sensor_key: str, value: Any) -> bool:
         """Push/write data values to given key on the device."""
         try:
             return await self.api.set_data(sensor_key, value)
-        except TimeOutException as err:
+        except TimeoutError as err:
             raise DeviceTimeoutError(f"Device push timed out: {err}") from err
         except (ClientError, ConnectionError, OSError) as err:
             raise DeviceConnectionError(f"Device push failed: {err}") from err

--- a/homeassistant/components/indevolt/manifest.json
+++ b/homeassistant/components/indevolt/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["indevolt-api==1.6.5"]
+  "requirements": ["indevolt-api==1.7.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1329,7 +1329,7 @@ imgw_pib==2.1.1
 incomfort-client==0.7.0
 
 # homeassistant.components.indevolt
-indevolt-api==1.6.5
+indevolt-api==1.7.1
 
 # homeassistant.components.influxdb
 influxdb-client==1.50.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1181,7 +1181,7 @@ imgw_pib==2.1.1
 incomfort-client==0.7.0
 
 # homeassistant.components.indevolt
-indevolt-api==1.6.5
+indevolt-api==1.7.1
 
 # homeassistant.components.influxdb
 influxdb-client==1.50.0

--- a/tests/components/indevolt/test_init.py
+++ b/tests/components/indevolt/test_init.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock
 
-from indevolt_api import TimeOutException
 import pytest
 
 from homeassistant.config_entries import ConfigEntryState
@@ -37,7 +36,7 @@ async def test_load_failure(
 ) -> None:
     """Test setup failure when coordinator update fails."""
     # Simulate timeout error during coordinator initialization
-    mock_indevolt.get_config.side_effect = TimeOutException
+    mock_indevolt.get_config.side_effect = TimeoutError
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The library and integration exceptions were not aligned and not following best practices (e.g. use available Python standard exceptions), see line 200+ in [diff](https://github.com/Xirt/indevolt-api/compare/v1.6.5..v1.7.1). This PR updates the library and replaces the TimeOutException with TimeoutError (otherwise tests will break - no way to pull this change apart).

_Note: The version (1.7+) of the library introduces also proper passive / active UDP discovery (earlier implementation in the library was incomplete), but this functionality is not leveraged by HA Indevolt. Instead, a PR will be raised to add DHCP discovery._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
