### PR TITLE
Add PARALLEL_UPDATES to goodwe sensor platform

### DIFF
--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -1,7 +1,5 @@
 """Support for GoodWe inverter via UDP."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -1,5 +1,6 @@
 """Support for GoodWe inverter via UDP."""
 
+from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
@@ -38,6 +39,9 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import GoodweConfigEntry, GoodweUpdateCoordinator
+
+# Coordinator handles all data updates, so parallel updates are not needed
+PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -1,6 +1,7 @@
 """Support for GoodWe inverter via UDP."""
 
 from __future__ import annotations
+
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta


### PR DESCRIPTION
## Proposed change

The `goodwe` sensor platform was missing two things:

- `from __future__ import annotations` was not imported, which is required for modern Python type annotation handling and is standard across all Home Assistant integrations.
- `PARALLEL_UPDATES = 0` was not set. When an integration uses a coordinator, all data fetching is centralized through it, meaning entities do not poll individually. Setting `PARALLEL_UPDATES = 0` is the correct value for read-only sensor platforms, as it tells Home Assistant not to throttle parallel state writes since the coordinator already handles update serialization. This follows the Home Assistant developer documentation recommendation for coordinator-based integrations.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: none
- This PR is related to issue: none
- Link to documentation pull request: none
- Link to developer documentation pull request: none
- Link to frontend pull request: none

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr