### PR TITLE
Fix grammar and clarity in homekit_controller/strings.json

### DIFF
--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -22,7 +22,7 @@
     "flow_title": "{name} ({category})",
     "step": {
       "busy_error": {
-        "description": "Abort pairing on all controllers, or try restarting the device, then try again.",
+        "description": "Abort pairing on all controllers, or try restarting the device, then try pairing again.",
         "title": "The device is already pairing with another controller"
       },
       "max_tries_error": {

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -38,7 +38,7 @@
         "title": "Pair with a device via HomeKit Accessory Protocol"
       },
       "protocol_error": {
-        "description": "The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then continue to resume pairing.",
+        "description": "The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then try pairing again.",
         "title": "Error communicating with the accessory"
       },
       "user": {

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -6,7 +6,7 @@
       "already_configured": "Accessory is already configured with this controller.",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
-      "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
+      "ignored_model": "HomeKit support for this model is blocked as a more feature-complete native integration is available.",
       "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting configuration entry for it in Home Assistant that must first be removed.",
       "invalid_properties": "Invalid properties announced by device.",
       "no_devices": "No unpaired devices could be found"
@@ -22,11 +22,11 @@
     "flow_title": "{name} ({category})",
     "step": {
       "busy_error": {
-        "description": "Abort pairing on all controllers, or try restarting the device, then continue to resume pairing.",
+        "description": "Abort pairing on all controllers, or try restarting the device, then try again.",
         "title": "The device is already pairing with another controller"
       },
       "max_tries_error": {
-        "description": "The device has received more than 100 unsuccessful authentication attempts. Try restarting the device, then continue to resume pairing.",
+        "description": "The device has received more than 100 unsuccessful authentication attempts. Try restarting the device, then try pairing again.",
         "title": "Maximum authentication attempts exceeded"
       },
       "pair": {


### PR DESCRIPTION
## Proposed change

This PR fixes a few grammar and clarity issues in user-facing strings in `homeassistant/components/homekit_controller/strings.json`.

- Fixed redundant wording "continue to resume pairing" -> "try again" / "try pairing again" (appeared twice)
- Fixed missing hyphen in compound adjective "more feature complete" -> "more feature-complete"

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: none
- This PR is related to issue: none
- Link to documentation pull request: none
- Link to developer documentation pull request: none
- Link to frontend pull request: none

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr