### PR TITLE
Add buttons platform to Marantz IR Remote (PM6006)

### DIFF
--- a/homeassistant/components/marantz_infrared/__init__.py
+++ b/homeassistant/components/marantz_infrared/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER]
 
 
 @dataclass

--- a/homeassistant/components/marantz_infrared/button.py
+++ b/homeassistant/components/marantz_infrared/button.py
@@ -1,0 +1,80 @@
+"""Button platform for Marantz IR integration.
+
+Only commands that aren't already exposed by the media player live here:
+speaker A/B, source-direct toggle, and loudness toggle.
+"""
+
+from dataclasses import dataclass
+
+from infrared_protocols.codes.marantz.audio import MarantzAudioCode
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import MarantzIrConfigEntry
+from .const import CONF_INFRARED_EMITTER_ENTITY_ID, CONF_MODEL, MODELS
+from .entity import MarantzIrEntity
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class MarantzIrButtonEntityDescription(ButtonEntityDescription):
+    """Describes Marantz IR button entity."""
+
+    command_code: MarantzAudioCode
+
+
+BUTTON_DESCRIPTIONS: tuple[MarantzIrButtonEntityDescription, ...] = (
+    MarantzIrButtonEntityDescription(
+        key="speaker_ab",
+        translation_key="speaker_ab",
+        command_code=MarantzAudioCode.SPEAKER_AB,
+    ),
+    MarantzIrButtonEntityDescription(
+        key="source_direct",
+        translation_key="source_direct",
+        command_code=MarantzAudioCode.SOURCE_DIRECT,
+    ),
+    MarantzIrButtonEntityDescription(
+        key="loudness",
+        translation_key="loudness",
+        command_code=MarantzAudioCode.LOUDNESS,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MarantzIrConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Marantz IR buttons from config entry."""
+    infrared_entity_id = entry.data[CONF_INFRARED_EMITTER_ENTITY_ID]
+    model_codes = MODELS[entry.data[CONF_MODEL]].codes
+    async_add_entities(
+        MarantzIrButton(entry, infrared_entity_id, description)
+        for description in BUTTON_DESCRIPTIONS
+        if description.command_code in model_codes
+    )
+
+
+class MarantzIrButton(MarantzIrEntity, ButtonEntity):
+    """Marantz IR button entity."""
+
+    entity_description: MarantzIrButtonEntityDescription
+
+    def __init__(
+        self,
+        entry: MarantzIrConfigEntry,
+        infrared_entity_id: str,
+        description: MarantzIrButtonEntityDescription,
+    ) -> None:
+        """Initialize Marantz IR button."""
+        super().__init__(entry, infrared_entity_id, unique_id_suffix=description.key)
+        self.entity_description = description
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self._send_marantz_command(self.entity_description.command_code)

--- a/homeassistant/components/marantz_infrared/strings.json
+++ b/homeassistant/components/marantz_infrared/strings.json
@@ -20,6 +20,17 @@
     }
   },
   "entity": {
+    "button": {
+      "loudness": {
+        "name": "Loudness"
+      },
+      "source_direct": {
+        "name": "Source direct"
+      },
+      "speaker_ab": {
+        "name": "Speaker A/B"
+      }
+    },
     "media_player": {
       "receiver": {
         "state_attributes": {

--- a/tests/components/marantz_infrared/snapshots/test_button.ambr
+++ b/tests/components/marantz_infrared/snapshots/test_button.ambr
@@ -1,0 +1,151 @@
+# serializer version: 1
+# name: test_entities[button.marantz_pm6006_integrated_amplifier_loudness-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.marantz_pm6006_integrated_amplifier_loudness',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loudness',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Loudness',
+    'platform': 'marantz_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loudness',
+    'unique_id': '01JTEST0000000000000000000_loudness',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button.marantz_pm6006_integrated_amplifier_loudness-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Marantz PM6006 Integrated Amplifier Loudness',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.marantz_pm6006_integrated_amplifier_loudness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[button.marantz_pm6006_integrated_amplifier_source_direct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.marantz_pm6006_integrated_amplifier_source_direct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Source direct',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Source direct',
+    'platform': 'marantz_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'source_direct',
+    'unique_id': '01JTEST0000000000000000000_source_direct',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button.marantz_pm6006_integrated_amplifier_source_direct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Marantz PM6006 Integrated Amplifier Source direct',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.marantz_pm6006_integrated_amplifier_source_direct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[button.marantz_pm6006_integrated_amplifier_speaker_a_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.marantz_pm6006_integrated_amplifier_speaker_a_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Speaker A/B',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Speaker A/B',
+    'platform': 'marantz_infrared',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'speaker_ab',
+    'unique_id': '01JTEST0000000000000000000_speaker_ab',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button.marantz_pm6006_integrated_amplifier_speaker_a_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Marantz PM6006 Integrated Amplifier Speaker A/B',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.marantz_pm6006_integrated_amplifier_speaker_a_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/marantz_infrared/test_button.py
+++ b/tests/components/marantz_infrared/test_button.py
@@ -1,0 +1,104 @@
+"""Tests for the Marantz Infrared button platform."""
+
+from infrared_protocols.codes.marantz.audio import MarantzAudioCode
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .utils import check_availability_follows_ir_entity
+
+from tests.common import MockConfigEntry, snapshot_platform
+from tests.components.infrared.common import MockInfraredEmitterEntity
+
+BUTTON_ENTITY_ID_SPEAKER_AB = "button.marantz_pm6006_integrated_amplifier_speaker_a_b"
+BUTTON_ENTITY_ID_SOURCE_DIRECT = (
+    "button.marantz_pm6006_integrated_amplifier_source_direct"
+)
+BUTTON_ENTITY_ID_LOUDNESS = "button.marantz_pm6006_integrated_amplifier_loudness"
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Return platforms to set up."""
+    return [Platform.BUTTON]
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test all button entities are created with correct attributes."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={("marantz_infrared", mock_config_entry.entry_id)}
+    )
+    assert device_entry
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    for entity_entry in entity_entries:
+        assert entity_entry.device_id == device_entry.id
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected_code"),
+    [
+        (BUTTON_ENTITY_ID_SPEAKER_AB, MarantzAudioCode.SPEAKER_AB),
+        (BUTTON_ENTITY_ID_SOURCE_DIRECT, MarantzAudioCode.SOURCE_DIRECT),
+        (BUTTON_ENTITY_ID_LOUDNESS, MarantzAudioCode.LOUDNESS),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_button_press_sends_correct_code(
+    hass: HomeAssistant,
+    mock_infrared_emitter_entity: MockInfraredEmitterEntity,
+    entity_id: str,
+    expected_code: MarantzAudioCode,
+) -> None:
+    """Test pressing a button sends the correct IR code."""
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert len(mock_infrared_emitter_entity.send_command_calls) == 1
+    assert mock_infrared_emitter_entity.send_command_calls[0] == expected_code
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["sr_7300_receiver"],
+    indirect=True,
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_only_supported_buttons_created(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that only buttons for codes supported by the model are created."""
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    button_entries = [e for e in entity_entries if e.domain == "button"]
+    assert len(button_entries) == 1
+    assert button_entries[0].translation_key == "speaker_ab"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_button_availability_follows_ir_entity(
+    hass: HomeAssistant,
+) -> None:
+    """Test button becomes unavailable when IR entity is unavailable."""
+    await check_availability_follows_ir_entity(hass, BUTTON_ENTITY_ID_LOUDNESS)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a buttons platform to the Marantz IR Remote integration for the **three commands the media player doesn't expose**:

- **Speaker A/B** – switches the active speaker pair on the amp.
- **Source Direct** – toggles the tone-control bypass.
- **Loudness** – toggles the loudness contour.

All three press alternate the same shared RC-5 toggle bit as the media player so the amp registers each invocation as a distinct press rather than a held-down repeat.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45132
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr