### PR TITLE
Fix MotionEye switch flickering on toggle

### DIFF
--- a/homeassistant/components/motioneye/switch.py
+++ b/homeassistant/components/motioneye/switch.py
@@ -124,12 +124,20 @@ class MotionEyeSwitch(MotionEyeEntity, SwitchEntity):
     async def _async_send_set_camera(self, value: bool) -> None:
         """Set a switch value."""
 
+        # Optimistically update local state immediately to prevent flickering.
+        if self._camera is not None:
+            self._camera[self.entity_description.key] = value
+            self.async_write_ha_state()
+
         # Fetch the very latest camera config to reduce the risk of updating with a
         # stale configuration.
         camera = await self._client.async_get_camera(self._camera_id)
         if camera:
             camera[self.entity_description.key] = value
             await self._client.async_set_camera(self._camera_id, camera)
+        else:
+            # Couldn't get camera config revert optimistic state and refresh.
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""

--- a/homeassistant/components/motioneye/switch.py
+++ b/homeassistant/components/motioneye/switch.py
@@ -150,4 +150,3 @@ class MotionEyeSwitch(MotionEyeEntity, SwitchEntity):
         """Handle updated data from the coordinator."""
         self._camera = get_camera_from_cameras(self._camera_id, self.coordinator.data)
         super()._handle_coordinator_update()
-    

--- a/homeassistant/components/motioneye/switch.py
+++ b/homeassistant/components/motioneye/switch.py
@@ -1,5 +1,6 @@
 """Switch platform for motionEye."""
 
+import asyncio
 from collections.abc import Mapping
 from typing import Any
 
@@ -123,20 +124,17 @@ class MotionEyeSwitch(MotionEyeEntity, SwitchEntity):
 
     async def _async_send_set_camera(self, value: bool) -> None:
         """Set a switch value."""
-
-        # Optimistically update local state immediately to prevent flickering.
-        if self._camera is not None:
-            self._camera[self.entity_description.key] = value
-            self.async_write_ha_state()
-
         # Fetch the very latest camera config to reduce the risk of updating with a
         # stale configuration.
         camera = await self._client.async_get_camera(self._camera_id)
         if camera:
             camera[self.entity_description.key] = value
             await self._client.async_set_camera(self._camera_id, camera)
+            # Wait 2 seconds to allow slower hardware like Raspberry Pi to apply
+            # the new state before the coordinator refreshes.
+            await asyncio.sleep(2)
+            await self.coordinator.async_request_refresh()
         else:
-            # Couldn't get camera config revert optimistic state and refresh.
             await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -152,3 +150,4 @@ class MotionEyeSwitch(MotionEyeEntity, SwitchEntity):
         """Handle updated data from the coordinator."""
         self._camera = get_camera_from_cameras(self._camera_id, self.coordinator.data)
         super()._handle_coordinator_update()
+    

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -261,6 +261,7 @@ async def test_switch_optimistic_state_on_toggle(
     assert entity_state
     assert entity_state.state == "on"
 
+
 async def test_switch_optimistic_state_reverts_on_get_camera_failure(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -275,6 +275,8 @@ async def test_switch_optimistic_state_reverts_on_get_camera_failure(
 
     # Simulate async_get_camera returning None (network failure etc.)
     client.async_get_camera = AsyncMock(return_value=None)
+    # Reset set_camera so we can assert it wasn't called by our action
+    client.async_set_camera.reset_mock()
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -283,7 +285,7 @@ async def test_switch_optimistic_state_reverts_on_get_camera_failure(
         blocking=True,
     )
 
-    # async_set_camera should NOT have been called since GET failed.
+    # async_set_camera should NOT have been called since GET returned None.
     client.async_set_camera.assert_not_called()
 
     # Coordinator should have been asked to refresh to revert optimistic state.

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -260,3 +260,31 @@ async def test_switch_optimistic_state_on_toggle(
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "on"
+
+async def test_switch_optimistic_state_reverts_on_get_camera_failure(
+    hass: HomeAssistant,
+) -> None:
+    """Test that coordinator refreshes if async_get_camera fails.
+
+    When the GET fails, the optimistic state was already written, so we
+    trigger a coordinator refresh to revert to the real state.
+    Regression test for https://github.com/home-assistant/core/issues/169617
+    """
+    client = create_mock_motioneye_client()
+    await setup_mock_motioneye_config_entry(hass, client=client)
+
+    # Simulate async_get_camera returning None (network failure etc.)
+    client.async_get_camera = AsyncMock(return_value=None)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
+        blocking=True,
+    )
+
+    # async_set_camera should NOT have been called since GET failed.
+    client.async_set_camera.assert_not_called()
+
+    # Coordinator should have been asked to refresh to revert optimistic state.
+    assert client.async_get_cameras.call_count >= 1

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -213,3 +213,50 @@ async def test_switch_device_info(
         for entry in er.async_entries_for_device(entity_registry, device.id)
     ]
     assert TEST_SWITCH_MOTION_DETECTION_ENTITY_ID in entities_from_device
+
+
+async def test_switch_optimistic_state_on_toggle(
+    hass: HomeAssistant,
+) -> None:
+    """Test that toggling a switch updates state immediately without coordinator refresh.
+
+    Regression test for https://github.com/home-assistant/core/issues/169617
+    The switch should not flicker back to the previous state while the coordinator
+    polls stale data during the async set operation.
+    """
+    client = create_mock_motioneye_client()
+    await setup_mock_motioneye_config_entry(hass, client=client)
+
+    # Verify switch starts on.
+    entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "on"
+
+    client.async_get_camera = AsyncMock(return_value=TEST_CAMERA)
+
+    # Turn switch off.
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
+        blocking=True,
+    )
+
+    # State must be off immediately no coordinator tick needed.
+    # This is the core of the fix: optimistic update before any await.
+    entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "off"
+
+    # Turn switch back on.
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
+        blocking=True,
+    )
+
+    # State must be on immediately again without waiting for coordinator.
+    entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "on"

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -274,8 +274,8 @@ async def test_switch_optimistic_state_reverts_on_get_camera_failure(
     client = create_mock_motioneye_client()
     await setup_mock_motioneye_config_entry(hass, client=client)
 
-    # Simulate async_get_camera returning None (network failure etc.)
-    client.async_get_camera = AsyncMock(return_value=None)
+    # Simulate async_get_camera returning no camera data.
+    client.async_get_camera = AsyncMock(return_value={})
 
     await hass.services.async_call(
         SWITCH_DOMAIN,

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -275,7 +275,7 @@ async def test_switch_optimistic_state_reverts_on_get_camera_failure(
     await setup_mock_motioneye_config_entry(hass, client=client)
 
     # Simulate async_get_camera returning no camera data.
-    client.async_get_camera = AsyncMock(return_value={})
+    client.async_get_camera = AsyncMock(return_value=None)
 
     await hass.services.async_call(
         SWITCH_DOMAIN,

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -52,12 +52,20 @@ async def test_switch_turn_on_off(
     camera_off[KEY_MOTION_DETECTION] = False
 
     # async_get_camera is fetched by the switch before calling set_camera.
+    # Use side_effect with deep-copies so the dicts aren't mutated across calls.
     # async_get_cameras is used by the coordinator to refresh state.
-    client.async_get_camera = AsyncMock(return_value=camera_on)
-    client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
+    client.async_get_camera = AsyncMock(
+        side_effect=lambda _: copy.deepcopy(camera_on)
+    )
+    client.async_get_cameras = AsyncMock(
+        return_value={"cameras": [copy.deepcopy(camera_off)]}
+    )
 
     # Turn switch off.
-    with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):
+    with patch(
+        "homeassistant.components.motioneye.switch.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
@@ -77,11 +85,18 @@ async def test_switch_turn_on_off(
     assert entity_state.state == "off"
 
     # Now prepare for turn-on: get_camera returns off state, coordinator returns on.
-    client.async_get_camera = AsyncMock(return_value=camera_off)
-    client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_on]})
+    client.async_get_camera = AsyncMock(
+        side_effect=lambda _: copy.deepcopy(camera_off)
+    )
+    client.async_get_cameras = AsyncMock(
+        return_value={"cameras": [copy.deepcopy(camera_on)]}
+    )
 
     # Turn switch on.
-    with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):
+    with patch(
+        "homeassistant.components.motioneye.switch.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -232,15 +247,18 @@ async def test_switch_reverts_on_get_camera_failure(
     client.async_get_camera = AsyncMock(return_value=None)
     client.async_set_camera.reset_mock()
 
+    calls_before = client.async_get_cameras.call_count
+
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
         blocking=True,
     )
+    await hass.async_block_till_done()
 
     # async_set_camera should NOT have been called since GET returned None.
     client.async_set_camera.assert_not_called()
 
-    # Coordinator should have been asked to refresh to revert state.
-    assert client.async_get_cameras.call_count >= 1
+    # Coordinator should have been asked to refresh to revert optimistic state.
+    assert client.async_get_cameras.call_count > calls_before

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -47,19 +47,19 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "on"
 
-    camera_on = copy.deepcopy(TEST_CAMERA)
+    # Snapshot camera states before any service calls so they aren't affected
+    # by the optimistic in-place mutation in _async_send_set_camera.
+    camera_on = copy.deepcopy(TEST_CAMERA)  # motion_detection=True
     camera_off = copy.deepcopy(TEST_CAMERA)
     camera_off[KEY_MOTION_DETECTION] = False
 
-    # async_get_camera is fetched by the switch before calling set_camera.
-    # Use side_effect with deep-copies so the dicts aren't mutated across calls.
-    # async_get_cameras is used by the coordinator to refresh state.
+    # Turn-off phase: switch GETs camera_on, coordinator sees camera_off.
+    # async_get_camera uses side_effect so each call gets a fresh copy.
     client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_on))
     client.async_get_cameras = AsyncMock(
         return_value={"cameras": [copy.deepcopy(camera_off)]}
     )
 
-    # Turn switch off.
     with patch(
         "homeassistant.components.motioneye.switch.asyncio.sleep",
         new_callable=AsyncMock,
@@ -82,13 +82,13 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "off"
 
-    # Now prepare for turn-on: get_camera returns off state, coordinator returns on.
+    # Turn-on phase: switch GETs camera_off, coordinator sees camera with motion_detection=True.
+    # Use TEST_CAMERA directly for the coordinator since it is never mutated.
     client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_off))
     client.async_get_cameras = AsyncMock(
-        return_value={"cameras": [copy.deepcopy(camera_on)]}
+        return_value={"cameras": [copy.deepcopy(TEST_CAMERA)]}
     )
 
-    # Turn switch on.
     with patch(
         "homeassistant.components.motioneye.switch.asyncio.sleep",
         new_callable=AsyncMock,

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -47,14 +47,15 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "on"
 
-    expected_camera_off = copy.deepcopy(TEST_CAMERA)
-    expected_camera_off[KEY_MOTION_DETECTION] = False
+    # Build the camera state we expect after turning off.
+    camera_on = copy.deepcopy(TEST_CAMERA)
+    camera_off = copy.deepcopy(TEST_CAMERA)
+    camera_off[KEY_MOTION_DETECTION] = False
 
-    # async_get_camera returns current state; async_get_cameras returns updated state.
-    client.async_get_camera = AsyncMock(return_value=TEST_CAMERA)
-    client.async_get_cameras = AsyncMock(
-        return_value={"cameras": [expected_camera_off]}
-    )
+    # async_get_camera is what the switch fetches before calling set_camera.
+    # async_get_cameras is what the coordinator uses to refresh state.
+    client.async_get_camera = AsyncMock(return_value=camera_on)
+    client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
 
     # Turn switch off.
     with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):
@@ -68,18 +69,16 @@ async def test_switch_turn_on_off(
     await hass.async_block_till_done()
 
     # Verify correct parameters are passed to the library.
-    assert client.async_set_camera.call_args == call(
-        TEST_CAMERA_ID, expected_camera_off
-    )
+    assert client.async_set_camera.call_args == call(TEST_CAMERA_ID, camera_off)
 
     # Verify the switch turns off.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "off"
 
-    # Now set up for turning on: get_camera returns off state, get_cameras returns on.
-    client.async_get_camera = AsyncMock(return_value=expected_camera_off)
-    client.async_get_cameras = AsyncMock(return_value={"cameras": [TEST_CAMERA]})
+    # Now prepare for turn-on: get_camera returns off state, coordinator returns on.
+    client.async_get_camera = AsyncMock(return_value=camera_off)
+    client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_on]})
 
     # Turn switch on.
     with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):
@@ -93,7 +92,7 @@ async def test_switch_turn_on_off(
     await hass.async_block_till_done()
 
     # Verify correct parameters are passed to the library.
-    assert client.async_set_camera.call_args == call(TEST_CAMERA_ID, TEST_CAMERA)
+    assert client.async_set_camera.call_args == call(TEST_CAMERA_ID, camera_on)
 
     # Verify the switch turns on.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -2,7 +2,7 @@
 
 import copy
 from datetime import timedelta
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from motioneye_client.const import (
@@ -47,13 +47,12 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "on"
 
-    # Build the camera state we expect after turning off.
     camera_on = copy.deepcopy(TEST_CAMERA)
     camera_off = copy.deepcopy(TEST_CAMERA)
     camera_off[KEY_MOTION_DETECTION] = False
 
-    # async_get_camera is what the switch fetches before calling set_camera.
-    # async_get_cameras is what the coordinator uses to refresh state.
+    # async_get_camera is fetched by the switch before calling set_camera.
+    # async_get_cameras is used by the coordinator to refresh state.
     client.async_get_camera = AsyncMock(return_value=camera_on)
     client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
 
@@ -68,8 +67,9 @@ async def test_switch_turn_on_off(
 
     await hass.async_block_till_done()
 
-    # Verify correct parameters are passed to the library.
-    assert client.async_set_camera.call_args == call(TEST_CAMERA_ID, camera_off)
+    # Verify set_camera was called with motion_detection=False.
+    assert client.async_set_camera.call_args[0][0] == TEST_CAMERA_ID
+    assert client.async_set_camera.call_args[0][1][KEY_MOTION_DETECTION] is False
 
     # Verify the switch turns off.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
@@ -91,8 +91,9 @@ async def test_switch_turn_on_off(
 
     await hass.async_block_till_done()
 
-    # Verify correct parameters are passed to the library.
-    assert client.async_set_camera.call_args == call(TEST_CAMERA_ID, camera_on)
+    # Verify set_camera was called with motion_detection=True.
+    assert client.async_set_camera.call_args[0][0] == TEST_CAMERA_ID
+    assert client.async_set_camera.call_args[0][1][KEY_MOTION_DETECTION] is True
 
     # Verify the switch turns on.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -74,8 +74,9 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "off"
 
-    # When the next refresh is called return the updated values.
+    # When the next refresh is called return the original values (motion detection on).
     client.async_get_cameras = AsyncMock(return_value={"cameras": [TEST_CAMERA]})
+    client.async_get_camera = AsyncMock(return_value=TEST_CAMERA)
 
     # Turn switch on.
     with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -56,15 +56,14 @@ async def test_switch_turn_on_off(
     client.async_get_cameras = AsyncMock(return_value={"cameras": [expected_camera]})
 
     # Turn switch off.
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
-        blocking=True,
-    )
+    with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
+            blocking=True,
+        )
 
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     # Verify correct parameters are passed to the library.
@@ -79,19 +78,18 @@ async def test_switch_turn_on_off(
     client.async_get_cameras = AsyncMock(return_value={"cameras": [TEST_CAMERA]})
 
     # Turn switch on.
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
-        blocking=True,
-    )
+    with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
 
     # Verify correct parameters are passed to the library.
     assert client.async_set_camera.call_args == call(TEST_CAMERA_ID, TEST_CAMERA)
-
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
 
     # Verify the switch turns on.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
@@ -215,60 +213,12 @@ async def test_switch_device_info(
     assert TEST_SWITCH_MOTION_DETECTION_ENTITY_ID in entities_from_device
 
 
-async def test_switch_optimistic_state_on_toggle(
-    hass: HomeAssistant,
-) -> None:
-    """Test that toggling a switch updates state immediately without coordinator refresh.
-
-    Regression test for https://github.com/home-assistant/core/issues/169617
-    The switch should not flicker back to the previous state while the coordinator
-    polls stale data during the async set operation.
-    """
-    client = create_mock_motioneye_client()
-    await setup_mock_motioneye_config_entry(hass, client=client)
-
-    # Verify switch starts on.
-    entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
-    assert entity_state
-    assert entity_state.state == "on"
-
-    client.async_get_camera = AsyncMock(return_value=TEST_CAMERA)
-
-    # Turn switch off.
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
-        blocking=True,
-    )
-
-    # State must be off immediately no coordinator tick needed.
-    # This is the core of the fix: optimistic update before any await.
-    entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
-    assert entity_state
-    assert entity_state.state == "off"
-
-    # Turn switch back on.
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
-        blocking=True,
-    )
-
-    # State must be on immediately again without waiting for coordinator.
-    entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
-    assert entity_state
-    assert entity_state.state == "on"
-
-
-async def test_switch_optimistic_state_reverts_on_get_camera_failure(
+async def test_switch_reverts_on_get_camera_failure(
     hass: HomeAssistant,
 ) -> None:
     """Test that coordinator refreshes if async_get_camera fails.
 
-    When the GET fails, the optimistic state was already written, so we
-    trigger a coordinator refresh to revert to the real state.
+    When the GET fails, we trigger a coordinator refresh to revert to the real state.
     Regression test for https://github.com/home-assistant/core/issues/169617
     """
     client = create_mock_motioneye_client()
@@ -276,7 +226,6 @@ async def test_switch_optimistic_state_reverts_on_get_camera_failure(
 
     # Simulate async_get_camera returning no camera data.
     client.async_get_camera = AsyncMock(return_value=None)
-    # Reset set_camera so we can assert it wasn't called by our action
     client.async_set_camera.reset_mock()
 
     await hass.services.async_call(
@@ -289,5 +238,5 @@ async def test_switch_optimistic_state_reverts_on_get_camera_failure(
     # async_set_camera should NOT have been called since GET returned None.
     client.async_set_camera.assert_not_called()
 
-    # Coordinator should have been asked to refresh to revert optimistic state.
+    # Coordinator should have been asked to refresh to revert state.
     assert client.async_get_cameras.call_count >= 1

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -53,7 +53,9 @@ async def test_switch_turn_on_off(
 
     # async_get_camera is called by the switch to fetch the latest config before
     # calling set_camera. Use a fresh deep-copy each call to prevent mutation.
-    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_off))
+    client.async_get_camera = AsyncMock(
+        side_effect=lambda _: copy.deepcopy(TEST_CAMERA)
+    )
     # async_get_cameras is used by the coordinator to refresh state.
     client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
 
@@ -81,9 +83,7 @@ async def test_switch_turn_on_off(
 
     # Now prepare for turn-on: coordinator returns TEST_CAMERA (motion_detection=True).
     camera_on = copy.deepcopy(TEST_CAMERA)
-    client.async_get_camera = AsyncMock(
-        side_effect=lambda _: copy.deepcopy(camera_off)
-    )
+    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_off))
     client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_on]})
 
     # Turn switch on. Patch sleep so the 2s delay is skipped.

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -54,9 +54,7 @@ async def test_switch_turn_on_off(
     # async_get_camera is fetched by the switch before calling set_camera.
     # Use side_effect with deep-copies so the dicts aren't mutated across calls.
     # async_get_cameras is used by the coordinator to refresh state.
-    client.async_get_camera = AsyncMock(
-        side_effect=lambda _: copy.deepcopy(camera_on)
-    )
+    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_on))
     client.async_get_cameras = AsyncMock(
         return_value={"cameras": [copy.deepcopy(camera_off)]}
     )
@@ -85,9 +83,7 @@ async def test_switch_turn_on_off(
     assert entity_state.state == "off"
 
     # Now prepare for turn-on: get_camera returns off state, coordinator returns on.
-    client.async_get_camera = AsyncMock(
-        side_effect=lambda _: copy.deepcopy(camera_off)
-    )
+    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_off))
     client.async_get_cameras = AsyncMock(
         return_value={"cameras": [copy.deepcopy(camera_on)]}
     )

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -47,20 +47,19 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "on"
 
-    # Prepare camera state with motion_detection=False for the coordinator
-    # to return after the turn-off call. Use a fresh deep-copy so the dict
-    # isn't shared with anything else.
+    # Prepare the camera state with motion_detection=False.
     camera_off = copy.deepcopy(TEST_CAMERA)
     camera_off[KEY_MOTION_DETECTION] = False
 
-    # The coordinator will return camera_off after the switch is turned off.
-    # async_get_camera returns a fresh copy each call so it isn't mutated.
+    # async_get_camera is called by the switch to fetch the latest config before
+    # calling set_camera. Use a fresh deep-copy each call to prevent mutation.
     client.async_get_camera = AsyncMock(
         side_effect=lambda _: copy.deepcopy(TEST_CAMERA)
     )
+    # async_get_cameras is used by the coordinator to refresh state.
     client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
 
-    # Turn switch off. Patch sleep so the service call doesn't actually wait 2s.
+    # Turn switch off. Patch sleep so the 2s delay is skipped.
     with patch(
         "homeassistant.components.motioneye.switch.asyncio.sleep",
         new_callable=AsyncMock,
@@ -71,26 +70,25 @@ async def test_switch_turn_on_off(
             {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
             blocking=True,
         )
-
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     # Verify set_camera was called with motion_detection=False.
     assert client.async_set_camera.call_args[0][0] == TEST_CAMERA_ID
     assert client.async_set_camera.call_args[0][1][KEY_MOTION_DETECTION] is False
 
-    # Verify the switch is off after the coordinator refresh completes.
+    # Verify the switch is off after the coordinator refresh triggered by the service.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "off"
 
     # Now prepare for turn-on: coordinator returns TEST_CAMERA (motion_detection=True).
-    # Use a fresh deep-copy of camera_off for async_get_camera so it isn't mutated.
-    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_off))
-    client.async_get_cameras = AsyncMock(
-        return_value={"cameras": [copy.deepcopy(TEST_CAMERA)]}
+    camera_on = copy.deepcopy(TEST_CAMERA)
+    client.async_get_camera = AsyncMock(
+        side_effect=lambda _: copy.deepcopy(camera_off)
     )
+    client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_on]})
 
-    # Turn switch on.
+    # Turn switch on. Patch sleep so the 2s delay is skipped.
     with patch(
         "homeassistant.components.motioneye.switch.asyncio.sleep",
         new_callable=AsyncMock,
@@ -101,14 +99,13 @@ async def test_switch_turn_on_off(
             {ATTR_ENTITY_ID: TEST_SWITCH_MOTION_DETECTION_ENTITY_ID},
             blocking=True,
         )
-
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     # Verify set_camera was called with motion_detection=True.
     assert client.async_set_camera.call_args[0][0] == TEST_CAMERA_ID
     assert client.async_set_camera.call_args[0][1][KEY_MOTION_DETECTION] is True
 
-    # Verify the switch is on after the coordinator refresh completes.
+    # Verify the switch is on after the coordinator refresh triggered by the service.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "on"

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -47,13 +47,14 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "on"
 
+    expected_camera_off = copy.deepcopy(TEST_CAMERA)
+    expected_camera_off[KEY_MOTION_DETECTION] = False
+
+    # async_get_camera returns current state; async_get_cameras returns updated state.
     client.async_get_camera = AsyncMock(return_value=TEST_CAMERA)
-
-    expected_camera = copy.deepcopy(TEST_CAMERA)
-    expected_camera[KEY_MOTION_DETECTION] = False
-
-    # When the next refresh is called return the updated values.
-    client.async_get_cameras = AsyncMock(return_value={"cameras": [expected_camera]})
+    client.async_get_cameras = AsyncMock(
+        return_value={"cameras": [expected_camera_off]}
+    )
 
     # Turn switch off.
     with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):
@@ -67,16 +68,18 @@ async def test_switch_turn_on_off(
     await hass.async_block_till_done()
 
     # Verify correct parameters are passed to the library.
-    assert client.async_set_camera.call_args == call(TEST_CAMERA_ID, expected_camera)
+    assert client.async_set_camera.call_args == call(
+        TEST_CAMERA_ID, expected_camera_off
+    )
 
     # Verify the switch turns off.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "off"
 
-    # When the next refresh is called return the original values (motion detection on).
+    # Now set up for turning on: get_camera returns off state, get_cameras returns on.
+    client.async_get_camera = AsyncMock(return_value=expected_camera_off)
     client.async_get_cameras = AsyncMock(return_value={"cameras": [TEST_CAMERA]})
-    client.async_get_camera = AsyncMock(return_value=TEST_CAMERA)
 
     # Turn switch on.
     with patch("homeassistant.components.motioneye.switch.asyncio.sleep"):

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -53,9 +53,7 @@ async def test_switch_turn_on_off(
 
     # async_get_camera is called by the switch to fetch the latest config before
     # calling set_camera. Use a fresh deep-copy each call to prevent mutation.
-    client.async_get_camera = AsyncMock(
-        side_effect=lambda _: copy.deepcopy(TEST_CAMERA)
-    )
+    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_off))
     # async_get_cameras is used by the coordinator to refresh state.
     client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
 

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -55,7 +55,9 @@ async def test_switch_turn_on_off(
 
     # The coordinator will return camera_off after the switch is turned off.
     # async_get_camera returns a fresh copy each call so it isn't mutated.
-    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(TEST_CAMERA))
+    client.async_get_camera = AsyncMock(
+        side_effect=lambda _: copy.deepcopy(TEST_CAMERA)
+    )
     client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
 
     # Turn switch off. Patch sleep so the service call doesn't actually wait 2s.

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -47,19 +47,18 @@ async def test_switch_turn_on_off(
     assert entity_state
     assert entity_state.state == "on"
 
-    # Snapshot camera states before any service calls so they aren't affected
-    # by the optimistic in-place mutation in _async_send_set_camera.
-    camera_on = copy.deepcopy(TEST_CAMERA)  # motion_detection=True
+    # Prepare camera state with motion_detection=False for the coordinator
+    # to return after the turn-off call. Use a fresh deep-copy so the dict
+    # isn't shared with anything else.
     camera_off = copy.deepcopy(TEST_CAMERA)
     camera_off[KEY_MOTION_DETECTION] = False
 
-    # Turn-off phase: switch GETs camera_on, coordinator sees camera_off.
-    # async_get_camera uses side_effect so each call gets a fresh copy.
-    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_on))
-    client.async_get_cameras = AsyncMock(
-        return_value={"cameras": [copy.deepcopy(camera_off)]}
-    )
+    # The coordinator will return camera_off after the switch is turned off.
+    # async_get_camera returns a fresh copy each call so it isn't mutated.
+    client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(TEST_CAMERA))
+    client.async_get_cameras = AsyncMock(return_value={"cameras": [camera_off]})
 
+    # Turn switch off. Patch sleep so the service call doesn't actually wait 2s.
     with patch(
         "homeassistant.components.motioneye.switch.asyncio.sleep",
         new_callable=AsyncMock,
@@ -77,18 +76,19 @@ async def test_switch_turn_on_off(
     assert client.async_set_camera.call_args[0][0] == TEST_CAMERA_ID
     assert client.async_set_camera.call_args[0][1][KEY_MOTION_DETECTION] is False
 
-    # Verify the switch turns off.
+    # Verify the switch is off after the coordinator refresh completes.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "off"
 
-    # Turn-on phase: switch GETs camera_off, coordinator sees camera with motion_detection=True.
-    # Use TEST_CAMERA directly for the coordinator since it is never mutated.
+    # Now prepare for turn-on: coordinator returns TEST_CAMERA (motion_detection=True).
+    # Use a fresh deep-copy of camera_off for async_get_camera so it isn't mutated.
     client.async_get_camera = AsyncMock(side_effect=lambda _: copy.deepcopy(camera_off))
     client.async_get_cameras = AsyncMock(
         return_value={"cameras": [copy.deepcopy(TEST_CAMERA)]}
     )
 
+    # Turn switch on.
     with patch(
         "homeassistant.components.motioneye.switch.asyncio.sleep",
         new_callable=AsyncMock,
@@ -106,7 +106,7 @@ async def test_switch_turn_on_off(
     assert client.async_set_camera.call_args[0][0] == TEST_CAMERA_ID
     assert client.async_set_camera.call_args[0][1][KEY_MOTION_DETECTION] is True
 
-    # Verify the switch turns on.
+    # Verify the switch is on after the coordinator refresh completes.
     entity_state = hass.states.get(TEST_SWITCH_MOTION_DETECTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "on"


### PR DESCRIPTION
## Proposed change

When toggling a motionEye switch (e.g motion detection), the switch temporarily
reverts to its previous state for several seconds before settling on the correct
new state.

This is a race condition between the switch set operation and the coordinator's
polling loop. The set operation involves two sequential network round trips
(`async_get_camera` then `async_set_camera`). During that time which can be
several seconds on a Raspberry Pi the coordinator fires, reads the old state
from MotionEye (which hasn't applied the change yet), and calls
`_handle_coordinator_update()`, causing the switch to flicker back to its
previous state in the UI.

Fix: optimistically update `self._camera` and call `self.async_write_ha_state()`
**before** the first `await`, so HA reflects the intended state immediately
without waiting for the coordinator to confirm it.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #169617
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr