### PR TITLE
openevse: Set up action exceptions

### DIFF
--- a/homeassistant/components/openevse/number.py
+++ b/homeassistant/components/openevse/number.py
@@ -4,7 +4,13 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+from aiohttp import ContentTypeError, ServerTimeoutError
 from openevsehttp.__main__ import OpenEVSE
+from openevsehttp.exceptions import (
+    AuthenticationError,
+    ParseJSONError,
+    UnsupportedFeature,
+)
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -18,6 +24,7 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -113,4 +120,23 @@ class OpenEVSENumber(CoordinatorEntity[OpenEVSEDataUpdateCoordinator], NumberEnt
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
-        await self.entity_description.set_value_fn(self.coordinator.charger, value)
+        try:
+            await self.entity_description.set_value_fn(self.coordinator.charger, value)
+        except ValueError as err:
+            raise ServiceValidationError(
+                f"Value {value} is out of range for the charger"
+            ) from err
+        except AuthenticationError as err:
+            raise HomeAssistantError(
+                "Authentication failed while communicating with the charger"
+            ) from err
+        except (
+            TimeoutError,
+            ServerTimeoutError,
+            ContentTypeError,
+            ParseJSONError,
+            UnsupportedFeature,
+        ) as err:
+            raise HomeAssistantError(
+                f"Failed to communicate with the charger: {err}"
+            ) from err

--- a/homeassistant/components/openevse/number.py
+++ b/homeassistant/components/openevse/number.py
@@ -124,18 +124,21 @@ class OpenEVSENumber(CoordinatorEntity[OpenEVSEDataUpdateCoordinator], NumberEnt
             await self.entity_description.set_value_fn(self.coordinator.charger, value)
         except ValueError as err:
             raise ServiceValidationError(
-                f"Value {value} is out of range for the charger"
+                f"Value {value} is invalid for the charger: {err}"
             ) from err
         except AuthenticationError as err:
             raise HomeAssistantError(
                 "Authentication failed while communicating with the charger"
+            ) from err
+        except UnsupportedFeature as err:
+            raise HomeAssistantError(
+                f"The charger does not support this feature: {err}"
             ) from err
         except (
             TimeoutError,
             ServerTimeoutError,
             ContentTypeError,
             ParseJSONError,
-            UnsupportedFeature,
         ) as err:
             raise HomeAssistantError(
                 f"Failed to communicate with the charger: {err}"

--- a/tests/components/openevse/test_number.py
+++ b/tests/components/openevse/test_number.py
@@ -2,6 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
+from aiohttp import ContentTypeError, ServerTimeoutError
+from openevsehttp.exceptions import (
+    AuthenticationError,
+    ParseJSONError,
+    UnsupportedFeature,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -12,6 +18,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
@@ -50,3 +57,44 @@ async def test_set_value(
         blocking=True,
     )
     mock_charger.set_current.assert_called_once_with(32.0)
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected"),
+    [
+        (ValueError("out of range"), ServiceValidationError),
+        (AuthenticationError("bad creds"), HomeAssistantError),
+        (TimeoutError("timed out"), HomeAssistantError),
+        (ServerTimeoutError("timed out"), HomeAssistantError),
+        (ParseJSONError("bad json"), HomeAssistantError),
+        (UnsupportedFeature("old firmware"), HomeAssistantError),
+        (
+            ContentTypeError(MagicMock(), (), message="bad content"),
+            HomeAssistantError,
+        ),
+    ],
+)
+async def test_set_value_raises(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+    raised: Exception,
+    expected: type[Exception],
+) -> None:
+    """Test that errors from the charger are translated to HA exceptions."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_charger.set_current.side_effect = raised
+
+    with pytest.raises(expected):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.openevse_mock_config_charge_rate",
+                ATTR_VALUE: 32.0,
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add exceptions for action exception


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
