### PR TITLE
Improve Assist LLM entity targeting

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -399,6 +399,8 @@ class EntityControlTool(Tool):
 
     def __init__(self, service_name: str) -> None:
         """Init the class."""
+        if service_name not in ENTITY_CONTROL_SERVICE_MAP:
+            raise ValueError(f"Unsupported entity control service: {service_name}")
         self._service_name = service_name
         service_label = (
             unicode_slug.slugify(service_name, separator="_").title().replace("_", "")
@@ -453,9 +455,11 @@ class EntityControlTool(Tool):
                 if service_name is None:
                     unsupported_domains.add(service_entity_domain)
                     continue
-                entity_service_calls.setdefault(
+                service_call_entity_ids = entity_service_calls.setdefault(
                     (service_domain, service_name), []
-                ).append(service_entity_id)
+                )
+                if service_entity_id not in service_call_entity_ids:
+                    service_call_entity_ids.append(service_entity_id)
 
             if not entity_service_calls:
                 failed[entity_id] = (
@@ -470,11 +474,14 @@ class EntityControlTool(Tool):
                     else f"Group contains domains that do not support {self._service_name}: "
                     f"{', '.join(sorted(unsupported_domains))}"
                 )
-                continue
 
-            valid_entity_ids.append(entity_id)
+            if entity_id not in valid_entity_ids:
+                valid_entity_ids.append(entity_id)
             for service_key, service_entity_ids in entity_service_calls.items():
-                service_calls.setdefault(service_key, []).extend(service_entity_ids)
+                service_call_entity_ids = service_calls.setdefault(service_key, [])
+                for service_entity_id in service_entity_ids:
+                    if service_entity_id not in service_call_entity_ids:
+                        service_call_entity_ids.append(service_entity_id)
 
         for (service_domain, service_name), service_entity_ids in service_calls.items():
             await hass.services.async_call(
@@ -497,7 +504,9 @@ class EntityControlTool(Tool):
     def _get_service(self, hass: HomeAssistant, domain: str) -> tuple[str, str | None]:
         """Get the service to call for a domain."""
         if (
-            service_name := ENTITY_CONTROL_SERVICE_MAP[self._service_name].get(domain)
+            service_name := ENTITY_CONTROL_SERVICE_MAP.get(self._service_name, {}).get(
+                domain
+            )
         ) and hass.services.has_service(domain, service_name):
             return domain, service_name
 
@@ -958,7 +967,10 @@ def selector_serializer(schema: Any) -> Any:  # noqa: C901
     """Convert selectors into OpenAPI schema."""
     if schema is _entity_control_entity_ids:
         return {
-            "type": "string",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}},
+            ],
             "description": "An entity_id or comma-separated entity_ids from the static context",
         }
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -14,21 +14,49 @@ import slugify as unicode_slug
 import voluptuous as vol
 from voluptuous_openapi import UNSUPPORTED, convert
 
+from homeassistant.components.button import (
+    DOMAIN as BUTTON_DOMAIN,
+    SERVICE_PRESS as SERVICE_PRESS_BUTTON,
+)
 from homeassistant.components.calendar import (
     DOMAIN as CALENDAR_DOMAIN,
     SERVICE_GET_EVENTS,
 )
-from homeassistant.components.cover import INTENT_CLOSE_COVER, INTENT_OPEN_COVER
-from homeassistant.components.homeassistant import async_should_expose
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    INTENT_CLOSE_COVER,
+    INTENT_OPEN_COVER,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+)
+from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.homeassistant import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    async_should_expose,
+)
+from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
 from homeassistant.components.intent import async_device_supports_timers
+from homeassistant.components.lock import (
+    DOMAIN as LOCK_DOMAIN,
+    SERVICE_LOCK,
+    SERVICE_UNLOCK,
+)
 from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
 from homeassistant.components.todo import DOMAIN as TODO_DOMAIN, TodoServices
+from homeassistant.components.valve import (
+    DOMAIN as VALVE_DOMAIN,
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+)
 from homeassistant.components.weather import INTENT_GET_WEATHER
 from homeassistant.const import (
     ATTR_DOMAIN,
+    ATTR_ENTITY_ID,
     ATTR_SERVICE,
     EVENT_HOMEASSISTANT_CLOSE,
     EVENT_SERVICE_REMOVED,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
 )
 from homeassistant.core import Context, Event, HomeAssistant, callback, split_entity_id
 from homeassistant.exceptions import HomeAssistantError
@@ -47,7 +75,29 @@ from . import (
     selector,
     service,
 )
+from .group import expand_entity_ids
 from .singleton import singleton
+
+ENTITY_CONTROL_SERVICE_MAP = {
+    SERVICE_TURN_ON: {
+        BUTTON_DOMAIN: SERVICE_PRESS_BUTTON,
+        COVER_DOMAIN: SERVICE_OPEN_COVER,
+        INPUT_BUTTON_DOMAIN: SERVICE_PRESS_BUTTON,
+        LOCK_DOMAIN: SERVICE_LOCK,
+        VALVE_DOMAIN: SERVICE_OPEN_VALVE,
+    },
+    SERVICE_TURN_OFF: {
+        COVER_DOMAIN: SERVICE_CLOSE_COVER,
+        LOCK_DOMAIN: SERVICE_UNLOCK,
+        VALVE_DOMAIN: SERVICE_CLOSE_VALVE,
+    },
+}
+
+
+def _entity_control_entity_ids(value: str | list) -> list[str]:
+    """Validate exact entity tool entity IDs."""
+    return cv.entity_ids(value)
+
 
 ACTION_PARAMETERS_CACHE: HassKey[
     dict[str, dict[str, tuple[str | None, vol.Schema]]]
@@ -72,10 +122,13 @@ NO_ENTITIES_PROMPT = (
 )
 
 DEVICE_CONTROL_TOOL_USAGE_PROMPT = (
-    "When controlling Home Assistant always call the intent tools. "
+    "When controlling Home Assistant, call intent tools for natural language "
+    "area, device, or domain requests. "
     "Use HassTurnOn to lock and HassTurnOff to unlock a lock. "
     "When controlling a device, prefer passing just name and domain. "
-    "When controlling an area, prefer passing just area name and domain."
+    "When controlling an area, prefer passing just area name and domain. "
+    "When the user requests a specific exposed entity and the static context "
+    "contains its entity_id, use the exact entity_id tool."
 )
 
 DYNAMIC_CONTEXT_PROMPT = (
@@ -341,6 +394,143 @@ class IntentTool(Tool):
         return IntentResponseDict(intent_response)
 
 
+class EntityControlTool(Tool):
+    """LLM tool for controlling exposed entities by exact entity_id."""
+
+    def __init__(self, service_name: str) -> None:
+        """Init the class."""
+        self._service_name = service_name
+        service_label = (
+            unicode_slug.slugify(service_name, separator="_").title().replace("_", "")
+        )
+        self.name = f"HassEntity{service_label}"
+        self.description = (
+            f"Execute Home Assistant {service_name} for exposed entities by exact entity_id. "
+            "Use entity_id values from the static context when a specific device is requested."
+        )
+        self.parameters = vol.Schema(
+            {vol.Required(ATTR_ENTITY_ID): _entity_control_entity_ids}
+        )
+
+    async def async_call(
+        self, hass: HomeAssistant, tool_input: ToolInput, llm_context: LLMContext
+    ) -> JsonObjectType:
+        """Call the Home Assistant turn service for exposed entities."""
+        try:
+            entity_ids = self.parameters(tool_input.tool_args)[ATTR_ENTITY_ID]
+        except vol.Invalid as err:
+            return {"success": False, "error": str(err)}
+
+        valid_entity_ids: list[str] = []
+        failed: dict[str, str] = {}
+        service_calls: dict[tuple[str, str], list[str]] = {}
+
+        for entity_id in entity_ids:
+            if hass.states.get(entity_id) is None:
+                failed[entity_id] = "Entity does not exist"
+                continue
+
+            if llm_context.assistant and not async_should_expose(
+                hass, llm_context.assistant, entity_id
+            ):
+                failed[entity_id] = "Entity is not exposed to this assistant"
+                continue
+
+            domain = split_entity_id(entity_id)[0]
+            service_entity_ids = (
+                expand_entity_ids(hass, [entity_id])
+                if domain == GROUP_DOMAIN
+                else [entity_id]
+            )
+            entity_service_calls: dict[tuple[str, str], list[str]] = {}
+            unsupported_domains: set[str] = set()
+
+            for service_entity_id in service_entity_ids:
+                service_entity_domain = split_entity_id(service_entity_id)[0]
+                service_domain, service_name = self._get_service(
+                    hass, service_entity_domain
+                )
+                if service_name is None:
+                    unsupported_domains.add(service_entity_domain)
+                    continue
+                entity_service_calls.setdefault(
+                    (service_domain, service_name), []
+                ).append(service_entity_id)
+
+            if not entity_service_calls:
+                failed[entity_id] = (
+                    f"Domain {domain} does not support {self._service_name}"
+                )
+                continue
+
+            if unsupported_domains:
+                failed[entity_id] = (
+                    f"Domain {domain} does not support {self._service_name}"
+                    if domain != GROUP_DOMAIN
+                    else f"Group contains domains that do not support {self._service_name}: "
+                    f"{', '.join(sorted(unsupported_domains))}"
+                )
+                continue
+
+            valid_entity_ids.append(entity_id)
+            for service_key, service_entity_ids in entity_service_calls.items():
+                service_calls.setdefault(service_key, []).extend(service_entity_ids)
+
+        for (service_domain, service_name), service_entity_ids in service_calls.items():
+            await hass.services.async_call(
+                service_domain,
+                service_name,
+                {ATTR_ENTITY_ID: service_entity_ids},
+                context=llm_context.context,
+                blocking=True,
+            )
+
+        return cast(
+            JsonObjectType,
+            {
+                "success": bool(valid_entity_ids) and not failed,
+                "done": valid_entity_ids,
+                "failed": failed,
+            },
+        )
+
+    def _get_service(self, hass: HomeAssistant, domain: str) -> tuple[str, str | None]:
+        """Get the service to call for a domain."""
+        if (
+            service_name := ENTITY_CONTROL_SERVICE_MAP[self._service_name].get(domain)
+        ) and hass.services.has_service(domain, service_name):
+            return domain, service_name
+
+        if domain == GROUP_DOMAIN and hass.services.has_service(
+            HOMEASSISTANT_DOMAIN, self._service_name
+        ):
+            return HOMEASSISTANT_DOMAIN, self._service_name
+
+        if hass.services.has_service(
+            HOMEASSISTANT_DOMAIN, self._service_name
+        ) and hass.services.has_service(domain, self._service_name):
+            return HOMEASSISTANT_DOMAIN, self._service_name
+
+        return domain, None
+
+    @staticmethod
+    def has_supported_domain_service(
+        hass: HomeAssistant, domain: str, service_name: str
+    ) -> bool:
+        """Return if the domain can be controlled by the exact entity tool."""
+        if service_name in ENTITY_CONTROL_SERVICE_MAP and (
+            mapped_service := ENTITY_CONTROL_SERVICE_MAP[service_name].get(domain)
+        ):
+            return hass.services.has_service(domain, mapped_service)
+
+        if domain == GROUP_DOMAIN:
+            return hass.services.has_service(HOMEASSISTANT_DOMAIN, service_name)
+
+        return hass.services.has_service(
+            HOMEASSISTANT_DOMAIN, service_name
+        ) and hass.services.has_service(domain, service_name)
+
+
 class IntentResponseDict(dict):
     """Dictionary to represent an intent response resulting from a tool call."""
 
@@ -569,7 +759,14 @@ class AssistAPI(API):
                 "Static Context: An overview of the areas"
                 " and the devices in this smart home:"
             )
-            prompt.append(yaml_util.dump(list(exposed_entities["entities"].values())))
+            prompt.append(
+                yaml_util.dump(
+                    [
+                        {"entity_id": entity_id, **info}
+                        for entity_id, info in exposed_entities["entities"].items()
+                    ]
+                )
+            )
 
         return prompt
 
@@ -639,6 +836,16 @@ class AssistAPI(API):
             )
 
         if exposed_domains:
+            tools.extend(
+                EntityControlTool(service_name)
+                for service_name in (SERVICE_TURN_ON, SERVICE_TURN_OFF)
+                if any(
+                    EntityControlTool.has_supported_domain_service(
+                        self.hass, domain, service_name
+                    )
+                    for domain in exposed_domains
+                )
+            )
             tools.append(GetLiveContextTool())
 
         return tools
@@ -712,10 +919,7 @@ def _get_exposed_entities(
                     area_names.append(area_entry.name)
                     area_names.extend(area_entry.aliases)
 
-        info: dict[str, Any] = {
-            "names": ", ".join(names),
-            "domain": state.domain,
-        }
+        info: dict[str, Any] = {"names": ", ".join(names), "domain": state.domain}
 
         if include_state:
             info["state"] = state.state
@@ -752,6 +956,12 @@ def _get_exposed_entities(
 
 def selector_serializer(schema: Any) -> Any:  # noqa: C901
     """Convert selectors into OpenAPI schema."""
+    if schema is _entity_control_entity_ids:
+        return {
+            "type": "string",
+            "description": "An entity_id or comma-separated entity_ids from the static context",
+        }
+
     if not isinstance(schema, selector.Selector):
         return UNSUPPORTED
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -94,7 +94,7 @@ ENTITY_CONTROL_SERVICE_MAP = {
 }
 
 
-def _entity_control_entity_ids(value: str | list) -> list[str]:
+def _entity_control_entity_ids(value: str | list[str]) -> list[str]:
     """Validate exact entity tool entity IDs."""
     return cv.entity_ids(value)
 
@@ -464,6 +464,9 @@ class EntityControlTool(Tool):
             if not entity_service_calls:
                 failed[entity_id] = (
                     f"Domain {domain} does not support {self._service_name}"
+                    if domain != GROUP_DOMAIN or not unsupported_domains
+                    else f"Group contains domains that do not support {self._service_name}: "
+                    f"{', '.join(sorted(unsupported_domains))}"
                 )
                 continue
 
@@ -968,8 +971,8 @@ def selector_serializer(schema: Any) -> Any:  # noqa: C901
     if schema is _entity_control_entity_ids:
         return {
             "anyOf": [
-                {"type": "string"},
-                {"type": "array", "items": {"type": "string"}},
+                {"type": "string", "format": "entity_id"},
+                {"type": "array", "items": {"type": "string", "format": "entity_id"}},
             ],
             "description": "An entity_id or comma-separated entity_ids from the static context",
         }

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -482,7 +482,7 @@ async def test_prompt_get(
     assert result.messages[0].role == "assistant"
     assert result.messages[0].content.type == "text"
     assert "When controlling Home Assistant" in result.messages[0].content.text
-    assert result.messages[0].content.text.endswith(EXPECTED_PROMPT_SUFFIX)
+    assert EXPECTED_PROMPT_SUFFIX in result.messages[0].content.text
 
 
 async def test_get_unknown_prompt(

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -61,8 +61,9 @@ INITIALIZE_MESSAGE = {
 }
 EVENT_PREFIX = "event: "
 DATA_PREFIX = "data: "
-EXPECTED_PROMPT_ENTITY_DEFINITION = """
-- names: Kitchen Light
+EXPECTED_PROMPT_SUFFIX = """
+- entity_id: light.kitchen
+  names: Kitchen Light
   domain: light
   areas: Kitchen
 """
@@ -481,7 +482,7 @@ async def test_prompt_get(
     assert result.messages[0].role == "assistant"
     assert result.messages[0].content.type == "text"
     assert "When controlling Home Assistant" in result.messages[0].content.text
-    assert EXPECTED_PROMPT_ENTITY_DEFINITION in result.messages[0].content.text
+    assert result.messages[0].content.text.endswith(EXPECTED_PROMPT_SUFFIX)
 
 
 async def test_get_unknown_prompt(

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1493,6 +1493,72 @@ async def test_entity_control_tool_calls_supported_members_in_mixed_groups(
     assert light_calls[0].data == {"entity_id": [exposed_light.entity_id]}
 
 
+async def test_entity_control_tool_reports_unsupported_group_member_domains(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test exact entity control reports unsupported group member domains."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "group", {})
+
+    exposed_sensor = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "exposed_sensor",
+        original_name="Exposed Sensor",
+        suggested_object_id="exposed_sensor",
+    )
+    exposed_binary_sensor = entity_registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "exposed_binary_sensor",
+        original_name="Exposed Binary Sensor",
+        suggested_object_id="exposed_binary_sensor",
+    )
+    hass.states.async_set(exposed_sensor.entity_id, "23")
+    hass.states.async_set(exposed_binary_sensor.entity_id, "on")
+    test_group = await group.Group.async_create_group(
+        hass,
+        "Test Unsupported Group",
+        created_by_service=False,
+        entity_ids=[exposed_sensor.entity_id, exposed_binary_sensor.entity_id],
+        icon=None,
+        mode=None,
+        object_id="test_unsupported_group",
+        order=None,
+    )
+    await hass.async_block_till_done()
+    async_expose_entity(hass, "conversation", test_group.entity_id, True)
+
+    api = await llm.async_get_api(
+        hass,
+        "assist",
+        llm.LLMContext(
+            platform="test_platform",
+            context=Context(),
+            language="*",
+            assistant="conversation",
+            device_id=None,
+        ),
+    )
+
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="HassEntityTurnOff",
+            tool_args={"entity_id": test_group.entity_id},
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "done": [],
+        "failed": {
+            test_group.entity_id: "Group contains domains that do not support turn_off: "
+            "binary_sensor, sensor"
+        },
+    }
+
+
 async def test_entity_control_tool_is_not_exposed_without_homeassistant_service(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -1794,8 +1860,8 @@ async def test_selector_serializer(
     )
     assert selector_serializer(entity_control_schema) == {
         "anyOf": [
-            {"type": "string"},
-            {"type": "array", "items": {"type": "string"}},
+            {"type": "string", "format": "entity_id"},
+            {"type": "array", "items": {"type": "string", "format": "entity_id"}},
         ],
         "description": "An entity_id or comma-separated entity_ids from the static context",
     }

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -2,15 +2,20 @@
 
 from datetime import timedelta
 from decimal import Decimal
+import re
 from unittest.mock import patch
 
 import pytest
 import voluptuous as vol
 
-from homeassistant.components import calendar, todo
+from homeassistant.components import calendar, group, todo
+from homeassistant.components.button import SERVICE_PRESS as SERVICE_PRESS_BUTTON
+from homeassistant.components.cover import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.intent import async_register_timer_handler
+from homeassistant.components.lock import SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.components.script import ScriptConfig
+from homeassistant.components.valve import SERVICE_CLOSE_VALVE, SERVICE_OPEN_VALVE
 from homeassistant.core import Context, HomeAssistant, State, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
@@ -28,6 +33,11 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonObjectType
 
 from tests.common import MockConfigEntry, async_mock_service
+
+
+def _strip_static_entity_ids(prompt: str) -> str:
+    """Strip entity IDs from the static context for legacy prompt assertions."""
+    return re.sub(r"- entity_id: [^\n]+\n  names:", "- names:", prompt)
 
 
 @pytest.fixture
@@ -156,6 +166,8 @@ async def test_assist_api(
         original_name="Kitchen",
         suggested_object_id="kitchen",
     ).write_unavailable_state(hass)
+    async_mock_service(hass, "light", "turn_on")
+    async_mock_service(hass, "light", "turn_off")
 
     test_context = Context()
     llm_context = llm.LLMContext(
@@ -183,7 +195,12 @@ async def test_assist_api(
 
     assert len(llm.async_get_apis(hass)) == 1
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert [tool.name for tool in api.tools] == ["GetDateTime", "GetLiveContext"]
+    assert [tool.name for tool in api.tools] == [
+        "GetDateTime",
+        "HassEntityTurnOn",
+        "HassEntityTurnOff",
+        "GetLiveContext",
+    ]
 
     # Match all
     intent_handler.platforms = None
@@ -192,6 +209,8 @@ async def test_assist_api(
     assert [tool.name for tool in api.tools] == [
         "test_intent",
         "GetDateTime",
+        "HassEntityTurnOn",
+        "HassEntityTurnOff",
         "GetLiveContext",
     ]
 
@@ -199,7 +218,7 @@ async def test_assist_api(
     intent_handler.platforms = {"light"}
 
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert len(api.tools) == 3
+    assert len(api.tools) == 5
     tool = api.tools[0]
     assert tool.name == "test_intent"
     assert tool.description == "Execute Home Assistant test_intent intent"
@@ -669,10 +688,13 @@ Static Context: An overview of the areas and the devices in this smart home:
   areas: Test Area 2
 """
     first_part_prompt = (
-        "When controlling Home Assistant always call the intent tools. "
+        "When controlling Home Assistant, call intent tools for natural language "
+        "area, device, or domain requests. "
         "Use HassTurnOn to lock and HassTurnOff to unlock a lock. "
         "When controlling a device, prefer passing just name and domain. "
-        "When controlling an area, prefer passing just area name and domain."
+        "When controlling an area, prefer passing just area name and domain. "
+        "When the user requests a specific exposed entity and the static context "
+        "contains its entity_id, use the exact entity_id tool."
     )
     no_timer_prompt = "This device is not able to start timers."
 
@@ -707,7 +729,8 @@ Static Context: An overview of the areas and the devices in this smart home:
         " knowledge.\n"
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert api.api_prompt == (
+    assert "entity_id: light.kitchen" in api.api_prompt
+    assert _strip_static_entity_ids(api.api_prompt) == (
         f"""{first_part_prompt}
 {dynamic_context_prompt}
 {stateless_exposed_entities_prompt}
@@ -732,7 +755,7 @@ Static Context: An overview of the areas and the devices in this smart home:
         "should target this area."
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert api.api_prompt == (
+    assert _strip_static_entity_ids(api.api_prompt) == (
         f"""{first_part_prompt}
 {dynamic_context_prompt}
 {stateless_exposed_entities_prompt}
@@ -749,7 +772,7 @@ Static Context: An overview of the areas and the devices in this smart home:
         "should target this area."
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert api.api_prompt == (
+    assert _strip_static_entity_ids(api.api_prompt) == (
         f"""{first_part_prompt}
 {dynamic_context_prompt}
 {stateless_exposed_entities_prompt}
@@ -762,7 +785,7 @@ Static Context: An overview of the areas and the devices in this smart home:
 
     api = await llm.async_get_api(hass, "assist", llm_context)
     # The no_timer_prompt is gone
-    assert api.api_prompt == (
+    assert _strip_static_entity_ids(api.api_prompt) == (
         f"""{first_part_prompt}
 {dynamic_context_prompt}
 {stateless_exposed_entities_prompt}
@@ -1059,6 +1082,359 @@ async def test_get_live_context_tool_filter(
     }
 
 
+async def test_entity_control_tool_uses_only_exposed_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test controlling exposed entities by exact entity_id."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    exposed_light = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "exposed_light",
+        original_name="Exposed Light",
+        suggested_object_id="exposed_light",
+    )
+    unexposed_light = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "unexposed_light",
+        original_name="Unexposed Light",
+        suggested_object_id="unexposed_light",
+    )
+    exposed_lock = entity_registry.async_get_or_create(
+        "lock",
+        "test",
+        "exposed_lock",
+        original_name="Exposed Lock",
+        suggested_object_id="exposed_lock",
+    )
+    exposed_sensor = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "exposed_sensor",
+        original_name="Exposed Sensor",
+        suggested_object_id="exposed_sensor",
+    )
+    hass.states.async_set(exposed_light.entity_id, "on")
+    hass.states.async_set(unexposed_light.entity_id, "on")
+    hass.states.async_set(exposed_lock.entity_id, "locked")
+    hass.states.async_set(exposed_sensor.entity_id, "23")
+    async_expose_entity(hass, "conversation", exposed_light.entity_id, True)
+    async_expose_entity(hass, "conversation", unexposed_light.entity_id, False)
+    async_expose_entity(hass, "conversation", exposed_lock.entity_id, True)
+    async_expose_entity(hass, "conversation", exposed_sensor.entity_id, True)
+
+    light_calls = async_mock_service(hass, "light", "turn_off")
+    unlock_calls = async_mock_service(hass, "lock", SERVICE_UNLOCK)
+    context = Context()
+    llm_context = llm.LLMContext(
+        platform="test_platform",
+        context=context,
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+    api = await llm.async_get_api(hass, "assist", llm_context)
+    assert "HassEntityTurnOff" in [tool.name for tool in api.tools]
+
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="HassEntityTurnOff", tool_args={})
+    )
+
+    assert result["success"] is False
+    assert "entity_id" in result["error"]
+
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="HassEntityTurnOff",
+            tool_args={"entity_id": f"{exposed_light.entity_id}, light.missing"},
+        )
+    )
+
+    assert len(light_calls) == 1
+    assert light_calls[0].data == {"entity_id": [exposed_light.entity_id]}
+    assert result == {
+        "success": False,
+        "done": [exposed_light.entity_id],
+        "failed": {"light.missing": "Entity does not exist"},
+    }
+    light_calls.clear()
+
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="HassEntityTurnOff",
+            tool_args={
+                "entity_id": [
+                    exposed_light.entity_id,
+                    unexposed_light.entity_id,
+                    exposed_lock.entity_id,
+                    exposed_sensor.entity_id,
+                    "light.missing",
+                ]
+            },
+        )
+    )
+
+    assert len(light_calls) == 1
+    assert light_calls[0].data == {"entity_id": [exposed_light.entity_id]}
+    assert light_calls[0].context is context
+    assert len(unlock_calls) == 1
+    assert unlock_calls[0].data == {"entity_id": [exposed_lock.entity_id]}
+    assert unlock_calls[0].context is context
+    assert result == {
+        "success": False,
+        "done": [exposed_light.entity_id, exposed_lock.entity_id],
+        "failed": {
+            unexposed_light.entity_id: "Entity is not exposed to this assistant",
+            exposed_sensor.entity_id: "Domain sensor does not support turn_off",
+            "light.missing": "Entity does not exist",
+        },
+    }
+
+
+async def test_entity_control_tool_maps_on_off_intent_special_domains(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test exact entity control maps the same special domains as on/off intents."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    exposed_cover = entity_registry.async_get_or_create(
+        "cover",
+        "test",
+        "exposed_cover",
+        original_name="Exposed Cover",
+        suggested_object_id="exposed_cover",
+    )
+    exposed_lock = entity_registry.async_get_or_create(
+        "lock",
+        "test",
+        "exposed_lock",
+        original_name="Exposed Lock",
+        suggested_object_id="exposed_lock",
+    )
+    exposed_valve = entity_registry.async_get_or_create(
+        "valve",
+        "test",
+        "exposed_valve",
+        original_name="Exposed Valve",
+        suggested_object_id="exposed_valve",
+    )
+    exposed_button = entity_registry.async_get_or_create(
+        "button",
+        "test",
+        "exposed_button",
+        original_name="Exposed Button",
+        suggested_object_id="exposed_button",
+    )
+    exposed_input_button = entity_registry.async_get_or_create(
+        "input_button",
+        "test",
+        "exposed_input_button",
+        original_name="Exposed Input Button",
+        suggested_object_id="exposed_input_button",
+    )
+    hass.states.async_set(exposed_cover.entity_id, "closed")
+    hass.states.async_set(exposed_lock.entity_id, "locked")
+    hass.states.async_set(exposed_valve.entity_id, "closed")
+    hass.states.async_set(exposed_button.entity_id, "unknown")
+    hass.states.async_set(exposed_input_button.entity_id, "unknown")
+    for entity_id in (
+        exposed_cover.entity_id,
+        exposed_lock.entity_id,
+        exposed_valve.entity_id,
+        exposed_button.entity_id,
+        exposed_input_button.entity_id,
+    ):
+        async_expose_entity(hass, "conversation", entity_id, True)
+
+    cover_open_calls = async_mock_service(hass, "cover", SERVICE_OPEN_COVER)
+    cover_close_calls = async_mock_service(hass, "cover", SERVICE_CLOSE_COVER)
+    lock_calls = async_mock_service(hass, "lock", SERVICE_LOCK)
+    unlock_calls = async_mock_service(hass, "lock", SERVICE_UNLOCK)
+    valve_open_calls = async_mock_service(hass, "valve", SERVICE_OPEN_VALVE)
+    valve_close_calls = async_mock_service(hass, "valve", SERVICE_CLOSE_VALVE)
+    button_calls = async_mock_service(hass, "button", SERVICE_PRESS_BUTTON)
+    input_button_calls = async_mock_service(hass, "input_button", SERVICE_PRESS_BUTTON)
+
+    api = await llm.async_get_api(
+        hass,
+        "assist",
+        llm.LLMContext(
+            platform="test_platform",
+            context=Context(),
+            language="*",
+            assistant="conversation",
+            device_id=None,
+        ),
+    )
+
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="HassEntityTurnOn",
+            tool_args={
+                "entity_id": [
+                    exposed_cover.entity_id,
+                    exposed_lock.entity_id,
+                    exposed_valve.entity_id,
+                    exposed_button.entity_id,
+                    exposed_input_button.entity_id,
+                ]
+            },
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "done": [
+            exposed_cover.entity_id,
+            exposed_lock.entity_id,
+            exposed_valve.entity_id,
+            exposed_button.entity_id,
+            exposed_input_button.entity_id,
+        ],
+        "failed": {},
+    }
+    assert cover_open_calls[0].data == {"entity_id": [exposed_cover.entity_id]}
+    assert lock_calls[0].data == {"entity_id": [exposed_lock.entity_id]}
+    assert valve_open_calls[0].data == {"entity_id": [exposed_valve.entity_id]}
+    assert button_calls[0].data == {"entity_id": [exposed_button.entity_id]}
+    assert input_button_calls[0].data == {"entity_id": [exposed_input_button.entity_id]}
+
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="HassEntityTurnOff",
+            tool_args={
+                "entity_id": [
+                    exposed_cover.entity_id,
+                    exposed_lock.entity_id,
+                    exposed_valve.entity_id,
+                    exposed_button.entity_id,
+                ]
+            },
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "done": [
+            exposed_cover.entity_id,
+            exposed_lock.entity_id,
+            exposed_valve.entity_id,
+        ],
+        "failed": {exposed_button.entity_id: "Domain button does not support turn_off"},
+    }
+    assert cover_close_calls[0].data == {"entity_id": [exposed_cover.entity_id]}
+    assert unlock_calls[0].data == {"entity_id": [exposed_lock.entity_id]}
+    assert valve_close_calls[0].data == {"entity_id": [exposed_valve.entity_id]}
+
+
+async def test_entity_control_tool_allows_exposed_groups(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test exact entity control expands groups and maps member services."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "group", {})
+
+    exposed_light = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "exposed_light",
+        original_name="Exposed Light",
+        suggested_object_id="exposed_light",
+    )
+    exposed_lock = entity_registry.async_get_or_create(
+        "lock",
+        "test",
+        "exposed_lock",
+        original_name="Exposed Lock",
+        suggested_object_id="exposed_lock",
+    )
+    hass.states.async_set(exposed_light.entity_id, "on")
+    hass.states.async_set(exposed_lock.entity_id, "locked")
+    test_group = await group.Group.async_create_group(
+        hass,
+        "Test Group",
+        created_by_service=False,
+        entity_ids=[exposed_light.entity_id, exposed_lock.entity_id],
+        icon=None,
+        mode=None,
+        object_id="test_group",
+        order=None,
+    )
+    await hass.async_block_till_done()
+    async_expose_entity(hass, "conversation", test_group.entity_id, True)
+
+    light_calls = async_mock_service(hass, "light", "turn_off")
+    unlock_calls = async_mock_service(hass, "lock", SERVICE_UNLOCK)
+
+    api = await llm.async_get_api(
+        hass,
+        "assist",
+        llm.LLMContext(
+            platform="test_platform",
+            context=Context(),
+            language="*",
+            assistant="conversation",
+            device_id=None,
+        ),
+    )
+
+    assert "HassEntityTurnOff" in [tool.name for tool in api.tools]
+
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="HassEntityTurnOff",
+            tool_args={"entity_id": test_group.entity_id},
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "done": [test_group.entity_id],
+        "failed": {},
+    }
+    assert light_calls[0].data == {"entity_id": [exposed_light.entity_id]}
+    assert unlock_calls[0].data == {"entity_id": [exposed_lock.entity_id]}
+
+
+async def test_entity_control_tool_is_not_exposed_without_homeassistant_service(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test exact entity control tools require homeassistant turn services."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    hass.services.async_remove("homeassistant", "turn_off")
+
+    exposed_light = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "exposed_light",
+        original_name="Exposed Light",
+        suggested_object_id="exposed_light",
+    )
+    hass.states.async_set(exposed_light.entity_id, "on")
+    async_expose_entity(hass, "conversation", exposed_light.entity_id, True)
+    async_mock_service(hass, "light", "turn_off")
+
+    api = await llm.async_get_api(
+        hass,
+        "assist",
+        llm.LLMContext(
+            platform="test_platform",
+            context=Context(),
+            language="*",
+            assistant="conversation",
+            device_id=None,
+        ),
+    )
+
+    assert "HassEntityTurnOff" not in [tool.name for tool in api.tools]
+
+
 async def test_script_tool(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -1321,6 +1697,13 @@ async def test_selector_serializer(
     api = await llm.async_get_api(hass, "assist", llm_context)
     selector_serializer = api.custom_serializer
 
+    entity_control_schema = next(
+        iter(llm.EntityControlTool("turn_off").parameters.schema.values())
+    )
+    assert selector_serializer(entity_control_schema) == {
+        "type": "string",
+        "description": "An entity_id or comma-separated entity_ids from the static context",
+    }
     assert selector_serializer(selector.ActionSelector()) == {"type": "string"}
     assert selector_serializer(selector.AddonSelector()) == {"type": "string"}
     assert selector_serializer(selector.AreaSelector()) == {"type": "string"}

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 from decimal import Decimal
-import re
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +15,7 @@ from homeassistant.components.intent import async_register_timer_handler
 from homeassistant.components.lock import SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.components.script import ScriptConfig
 from homeassistant.components.valve import SERVICE_CLOSE_VALVE, SERVICE_OPEN_VALVE
+from homeassistant.const import SERVICE_TURN_OFF
 from homeassistant.core import Context, HomeAssistant, State, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
@@ -29,7 +29,7 @@ from homeassistant.helpers import (
     selector,
 )
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, yaml as yaml_util
 from homeassistant.util.json import JsonObjectType
 
 from tests.common import MockConfigEntry, async_mock_service
@@ -37,7 +37,30 @@ from tests.common import MockConfigEntry, async_mock_service
 
 def _strip_static_entity_ids(prompt: str) -> str:
     """Strip entity IDs from the static context for legacy prompt assertions."""
-    return re.sub(r"- entity_id: [^\n]+\n  names:", "- names:", prompt)
+    marker = (
+        "Static Context: An overview of the areas and the devices in this smart home:\n"
+    )
+    prefix, separator, static_context = prompt.partition(marker)
+    if not separator:
+        return prompt
+
+    yaml_lines: list[str] = []
+    suffix_lines: list[str] = []
+    in_suffix = False
+    for line in static_context.splitlines(keepends=True):
+        if not in_suffix and line.startswith(("- ", "  ")):
+            yaml_lines.append(line)
+        else:
+            in_suffix = True
+            suffix_lines.append(line)
+
+    entities = yaml_util.parse_yaml("".join(yaml_lines))
+    assert isinstance(entities, list)
+    for entity in entities:
+        assert isinstance(entity, dict)
+        entity.pop("entity_id", None)
+
+    return f"{prefix}{separator}{yaml_util.dump(entities)}{''.join(suffix_lines)}"
 
 
 @pytest.fixture
@@ -1168,6 +1191,7 @@ async def test_entity_control_tool_uses_only_exposed_entities(
             tool_args={
                 "entity_id": [
                     exposed_light.entity_id,
+                    exposed_light.entity_id,
                     unexposed_light.entity_id,
                     exposed_lock.entity_id,
                     exposed_sensor.entity_id,
@@ -1399,6 +1423,74 @@ async def test_entity_control_tool_allows_exposed_groups(
     }
     assert light_calls[0].data == {"entity_id": [exposed_light.entity_id]}
     assert unlock_calls[0].data == {"entity_id": [exposed_lock.entity_id]}
+
+
+async def test_entity_control_tool_calls_supported_members_in_mixed_groups(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test exact entity control calls supported members in mixed groups."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "group", {})
+
+    exposed_light = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "exposed_light",
+        original_name="Exposed Light",
+        suggested_object_id="exposed_light",
+    )
+    exposed_sensor = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "exposed_sensor",
+        original_name="Exposed Sensor",
+        suggested_object_id="exposed_sensor",
+    )
+    hass.states.async_set(exposed_light.entity_id, "on")
+    hass.states.async_set(exposed_sensor.entity_id, "23")
+    test_group = await group.Group.async_create_group(
+        hass,
+        "Test Mixed Group",
+        created_by_service=False,
+        entity_ids=[exposed_light.entity_id, exposed_sensor.entity_id],
+        icon=None,
+        mode=None,
+        object_id="test_mixed_group",
+        order=None,
+    )
+    await hass.async_block_till_done()
+    async_expose_entity(hass, "conversation", test_group.entity_id, True)
+
+    light_calls = async_mock_service(hass, "light", "turn_off")
+
+    api = await llm.async_get_api(
+        hass,
+        "assist",
+        llm.LLMContext(
+            platform="test_platform",
+            context=Context(),
+            language="*",
+            assistant="conversation",
+            device_id=None,
+        ),
+    )
+
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="HassEntityTurnOff",
+            tool_args={"entity_id": test_group.entity_id},
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "done": [test_group.entity_id],
+        "failed": {
+            test_group.entity_id: "Group contains domains that do not support turn_off: sensor"
+        },
+    }
+    assert light_calls[0].data == {"entity_id": [exposed_light.entity_id]}
 
 
 async def test_entity_control_tool_is_not_exposed_without_homeassistant_service(
@@ -1698,10 +1790,13 @@ async def test_selector_serializer(
     selector_serializer = api.custom_serializer
 
     entity_control_schema = next(
-        iter(llm.EntityControlTool("turn_off").parameters.schema.values())
+        iter(llm.EntityControlTool(SERVICE_TURN_OFF).parameters.schema.values())
     )
     assert selector_serializer(entity_control_schema) == {
-        "type": "string",
+        "anyOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}},
+        ],
         "description": "An entity_id or comma-separated entity_ids from the static context",
     }
     assert selector_serializer(selector.ActionSelector()) == {"type": "string"}


### PR DESCRIPTION
## Summary

Improves the Assist LLM API for specific entity control:

- includes each exposed entity id in the static Assist context
- adds `HassEntityTurnOn` and `HassEntityTurnOff` tools for exact exposed `entity_id` control
- rejects missing or non-exposed entities before calling Home Assistant services

This gives LLM-backed conversation agents a canonical path for commands that refer to a specific entity when fuzzy intent matching is ambiguous.

## Validation

- `python3 -m py_compile homeassistant/helpers/llm.py tests/helpers/test_llm.py`
- `/tmp/ha-core-test-venv/bin/ruff check homeassistant/helpers/llm.py tests/helpers/test_llm.py`

Targeted pytest could not be run locally in my Python 3.13 environment because this checkout uses syntax that is not accepted by Python 3.13 before test collection. CI should run in the project-supported environment.