### PR TITLE
Add opening/closing state icons to valve domain

### DIFF
--- a/homeassistant/components/valve/icons.json
+++ b/homeassistant/components/valve/icons.json
@@ -11,7 +11,9 @@
     "_": {
       "default": "mdi:valve-open",
       "state": {
-        "closed": "mdi:valve-closed"
+        "closed": "mdi:valve-closed",
+        "closing": "mdi:valve",
+        "opening": "mdi:valve"
       }
     },
     "gas": {
@@ -20,7 +22,9 @@
     "water": {
       "default": "mdi:valve-open",
       "state": {
-        "closed": "mdi:valve-closed"
+        "closed": "mdi:valve-closed",
+        "closing": "mdi:valve",
+        "opening": "mdi:valve"
       }
     }
   },


### PR DESCRIPTION
## Proposed change
Adds state-based icons for `opening` and `closing` states in the `valve` domain. Currently these transient states fall back to the default open icon (`mdi:valve-open`), making them visually indistinguishable from the fully `open` state.

The `cover` domain already differentiates these states (with directional arrows). This change brings the `valve` domain in line.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
