### PR TITLE
Catch additional errors as potentially retryable errors during energy data updates

### DIFF
--- a/homeassistant/components/waterfurnace/coordinator.py
+++ b/homeassistant/components/waterfurnace/coordinator.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from waterfurnace.waterfurnace import (
     WaterFurnace,
     WFCredentialError,
+    WFError,
     WFException,
     WFGateway,
     WFNoDataError,
@@ -172,7 +173,7 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
                 frequency="1H",
                 timezone_str=self.hass.config.time_zone,
             )
-        except WFCredentialError:
+        except WFCredentialError, WFError:
             try:
                 self.client.login()
             except WFCredentialError as err:
@@ -189,6 +190,10 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
             except WFCredentialError as err:
                 raise UpdateFailed(
                     "Authentication failed during energy data fetch"
+                ) from err
+            except WFError as err:
+                raise UpdateFailed(
+                    "Error fetching energy data after re-authentication"
                 ) from err
         return [
             (reading.timestamp, reading.total_power)

--- a/tests/components/waterfurnace/test_statistics.py
+++ b/tests/components/waterfurnace/test_statistics.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from waterfurnace.waterfurnace import WFCredentialError, WFEnergyData, WFNoDataError
+from waterfurnace.waterfurnace import (
+    WFCredentialError,
+    WFEnergyData,
+    WFError,
+    WFException,
+    WFNoDataError,
+)
 
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.models.statistics import StatisticData
@@ -225,6 +231,10 @@ async def test_no_data_error_handled_gracefully(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
+@pytest.mark.parametrize(
+    "energy_error",
+    [WFCredentialError("session expired"), WFError("401 Unauthorized")],
+)
 @pytest.mark.freeze_time(NOW)
 @pytest.mark.usefixtures("seed_statistics")
 async def test_login_credential_error_raises_update_failed(
@@ -233,16 +243,15 @@ async def test_login_credential_error_raises_update_failed(
     mock_config_entry: MockConfigEntry,
     mock_waterfurnace_client: Mock,
     freezer: FrozenDateTimeFactory,
+    energy_error: WFException,
 ) -> None:
-    """Test that WFCredentialError during energy login raises UpdateFailed."""
+    """Test that WFCredentialError/WFError during energy fetch triggers re-login."""
     await _setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     # On next poll, get_energy_data fails with expired session, then
     # re-login also fails with credential error.
-    mock_waterfurnace_client.get_energy_data.side_effect = WFCredentialError(
-        "session expired"
-    )
+    mock_waterfurnace_client.get_energy_data.side_effect = energy_error
     mock_waterfurnace_client.login.side_effect = WFCredentialError("bad creds")
 
     await _trigger_energy_poll(hass, freezer)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an additional check for `WFError` in the energy coordinator as a possible error that could be retried.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Found during testing the beta that sometimes we'd lose a valid session from the server after some time (seems weirdly inconsistent from testing, anywhere from 1h to 6h).


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
