### PR TITLE
Add a test that reproduces a port matching issue in `get_url`

### DIFF
--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -587,6 +587,49 @@ async def test_get_url(hass: HomeAssistant) -> None:
         assert get_url(hass, allow_internal=False)
 
 
+@pytest.mark.parametrize("prefer_external", [False, True])
+@pytest.mark.parametrize(
+    ("internal_url", "external_url"),
+    [
+        ("https://example.com", "https://example.com:18123"),
+        ("https://example.com:18123", "https://example.com"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("host_header", "expected_url"),
+    [
+        ("example.com", "https://example.com"),
+        ("example.com:443", "https://example.com"),
+        ("example.com:18123", "https://example.com:18123"),
+    ],
+)
+async def test_get_url_host_matching_respects_port(
+    hass: HomeAssistant,
+    internal_url: str,
+    external_url: str,
+    host_header: str,
+    expected_url: str,
+    prefer_external: bool,
+) -> None:
+    """Test that get_url respects the port when matching the request host."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": internal_url,
+            "external_url": external_url,
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.headers = {hdrs.HOST: host_header}
+        mock_request_context.get.return_value = mock_request
+
+        assert (
+            get_url(hass, require_current_request=True, prefer_external=prefer_external)
+            == expected_url
+        )
+
+
 async def test_get_request_host_with_port(hass: HomeAssistant) -> None:
     """Test getting the host of the current web request from the request context."""
     with pytest.raises(NoURLAvailableError):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a test that reproduces a port matching issue in `get_url`. This is meant to start a discussion about potential risks for fixing this.


Steps to reproduce the existing issue:

1. Configure internal url and external url as the same hostname but with different ports
2. Call get_url matching the request

Expected behavior:

- Returned url matches the request url

Actual behavior:

- Returned url differs depending on whether prefer_external is set or not and which host matches first


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #153820
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
