### PR TITLE
Prefer external URL in WWW-Authenticate header for RFC 9728

### DIFF
--- a/homeassistant/helpers/http.py
+++ b/homeassistant/helpers/http.py
@@ -59,13 +59,17 @@ def request_handler_factory(
             # Import here to avoid circular dependency with network.py
             from .network import NoURLAvailableError, get_url  # noqa: PLC0415
 
+            # Get the current request header to include as resource metadata
+            # endpoint for RFC9728. We currently prefer external since this
+            # is likely most used by remote OAuth clients
             try:
-                url_prefix = get_url(hass, require_current_request=True)
+                url_prefix = get_url(
+                    hass, require_current_request=True, prefer_external=True
+                )
             except NoURLAvailableError:
                 # Omit header to avoid leaking configured URLs
                 raise HTTPUnauthorized from None
             raise HTTPUnauthorized(
-                # Include resource metadata endpoint for RFC9728
                 headers={
                     "WWW-Authenticate": (
                         f'Bearer resource_metadata="{url_prefix}'

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -190,8 +190,8 @@ def mock_current_request(
         # ("https://foo.com:18123", "https://foo.com", "foo.com:18123", "https://foo.com:18123"),
     ],
     ids=[
-        "request_host_matches_external",
         "request_host_matches_internal",
+        "request_host_matches_external",
         "internal_no_port_request_external",
         "internal_port_request_external",
         "request_internal_distinct_host",

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -1,11 +1,13 @@
 """Tests for Home Assistant View."""
 
+from collections.abc import Generator
 from decimal import Decimal
 from http import HTTPStatus
 import json
 import math
 from unittest.mock import AsyncMock, Mock, patch
 
+from aiohttp import hdrs
 from aiohttp.web_exceptions import (
     HTTPBadRequest,
     HTTPInternalServerError,
@@ -15,10 +17,12 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.http import KEY_HASS
+from homeassistant.components.http.request_context import current_request
 from homeassistant.components.http.view import (
     HomeAssistantView,
     request_handler_factory,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotFound, Unauthorized
 from homeassistant.helpers.network import NoURLAvailableError
 
@@ -143,3 +147,75 @@ async def test_requires_auth_omits_www_authenticate_without_url(
             AsyncMock(),
         )(mock_request)
     assert "WWW-Authenticate" not in exc_info.value.headers
+
+
+@pytest.fixture
+def mock_current_request(
+    mock_request: Mock, request_host: str, hass: HomeAssistant
+) -> Generator[Mock]:
+    """Set the current request context."""
+    mock_request.get = Mock(return_value=False)
+    mock_request.headers = {hdrs.HOST: request_host}
+    mock_request.app = {KEY_HASS: hass}
+
+    token = current_request.set(mock_request)
+    yield mock_request
+    current_request.reset(token)
+
+
+@pytest.mark.parametrize(
+    ("internal_url", "external_url", "request_host", "expected_url"),
+    [
+        # Match either internal or external
+        ("https://foo.com", "https://example.com", "foo.com:18123", "https://foo.com"),
+        ("https://example.com", "https://foo.com", "foo.com:18123", "https://foo.com"),
+        # Requests have a port and match external url
+        (
+            "https://foo.com",
+            "https://foo.com:18123",
+            "foo.com:18123",
+            "https://foo.com:18123",
+        ),
+        ("https://foo.com:18123", "https://foo.com", "foo.com", "https://foo.com"),
+        (
+            "http://192.168.1.2:8123",
+            "https://foo.com:18123",
+            "192.168.1.2:8123",
+            "http://192.168.1.2:8123",
+        ),
+        # Note: We currently do not fully properly handle port matching for
+        # internal urls. The tests above work because of prefer_external=True, and
+        # we can improve get_url so that these cases also work in the future:
+        # ("https://foo.com", "https://foo.com:18123", "foo.com", "https://foo.com"),
+        # ("https://foo.com:18123", "https://foo.com", "foo.com:18123", "https://foo.com:18123"),
+    ],
+    ids=[
+        "request_host_matches_external",
+        "request_host_matches_internal",
+        "internal_no_port_request_external",
+        "internal_port_request_external",
+        "request_internal_distinct_host",
+    ],
+)
+async def test_requires_auth_www_authenticate_prefer_external(
+    mock_current_request: Mock,
+    hass: HomeAssistant,
+    internal_url: str,
+    external_url: str,
+    expected_url: str,
+) -> None:
+    """Test that 401 responses include WWW-Authenticate header matching the requested URL."""
+    hass.config.internal_url = internal_url
+    hass.config.external_url = external_url
+
+    with pytest.raises(HTTPUnauthorized) as exc_info:
+        await request_handler_factory(
+            hass,
+            Mock(requires_auth=True),
+            AsyncMock(),
+        )(mock_current_request)
+
+    assert exc_info.value.headers["WWW-Authenticate"] == (
+        "Bearer resource_metadata="
+        f'"{expected_url}/.well-known/oauth-protected-resource"'
+    )

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -170,6 +170,12 @@ def mock_current_request(
         ("https://foo.com", "https://example.com", "foo.com:18123", "https://foo.com"),
         ("https://example.com", "https://foo.com", "foo.com:18123", "https://foo.com"),
         # Requests have a port and match external url
+        # Note: We currently do not fully properly handle port matching for
+        # internal urls. The tests here work because of prefer_external=True. We
+        # can improve get_url so that additional cases where the internal url
+        # have the same hostname work in future:
+        # - Match request to internal url when external url has a port
+        # - Match request to external url when internal url has a port
         (
             "https://foo.com",
             "https://foo.com:18123",
@@ -183,11 +189,6 @@ def mock_current_request(
             "192.168.1.2:8123",
             "http://192.168.1.2:8123",
         ),
-        # Note: We currently do not fully properly handle port matching for
-        # internal urls. The tests above work because of prefer_external=True, and
-        # we can improve get_url so that these cases also work in the future:
-        # ("https://foo.com", "https://foo.com:18123", "foo.com", "https://foo.com"),
-        # ("https://foo.com:18123", "https://foo.com", "foo.com:18123", "https://foo.com:18123"),
     ],
     ids=[
         "request_host_matches_internal",


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update the HTTP view request handler to use `prefer_external=True` when generating the resource metadata URL in the `WWW-Authenticate` header. This ensures that remote OAuth clients (targeted at MCP clients) can correctly locate authentication information. 

This is working around a larger issue related to port matching that I am looking at in #169654. This is a smaller scoped changed for `WWW-Authenticate` to reduce the scope.

Chagnes:
- Add comprehensive regression tests in `test_view.py` for URL matching.
- Refactor `test_view.py` to use a cleaner, fixture-based approach for mocking the current request context.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #153820
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
