### PR TITLE
Bump pyisy to 3.5.1

### DIFF
--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -24,7 +24,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["pyisy"],
-  "requirements": ["pyisy==3.4.1"],
+  "requirements": ["pyisy==3.5.1"],
   "ssdp": [
     {
       "deviceType": "urn:udi-com:device:X_Insteon_Lighting_Device:1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2213,7 +2213,7 @@ pyiskra==0.1.27
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.4.1
+pyisy==3.5.1
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1899,7 +1899,7 @@ pyiskra==0.1.27
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.4.1
+pyisy==3.5.1
 
 # homeassistant.components.ituran
 pyituran==0.1.5

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -4,7 +4,6 @@ import re
 from unittest.mock import patch
 
 from pyisy import ISYConnectionError, ISYInvalidAuthError
-import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.isy994.const import (

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -190,9 +190,7 @@ async def test_form_isy_connection_error(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_isy_parse_response_error(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_form_isy_parse_response_error(hass: HomeAssistant) -> None:
     """Test we handle poorly formatted XML response from ISY."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -207,7 +205,7 @@ async def test_form_isy_parse_response_error(
         )
 
     assert result2["type"] is FlowResultType.FORM
-    assert "ISY Could not parse response, poorly formatted XML." in caplog.text
+    assert result2["errors"] == {"base": "cannot_connect"}
 
 
 async def test_form_no_name_in_response(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump `pyisy` from 3.4.1 to 3.5.1. No changes required on HA side.

Notable upstream changes affecting this integration:

- `ISY.initialize()` now fail-fasts with `ISYResponseParseError` when the controller does not return load-bearing setup data (status / time / nodes / programs). Already handled here — converted to `ConfigEntryNotReady`, so cases that previously silently mounted an empty controller will now retry.
- Event-stream status constants migrated to a `StrEnum` (`EventStreamStatus`); the old `ES_*` module-level names are kept as back-compat aliases. This integration does not import any of them, so no code change is required.
- `get_network()` now returns `None` on 404 / empty payloads instead of erroring; `NetworkResources` handles `xml=None` and `isy.networking.nobjs` will simply be empty when the controller has no network resources.
- Added `retry404=True` on command-issuing endpoints (`ISY.query`, `send_x10_cmd`, …) to absorb spurious 404s that the ISY-994 emits when the Insteon network is busy.
- Drops the `python-dateutil` runtime dependency in favor of an internal datetime parser.
- Minimum Python bumped to 3.11 (Home Assistant already requires ≥ 3.13).

No changes required in `homeassistant/components/isy994/`.

https://github.com/automicus/PyISY/releases/tag/v3.5.1

https://github.com/automicus/PyISY/compare/v3.4.1...v3.5.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #n/a
- This PR is related to issue: (all upstream)
- Link to documentation pull request: n/a
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

Diff between library versions: https://github.com/automicus/PyISY/compare/v3.4.1...v3.5.1
Release notes: https://github.com/automicus/PyISY/releases/tag/v3.5.1

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. **Live tested against PROD system**
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr