### PR TITLE
Add vehicle images for Renault integration

### DIFF
--- a/homeassistant/components/renault/const.py
+++ b/homeassistant/components/renault/const.py
@@ -18,6 +18,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.DEVICE_TRACKER,
+    Platform.IMAGE,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/renault/image.py
+++ b/homeassistant/components/renault/image.py
@@ -1,0 +1,48 @@
+"""Support for Renault image entities."""
+
+from homeassistant.components.image import ImageEntity, ImageEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from . import RenaultConfigEntry
+from .entity import RenaultEntity
+from .renault_vehicle import RenaultVehicleProxy
+
+PARALLEL_UPDATES = 0
+
+VEHICLE_IMAGE_DESCRIPTION = ImageEntityDescription(
+    key="vehicle_image",
+    translation_key="vehicle_image",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: RenaultConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Renault image entities from config entry."""
+    entities = [
+        RenaultImageSensor(vehicle, VEHICLE_IMAGE_DESCRIPTION)
+        for vehicle in config_entry.runtime_data.vehicles.values()
+        if vehicle.details.get_picture()
+    ]
+    async_add_entities(entities)
+
+
+class RenaultImageSensor(RenaultEntity, ImageEntity):
+    """Representation of a Renault vehicle image."""
+
+    def __init__(
+        self, vehicle: RenaultVehicleProxy, description: ImageEntityDescription
+    ) -> None:
+        """Initialize the image entity."""
+        RenaultEntity.__init__(self, vehicle, description)
+        ImageEntity.__init__(self, vehicle.hass)
+        self._attr_image_last_updated = dt_util.utcnow()
+
+    @property
+    def image_url(self) -> str | None:
+        """Return the URL for the image."""
+        return self.vehicle.details.get_picture()

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -94,6 +94,11 @@
         "name": "[%key:common::config_flow::data::location%]"
       }
     },
+    "image": {
+      "vehicle_image": {
+        "name": "Vehicle image"
+      }
+    },
     "number": {
       "charge_limit_min": {
         "name": "Minimum charge level"

--- a/tests/components/renault/snapshots/test_image.ambr
+++ b/tests/components/renault/snapshots/test_image.ambr
@@ -1,0 +1,313 @@
+# serializer version: 1
+# name: test_images[captur_fuel][image.reg_captur_fuel_vehicle_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.reg_captur_fuel_vehicle_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle image',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vehicle image',
+    'platform': 'renault',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_image',
+    'unique_id': 'vf1capturfuelvin_vehicle_image',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[captur_fuel][image.reg_captur_fuel_vehicle_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': '31e4701317bfcb0fd2cd8246a8546e699cfa19b3ebbbb67fa636e594085f3e42',
+      'entity_picture': '/api/image_proxy/image.reg_captur_fuel_vehicle_image?token=31e4701317bfcb0fd2cd8246a8546e699cfa19b3ebbbb67fa636e594085f3e42',
+      'friendly_name': 'REG-CAPTUR-FUEL Vehicle image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.reg_captur_fuel_vehicle_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-05-02T17:59:58.443472+00:00',
+  })
+# ---
+# name: test_images[captur_phev][image.reg_captur_phev_vehicle_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.reg_captur_phev_vehicle_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle image',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vehicle image',
+    'platform': 'renault',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_image',
+    'unique_id': 'vf1capturphevvin_vehicle_image',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[captur_phev][image.reg_captur_phev_vehicle_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': 'a36c44b6f40ee7ffad2974ea9b19b6fd7558e88c5930bcc1a7ecc0cbc8d7b258',
+      'entity_picture': '/api/image_proxy/image.reg_captur_phev_vehicle_image?token=a36c44b6f40ee7ffad2974ea9b19b6fd7558e88c5930bcc1a7ecc0cbc8d7b258',
+      'friendly_name': 'REG-CAPTUR_PHEV Vehicle image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.reg_captur_phev_vehicle_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-05-02T17:59:58.413599+00:00',
+  })
+# ---
+# name: test_images[megane_e_tech][image.reg_meg_0_vehicle_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.reg_meg_0_vehicle_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle image',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vehicle image',
+    'platform': 'renault',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_image',
+    'unique_id': 'vf1meganeetechvin_vehicle_image',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[megane_e_tech][image.reg_meg_0_vehicle_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': 'cb732dcbc090c3c4b48de7c9a520ee90f02184de86d91f47f143a5ed181342fe',
+      'entity_picture': '/api/image_proxy/image.reg_meg_0_vehicle_image?token=cb732dcbc090c3c4b48de7c9a520ee90f02184de86d91f47f143a5ed181342fe',
+      'friendly_name': 'REG-MEG-0 Vehicle image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.reg_meg_0_vehicle_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-05-02T17:59:58.497501+00:00',
+  })
+# ---
+# name: test_images[twingo_3_electric][image.reg_twingo_iii_vehicle_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.reg_twingo_iii_vehicle_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle image',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vehicle image',
+    'platform': 'renault',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_image',
+    'unique_id': 'vf1twingoiiivin_vehicle_image',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[twingo_3_electric][image.reg_twingo_iii_vehicle_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': '46c3df21535b5410990fbc0d55f4c1353126588ea411220c0733a4c4e948b4fa',
+      'entity_picture': '/api/image_proxy/image.reg_twingo_iii_vehicle_image?token=46c3df21535b5410990fbc0d55f4c1353126588ea411220c0733a4c4e948b4fa',
+      'friendly_name': 'REG-TWINGO-III Vehicle image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.reg_twingo_iii_vehicle_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-05-02T17:59:58.470672+00:00',
+  })
+# ---
+# name: test_images[zoe_40][image.reg_zoe_40_vehicle_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.reg_zoe_40_vehicle_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle image',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vehicle image',
+    'platform': 'renault',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_image',
+    'unique_id': 'vf1zoe40vin_vehicle_image',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[zoe_40][image.reg_zoe_40_vehicle_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': '6b6622054e76adb3a91798b41eb018543334b6fd4ced8c3437397841e45b33e6',
+      'entity_picture': '/api/image_proxy/image.reg_zoe_40_vehicle_image?token=6b6622054e76adb3a91798b41eb018543334b6fd4ced8c3437397841e45b33e6',
+      'friendly_name': 'REG-ZOE-40 Vehicle image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.reg_zoe_40_vehicle_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-05-02T17:59:58.354900+00:00',
+  })
+# ---
+# name: test_images[zoe_50][image.reg_zoe_50_vehicle_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.reg_zoe_50_vehicle_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle image',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Vehicle image',
+    'platform': 'renault',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_image',
+    'unique_id': 'vf1zoe50vin_vehicle_image',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_images[zoe_50][image.reg_zoe_50_vehicle_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': '11ac21220d87b8b36842bfc56330534ba254a4955eb71dd583471462a9da35f9',
+      'entity_picture': '/api/image_proxy/image.reg_zoe_50_vehicle_image?token=11ac21220d87b8b36842bfc56330534ba254a4955eb71dd583471462a9da35f9',
+      'friendly_name': 'REG-ZOE-50 Vehicle image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.reg_zoe_50_vehicle_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-05-02T17:59:58.384733+00:00',
+  })
+# ---

--- a/tests/components/renault/snapshots/test_image.ambr
+++ b/tests/components/renault/snapshots/test_image.ambr
@@ -39,8 +39,8 @@
 # name: test_images[captur_fuel][image.reg_captur_fuel_vehicle_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'access_token': '31e4701317bfcb0fd2cd8246a8546e699cfa19b3ebbbb67fa636e594085f3e42',
-      'entity_picture': '/api/image_proxy/image.reg_captur_fuel_vehicle_image?token=31e4701317bfcb0fd2cd8246a8546e699cfa19b3ebbbb67fa636e594085f3e42',
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.reg_captur_fuel_vehicle_image?token=1',
       'friendly_name': 'REG-CAPTUR-FUEL Vehicle image',
     }),
     'context': <ANY>,
@@ -48,7 +48,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-05-02T17:59:58.443472+00:00',
+    'state': '2024-01-01T00:00:00+00:00',
   })
 # ---
 # name: test_images[captur_phev][image.reg_captur_phev_vehicle_image-entry]
@@ -91,8 +91,8 @@
 # name: test_images[captur_phev][image.reg_captur_phev_vehicle_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'access_token': 'a36c44b6f40ee7ffad2974ea9b19b6fd7558e88c5930bcc1a7ecc0cbc8d7b258',
-      'entity_picture': '/api/image_proxy/image.reg_captur_phev_vehicle_image?token=a36c44b6f40ee7ffad2974ea9b19b6fd7558e88c5930bcc1a7ecc0cbc8d7b258',
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.reg_captur_phev_vehicle_image?token=1',
       'friendly_name': 'REG-CAPTUR_PHEV Vehicle image',
     }),
     'context': <ANY>,
@@ -100,7 +100,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-05-02T17:59:58.413599+00:00',
+    'state': '2024-01-01T00:00:00+00:00',
   })
 # ---
 # name: test_images[megane_e_tech][image.reg_meg_0_vehicle_image-entry]
@@ -143,8 +143,8 @@
 # name: test_images[megane_e_tech][image.reg_meg_0_vehicle_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'access_token': 'cb732dcbc090c3c4b48de7c9a520ee90f02184de86d91f47f143a5ed181342fe',
-      'entity_picture': '/api/image_proxy/image.reg_meg_0_vehicle_image?token=cb732dcbc090c3c4b48de7c9a520ee90f02184de86d91f47f143a5ed181342fe',
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.reg_meg_0_vehicle_image?token=1',
       'friendly_name': 'REG-MEG-0 Vehicle image',
     }),
     'context': <ANY>,
@@ -152,7 +152,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-05-02T17:59:58.497501+00:00',
+    'state': '2024-01-01T00:00:00+00:00',
   })
 # ---
 # name: test_images[twingo_3_electric][image.reg_twingo_iii_vehicle_image-entry]
@@ -195,8 +195,8 @@
 # name: test_images[twingo_3_electric][image.reg_twingo_iii_vehicle_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'access_token': '46c3df21535b5410990fbc0d55f4c1353126588ea411220c0733a4c4e948b4fa',
-      'entity_picture': '/api/image_proxy/image.reg_twingo_iii_vehicle_image?token=46c3df21535b5410990fbc0d55f4c1353126588ea411220c0733a4c4e948b4fa',
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.reg_twingo_iii_vehicle_image?token=1',
       'friendly_name': 'REG-TWINGO-III Vehicle image',
     }),
     'context': <ANY>,
@@ -204,7 +204,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-05-02T17:59:58.470672+00:00',
+    'state': '2024-01-01T00:00:00+00:00',
   })
 # ---
 # name: test_images[zoe_40][image.reg_zoe_40_vehicle_image-entry]
@@ -247,8 +247,8 @@
 # name: test_images[zoe_40][image.reg_zoe_40_vehicle_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'access_token': '6b6622054e76adb3a91798b41eb018543334b6fd4ced8c3437397841e45b33e6',
-      'entity_picture': '/api/image_proxy/image.reg_zoe_40_vehicle_image?token=6b6622054e76adb3a91798b41eb018543334b6fd4ced8c3437397841e45b33e6',
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.reg_zoe_40_vehicle_image?token=1',
       'friendly_name': 'REG-ZOE-40 Vehicle image',
     }),
     'context': <ANY>,
@@ -256,7 +256,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-05-02T17:59:58.354900+00:00',
+    'state': '2024-01-01T00:00:00+00:00',
   })
 # ---
 # name: test_images[zoe_50][image.reg_zoe_50_vehicle_image-entry]
@@ -299,8 +299,8 @@
 # name: test_images[zoe_50][image.reg_zoe_50_vehicle_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'access_token': '11ac21220d87b8b36842bfc56330534ba254a4955eb71dd583471462a9da35f9',
-      'entity_picture': '/api/image_proxy/image.reg_zoe_50_vehicle_image?token=11ac21220d87b8b36842bfc56330534ba254a4955eb71dd583471462a9da35f9',
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.reg_zoe_50_vehicle_image?token=1',
       'friendly_name': 'REG-ZOE-50 Vehicle image',
     }),
     'context': <ANY>,
@@ -308,6 +308,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-05-02T17:59:58.384733+00:00',
+    'state': '2024-01-01T00:00:00+00:00',
   })
 # ---

--- a/tests/components/renault/test_image.py
+++ b/tests/components/renault/test_image.py
@@ -23,6 +23,35 @@ def override_platforms() -> Generator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def mock_getrandbits() -> Generator[None]:
+    """Mock image access token which normally is randomized."""
+    with patch(
+        "homeassistant.components.image.SystemRandom.getrandbits",
+        return_value=1,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("fixtures_with_data")
+@pytest.mark.parametrize("vehicle_type", ["zoe_50"], indirect=True)
+async def test_images_no_picture(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that no image entities are created when vehicle has no picture."""
+    with patch(
+        "renault_api.kamereon.models.KamereonVehicleDetails.get_picture",
+        return_value=None,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(entity_registry.entities) == 0
+
+
+@pytest.mark.freeze_time("2024-01-01 00:00:00+00:00")
 @pytest.mark.usefixtures("fixtures_with_data")
 async def test_images(
     hass: HomeAssistant,

--- a/tests/components/renault/test_image.py
+++ b/tests/components/renault/test_image.py
@@ -1,0 +1,37 @@
+"""Tests for Renault image entities."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import snapshot_platform
+
+pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicles")
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.renault.PLATFORMS", [Platform.IMAGE]):
+        yield
+
+
+@pytest.mark.usefixtures("fixtures_with_data")
+async def test_images(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test for Renault image entities."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds an image sensor showing the vehicle image, for each vehicle reported by the Renault integration. The image data is – as far as I can see – always returned. Although, the code checks if the image is present and creates the image sensor accordingly. It leverages the capacbility of the `renault-api` to [get that information](https://github.com/hacf-fr/renault-api/pull/722).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45146
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
