### PR TITLE
Fix wrapped connection errors in Duco discovery flows

### DIFF
--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -65,7 +65,9 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             box_name, mac = await self._validate_input(discovery_info.host)
         except DucoConnectionError:
             return self.async_abort(reason="cannot_connect")
-        except DucoError:
+        except DucoError as err:
+            if _is_connection_error(err):
+                return self.async_abort(reason="cannot_connect")
             _LOGGER.exception("Unexpected error discovering Duco box via zeroconf")
             return self.async_abort(reason="unknown")
 
@@ -106,9 +108,12 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
                 box_name, mac = await self._validate_input(user_input[CONF_HOST])
             except DucoConnectionError:
                 errors["base"] = "cannot_connect"
-            except DucoError:
-                _LOGGER.exception("Unexpected error connecting to Duco box")
-                errors["base"] = "unknown"
+            except DucoError as err:
+                if _is_connection_error(err):
+                    errors["base"] = "cannot_connect"
+                else:
+                    _LOGGER.exception("Unexpected error connecting to Duco box")
+                    errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id(format_mac(mac))
                 self._abort_if_unique_id_mismatch()
@@ -137,9 +142,12 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
                 box_name, mac = await self._validate_input(user_input[CONF_HOST])
             except DucoConnectionError:
                 errors["base"] = "cannot_connect"
-            except DucoError:
-                _LOGGER.exception("Unexpected error connecting to Duco box")
-                errors["base"] = "unknown"
+            except DucoError as err:
+                if _is_connection_error(err):
+                    errors["base"] = "cannot_connect"
+                else:
+                    _LOGGER.exception("Unexpected error connecting to Duco box")
+                    errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id(format_mac(mac), raise_on_progress=False)
                 self._abort_if_unique_id_configured()
@@ -169,3 +177,13 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
         board_info = await client.async_get_board_info()
         lan_info = await client.async_get_lan_info()
         return board_info.box_name, lan_info.mac
+
+
+def _is_connection_error(err: BaseException) -> bool:
+    """Return if an error was ultimately caused by a connection failure."""
+    current: BaseException | None = err
+    while current is not None:
+        if isinstance(current, DucoConnectionError):
+            return True
+        current = current.__cause__
+    return False

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -47,7 +47,9 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             box_name, _ = await self._validate_input(discovery_info.ip)
         except DucoConnectionError:
             return self.async_abort(reason="cannot_connect")
-        except DucoError:
+        except DucoError as err:
+            if _is_connection_error(err):
+                return self.async_abort(reason="cannot_connect")
             _LOGGER.exception("Unexpected error discovering Duco box via DHCP")
             return self.async_abort(reason="unknown")
 

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -6,7 +6,7 @@ from ipaddress import IPv4Address
 from ssl import SSLContext
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
-from duco.exceptions import DucoConnectionError, DucoError
+from duco.exceptions import DucoAuthenticationError, DucoConnectionError, DucoError
 from duco.models import BoardInfo, LanInfo
 import pytest
 
@@ -39,6 +39,13 @@ DHCP_DISCOVERY = DhcpServiceInfo(
 )
 
 
+def _wrapped_connection_error() -> DucoAuthenticationError:
+    """Return an authentication error caused by a connection failure."""
+    err = DucoAuthenticationError("Failed to fetch device info for API key generation")
+    err.__cause__ = DucoConnectionError("Connection refused")
+    return err
+
+
 async def test_user_flow_success(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,
@@ -66,6 +73,7 @@ async def test_user_flow_success(
     ("exception", "expected_error"),
     [
         (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (_wrapped_connection_error(), "cannot_connect"),
         (DucoError("Unexpected error"), "unknown"),
     ],
 )
@@ -195,6 +203,7 @@ async def test_zeroconf_discovery_already_configured_same_ip(
     ("exception", "expected_reason"),
     [
         (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (_wrapped_connection_error(), "cannot_connect"),
         (DucoError("Unexpected error"), "unknown"),
     ],
 )
@@ -290,6 +299,7 @@ async def test_reconfigure_flow_wrong_device(
     ("exception", "expected_error"),
     [
         (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (_wrapped_connection_error(), "cannot_connect"),
         (DucoError("Unexpected error"), "unknown"),
     ],
 )

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -407,6 +407,7 @@ async def test_dhcp_discovery_already_configured_same_ip(
     ("exception", "expected_reason"),
     [
         (DucoConnectionError("Connection refused"), "cannot_connect"),
+        (_wrapped_connection_error(), "cannot_connect"),
         (DucoError("Unexpected error"), "unknown"),
     ],
 )


### PR DESCRIPTION
## Proposed change
This change fixes a Duco discovery bug where a transport failure can be wrapped by the Duco library as a `DucoAuthenticationError` during API key generation.

Before this change, the config flow treated that wrapped failure as an unexpected Duco error, which caused noisy `Unexpected error discovering Duco box` log entries during discovery even though the underlying problem was simply that the device could not be reached.

This PR walks the exception cause chain and maps wrapped connection failures to `cannot_connect` in all relevant config flow paths:
- DHCP discovery
- Zeroconf discovery
- User setup
- Reconfigure

The tests were updated to cover wrapped connection failures so the flow behavior stays aligned across all discovery and setup paths.

> [!CAUTION]
> Please consider adding this PR to milestone `2026.5.0` so this fix can be included in the upcoming May release.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Milestone request: Please consider adding this PR to milestone `2026.5.0`.

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr