### PR TITLE
Fix UniFi wired client speed sensor respecting track_clients option

### DIFF
--- a/homeassistant/components/unifi/hub/config.py
+++ b/homeassistant/components/unifi/hub/config.py
@@ -56,9 +56,9 @@ class UnifiConfig:
 
     # Device tracker options
 
-    option_track_clients: list[str]
+    option_track_clients: bool
     """Config entry option to not track clients."""
-    option_track_wired_clients: list[str]
+    option_track_wired_clients: bool
     """Config entry option to not track wired clients."""
     option_track_devices: bool
     """Config entry option to not track devices."""

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -107,6 +107,11 @@ def async_client_uptime_value_fn(hub: UnifiHub, client: Client) -> datetime:
 @callback
 def async_wired_client_allowed_fn(hub: UnifiHub, obj_id: str) -> bool:
     """Check if client is wired and allowed."""
+    if (
+        obj_id not in hub.config.option_supported_clients
+        and not hub.config.option_track_clients
+    ):
+        return False
     client = hub.api.clients[obj_id]
     if not client.is_wired or client.wired_rate_mbps <= 0:
         return False

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -107,9 +107,8 @@ def async_client_uptime_value_fn(hub: UnifiHub, client: Client) -> datetime:
 @callback
 def async_wired_client_allowed_fn(hub: UnifiHub, obj_id: str) -> bool:
     """Check if client is wired and allowed."""
-    if (
-        obj_id not in hub.config.option_supported_clients
-        and not hub.config.option_track_clients
+    if obj_id not in hub.config.option_supported_clients and (
+        not hub.config.option_track_clients or not hub.config.option_track_wired_clients
     ):
         return False
     client = hub.api.clients[obj_id]

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -24,6 +24,7 @@ from homeassistant.components.unifi.const import (
     CONF_DETECTION_TIME,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
+    CONF_TRACK_WIRED_CLIENTS,
     DEFAULT_DETECTION_TIME,
     DEVICE_STATES,
 )
@@ -588,6 +589,17 @@ async def test_wired_client_speed_sensor_tracking_disabled(
     hass: HomeAssistant,
 ) -> None:
     """Verify wired client speed sensor is not created when track_clients is disabled."""
+    assert hass.states.get("sensor.wired_client_link_speed") is None
+
+
+@pytest.mark.parametrize("config_entry_options", [{CONF_TRACK_WIRED_CLIENTS: False}])
+@pytest.mark.parametrize("client_payload", [[WIRED_CLIENT]])
+@pytest.mark.usefixtures("config_entry_setup")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_wired_client_speed_sensor_wired_tracking_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """Verify wired client speed sensor is not created when track_wired_clients is disabled."""
     assert hass.states.get("sensor.wired_client_link_speed") is None
 
 

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -20,6 +20,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
     CONF_ALLOW_UPTIME_SENSORS,
+    CONF_CLIENT_SOURCE,
     CONF_DETECTION_TIME,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
@@ -577,6 +578,31 @@ async def test_wired_client_speed_sensor(
         await hass.async_block_till_done()
 
     assert hass.states.get("sensor.wired_client_link_speed").state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("config_entry_options", [{CONF_TRACK_CLIENTS: False}])
+@pytest.mark.parametrize("client_payload", [[WIRED_CLIENT]])
+@pytest.mark.usefixtures("config_entry_setup")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_wired_client_speed_sensor_tracking_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """Verify wired client speed sensor is not created when track_clients is disabled."""
+    assert hass.states.get("sensor.wired_client_link_speed") is None
+
+
+@pytest.mark.parametrize(
+    "config_entry_options",
+    [{CONF_TRACK_CLIENTS: False, CONF_CLIENT_SOURCE: [WIRED_CLIENT["mac"]]}],
+)
+@pytest.mark.parametrize("client_payload", [[WIRED_CLIENT]])
+@pytest.mark.usefixtures("config_entry_setup")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_wired_client_speed_sensor_supported_client_bypass(
+    hass: HomeAssistant,
+) -> None:
+    """Verify wired client speed sensor is created for supported clients even when tracking is disabled."""
+    assert hass.states.get("sensor.wired_client_link_speed").state == "1000"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The UniFi integration creates a "wired client link speed" diagnostic sensor for every wired network device (non-Ubiquiti clients), even when the user has disabled client tracking via the `track_clients` option. This causes unwanted (disabled) entities to appear in Home Assistant for all wired network clients.

This PR fixes `async_wired_client_allowed_fn` in `sensor.py` to respect `option_track_clients`, consistent with how `async_bandwidth_sensor_allowed_fn` and `async_uptime_sensor_allowed_fn` already handle this option. Clients explicitly listed in `option_supported_clients` (Entity Sources) are still allowed regardless.

Additionally, the incorrect type annotations for `option_track_clients` and `option_track_wired_clients` in `hub/config.py` are corrected from `list[str]` to `bool` — they were always stored and used as booleans.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
