### PR TITLE
Improve ProxmoxVE config flow preparing bug fixing

### DIFF
--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -394,7 +394,7 @@ class ProxmoxNoNodesFound(ProxmoxError):
 
 
 class ProxmoxNoVMLXCFound(ProxmoxError):
-    """Error to indicate no lxc or vm found."""
+    """Error to indicate no LXC or VM found."""
 
 
 class ProxmoxInitFailed(ProxmoxError):

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -97,6 +97,19 @@ def _get_nodes_data(data: dict[str, Any]) -> list[dict[str, Any]]:
             verify_ssl=data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
             **auth_kwargs,
         )
+    except AuthenticationError as err:
+        raise ProxmoxAuthenticationError from err
+    except SSLError as err:
+        raise ProxmoxSSLError from err
+    except ConnectTimeout as err:
+        raise ProxmoxConnectTimeout from err
+    except ResourceException as err:
+        _LOGGER.debug("Error during Proxmox client initialisation", exc_info=True)
+        raise ProxmoxInitFailed from err
+    except requests.exceptions.ConnectionError as err:
+        raise ProxmoxConnectionError from err
+
+    try:
         nodes = client.nodes.get()
     except AuthenticationError as err:
         raise ProxmoxAuthenticationError from err
@@ -105,6 +118,7 @@ def _get_nodes_data(data: dict[str, Any]) -> list[dict[str, Any]]:
     except ConnectTimeout as err:
         raise ProxmoxConnectTimeout from err
     except ResourceException as err:
+        _LOGGER.debug("Error fetching nodes", exc_info=True)
         raise ProxmoxNoNodesFound from err
     except requests.exceptions.ConnectionError as err:
         raise ProxmoxConnectionError from err
@@ -115,7 +129,10 @@ def _get_nodes_data(data: dict[str, Any]) -> list[dict[str, Any]]:
             vms = client.nodes(node["node"]).qemu.get()
             containers = client.nodes(node["node"]).lxc.get()
         except ResourceException as err:
-            raise ProxmoxNoNodesFound from err
+            _LOGGER.debug(
+                "Error fetching VMs/LXC for node %s", node["node"], exc_info=True
+            )
+            raise ProxmoxNoVMLXCFound from err
         except requests.exceptions.ConnectionError as err:
             raise ProxmoxConnectionError from err
 
@@ -298,8 +315,14 @@ class ProxmoxveConfigFlow(ConfigFlow, domain=DOMAIN):
         except ProxmoxSSLError as exc:
             errors["base"] = "ssl_error"
             err = exc
+        except ProxmoxInitFailed as exc:
+            errors["base"] = "api_error_no_details"
+            err = exc
         except ProxmoxNoNodesFound as exc:
             errors["base"] = "no_nodes_found"
+            err = exc
+        except ProxmoxNoVMLXCFound as exc:
+            errors["base"] = "no_vmlxc_found"
             err = exc
         except ProxmoxConnectionError as exc:
             errors["base"] = "cannot_connect"
@@ -368,6 +391,14 @@ class ProxmoxError(HomeAssistantError):
 
 class ProxmoxNoNodesFound(ProxmoxError):
     """Error to indicate no nodes found."""
+
+
+class ProxmoxNoVMLXCFound(ProxmoxError):
+    """Error to indicate no lxc or vm found."""
+
+
+class ProxmoxInitFailed(ProxmoxError):
+    """Error to indicate API initialisation failure."""
 
 
 class ProxmoxConnectTimeout(ProxmoxError):

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -6,7 +6,7 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
-      "api_error_no_details": "An error occurred while communicating with the Proxmox VE instance",
+      "api_error_no_details": "An error occurred while communicating with the Proxmox VE instance.",
       "cannot_connect": "Cannot connect to Proxmox VE server",
       "connect_timeout": "[%key:common::config_flow::error::timeout_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -11,7 +11,7 @@
       "connect_timeout": "[%key:common::config_flow::error::timeout_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "no_nodes_found": "No active nodes were found on the Proxmox VE server.",
-      "no_vmlxc_found": "No LCX or VM were found on the Proxmox VE server.",
+      "no_vmlxc_found": "No LXC or VM were found on the Proxmox VE server.",
       "ssl_error": "SSL check failed. Check the SSL settings"
     },
     "step": {
@@ -327,7 +327,7 @@
       "message": "The configured Proxmox VE user does not have permission to manage the power state of VMs and containers. Please grant the user the 'VM.PowerMgmt' permission and try again."
     },
     "no_vmlxc_found": {
-      "message": "No LCX or VM were found on the Proxmox VE server."
+      "message": "No LXC or VM were found on the Proxmox VE server."
     },
     "permissions_error": {
       "message": "Failed to retrieve Proxmox VE permissions. Please check your credentials and try again."

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -6,10 +6,12 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
+      "api_error_no_details": "An error occurred while communicating with the Proxmox VE instance",
       "cannot_connect": "Cannot connect to Proxmox VE server",
       "connect_timeout": "[%key:common::config_flow::error::timeout_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "no_nodes_found": "No active nodes found",
+      "no_nodes_found": "No active nodes were found on the Proxmox VE server.",
+      "no_vmlxc_found": "No LCX or VM were found on the Proxmox VE server.",
       "ssl_error": "SSL check failed. Check the SSL settings"
     },
     "step": {
@@ -323,6 +325,9 @@
     },
     "no_permission_vm_lxc_power": {
       "message": "The configured Proxmox VE user does not have permission to manage the power state of VMs and containers. Please grant the user the 'VM.PowerMgmt' permission and try again."
+    },
+    "no_vmlxc_found": {
+      "message": "No LCX or VM were found on the Proxmox VE server."
     },
     "permissions_error": {
       "message": "Failed to retrieve Proxmox VE permissions. Please check your credentials and try again."

--- a/tests/components/proxmoxve/conftest.py
+++ b/tests/components/proxmoxve/conftest.py
@@ -85,8 +85,8 @@ def mock_setup_entry() -> Generator[AsyncMock]:
     with patch(
         "homeassistant.components.proxmoxve.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+    ) as mock_setup:
+        yield mock_setup
 
 
 @pytest.fixture
@@ -103,6 +103,9 @@ def mock_proxmox_client():
         mock_instance = MagicMock()
         mock_api.return_value = mock_instance
         mock_api_cf.return_value = mock_instance
+
+        mock_instance._mock_api = mock_api
+        mock_instance._mock_api_cf = mock_api_cf
 
         mock_instance.access.ticket.post.return_value = load_json_object_fixture(
             "access_ticket.json", DOMAIN

--- a/tests/components/proxmoxve/test_config_flow.py
+++ b/tests/components/proxmoxve/test_config_flow.py
@@ -147,8 +147,8 @@ async def test_form(
             "connect_timeout",
         ),
         (
-            ResourceException("404", "status_message", "content"),
-            "no_nodes_found",
+            ResourceException("500", "status_message", "content"),
+            "api_error_no_details",
         ),
         (
             requests.exceptions.ConnectionError("Connection error"),
@@ -157,6 +157,71 @@ async def test_form(
     ],
 )
 async def test_form_exceptions(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    exception: Exception,
+    reason: str,
+) -> None:
+    """Test we handle all exceptions."""
+    mock_proxmox_client._mock_api_cf.side_effect = exception
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_USER_STEP,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user_auth"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_USER_AUTH_STEP_PASSWORD,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": reason}
+
+    mock_proxmox_client._mock_api_cf.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_USER_AUTH_STEP_PASSWORD
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.parametrize(
+    ("exception", "reason"),
+    [
+        (
+            AuthenticationError("Invalid credentials"),
+            "invalid_auth",
+        ),
+        (
+            SSLError("SSL handshake failed"),
+            "ssl_error",
+        ),
+        (
+            ConnectTimeout("Connection timed out"),
+            "connect_timeout",
+        ),
+        (
+            ResourceException("400", "status_message", "content"),
+            "no_nodes_found",
+        ),
+        (
+            requests.exceptions.ConnectionError("Connection error"),
+            "cannot_connect",
+        ),
+    ],
+)
+async def test_form_node_exceptions(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
     exception: Exception,
@@ -201,7 +266,7 @@ async def test_form_exceptions(
     [
         (
             ResourceException("404", "status_message", "content"),
-            "no_nodes_found",
+            "no_vmlxc_found",
         ),
         (
             requests.exceptions.ConnectionError("Connection error"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Improvement of the config_flow raising specific instead of generic 'no nodes found' as a prequel to provide a fix for API Token authentication as raised by #169295
(and a mypy nitpick)

This basically splits the try for API init and the initial `nodes.get()` while returning no vm/lxc instead of raising no nodes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #169295
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
