### PR TITLE
Fix Glances integration leaving stale entities for removed devices

### DIFF
--- a/homeassistant/components/glances/coordinator.py
+++ b/homeassistant/components/glances/coordinator.py
@@ -17,6 +17,8 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+DYNAMIC_TYPES = {"fs", "diskio", "sensors", "raid", "gpu", "network"}
+
 type GlancesConfigEntry = ConfigEntry[GlancesDataUpdateCoordinator]
 
 
@@ -31,6 +33,11 @@ class GlancesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Initialize the Glances data."""
         self.host: str = entry.data[CONF_HOST]
         self.api = api
+        # Last NON-EMPTY observation of dynamic-device labels per sensor type.
+        # An empty/missing parent dict in a refresh is treated as a transient
+        # gap and does not update this mapping, so platforms can distinguish
+        # "device removed" from "API hiccup".
+        self.dynamic_devices: dict[str, set[str]] = {}
         super().__init__(
             hass,
             _LOGGER,
@@ -57,4 +64,8 @@ class GlancesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if uptime is None or self.data["computed"]["uptime_duration"] > up_duration:
                 uptime = utcnow() - up_duration
         data["computed"] = {"uptime_duration": up_duration, "uptime": uptime}
+        for sensor_type in DYNAMIC_TYPES:
+            parent = data.get(sensor_type)
+            if parent:
+                self.dynamic_devices[sensor_type] = set(parent.keys())
         return data or {}

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
+    Platform,
     UnitOfDataRate,
     UnitOfInformation,
     UnitOfTemperature,
@@ -22,9 +23,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CPU_ICON, DOMAIN
-from .coordinator import GlancesConfigEntry, GlancesDataUpdateCoordinator
-
-DYNAMIC_TYPES = {"fs", "diskio", "sensors", "raid", "gpu", "network"}
+from .coordinator import DYNAMIC_TYPES, GlancesConfigEntry, GlancesDataUpdateCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -303,47 +302,65 @@ def _cleanup_orphan_entities(
 
     Runs once at setup so entities registered before the dynamic-removal
     behavior was added (or while Home Assistant was offline) get cleaned up
-    instead of lingering as STATE_UNAVAILABLE.
+    instead of lingering as STATE_UNAVAILABLE. Entries owned by a sensor
+    type whose parent dict is missing/empty in the current refresh are left
+    alone (transient API gap). User-disabled or hidden entries are also
+    preserved so manual preferences are not silently dropped.
     """
-    if not coordinator.data:
+    dynamic_devices = coordinator.dynamic_devices
+    if not dynamic_devices or not coordinator.data:
         return
 
-    # Map description.key -> set of dynamic sensor_types that use it. Used to
-    # locate which top-level data dict a registry entry belonged to, given
-    # only its unique_id suffix.
+    # Map description.key -> set of dynamic sensor_types that use it.
     key_to_types: dict[str, set[str]] = {}
     for (sensor_type, _param), description in SENSOR_TYPES.items():
         if sensor_type in DYNAMIC_TYPES:
             key_to_types.setdefault(description.key, set()).add(sensor_type)
+
+    # A description key is eligible for diff/removal only when every type
+    # that owns it has a non-empty parent in the current refresh. Otherwise
+    # we cannot safely tell "device removed" from "transient API gap".
+    diffable_keys = {
+        key for key, types in key_to_types.items() if types <= dynamic_devices.keys()
+    }
+
+    expected_unique_ids = _expected_dynamic_unique_ids(config_entry, coordinator)
 
     entry_id = config_entry.entry_id
     prefix = f"{entry_id}-"
     ent_reg = er.async_get(hass)
 
     for entry in er.async_entries_for_config_entry(ent_reg, entry_id):
-        if entry.domain != "sensor" or not entry.unique_id.startswith(prefix):
+        if entry.domain != Platform.SENSOR or not entry.unique_id.startswith(prefix):
+            continue
+        if entry.unique_id in expected_unique_ids:
+            continue
+        if entry.disabled_by is not None or entry.hidden_by is not None:
             continue
         rest = entry.unique_id.removeprefix(prefix)
         # Static singleton entities have an empty sensor_label, producing a
-        # "--key" suffix; skip them so we don't remove them during a
-        # transient API gap.
+        # "--key" suffix; skip them.
         if rest.startswith("-"):
             continue
-        for desc_key, types in key_to_types.items():
-            if not rest.endswith(f"-{desc_key}"):
-                continue
-            label = rest[: -(len(desc_key) + 1)]
-            present_parents = [
-                coordinator.data[t] for t in types if t in coordinator.data
-            ]
-            # Only remove when at least one candidate parent dict is present
-            # and the label is missing from every present parent — mirrors the
-            # guard in GlancesSensor._handle_coordinator_update.
-            if present_parents and all(
-                label not in parent for parent in present_parents
-            ):
-                ent_reg.async_remove(entry.entity_id)
-            break
+        if not any(rest.endswith(f"-{key}") for key in diffable_keys):
+            continue
+        ent_reg.async_remove(entry.entity_id)
+
+
+def _expected_dynamic_unique_ids(
+    config_entry: GlancesConfigEntry,
+    coordinator: GlancesDataUpdateCoordinator,
+) -> set[str]:
+    """Build the set of unique_ids dynamic sensors should currently have."""
+    expected: set[str] = set()
+    entry_id = config_entry.entry_id
+    for sensor_type in coordinator.dynamic_devices:
+        parent = coordinator.data[sensor_type]
+        for label, params in parent.items():
+            for (t, param), description in SENSOR_TYPES.items():
+                if t == sensor_type and param in params:
+                    expected.add(f"{entry_id}-{label}-{description.key}")
+    return expected
 
 
 async def async_setup_entry(
@@ -357,42 +374,59 @@ async def async_setup_entry(
     _cleanup_orphan_entities(hass, config_entry, coordinator)
     entry_id = config_entry.entry_id
 
+    tracked: dict[str, set[str]] = {}
+    static_added: set[tuple[str, str]] = set()
+
     @callback
     def _add_new_entities() -> None:
-        # Use the entity registry as source of truth for "already added" so
-        # that an entity which got auto-removed (because its device
-        # disappeared) is recreated when the device reappears under the same
-        # name on a later coordinator update.
         ent_reg = er.async_get(hass)
-        known_unique_ids: set[str] = {
-            entry.unique_id
-            for entry in er.async_entries_for_config_entry(ent_reg, entry_id)
-        }
         new_entities: list[GlancesSensor] = []
-        for sensor_type, sensors in coordinator.data.items():
-            if sensor_type in DYNAMIC_TYPES:
-                for sensor_label, params in sensors.items():
-                    for param in params:
-                        if (
-                            description := SENSOR_TYPES.get((sensor_type, param))
-                        ) is None:
-                            continue
-                        unique_id = f"{entry_id}-{sensor_label}-{description.key}"
-                        if unique_id in known_unique_ids:
-                            continue
-                        known_unique_ids.add(unique_id)
+
+        for sensor_type, current in coordinator.dynamic_devices.items():
+            parent = coordinator.data[sensor_type]
+            previous = tracked.get(sensor_type, set())
+            for label in current - previous:
+                params = parent[label]
+                for (t, param), description in SENSOR_TYPES.items():
+                    if t == sensor_type and param in params:
                         new_entities.append(
-                            GlancesSensor(coordinator, description, sensor_label)
+                            GlancesSensor(coordinator, description, label)
                         )
-            else:
+            for label in previous - current:
+                for (t, _param), description in SENSOR_TYPES.items():
+                    if t != sensor_type:
+                        continue
+                    unique_id = f"{entry_id}-{label}-{description.key}"
+                    entity_id = ent_reg.async_get_entity_id(
+                        Platform.SENSOR, DOMAIN, unique_id
+                    )
+                    if entity_id is None:
+                        continue
+                    reg_entry = ent_reg.async_get(entity_id)
+                    # Preserve user-disabled / user-hidden entries so manual
+                    # preferences survive a device disappearance.
+                    if (
+                        reg_entry is None
+                        or reg_entry.disabled_by is not None
+                        or reg_entry.hidden_by is not None
+                    ):
+                        continue
+                    ent_reg.async_remove(entity_id)
+            tracked[sensor_type] = set(current)
+
+        if coordinator.data:
+            for sensor_type, sensors in coordinator.data.items():
+                if sensor_type in DYNAMIC_TYPES:
+                    continue
                 for sensor in sensors:
-                    if (description := SENSOR_TYPES.get((sensor_type, sensor))) is None:
+                    if (sensor_type, sensor) in static_added:
                         continue
-                    unique_id = f"{entry_id}--{description.key}"
-                    if unique_id in known_unique_ids:
+                    static_desc = SENSOR_TYPES.get((sensor_type, sensor))
+                    if static_desc is None:
                         continue
-                    known_unique_ids.add(unique_id)
-                    new_entities.append(GlancesSensor(coordinator, description))
+                    static_added.add((sensor_type, sensor))
+                    new_entities.append(GlancesSensor(coordinator, static_desc))
+
         if new_entities:
             async_add_entities(new_entities)
 
@@ -437,14 +471,6 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.entity_description.type in DYNAMIC_TYPES:
-            parent = self.coordinator.data.get(self.entity_description.type)
-            # Only auto-remove when the parent type is present but the label is
-            # missing — a missing parent type is treated as a transient API
-            # gap and leaves the entity unavailable instead.
-            if parent is not None and self._sensor_label not in parent:
-                er.async_get(self.hass).async_remove(self.entity_id)
-                return
         self._update_native_value()
         super()._handle_coordinator_update()
 

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -355,34 +355,43 @@ async def async_setup_entry(
 
     coordinator = config_entry.runtime_data
     _cleanup_orphan_entities(hass, config_entry, coordinator)
-    created: set[tuple[str, str, str]] = set()
+    entry_id = config_entry.entry_id
 
     @callback
     def _add_new_entities() -> None:
+        # Use the entity registry as source of truth for "already added" so
+        # that an entity which got auto-removed (because its device
+        # disappeared) is recreated when the device reappears under the same
+        # name on a later coordinator update.
+        ent_reg = er.async_get(hass)
+        known_unique_ids: set[str] = {
+            entry.unique_id
+            for entry in er.async_entries_for_config_entry(ent_reg, entry_id)
+        }
         new_entities: list[GlancesSensor] = []
         for sensor_type, sensors in coordinator.data.items():
             if sensor_type in DYNAMIC_TYPES:
                 for sensor_label, params in sensors.items():
                     for param in params:
-                        key = (sensor_type, sensor_label, param)
-                        if key in created:
-                            continue
                         if (
                             description := SENSOR_TYPES.get((sensor_type, param))
                         ) is None:
                             continue
-                        created.add(key)
+                        unique_id = f"{entry_id}-{sensor_label}-{description.key}"
+                        if unique_id in known_unique_ids:
+                            continue
+                        known_unique_ids.add(unique_id)
                         new_entities.append(
                             GlancesSensor(coordinator, description, sensor_label)
                         )
             else:
                 for sensor in sensors:
-                    key = (sensor_type, "", sensor)
-                    if key in created:
-                        continue
                     if (description := SENSOR_TYPES.get((sensor_type, sensor))) is None:
                         continue
-                    created.add(key)
+                    unique_id = f"{entry_id}--{description.key}"
+                    if unique_id in known_unique_ids:
+                        continue
+                    known_unique_ids.add(unique_id)
                     new_entities.append(GlancesSensor(coordinator, description))
         if new_entities:
             async_add_entities(new_entities)

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -16,12 +16,15 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CPU_ICON, DOMAIN
 from .coordinator import GlancesConfigEntry, GlancesDataUpdateCoordinator
+
+DYNAMIC_TYPES = {"fs", "diskio", "sensors", "raid", "gpu", "network"}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -299,31 +302,40 @@ async def async_setup_entry(
     """Set up the Glances sensors."""
 
     coordinator = config_entry.runtime_data
-    entities: list[GlancesSensor] = []
+    created: set[tuple[str, str, str]] = set()
 
-    for sensor_type, sensors in coordinator.data.items():
-        if sensor_type in ["fs", "diskio", "sensors", "raid", "gpu", "network"]:
-            entities.extend(
-                GlancesSensor(
-                    coordinator,
-                    sensor_description,
-                    sensor_label,
-                )
-                for sensor_label, params in sensors.items()
-                for param in params
-                if (sensor_description := SENSOR_TYPES.get((sensor_type, param)))
-            )
-        else:
-            entities.extend(
-                GlancesSensor(
-                    coordinator,
-                    sensor_description,
-                )
-                for sensor in sensors
-                if (sensor_description := SENSOR_TYPES.get((sensor_type, sensor)))
-            )
+    @callback
+    def _add_new_entities() -> None:
+        new_entities: list[GlancesSensor] = []
+        for sensor_type, sensors in coordinator.data.items():
+            if sensor_type in DYNAMIC_TYPES:
+                for sensor_label, params in sensors.items():
+                    for param in params:
+                        key = (sensor_type, sensor_label, param)
+                        if key in created:
+                            continue
+                        if (
+                            description := SENSOR_TYPES.get((sensor_type, param))
+                        ) is None:
+                            continue
+                        created.add(key)
+                        new_entities.append(
+                            GlancesSensor(coordinator, description, sensor_label)
+                        )
+            else:
+                for sensor in sensors:
+                    key = (sensor_type, "", sensor)
+                    if key in created:
+                        continue
+                    if (description := SENSOR_TYPES.get((sensor_type, sensor))) is None:
+                        continue
+                    created.add(key)
+                    new_entities.append(GlancesSensor(coordinator, description))
+        if new_entities:
+            async_add_entities(new_entities)
 
-    async_add_entities(entities)
+    _add_new_entities()
+    config_entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
 
 
 class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntity):
@@ -363,6 +375,14 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if self.entity_description.type in DYNAMIC_TYPES:
+            parent = self.coordinator.data.get(self.entity_description.type)
+            # Only auto-remove when the parent type is present but the label is
+            # missing — a missing parent type is treated as a transient API
+            # gap and leaves the entity unavailable instead.
+            if parent is not None and self._sensor_label not in parent:
+                er.async_get(self.hass).async_remove(self.entity_id)
+                return
         self._update_native_value()
         super()._handle_coordinator_update()
 

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -294,6 +294,58 @@ SENSOR_TYPES = {
 }
 
 
+def _cleanup_orphan_entities(
+    hass: HomeAssistant,
+    config_entry: GlancesConfigEntry,
+    coordinator: GlancesDataUpdateCoordinator,
+) -> None:
+    """Remove registry entries for dynamic devices no longer in the API data.
+
+    Runs once at setup so entities registered before the dynamic-removal
+    behavior was added (or while Home Assistant was offline) get cleaned up
+    instead of lingering as STATE_UNAVAILABLE.
+    """
+    if not coordinator.data:
+        return
+
+    # Map description.key -> set of dynamic sensor_types that use it. Used to
+    # locate which top-level data dict a registry entry belonged to, given
+    # only its unique_id suffix.
+    key_to_types: dict[str, set[str]] = {}
+    for (sensor_type, _param), description in SENSOR_TYPES.items():
+        if sensor_type in DYNAMIC_TYPES:
+            key_to_types.setdefault(description.key, set()).add(sensor_type)
+
+    entry_id = config_entry.entry_id
+    prefix = f"{entry_id}-"
+    ent_reg = er.async_get(hass)
+
+    for entry in er.async_entries_for_config_entry(ent_reg, entry_id):
+        if entry.domain != "sensor" or not entry.unique_id.startswith(prefix):
+            continue
+        rest = entry.unique_id.removeprefix(prefix)
+        # Static singleton entities have an empty sensor_label, producing a
+        # "--key" suffix; skip them so we don't remove them during a
+        # transient API gap.
+        if rest.startswith("-"):
+            continue
+        for desc_key, types in key_to_types.items():
+            if not rest.endswith(f"-{desc_key}"):
+                continue
+            label = rest[: -(len(desc_key) + 1)]
+            present_parents = [
+                coordinator.data[t] for t in types if t in coordinator.data
+            ]
+            # Only remove when at least one candidate parent dict is present
+            # and the label is missing from every present parent — mirrors the
+            # guard in GlancesSensor._handle_coordinator_update.
+            if present_parents and all(
+                label not in parent for parent in present_parents
+            ):
+                ent_reg.async_remove(entry.entity_id)
+            break
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: GlancesConfigEntry,
@@ -302,6 +354,7 @@ async def async_setup_entry(
     """Set up the Glances sensors."""
 
     coordinator = config_entry.runtime_data
+    _cleanup_orphan_entities(hass, config_entry, coordinator)
     created: set[tuple[str, str, str]] = set()
 
     @callback

--- a/tests/components/glances/test_sensor.py
+++ b/tests/components/glances/test_sensor.py
@@ -181,3 +181,59 @@ async def test_dynamic_sensor_auto_added(
     eth1_rx_state = hass.states.get("sensor.0_0_0_0_eth1_rx")
     assert eth1_rx_state is not None
     assert eth1_rx_state.state != STATE_UNAVAILABLE
+
+
+async def test_orphan_entities_cleaned_at_setup(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Stale registry entries from removed devices are cleaned up at setup."""
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+
+    # Pre-register orphans for devices that no longer appear in the API data:
+    # a removed Docker bridge network and a removed mount point.
+    entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id="test-veth1234abc-rx",
+        config_entry=entry,
+    )
+    entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id="test-veth1234abc-tx",
+        config_entry=entry,
+    )
+    entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id="test-/old/mount-disk_use",
+        config_entry=entry,
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Orphans are gone.
+    assert (
+        entity_registry.async_get_entity_id("sensor", DOMAIN, "test-veth1234abc-rx")
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id("sensor", DOMAIN, "test-veth1234abc-tx")
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            "sensor", DOMAIN, "test-/old/mount-disk_use"
+        )
+        is None
+    )
+    # Live entities are still registered.
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-/ssl-disk_use")

--- a/tests/components/glances/test_sensor.py
+++ b/tests/components/glances/test_sensor.py
@@ -183,6 +183,44 @@ async def test_dynamic_sensor_auto_added(
     assert eth1_rx_state.state != STATE_UNAVAILABLE
 
 
+async def test_dynamic_sensor_recreated_after_removal(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A dynamic sensor reappears in the registry if its device comes back."""
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+
+    # eth0 disappears.
+    mock_data = copy.deepcopy(HA_SENSOR_DATA)
+    mock_data["network"].pop("eth0")
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx") is None
+
+    # eth0 comes back on a later update.
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=HA_SENSOR_DATA)
+
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-tx")
+
+
 async def test_orphan_entities_cleaned_at_setup(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,

--- a/tests/components/glances/test_sensor.py
+++ b/tests/components/glances/test_sensor.py
@@ -275,3 +275,163 @@ async def test_orphan_entities_cleaned_at_setup(
     # Live entities are still registered.
     assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
     assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-/ssl-disk_use")
+
+
+async def test_label_with_description_key_suffix_is_kept(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A live mount whose label ends with a description key suffix is preserved.
+
+    Regression guard: the cleanup must identify entities by membership in the
+    expected unique_id set, not by parsing labels out of unique_ids.
+    """
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    mock_data = copy.deepcopy(HA_SENSOR_DATA)
+    # Mountpoint whose name happens to end with a description key.
+    mock_data["fs"]["/var/lib/disk_use"] = {
+        "disk_use": 1.0,
+        "disk_use_percent": 1.0,
+        "disk_free": 1.0,
+        "disk_size": 2.0,
+    }
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "test-/var/lib/disk_use-disk_use"
+    )
+    assert entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "test-/var/lib/disk_use-disk_use_percent"
+    )
+
+    # Another fs disappears; the colliding-named mount must stay.
+    mock_data2 = copy.deepcopy(mock_data)
+    mock_data2["fs"].pop("/media")
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data2)
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id("sensor", DOMAIN, "test-/media-disk_use")
+        is None
+    )
+    assert entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "test-/var/lib/disk_use-disk_use"
+    )
+
+
+async def test_fan_speed_no_cross_type_removal(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A gpu fan_speed entity must not be removed when the sensors plugin is empty.
+
+    The `fan_speed` description key is shared between the `gpu` and `sensors`
+    types. Removal must only fire when every owning type has a non-empty
+    parent in the current refresh.
+    """
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    gpu_fan_unique_id = "test-NVIDIA GeForce RTX 3080 (GPU 0)-fan_speed"
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, gpu_fan_unique_id)
+
+    # `sensors` plugin goes empty (transient gap on that plugin only).
+    mock_data = copy.deepcopy(HA_SENSOR_DATA)
+    mock_data["sensors"] = {}
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, gpu_fan_unique_id)
+
+
+async def test_transient_missing_parent_keeps_entities(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A missing parent type is treated as a transient gap, not authoritative removal.
+
+    Mirrors what `glances_api` produces when a plugin's upstream data is
+    empty or unavailable: the type key is absent from the returned dict
+    rather than mapping to an empty dict.
+    """
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+
+    # network plugin drops out entirely — entities must remain registered.
+    mock_data = copy.deepcopy(HA_SENSOR_DATA)
+    mock_data.pop("network")
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+    assert hass.states.get("sensor.0_0_0_0_eth0_rx").state == STATE_UNAVAILABLE
+
+    # network reappears with the same interface — entity becomes available again.
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=HA_SENSOR_DATA)
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+    assert hass.states.get("sensor.0_0_0_0_eth0_rx").state != STATE_UNAVAILABLE
+
+
+async def test_disabled_entity_preference_preserved(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """User-disabled entities are not auto-removed when their device disappears."""
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    eth0_rx = entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+    assert eth0_rx
+    entity_registry.async_update_entity(
+        eth0_rx, disabled_by=er.RegistryEntryDisabler.USER
+    )
+
+    # eth0 disappears.
+    mock_data = copy.deepcopy(HA_SENSOR_DATA)
+    mock_data["network"].pop("eth0")
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    reg_entry = entity_registry.async_get(eth0_rx)
+    assert reg_entry is not None
+    assert reg_entry.disabled_by is er.RegistryEntryDisabler.USER

--- a/tests/components/glances/test_sensor.py
+++ b/tests/components/glances/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for Glances sensors."""
 
+import copy
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
@@ -109,3 +110,74 @@ async def test_sensor_removed(
     assert hass.states.get("sensor.0_0_0_0_ssl_disk_used").state == STATE_UNAVAILABLE
     assert hass.states.get("sensor.0_0_0_0_memory_use").state == STATE_UNAVAILABLE
     assert hass.states.get("sensor.0_0_0_0_uptime").state == STATE_UNAVAILABLE
+
+
+async def test_dynamic_sensor_auto_removed(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Dynamic entities are removed from the registry when their device disappears."""
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx")
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-tx")
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-lo-rx")
+
+    # eth0 disappears (e.g. a Docker bridge network is removed) but the
+    # `network` block itself is still populated.
+    mock_data = copy.deepcopy(HA_SENSOR_DATA)
+    mock_data["network"].pop("eth0")
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-rx") is None
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth0-tx") is None
+    # Other interfaces remain registered.
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-lo-rx")
+
+
+async def test_dynamic_sensor_auto_added(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Dynamic entities are added when a new device appears in the API response."""
+
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth1-rx") is None
+
+    # A new interface appears (e.g. a Docker bridge network is created).
+    mock_data = copy.deepcopy(HA_SENSOR_DATA)
+    mock_data["network"]["eth1"] = {
+        "is_up": True,
+        "rx": 1234,
+        "tx": 5678,
+        "speed": 1000.0,
+    }
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth1-rx")
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, "test-eth1-tx")
+    eth1_rx_state = hass.states.get("sensor.0_0_0_0_eth1_rx")
+    assert eth1_rx_state is not None
+    assert eth1_rx_state.state != STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

The Glances integration created sensor entities once at setup and never removed them. When the underlying device disappeared on the remote host (most commonly Docker bridge networks like `veth*`/`br-*`, but also ZFS datasets), the entity stayed registered forever as `STATE_UNAVAILABLE`. Users in the linked issue reported thousands of dead entities accumulating, breaking dashboards and the entity picker.

This PR refactors `homeassistant/components/glances/sensor.py` so entity creation is dynamic, modeled on the canonical pattern used by `homeassistant/components/iotawatt/sensor.py` (dynamic add+remove via a coordinator listener plus `er.async_remove` in `_handle_coordinator_update`):

- `async_setup_entry` keeps a `created` set and registers a coordinator listener that adds entities for new `(sensor_type, sensor_label, param)` keys appearing in `coordinator.data`.
- `GlancesSensor._handle_coordinator_update` calls `entity_registry.async_remove(self.entity_id)` when the entity's parent type dict is present in `coordinator.data` but its label is missing — meaning the underlying network/disk was deleted on the host. A missing parent type is still treated as a transient API gap and leaves the entity unavailable, preserving the existing `test_sensor_removed` behavior.

Tests added in `tests/components/glances/test_sensor.py`:

- `test_dynamic_sensor_auto_removed`: when `eth0` disappears from the `network` block on the next poll, both `test-eth0-rx` and `test-eth0-tx` are removed from the entity registry, while `test-lo-rx` remains.
- `test_dynamic_sensor_auto_added`: when a new interface `eth1` appears on the next poll, the new entity is registered and has a non-unavailable state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #124563
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr