### PR TITLE
Update Nest doorbell event to use standard DoorbellEventType.RING

### DIFF
--- a/homeassistant/components/nest/event.py
+++ b/homeassistant/components/nest/event.py
@@ -8,6 +8,7 @@ from google_nest_sdm.event import EventMessage, EventType
 from google_nest_sdm.traits import TraitType
 
 from homeassistant.components.event import (
+    DoorbellEventType,
     EventDeviceClass,
     EventEntity,
     EventEntityDescription,
@@ -42,7 +43,7 @@ ENTITY_DESCRIPTIONS = [
         key=EVENT_DOORBELL_CHIME,
         translation_key="chime",
         device_class=EventDeviceClass.DOORBELL,
-        event_types=[EVENT_DOORBELL_CHIME],
+        event_types=[DoorbellEventType.RING],
         trait_types=[TraitType.DOORBELL_CHIME],
         api_event_types=[EventType.DOORBELL_CHIME],
     ),
@@ -80,7 +81,7 @@ async def async_setup_entry(
 
 
 class NestTraitEventEntity(EventEntity):
-    """Nest doorbell event entity."""
+    """Nest event entity for event entity descriptions."""
 
     entity_description: NestEventEntityDescription
     _attr_has_entity_name = True
@@ -112,6 +113,9 @@ class NestTraitEventEntity(EventEntity):
             if last_nest_event_id is not None and last_nest_event_id == nest_event_id:
                 # This event is a duplicate message in the same thread
                 return
+
+            if event_type == EVENT_DOORBELL_CHIME:
+                event_type = DoorbellEventType.RING
 
             self._trigger_event(
                 event_type,

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -113,7 +113,7 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "doorbell_chime": "[%key:component::nest::entity::event::chime::name%]"
+              "ring": "[%key:component::event::entity_component::doorbell::state_attributes::event_type::state::ring%]"
             }
           }
         }

--- a/tests/components/nest/test_event.py
+++ b/tests/components/nest/test_event.py
@@ -100,11 +100,11 @@ def create_event_messages(
             "event.front_chime",
             {
                 "device_class": "doorbell",
-                "event_types": ["doorbell_chime"],
+                "event_types": ["ring"],
                 "friendly_name": "Front Chime",
             },
             EventType.DOORBELL_CHIME,
-            "doorbell_chime",
+            "ring",
         ),
         (
             [TraitType.CAMERA_MOTION, TraitType.CAMERA_PERSON, TraitType.CAMERA_SOUND],
@@ -205,7 +205,7 @@ async def test_ignore_unrelated_event(
     assert state.attributes == {
         "device_class": "doorbell",
         "event_type": None,
-        "event_types": ["doorbell_chime"],
+        "event_types": ["ring"],
         "friendly_name": "Front Chime",
     }
 
@@ -249,9 +249,9 @@ async def test_event_threads(
     assert state.state == "2024-08-24T12:00:02.000+00:00"
     assert state.attributes == {
         "device_class": "doorbell",
-        "event_types": ["doorbell_chime"],
+        "event_types": ["ring"],
         "friendly_name": "Front Chime",
-        "event_type": "doorbell_chime",
+        "event_type": "ring",
         "nest_event_id": ENCODED_EVENT_ID,
     }
 
@@ -280,9 +280,9 @@ async def test_event_threads(
     )  # A second event is not received
     assert state.attributes == {
         "device_class": "doorbell",
-        "event_types": ["doorbell_chime"],
+        "event_types": ["ring"],
         "friendly_name": "Front Chime",
-        "event_type": "doorbell_chime",
+        "event_type": "ring",
         "nest_event_id": ENCODED_EVENT_ID,
     }
 
@@ -309,8 +309,8 @@ async def test_event_threads(
     assert state.state == "2024-08-24T12:00:06.000+00:00"  # Third event is received
     assert state.attributes == {
         "device_class": "doorbell",
-        "event_types": ["doorbell_chime"],
+        "event_types": ["ring"],
         "friendly_name": "Front Chime",
-        "event_type": "doorbell_chime",
+        "event_type": "ring",
         "nest_event_id": ENCODED_EVENT_ID2,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If you are currently using the Event Entity event type `doorbell_chime`, you need to replace it with the new standardized event `ring`.
This change intends to standardize the event type across different integrations, so they can be seamlessly used in the new triggers and conditions.

Event types for device triggers are not changed.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update Nest Doorbell event entity to use the standard new event type.

Doorbell event entities now have a standard `ring` event type. Integrations that use `EventDeviceClass.DOORBELL` must include `DoorbellEventType.RING` in their `event_types` list.

See https://developers.home-assistant.io/blog/2026/04/15/doorbell-standard-event-type

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169647
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45155
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
