### PR TITLE
Expose SET_SPEED for all fans via PercentSetting in Matter

### DIFF
--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -253,8 +253,10 @@ class MatterFan(MatterEntity, FanEntity):
             return
         self._feature_map = feature_map
         self._attr_supported_features = FanEntityFeature(0)
+        # PercentSetting is always a mandatory attribute of the FanControl cluster,
+        # so percentage-based speed control is always available.
+        self._attr_supported_features |= FanEntityFeature.SET_SPEED
         if feature_map & FanControlFeature.kMultiSpeed:
-            self._attr_supported_features |= FanEntityFeature.SET_SPEED
             self._attr_speed_count = int(
                 self.get_matter_attribute_value(clusters.FanControl.Attributes.SpeedMax)
             )

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -253,9 +253,6 @@ class MatterFan(MatterEntity, FanEntity):
             return
         self._feature_map = feature_map
         self._attr_supported_features = FanEntityFeature(0)
-        # PercentSetting is always a mandatory attribute of the FanControl cluster,
-        # so percentage-based speed control is always available.
-        self._attr_supported_features |= FanEntityFeature.SET_SPEED
         # Reset to default so a featuremap change from MultiSpeed -> non-MultiSpeed
         # does not leave a stale speed_count / percentage_step.
         self._attr_speed_count = 100
@@ -309,8 +306,12 @@ class MatterFan(MatterEntity, FanEntity):
         if feature_map & FanControlFeature.kAirflowDirection:
             self._attr_supported_features |= FanEntityFeature.DIRECTION
 
+        # PercentSetting is always a mandatory attribute of the FanControl cluster,
+        # so percentage-based speed control is always available.
         self._attr_supported_features |= (
-            FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
         )
 
 

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -256,6 +256,9 @@ class MatterFan(MatterEntity, FanEntity):
         # PercentSetting is always a mandatory attribute of the FanControl cluster,
         # so percentage-based speed control is always available.
         self._attr_supported_features |= FanEntityFeature.SET_SPEED
+        # Reset to default so a featuremap change from MultiSpeed -> non-MultiSpeed
+        # does not leave a stale speed_count / percentage_step.
+        self._attr_speed_count = 100
         if feature_map & FanControlFeature.kMultiSpeed:
             self._attr_speed_count = int(
                 self.get_matter_attribute_value(clusters.FanControl.Attributes.SpeedMax)

--- a/tests/components/matter/snapshots/test_fan.ambr
+++ b/tests/components/matter/snapshots/test_fan.ambr
@@ -37,7 +37,7 @@
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <FanEntityFeature: 56>,
+    'supported_features': <FanEntityFeature: 57>,
     'translation_key': 'fan',
     'unique_id': '00000000000004D2-0000000000000004-MatterNodeDevice-1-MatterFan-514-0',
     'unit_of_measurement': None,
@@ -47,6 +47,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Longan link HVAC',
+      'percentage': 0,
+      'percentage_step': 1.0,
       'preset_mode': None,
       'preset_modes': list([
         'low',
@@ -54,7 +56,7 @@
         'high',
         'auto',
       ]),
-      'supported_features': <FanEntityFeature: 56>,
+      'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
     'entity_id': 'fan.longan_link_hvac',
@@ -174,7 +176,7 @@
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <FanEntityFeature: 56>,
+    'supported_features': <FanEntityFeature: 57>,
     'translation_key': 'fan',
     'unique_id': '00000000000004D2-0000000000000049-MatterNodeDevice-1-MatterFan-514-0',
     'unit_of_measurement': None,
@@ -184,13 +186,15 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Extractor hood',
+      'percentage': 0,
+      'percentage_step': 1.0,
       'preset_mode': None,
       'preset_modes': list([
         'low',
         'medium',
         'high',
       ]),
-      'supported_features': <FanEntityFeature: 56>,
+      'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
     'entity_id': 'fan.mock_extractor_hood',
@@ -450,7 +454,7 @@
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <FanEntityFeature: 56>,
+    'supported_features': <FanEntityFeature: 57>,
     'translation_key': 'fan',
     'unique_id': '00000000000004D2-0000000000000072-MatterNodeDevice-1-MatterFan-514-0',
     'unit_of_measurement': None,
@@ -460,13 +464,15 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'SL-RangeHood',
+      'percentage': 0,
+      'percentage_step': 1.0,
       'preset_mode': None,
       'preset_modes': list([
         'low',
         'medium',
         'high',
       ]),
-      'supported_features': <FanEntityFeature: 56>,
+      'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
     'entity_id': 'fan.sl_rangehood',

--- a/tests/components/matter/test_fan.py
+++ b/tests/components/matter/test_fan.py
@@ -16,6 +16,7 @@ from homeassistant.components.fan import (
     DOMAIN as FAN_DOMAIN,
     SERVICE_OSCILLATE,
     SERVICE_SET_DIRECTION,
+    SERVICE_SET_PERCENTAGE,
     FanEntityFeature,
 )
 from homeassistant.const import (
@@ -441,3 +442,34 @@ async def test_fan_features(
     state = hass.states.get(entity_id)
     assert state
     assert state.attributes["preset_modes"] == preset_modes
+
+
+@pytest.mark.parametrize("node_fixture", ["silabs_range_hood"])
+async def test_fan_set_percentage_without_multispeed(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test percentage control on a fan without the MultiSpeed feature.
+
+    PercentSetting is mandatory in the FanControl cluster regardless of features,
+    so SET_SPEED must be available and write to PercentSetting (attribute 0x0002).
+    """
+    entity_id = "fan.sl_rangehood"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] & FanEntityFeature.SET_SPEED
+    assert state.attributes["percentage_step"] == 1.0
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 75},
+        blocking=True,
+    )
+    assert matter_client.write_attribute.call_count == 1
+    assert matter_client.write_attribute.call_args == call(
+        node_id=matter_node.node_id,
+        attribute_path="1/514/2",
+        value=75,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`PercentSetting` (attribute `0x0002`) is a **mandatory** attribute of the Matter FanControl cluster, present on every fan that passes discovery — regardless of which optional features are advertised in the `FeatureMap`.

Previously, `FanEntityFeature.SET_SPEED` was only enabled when the `MultiSpeed` feature bit was set, so fans without `MultiSpeed` (e.g. range hoods, HVAC fans) could not have their speed controlled by percentage.

This PR moves `SET_SPEED` outside the `kMultiSpeed` guard so that percentage-based speed control is always exposed, matching how Apple Home handles the same devices (it always writes to `PercentSetting`).

When `kMultiSpeed` is present, `speed_count` is still derived from `SpeedMax`, giving the correct discrete step size. Without `kMultiSpeed`, HA defaults to 100 steps (1% granularity).

### Affected devices

Fans that previously only had preset-mode control and now also gain `SET_SPEED`:
- Longan Link thermostat fan
- Extractor / range hoods

### Tests

Added `test_fan_set_percentage_without_multispeed` to explicitly verify that a fan with `FeatureMap = 0` (no `MultiSpeed`) exposes `SET_SPEED`, reports `percentage_step = 1.0`, and writes the correct value to `PercentSetting` when `set_percentage` is called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/156285
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
