### PR TITLE
Revert "Bump deebot-client to 18.2.0"

### DIFF
--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks", "deebot_client"],
-  "requirements": ["py-sucks==0.9.11", "deebot-client==18.2.0"]
+  "requirements": ["py-sucks==0.9.11", "deebot-client==18.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -794,7 +794,7 @@ debugpy==1.8.17
 decora-wifi==1.4
 
 # homeassistant.components.ecovacs
-deebot-client==18.2.0
+deebot-client==18.1.0
 
 # homeassistant.components.ihc
 # homeassistant.components.ohmconnect

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -706,7 +706,7 @@ debugpy==1.8.17
 decora-wifi==1.4
 
 # homeassistant.components.ecovacs
-deebot-client==18.2.0
+deebot-client==18.1.0
 
 # homeassistant.components.ihc
 # homeassistant.components.ohmconnect


### PR DESCRIPTION
Reverts home-assistant/core#169003

deebot-client fails to build in home-assistant/core due to rust 1.95 requirement being unobtanium. Core is still on Alpine 3.22 which is rust 1.87 and even Alpine 3.23 only has rust 1.91.1

Filed upstream bug DeebotUniverse/client.py#1571 to rollback rust version to 1.91 although that will still be a blocker until home-assistant/core moves to Alpine 3.23