### PR TITLE
fix(esphome): allow saving unreachable reconfigure host

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -269,8 +269,51 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         if response == ERROR_REQUIRES_ENCRYPTION_KEY:
             return await self.async_step_encryption_key()
         if response is not None:
+            if (
+                self.source == SOURCE_RECONFIGURE
+                and response in ("connection_error", "resolve_error")
+                and self._async_reconfigure_host_changed()
+            ):
+                return await self.async_step_reconfigure_confirm_unreachable()
             return await self._async_step_user_base(error=response)
         return await self._async_authenticate_or_add()
+
+    @callback
+    def _async_reconfigure_host_changed(self) -> bool:
+        """Return if the reconfigure flow has a new host or port."""
+        assert self._host is not None
+        assert self._port is not None
+        return self._host != self._reconfig_entry.data.get(
+            CONF_HOST
+        ) or self._port != self._reconfig_entry.data.get(CONF_PORT, DEFAULT_PORT)
+
+    async def async_step_reconfigure_confirm_unreachable(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm saving a reconfigured host when the device is unreachable."""
+        assert self._host is not None
+        assert self._port is not None
+
+        if user_input is not None:
+            return self.async_update_reload_and_abort(
+                self._reconfig_entry,
+                data=self._reconfig_entry.data
+                | {
+                    CONF_HOST: self._host,
+                    CONF_PORT: self._port,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure_confirm_unreachable",
+            description_placeholders={
+                "host": self._host,
+                "name": self._reconfig_entry.data.get(
+                    CONF_DEVICE_NAME, self._reconfig_entry.title
+                ),
+                "port": self._port,
+            },
+        )
 
     async def _async_authenticate_or_add(self) -> ConfigFlowResult:
         # Only show authentication step if device uses password

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -2,6 +2,7 @@
 
 from collections import OrderedDict
 from collections.abc import Mapping
+from ipaddress import IPv6Address, ip_address
 import json
 import logging
 from typing import Any, cast
@@ -63,10 +64,23 @@ from .manager import async_replace_device
 ERROR_REQUIRES_ENCRYPTION_KEY = "requires_encryption_key"
 ERROR_INVALID_ENCRYPTION_KEY = "invalid_psk"
 ERROR_INVALID_PASSWORD_AUTH = "invalid_auth"
+ERROR_CONNECTION = "connection_error"
+ERROR_RESOLVE = "resolve_error"
 _LOGGER = logging.getLogger(__name__)
 
 ZERO_NOISE_PSK = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
 DEFAULT_NAME = "ESPHome"
+
+
+def _format_host_for_display(host: str) -> str:
+    """Return host formatted for host:port display."""
+    try:
+        address = ip_address(host)
+    except ValueError:
+        return host
+    if isinstance(address, IPv6Address):
+        return f"[{host}]"
+    return host
 
 
 class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -271,15 +285,15 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         if response is not None:
             if (
                 self.source == SOURCE_RECONFIGURE
-                and response in ("connection_error", "resolve_error")
-                and self._async_reconfigure_host_changed()
+                and response in (ERROR_CONNECTION, ERROR_RESOLVE)
+                and self._async_reconfigure_connection_changed()
             ):
                 return await self.async_step_reconfigure_confirm_unreachable()
             return await self._async_step_user_base(error=response)
         return await self._async_authenticate_or_add()
 
     @callback
-    def _async_reconfigure_host_changed(self) -> bool:
+    def _async_reconfigure_connection_changed(self) -> bool:
         """Return if the reconfigure flow has a new host or port."""
         assert self._host is not None
         assert self._port is not None
@@ -290,15 +304,15 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure_confirm_unreachable(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Confirm saving a reconfigured host when the device is unreachable."""
+        """Confirm saving reconfigured connection details without validation."""
         assert self._host is not None
         assert self._port is not None
 
         if user_input is not None:
             return self.async_update_reload_and_abort(
                 self._reconfig_entry,
-                data=self._reconfig_entry.data
-                | {
+                data={
+                    **self._reconfig_entry.data,
                     CONF_HOST: self._host,
                     CONF_PORT: self._port,
                 },
@@ -307,11 +321,9 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure_confirm_unreachable",
             description_placeholders={
-                "host": self._host,
-                "name": self._reconfig_entry.data.get(
-                    CONF_DEVICE_NAME, self._reconfig_entry.title
-                ),
-                "port": self._port,
+                "host": _format_host_for_display(self._host),
+                "name": self._async_get_human_readable_name(),
+                "port": str(self._port),
             },
         )
 
@@ -846,9 +858,9 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                     self._name = ex.received_name
             return ERROR_INVALID_ENCRYPTION_KEY
         except ResolveAPIError:
-            return "resolve_error"
+            return ERROR_RESOLVE
         except APIConnectionError:
-            return "connection_error"
+            return ERROR_CONNECTION
         finally:
             await cli.disconnect(force=True)
         self._device_mac = format_mac(self._device_info.mac_address)
@@ -896,7 +908,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         except InvalidAuthAPIError:
             return "invalid_auth"
         except APIConnectionError:
-            return "connection_error"
+            return ERROR_CONNECTION
         finally:
             await cli.disconnect(force=True)
 

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -70,6 +70,10 @@
       "reauth_encryption_removed_confirm": {
         "description": "The ESPHome device `{name}` disabled transport encryption. Please confirm that you want to remove the encryption key and allow unencrypted connections."
       },
+      "reconfigure_confirm_unreachable": {
+        "description": "Home Assistant could not validate `{host}:{port}` for `{name}` because the device is currently unreachable.\n\nOnly continue if you are sure this is the correct new address. Home Assistant will keep the existing device identity and update only the host and port.",
+        "title": "Confirm unreachable ESPHome address"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -71,8 +71,8 @@
         "description": "The ESPHome device `{name}` disabled transport encryption. Please confirm that you want to remove the encryption key and allow unencrypted connections."
       },
       "reconfigure_confirm_unreachable": {
-        "description": "Home Assistant could not validate `{host}:{port}` for `{name}` because the device is currently unreachable.\n\nOnly continue if you are sure this is the correct new address. Home Assistant will keep the existing device identity and update only the host and port.",
-        "title": "Confirm unreachable ESPHome address"
+        "description": "Home Assistant could not validate `{host}:{port}` for `{name}` because the device is currently unreachable or the hostname could not be resolved.\n\nOnly continue if you are sure these are the correct new connection settings. Home Assistant will keep the existing device identity and update only the host and port.",
+        "title": "Confirm unreachable ESPHome connection settings"
       },
       "user": {
         "data": {

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -2391,6 +2391,85 @@ async def test_reconfig_success_with_new_ip_same_name(
 
 
 @pytest.mark.usefixtures("mock_zeroconf", "mock_setup_entry")
+async def test_reconfig_can_save_changed_unreachable_host(
+    hass: HomeAssistant, mock_client: APIClient
+) -> None:
+    """Test reconfig can save a changed host when the device is unreachable."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "test",
+            CONF_NOISE_PSK: VALID_NOISE_PSK,
+        },
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    mock_client.device_info.side_effect = APIConnectionError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: "127.0.0.2", CONF_PORT: 6053}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm_unreachable"
+    assert result["description_placeholders"] == {
+        "host": "127.0.0.2",
+        "name": "test",
+        "port": 6053,
+    }
+    assert entry.data[CONF_HOST] == "127.0.0.1"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == {
+        CONF_HOST: "127.0.0.2",
+        CONF_PORT: 6053,
+        CONF_PASSWORD: "",
+        CONF_DEVICE_NAME: "test",
+        CONF_NOISE_PSK: VALID_NOISE_PSK,
+    }
+
+
+@pytest.mark.usefixtures("mock_zeroconf", "mock_setup_entry")
+async def test_reconfig_same_unreachable_host_shows_error(
+    hass: HomeAssistant, mock_client: APIClient
+) -> None:
+    """Test reconfig does not confirm unchanged unreachable connection details."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "test",
+        },
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    mock_client.device_info.side_effect = APIConnectionError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: "127.0.0.1", CONF_PORT: 6053}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "connection_error"}
+    assert entry.data[CONF_HOST] == "127.0.0.1"
+
+
+@pytest.mark.usefixtures("mock_zeroconf", "mock_setup_entry")
 async def test_reconfig_success_noise_psk_changes(
     hass: HomeAssistant, mock_client: APIClient
 ) -> None:

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -2391,12 +2391,32 @@ async def test_reconfig_success_with_new_ip_same_name(
 
 
 @pytest.mark.usefixtures("mock_zeroconf", "mock_setup_entry")
-async def test_reconfig_can_save_changed_unreachable_host(
-    hass: HomeAssistant, mock_client: APIClient
+@pytest.mark.parametrize(
+    ("host", "port", "error", "placeholder_host"),
+    [
+        ("127.0.0.2", 6053, APIConnectionError(), "127.0.0.2"),
+        ("127.0.0.1", 6054, APIConnectionError(), "127.0.0.1"),
+        ("2001:db8::2", 6053, ResolveAPIError(), "[2001:db8::2]"),
+        (
+            "kitchen-sensor.local",
+            6053,
+            APIConnectionError(),
+            "kitchen-sensor.local",
+        ),
+    ],
+)
+async def test_reconfig_can_save_changed_unreachable_connection(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    host: str,
+    port: int,
+    error: Exception,
+    placeholder_host: str,
 ) -> None:
-    """Test reconfig can save a changed host when the device is unreachable."""
+    """Test reconfig can save changed connection details when unreachable."""
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="Kitchen Sensor",
         data={
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 6053,
@@ -2410,17 +2430,17 @@ async def test_reconfig_can_save_changed_unreachable_host(
 
     result = await entry.start_reconfigure_flow(hass)
 
-    mock_client.device_info.side_effect = APIConnectionError
+    mock_client.device_info.side_effect = error
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_HOST: "127.0.0.2", CONF_PORT: 6053}
+        result["flow_id"], user_input={CONF_HOST: host, CONF_PORT: port}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure_confirm_unreachable"
     assert result["description_placeholders"] == {
-        "host": "127.0.0.2",
-        "name": "test",
-        "port": 6053,
+        "host": placeholder_host,
+        "name": "Kitchen Sensor (test)",
+        "port": str(port),
     }
     assert entry.data[CONF_HOST] == "127.0.0.1"
 
@@ -2431,8 +2451,8 @@ async def test_reconfig_can_save_changed_unreachable_host(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert entry.data == {
-        CONF_HOST: "127.0.0.2",
-        CONF_PORT: 6053,
+        CONF_HOST: host,
+        CONF_PORT: port,
         CONF_PASSWORD: "",
         CONF_DEVICE_NAME: "test",
         CONF_NOISE_PSK: VALID_NOISE_PSK,
@@ -2458,7 +2478,7 @@ async def test_reconfig_same_unreachable_host_shows_error(
 
     result = await entry.start_reconfigure_flow(hass)
 
-    mock_client.device_info.side_effect = APIConnectionError
+    mock_client.device_info.side_effect = APIConnectionError()
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.1", CONF_PORT: 6053}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

ESPHome reconfigure currently validates the new connection details before saving them. That blocks stale-address recovery when the old address is no longer useful, the new address is temporarily offline, or the hostname cannot be resolved from Home Assistant at that moment.

This PR adds an explicit confirmation step for reconfigure when the changed host or port cannot be reached or resolved. If the user confirms, Home Assistant updates only the saved host and port on the existing config entry. It keeps the existing entry identity, device name, password, and noise key, and it keeps the normal reachable-device validation path so MAC/unique_id changes still abort instead of silently retargeting the entry.

Validation run locally with Python 3.14.4, matching the current `requires-python >=3.14.2` constraint:

- `venv/bin/python -m py_compile homeassistant/components/esphome/config_flow.py tests/components/esphome/test_config_flow.py`
- `venv/bin/python -m json.tool homeassistant/components/esphome/strings.json >/tmp/esphome_strings.json`
- `venv/bin/python -m ruff check homeassistant/components/esphome/config_flow.py tests/components/esphome/test_config_flow.py`
- `venv/bin/python -m script.translations develop --all`
- `venv/bin/python -m pytest tests/components/esphome/test_config_flow.py -k 'reconfig_can_save_changed_unreachable_connection or reconfig_same_unreachable_host_shows_error or reconfig_attempt_to_change_mac_aborts or reconfig_success_with_new_ip_new_name' -q` (`7 passed, 70 deselected`)
- `git diff --check`
- `codex review --base origin/dev`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
