### PR TITLE
netatmo: add doortag direct category fetch

### DIFF
--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -70,7 +70,13 @@ def get_opening_category(netatmo_device: NetatmoDevice) -> str:
     """Helper function to get opening category for doortag."""
 
     # From pyatmo v9.4.0, category is available as an attribute on the device object
-    return getattr(netatmo_device.device, "doortag_category", DOORTAG_CATEGORY_OTHER)
+    device = netatmo_device.device
+    try:
+        category = device.doortag_category
+    except AttributeError:
+        return DOORTAG_CATEGORY_OTHER
+
+    return category if category is not None else DOORTAG_CATEGORY_OTHER
 
 
 OPENING_CATEGORY_TO_KEY: Final[dict[str, str | None]] = {

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -69,8 +69,6 @@ OPENING_CATEGORY_TO_DEVICE_CLASS: Final[dict[str | None, BinarySensorDeviceClass
 def get_opening_category(netatmo_device: NetatmoDevice) -> str:
     """Helper function to get opening category for doortag."""
 
-    # From pyatmo v9.4.0, category is available as an attribute on the device object
-    # direct getting of the attribute with default to "other" if not present
     return (
         getattr(netatmo_device.device, "doortag_category", None)
         or DOORTAG_CATEGORY_OTHER

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -70,7 +70,11 @@ def get_opening_category(netatmo_device: NetatmoDevice) -> str:
     """Helper function to get opening category for doortag."""
 
     # From pyatmo v9.4.0, category is available as an attribute on the device object
-    return getattr(netatmo_device.device, "doortag_category", DOORTAG_CATEGORY_OTHER)
+    # direct getting of the attribute with default to "other" if not present
+    return (
+        getattr(netatmo_device.device, "doortag_category", None)
+        or DOORTAG_CATEGORY_OTHER
+    )
 
 
 OPENING_CATEGORY_TO_KEY: Final[dict[str, str | None]] = {

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -71,7 +71,7 @@ def get_opening_category(netatmo_device: NetatmoDevice) -> str:
 
     # From pyatmo v9.4.0, category is available as an attribute on the device object,
     # so we check it first to avoid iterating through raw data for every update
-    category: str | None = getattr(netatmo_device.device, "category", None)
+    category: str | None = getattr(netatmo_device.device, "doortag_category", None)
     if category is not None:
         return category
 

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -67,9 +67,9 @@ OPENING_CATEGORY_TO_DEVICE_CLASS: Final[dict[str | None, BinarySensorDeviceClass
 
 
 def get_opening_category(netatmo_device: NetatmoDevice) -> str:
-    """Helper function to get opening category from Netatmo API raw data."""
+    """Helper function to get opening category for doortag."""
 
-    # From pyatmo v9.4.0, category is available as an attribute on the device object,
+    # From pyatmo v9.4.0, category is available as an attribute on the device object
     return getattr(netatmo_device.device, "doortag_category", DOORTAG_CATEGORY_OTHER)
 
 

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -70,31 +70,7 @@ def get_opening_category(netatmo_device: NetatmoDevice) -> str:
     """Helper function to get opening category from Netatmo API raw data."""
 
     # From pyatmo v9.4.0, category is available as an attribute on the device object,
-    # so we check it first to avoid iterating through raw data for every update
-    category: str | None = getattr(netatmo_device.device, "doortag_category", None)
-    if category is not None:
-        return category
-
-    # Iterate through each home in the raw data.
-    # Candidate for removal after requirements bump pyatmo v9.4.0+ as we should have
-    # category available directly on the device object by then this will be dead code
-    for home in netatmo_device.data_handler.account.raw_data["homes"]:
-        # Check if the modules list exists for the current home.
-        if "modules" in home:
-            # Iterate through each module to find a matching ID.
-            for module in home["modules"]:
-                if module["id"] == netatmo_device.device.entity_id:
-                    # We found the matching device. Get its category.
-                    if module.get("category") is not None:
-                        return cast(str, module["category"])
-                    raise ValueError(
-                        f"Device {netatmo_device.device.entity_id} found, "
-                        "but 'category' is missing in raw data."
-                    )
-
-    raise ValueError(
-        f"Device {netatmo_device.device.entity_id} not found in Netatmo raw data."
-    )
+    return getattr(netatmo_device.device, "doortag_category", DOORTAG_CATEGORY_OTHER)
 
 
 OPENING_CATEGORY_TO_KEY: Final[dict[str, str | None]] = {

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -76,7 +76,7 @@ def get_opening_category(netatmo_device: NetatmoDevice) -> str:
         return category
 
     # Iterate through each home in the raw data.
-    # Candidate for removal after requirements dump pyatmo v9.4.0+ as we should have
+    # Candidate for removal after requirements bump pyatmo v9.4.0+ as we should have
     # category available directly on the device object by then this will be dead code
     for home in netatmo_device.data_handler.account.raw_data["homes"]:
         # Check if the modules list exists for the current home.

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -70,13 +70,7 @@ def get_opening_category(netatmo_device: NetatmoDevice) -> str:
     """Helper function to get opening category for doortag."""
 
     # From pyatmo v9.4.0, category is available as an attribute on the device object
-    device = netatmo_device.device
-    try:
-        category = device.doortag_category
-    except AttributeError:
-        return DOORTAG_CATEGORY_OTHER
-
-    return category if category is not None else DOORTAG_CATEGORY_OTHER
+    return getattr(netatmo_device.device, "doortag_category", DOORTAG_CATEGORY_OTHER)
 
 
 OPENING_CATEGORY_TO_KEY: Final[dict[str, str | None]] = {

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -69,7 +69,15 @@ OPENING_CATEGORY_TO_DEVICE_CLASS: Final[dict[str | None, BinarySensorDeviceClass
 def get_opening_category(netatmo_device: NetatmoDevice) -> str:
     """Helper function to get opening category from Netatmo API raw data."""
 
+    # From pyatmo v9.4.0, category is available as an attribute on the device object,
+    # so we check it first to avoid iterating through raw data for every update
+    category: str | None = getattr(netatmo_device.device, "category", None)
+    if category is not None:
+        return category
+
     # Iterate through each home in the raw data.
+    # Candidate for removal after requirements dump pyatmo v9.4.0+ as we should have
+    # category available directly on the device object by then this will be dead code
     for home in netatmo_device.data_handler.account.raw_data["homes"]:
         # Check if the modules list exists for the current home.
         if "modules" in home:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

From pyatmo v9.4.0 the category attribute of doortags are available directly. This change utilize this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
