### PR TITLE
Add reconfiguration flow to actron_air integration

### DIFF
--- a/homeassistant/components/actron_air/config_flow.py
+++ b/homeassistant/components/actron_air/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from actron_neo_api import ActronAirAPI, ActronAirAuthError
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_API_TOKEN
 from homeassistant.exceptions import HomeAssistantError
 
@@ -105,6 +105,14 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_updates={CONF_API_TOKEN: self._api.refresh_token_value},
             )
 
+        # Check if this is a reconfigure flow
+        if self.source == SOURCE_RECONFIGURE:
+            self._abort_if_unique_id_mismatch(reason="wrong_account")
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(),
+                data_updates={CONF_API_TOKEN: self._api.refresh_token_value},
+            )
+
         self._abort_if_unique_id_configured()
         return self.async_create_entry(
             title=user_data.email,
@@ -138,6 +146,20 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="reauth_confirm")
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration request."""
+        return await self.async_step_reconfigure_confirm()
+
+    async def async_step_reconfigure_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reconfiguration dialog."""
+        if user_input is not None:
+            return await self.async_step_user()
+        return self.async_show_form(step_id="reconfigure_confirm")
+    
     async def async_step_connection_error(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/actron_air/config_flow.py
+++ b/homeassistant/components/actron_air/config_flow.py
@@ -6,7 +6,12 @@ from typing import Any
 
 from actron_neo_api import ActronAirAPI, ActronAirAuthError
 
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 from homeassistant.const import CONF_API_TOKEN
 from homeassistant.exceptions import HomeAssistantError
 
@@ -159,7 +164,7 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return await self.async_step_user()
         return self.async_show_form(step_id="reconfigure_confirm")
-    
+
     async def async_step_connection_error(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/actron_air/quality_scale.yaml
+++ b/homeassistant/components/actron_air/quality_scale.yaml
@@ -60,7 +60,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: This integration does not have any known issues that require repair.

--- a/homeassistant/components/actron_air/strings.json
+++ b/homeassistant/components/actron_air/strings.json
@@ -5,7 +5,7 @@
       "oauth2_error": "Failed to start authentication flow",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "wrong_account": "You must reauthenticate with the same Actron Air account that was originally configured."
+      "wrong_account": "You must authenticate with the same Actron Air account that was originally configured."
     },
     "error": {
       "oauth2_error": "Failed to start authentication flow. Please try again later."

--- a/homeassistant/components/actron_air/strings.json
+++ b/homeassistant/components/actron_air/strings.json
@@ -4,6 +4,7 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "oauth2_error": "Failed to start authentication flow",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "wrong_account": "You must reauthenticate with the same Actron Air account that was originally configured."
     },
     "error": {
@@ -21,6 +22,10 @@
       "reauth_confirm": {
         "description": "Your Actron Air authentication has expired. Select continue to reauthenticate with your Actron Air account. You will be prompted to log in again to restore the connection.",
         "title": "Authentication expired"
+      },
+      "reconfigure_confirm": {
+        "description": "Reconfigure your Actron Air account. You will be prompted to log in again. Note: you must use the same account that was originally configured.",
+        "title": "Reconfigure Actron Air"
       },
       "timeout": {
         "data": {},

--- a/tests/components/actron_air/test_config_flow.py
+++ b/tests/components/actron_air/test_config_flow.py
@@ -350,4 +350,48 @@ async def test_reconfigure_flow_success(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure_confirm"
 
-    result = await hass.config
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "user"
+    assert result["progress_action"] == "wait_for_authorization"
+
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_API_TOKEN] == "test_refresh_token"
+
+
+async def test_reconfigure_flow_wrong_account(
+    hass: HomeAssistant,
+    mock_actron_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguration flow aborts when wrong account is used."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_actron_api.get_user_info = AsyncMock(
+        return_value=ActronAirUserInfo(
+            id="different_user_id", email="different@example.com"
+        )
+    )
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "user"
+
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"

--- a/tests/components/actron_air/test_config_flow.py
+++ b/tests/components/actron_air/test_config_flow.py
@@ -312,6 +312,7 @@ async def test_user_flow_timeout(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test@example.com"
 
+
 async def test_finish_login_auth_error(
     hass: HomeAssistant, mock_actron_api: AsyncMock, mock_setup_entry: AsyncMock
 ) -> None:
@@ -335,6 +336,7 @@ async def test_finish_login_auth_error(
     # Should abort with oauth2_error
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "oauth2_error"
+
 
 async def test_reconfigure_flow_success(
     hass: HomeAssistant,

--- a/tests/components/actron_air/test_config_flow.py
+++ b/tests/components/actron_air/test_config_flow.py
@@ -312,7 +312,6 @@ async def test_user_flow_timeout(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test@example.com"
 
-
 async def test_finish_login_auth_error(
     hass: HomeAssistant, mock_actron_api: AsyncMock, mock_setup_entry: AsyncMock
 ) -> None:
@@ -336,3 +335,19 @@ async def test_finish_login_auth_error(
     # Should abort with oauth2_error
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "oauth2_error"
+
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_actron_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test successful reconfiguration flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+
+    result = await hass.config


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a reconfiguration flow to the Actron Air integration, allowing users 
to reconfigure their account credentials without needing to delete and 
re-add the integration.

Changes:
- Added `async_step_reconfigure` and `async_step_reconfigure_confirm` to 
  `config_flow.py`, following the same OAuth device flow pattern as the 
  existing reauth flow
- Added `reconfigure_confirm` step strings to `strings.json`
- Added `reconfigure_successful` abort string to `strings.json`
- Updated `quality_scale.yaml` to mark `reconfiguration-flow: done`
- Added tests for the reconfigure flow (success and wrong account scenarios)

Note: Claude AI was used to assist in drafting this contribution. The 
contents have been reviewed and verified against the integration source code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
