### PR TITLE
Ignore location FORBIDDEN response for the Volvo integration

### DIFF
--- a/homeassistant/components/volvo/coordinator.py
+++ b/homeassistant/components/volvo/coordinator.py
@@ -263,9 +263,21 @@ class VolvoSlowIntervalCoordinator(VolvoBaseCoordinator):
             api.async_get_odometer,
         ]
 
-        location = await api.async_get_location()
+        # Volvo is returning FORBIDDEN for the location request in case the vehicle
+        # is in an unsupported region. Since we can't know where the vehicle is
+        # located, we silently ignore the failure. If (re-)authentication is needed,
+        # other requests will fail as well and trigger the re-auth flow.
+        location = None
+        try:
+            location = await api.async_get_location()
+        except VolvoAuthException as ex:
+            _LOGGER.debug(
+                "%s - Location not supported for this vehicle. %s",
+                self.config_entry.entry_id,
+                ex.message,
+            )
 
-        if location.get("location") is not None:
+        if location and location.get("location") is not None:
             api_calls.append(api.async_get_location)
 
         return api_calls

--- a/tests/components/volvo/test_coordinator.py
+++ b/tests/components/volvo/test_coordinator.py
@@ -143,6 +143,10 @@ async def test_coordinator_location_auth_exception(
     )
     assert await setup_integration()
 
+    # Verify no reauthentication flow is started
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert not flows
+
     # Verify integration loads without location entity
     device_tracker_states = hass.states.async_all(domain_filter="device_tracker")
     assert len(device_tracker_states) == 0

--- a/tests/components/volvo/test_coordinator.py
+++ b/tests/components/volvo/test_coordinator.py
@@ -130,6 +130,29 @@ async def test_update_coordinator_all_error(
             assert state.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.freeze_time("2025-05-31T10:00:00+00:00")
+async def test_coordinator_location_auth_exception(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    setup_integration: Callable[[], Awaitable[bool]],
+    mock_api: VolvoCarsApi,
+) -> None:
+    """Test coordinator setup when location returns VolvoAuthException."""
+    configure_mock(
+        mock_api.async_get_location, side_effect=VolvoAuthException(403, "Forbidden")
+    )
+    assert await setup_integration()
+
+    # Verify integration loads without location entity
+    device_tracker_states = hass.states.async_all(domain_filter="device_tracker")
+    assert len(device_tracker_states) == 0
+
+    # Verify other entities still work
+    sensor_id = "sensor.volvo_xc40_odometer"
+    state = hass.states.get(sensor_id)
+    assert state.state == "30000"
+
+
 def _mock_api_failure(mock_api: VolvoCarsApi) -> AsyncMock:
     """Mock the Volvo API so that it raises an exception for all calls."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Volvo is now returning FORBIDDEN for the location request in case the vehicle is in an unsupported region. Since we can't know where the vehicle is located, we silently ignore the failure. If (re-)authentication is needed, other requests will fail as well and trigger the re-auth flow.

Would it be possible to include this in the 2026.5.0 release, please?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169582
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
