### PR TITLE
Add missing initialization charging power status option to Volvo

### DIFF
--- a/homeassistant/components/volvo/sensor.py
+++ b/homeassistant/components/volvo/sensor.py
@@ -99,6 +99,7 @@ def _direction_value(field: VolvoCarsApiBaseModel) -> str | None:
 
 _CHARGING_POWER_STATUS_OPTIONS = [
     "fault",
+    "initialization",
     "power_available_but_not_activated",
     "providing_power",
     "no_power_available",

--- a/homeassistant/components/volvo/strings.json
+++ b/homeassistant/components/volvo/strings.json
@@ -281,6 +281,7 @@
         "name": "Charging power status",
         "state": {
           "fault": "[%key:common::state::fault%]",
+          "initialization": "Initialization",
           "no_power_available": "No power",
           "power_available_but_not_activated": "Power available",
           "providing_power": "Providing power"

--- a/tests/components/volvo/snapshots/test_sensor.ambr
+++ b/tests/components/volvo/snapshots/test_sensor.ambr
@@ -307,6 +307,7 @@
     'capabilities': dict({
       'options': list([
         'fault',
+        'initialization',
         'power_available_but_not_activated',
         'providing_power',
         'no_power_available',
@@ -349,6 +350,7 @@
       'friendly_name': 'Volvo EX30 Charging power status',
       'options': list([
         'fault',
+        'initialization',
         'power_available_but_not_activated',
         'providing_power',
         'no_power_available',
@@ -2574,6 +2576,7 @@
     'capabilities': dict({
       'options': list([
         'fault',
+        'initialization',
         'power_available_but_not_activated',
         'providing_power',
         'no_power_available',
@@ -2616,6 +2619,7 @@
       'friendly_name': 'Volvo XC40 Charging power status',
       'options': list([
         'fault',
+        'initialization',
         'power_available_but_not_activated',
         'providing_power',
         'no_power_available',
@@ -5857,6 +5861,7 @@
     'capabilities': dict({
       'options': list([
         'fault',
+        'initialization',
         'power_available_but_not_activated',
         'providing_power',
         'no_power_available',
@@ -5899,6 +5904,7 @@
       'friendly_name': 'Volvo XC90 Charging power status',
       'options': list([
         'fault',
+        'initialization',
         'power_available_but_not_activated',
         'providing_power',
         'no_power_available',


### PR DESCRIPTION
## Proposed change

Add the missing `initialization` option to the charging power status sensor in the Volvo integration. The Volvo API can return this status value, but it was not listed as a valid option since the possible values are not documented by Volvo.

Fixes #169414

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169414
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr