### PR TITLE
Bump victron-ble-ha-parser to 0.7.0

### DIFF
--- a/homeassistant/components/victron_ble/manifest.json
+++ b/homeassistant/components/victron_ble/manifest.json
@@ -15,5 +15,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["victron-ble-ha-parser==0.6.3"]
+  "requirements": ["victron-ble-ha-parser==0.7.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3249,7 +3249,7 @@ venstarcolortouch==0.21
 viaggiatreno_ha==0.2.4
 
 # homeassistant.components.victron_ble
-victron-ble-ha-parser==0.6.3
+victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
 victron-mqtt==2026.4.17

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2761,7 +2761,7 @@ velbus-aio==2026.4.1
 venstarcolortouch==0.21
 
 # homeassistant.components.victron_ble
-victron-ble-ha-parser==0.6.3
+victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
 victron-mqtt==2026.4.17

--- a/tests/components/victron_ble/fixtures.py
+++ b/tests/components/victron_ble/fixtures.py
@@ -112,6 +112,18 @@ VICTRON_INVERTER_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+VICTRON_INVERTER_RS_SERVICE_INFO = BluetoothServiceInfo(
+    name="Inverter RS",
+    address="01:02:03:04:05:16",
+    rssi=-60,
+    manufacturer_data={
+        0x02E1: bytes.fromhex("1000a2a2061252dad26f0b8eb39162074d140df410"),
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
 # SmartLithium (8-cell, 24V)
 
 VICTRON_SMART_LITHIUM_SERVICE_INFO = BluetoothServiceInfo(

--- a/tests/components/victron_ble/test_config_flow.py
+++ b/tests/components/victron_ble/test_config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .fixtures import (
     NOT_VICTRON_SERVICE_INFO,
-    VICTRON_INVERTER_SERVICE_INFO,
+    VICTRON_INVERTER_RS_SERVICE_INFO,
     VICTRON_TEST_WRONG_TOKEN,
     VICTRON_VEBUS_SERVICE_INFO,
     VICTRON_VEBUS_TOKEN,
@@ -96,7 +96,7 @@ async def test_async_step_bluetooth_invalid_key_retry(
         ),
         (
             SOURCE_BLUETOOTH,
-            VICTRON_INVERTER_SERVICE_INFO,
+            VICTRON_INVERTER_RS_SERVICE_INFO,
             "not_supported",
         ),
         (


### PR DESCRIPTION
## Proposed change

Bump victron-ble-ha-parser from 0.6.3 to 0.7.0.

This release adds support for:
- Orion XS DC-DC charger (mode 0x0F)
- Inverter (mode 0x03)
- Fixes stale sensor data leaking across updates

Changelog: https://github.com/rajlaud/victron-ble-ha-parser/compare/v0.6.3...v0.7.0

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR fixes or closes issue: fixes #158167
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
