### PR TITLE
Fix IntelliFire setup recovery

### DIFF
--- a/homeassistant/components/intellifire/__init__.py
+++ b/homeassistant/components/intellifire/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+import aiohttp
 from intellifire4py import UnifiedFireplace
 from intellifire4py.cloud_interface import IntelliFireCloudInterface
 from intellifire4py.const import IntelliFireApiMode
@@ -152,6 +153,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: IntellifireConfigEntry) 
     except TimeoutError as err:
         raise ConfigEntryNotReady(
             "Initialization of fireplace timed out after 10 minutes"
+        ) from err
+    except (aiohttp.ClientConnectionError, ConnectionError) as err:
+        raise ConfigEntryNotReady(
+            "Error communicating with fireplace during initialization"
         ) from err
 
     # Construct coordinator

--- a/homeassistant/components/intellifire/config_flow.py
+++ b/homeassistant/components/intellifire/config_flow.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -287,36 +288,32 @@ class IntelliFireOptionsFlowHandler(OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            if (
-                coordinator := getattr(self.config_entry, "runtime_data", None)
-            ) is None:
-                return self.async_abort(reason="not_loaded")
+            if self.config_entry.state is ConfigEntryState.LOADED:
+                fireplace = self.config_entry.runtime_data.fireplace
 
-            fireplace = coordinator.fireplace
+                # Refresh connectivity status before validating
+                await fireplace.async_validate_connectivity()
 
-            # Refresh connectivity status before validating
-            await fireplace.async_validate_connectivity()
-
-            if (
-                user_input[CONF_READ_MODE] == API_MODE_LOCAL
-                and not fireplace.local_connectivity
-            ):
-                errors[CONF_READ_MODE] = "local_unavailable"
-            if (
-                user_input[CONF_READ_MODE] == API_MODE_CLOUD
-                and not fireplace.cloud_connectivity
-            ):
-                errors[CONF_READ_MODE] = "cloud_unavailable"
-            if (
-                user_input[CONF_CONTROL_MODE] == API_MODE_LOCAL
-                and not fireplace.local_connectivity
-            ):
-                errors[CONF_CONTROL_MODE] = "local_unavailable"
-            if (
-                user_input[CONF_CONTROL_MODE] == API_MODE_CLOUD
-                and not fireplace.cloud_connectivity
-            ):
-                errors[CONF_CONTROL_MODE] = "cloud_unavailable"
+                if (
+                    user_input[CONF_READ_MODE] == API_MODE_LOCAL
+                    and not fireplace.local_connectivity
+                ):
+                    errors[CONF_READ_MODE] = "local_unavailable"
+                if (
+                    user_input[CONF_READ_MODE] == API_MODE_CLOUD
+                    and not fireplace.cloud_connectivity
+                ):
+                    errors[CONF_READ_MODE] = "cloud_unavailable"
+                if (
+                    user_input[CONF_CONTROL_MODE] == API_MODE_LOCAL
+                    and not fireplace.local_connectivity
+                ):
+                    errors[CONF_CONTROL_MODE] = "local_unavailable"
+                if (
+                    user_input[CONF_CONTROL_MODE] == API_MODE_CLOUD
+                    and not fireplace.cloud_connectivity
+                ):
+                    errors[CONF_CONTROL_MODE] = "cloud_unavailable"
 
             if not errors:
                 return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/intellifire/config_flow.py
+++ b/homeassistant/components/intellifire/config_flow.py
@@ -287,34 +287,36 @@ class IntelliFireOptionsFlowHandler(OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            # Validate connectivity for requested modes if runtime data is available
-            coordinator = self.config_entry.runtime_data
-            if coordinator is not None:
-                fireplace = coordinator.fireplace
+            if (
+                coordinator := getattr(self.config_entry, "runtime_data", None)
+            ) is None:
+                return self.async_abort(reason="not_loaded")
 
-                # Refresh connectivity status before validating
-                await fireplace.async_validate_connectivity()
+            fireplace = coordinator.fireplace
 
-                if (
-                    user_input[CONF_READ_MODE] == API_MODE_LOCAL
-                    and not fireplace.local_connectivity
-                ):
-                    errors[CONF_READ_MODE] = "local_unavailable"
-                if (
-                    user_input[CONF_READ_MODE] == API_MODE_CLOUD
-                    and not fireplace.cloud_connectivity
-                ):
-                    errors[CONF_READ_MODE] = "cloud_unavailable"
-                if (
-                    user_input[CONF_CONTROL_MODE] == API_MODE_LOCAL
-                    and not fireplace.local_connectivity
-                ):
-                    errors[CONF_CONTROL_MODE] = "local_unavailable"
-                if (
-                    user_input[CONF_CONTROL_MODE] == API_MODE_CLOUD
-                    and not fireplace.cloud_connectivity
-                ):
-                    errors[CONF_CONTROL_MODE] = "cloud_unavailable"
+            # Refresh connectivity status before validating
+            await fireplace.async_validate_connectivity()
+
+            if (
+                user_input[CONF_READ_MODE] == API_MODE_LOCAL
+                and not fireplace.local_connectivity
+            ):
+                errors[CONF_READ_MODE] = "local_unavailable"
+            if (
+                user_input[CONF_READ_MODE] == API_MODE_CLOUD
+                and not fireplace.cloud_connectivity
+            ):
+                errors[CONF_READ_MODE] = "cloud_unavailable"
+            if (
+                user_input[CONF_CONTROL_MODE] == API_MODE_LOCAL
+                and not fireplace.local_connectivity
+            ):
+                errors[CONF_CONTROL_MODE] = "local_unavailable"
+            if (
+                user_input[CONF_CONTROL_MODE] == API_MODE_CLOUD
+                and not fireplace.cloud_connectivity
+            ):
+                errors[CONF_CONTROL_MODE] = "cloud_unavailable"
 
             if not errors:
                 return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/intellifire/strings.json
+++ b/homeassistant/components/intellifire/strings.json
@@ -155,9 +155,6 @@
     }
   },
   "options": {
-    "abort": {
-      "not_loaded": "The IntelliFire integration is not loaded."
-    },
     "error": {
       "cloud_unavailable": "Cloud connectivity is not available",
       "local_unavailable": "Local connectivity is not available"

--- a/homeassistant/components/intellifire/strings.json
+++ b/homeassistant/components/intellifire/strings.json
@@ -155,6 +155,9 @@
     }
   },
   "options": {
+    "abort": {
+      "not_loaded": "The IntelliFire integration is not loaded."
+    },
     "error": {
       "cloud_unavailable": "Cloud connectivity is not available",
       "local_unavailable": "Local connectivity is not available"

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -272,11 +272,11 @@ async def test_options_flow(
     }
 
 
-async def test_options_flow_not_loaded_on_submit(
+async def test_options_flow_allows_submit_when_not_loaded(
     hass: HomeAssistant,
     mock_config_entry_current: MockConfigEntry,
 ) -> None:
-    """Test options flow aborts when runtime data is missing on submit."""
+    """Test options flow allows submit when runtime data is missing."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         version=mock_config_entry_current.version,
@@ -297,8 +297,11 @@ async def test_options_flow_not_loaded_on_submit(
         {CONF_READ_MODE: API_MODE_CLOUD, CONF_CONTROL_MODE: API_MODE_LOCAL},
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "not_loaded"
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_READ_MODE: API_MODE_CLOUD,
+        CONF_CONTROL_MODE: API_MODE_LOCAL,
+    }
 
 
 async def test_options_flow_local_read_unavailable(

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -272,6 +272,35 @@ async def test_options_flow(
     }
 
 
+async def test_options_flow_not_loaded_on_submit(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+) -> None:
+    """Test options flow aborts when runtime data is missing on submit."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=mock_config_entry_current.version,
+        minor_version=mock_config_entry_current.minor_version,
+        data=dict(mock_config_entry_current.data),
+        options=dict(mock_config_entry_current.options),
+        unique_id=mock_config_entry_current.unique_id,
+        state=config_entries.ConfigEntryState.SETUP_ERROR,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_READ_MODE: API_MODE_CLOUD, CONF_CONTROL_MODE: API_MODE_LOCAL},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_loaded"
+
+
 async def test_options_flow_local_read_unavailable(
     hass: HomeAssistant,
     mock_config_entry_current: MockConfigEntry,

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -1,8 +1,10 @@
 """Test the IntelliFire config flow."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 from intellifire4py.const import IntelliFireApiMode
+import pytest
 
 from homeassistant.components.intellifire import CONF_USER_ID
 from homeassistant.components.intellifire.const import (
@@ -159,22 +161,28 @@ async def test_init_with_no_username(hass: HomeAssistant, mock_apis_single_fp) -
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_connectivity_bad(
+@pytest.mark.parametrize(
+    "setup_error",
+    [aiohttp.ClientConnectionError, ConnectionError, TimeoutError],
+)
+async def test_connectivity_error_during_setup_retries(
     hass: HomeAssistant,
-    mock_config_entry_current,
-    mock_apis_single_fp,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp: tuple[AsyncMock, AsyncMock, MagicMock],
+    setup_error: type[Exception],
 ) -> None:
-    """Test a timeout error on the setup flow."""
+    """Test a connection error during setup retries the config entry."""
 
     with patch(
         "homeassistant.components.intellifire.UnifiedFireplace.build_fireplace_from_common",
         new_callable=AsyncMock,
-        side_effect=TimeoutError,
+        side_effect=setup_error,
     ):
         mock_config_entry_current.add_to_hass(hass)
         await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
 
         await hass.async_block_till_done()
+        assert mock_config_entry_current.state is ConfigEntryState.SETUP_RETRY
         assert len(hass.states.async_all()) == 0
 
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Fix two IntelliFire setup recovery issues.

When an IntelliFire config entry is not loaded, submitting the options flow no longer raises an `AttributeError` because `runtime_data` is missing. The options flow now aborts cleanly with a translated `not_loaded` reason.

When transient connection errors occur while the fireplace object is being built or initialized, setup now raises `ConfigEntryNotReady` so Home Assistant retries the config entry instead of leaving it in a permanent setup error state.

Tests were added for both paths.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
