### PR TITLE
Fix invalid except syntax in growatt_server coordinator

### DIFF
--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -186,7 +186,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     combined["lastdataupdate"] = parsed.replace(
                         tzinfo=dt_util.get_default_time_zone()
                     )
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     _LOGGER.debug(
                         "Could not parse SPH time field for %s: %r",
                         self.device_id,
@@ -478,7 +478,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             parts = str(time_raw).split(":")
             hour = int(parts[0])
             minute = int(parts[1])
-        except ValueError, IndexError:
+        except (ValueError, IndexError):
             return "00:00"
         else:
             return f"{hour:02d}:{minute:02d}"


### PR DESCRIPTION
`except A, B:` is Python 2 syntax. Python 3 requires the exception types to be parenthesized (`except (A, B):`); without the parentheses, the module fails to parse with a SyntaxError and the integration cannot be loaded.


## Breaking change
Fix invalid `except A, B:` syntax in the growatt_server coordinator.

This is Python 2 syntax. Python 3 requires the exception types to be parenthesized (`except (A, B):`); without the parentheses, the module fails to parse with a SyntaxError and the integration cannot be loaded.


## Proposed change
Two occurrences fixed in `homeassistant/components/growatt_server/coordinator.py` — the SPH `lastdataupdate` parsing and the time-field helper for charge/discharge service calls.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

NA

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure