### PR TITLE
Fix uptime template sensor

### DIFF
--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -191,7 +191,7 @@ def validate_datetime(
     """Converts the template result into a datetime or date."""
 
     def convert(result: Any) -> datetime | date | None:
-        if resolve_as == SensorDeviceClass.TIMESTAMP:
+        if resolve_as in (SensorDeviceClass.TIMESTAMP, SensorDeviceClass.UPTIME):
             if isinstance(result, datetime):
                 return result
 
@@ -263,6 +263,7 @@ class AbstractTemplateSensor(AbstractTemplateEntity, RestoreSensor):
         if result is None or self.device_class not in (
             SensorDeviceClass.DATE,
             SensorDeviceClass.TIMESTAMP,
+            SensorDeviceClass.UPTIME,
         ):
             return result
 

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1362,93 +1362,6 @@ async def test_trigger_attribute_order(
     )
 
 
-async def test_trigger_entity_device_class_parsing_works(hass: HomeAssistant) -> None:
-    """Test trigger entity device class parsing works."""
-    assert await async_setup_component(
-        hass,
-        "template",
-        {
-            "template": [
-                {
-                    "trigger": {"platform": "event", "event_type": "test_event"},
-                    "sensor": [
-                        {
-                            "name": "Date entity",
-                            "state": "{{ now().date() }}",
-                            "device_class": "date",
-                        },
-                        {
-                            "name": "Timestamp entity",
-                            "state": "{{ now() }}",
-                            "device_class": "timestamp",
-                        },
-                    ],
-                },
-            ],
-        },
-    )
-
-    await hass.async_block_till_done()
-
-    # State of timestamp sensors are always in UTC
-    now = dt_util.utcnow()
-
-    with patch("homeassistant.util.dt.now", return_value=now):
-        hass.bus.async_fire("test_event")
-        await hass.async_block_till_done()
-
-    date_state = hass.states.get("sensor.date_entity")
-    assert date_state is not None
-    assert date_state.state == now.date().isoformat()
-
-    ts_state = hass.states.get("sensor.timestamp_entity")
-    assert ts_state is not None
-    assert ts_state.state == now.isoformat(timespec="seconds")
-
-
-async def test_trigger_entity_device_class_errors_works(hass: HomeAssistant) -> None:
-    """Test trigger entity device class errors works."""
-    assert await async_setup_component(
-        hass,
-        "template",
-        {
-            "template": [
-                {
-                    "trigger": {"platform": "event", "event_type": "test_event"},
-                    "sensor": [
-                        {
-                            "name": "Date entity",
-                            "state": "invalid",
-                            "device_class": "date",
-                        },
-                        {
-                            "name": "Timestamp entity",
-                            "state": "invalid",
-                            "device_class": "timestamp",
-                        },
-                    ],
-                },
-            ],
-        },
-    )
-
-    await hass.async_block_till_done()
-
-    now = dt_util.now()
-
-    with patch("homeassistant.util.dt.now", return_value=now):
-        hass.bus.async_fire("test_event")
-        await hass.async_block_till_done()
-
-    date_state = hass.states.get("sensor.date_entity")
-    assert date_state is not None
-    assert date_state.state == STATE_UNKNOWN
-
-    ts_state = hass.states.get("sensor.timestamp_entity")
-    assert ts_state is not None
-    assert ts_state.state == STATE_UNKNOWN
-
-
 async def test_entity_last_reset_total_increasing(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -1560,46 +1473,60 @@ async def test_invalid_last_reset(
     assert err in caplog_setup_text or err in caplog.text
 
 
-async def test_entity_device_class_errors_works(hass: HomeAssistant) -> None:
-    """Test entity device class errors works."""
-    assert await async_setup_component(
-        hass,
-        "template",
-        {
-            "template": [
-                {
-                    "sensor": [
-                        {
-                            "name": "Date entity",
-                            "state": "invalid",
-                            "device_class": "date",
-                        },
-                        {
-                            "name": "Timestamp entity",
-                            "state": "invalid",
-                            "device_class": "timestamp",
-                        },
-                    ],
-                },
-            ],
-        },
-    )
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"device_class": "timestamp"},
+        {"device_class": "uptime"},
+    ],
+)
+@pytest.mark.parametrize(
+    ("state_template", "expected_state"),
+    [
+        ("invalid", STATE_UNKNOWN),
+        ("{{ now() }}", "2026-05-04T00:00:00+00:00"),
+        ("{{ now().isoformat() }}", "2026-05-04T00:00:00+00:00"),
+    ],
+)
+@pytest.mark.usefixtures("setup_state_sensor")
+@pytest.mark.freeze_time("2026-05-04 00:00:00+00:00")
+async def test_sensor_datetime_device_classes(
+    hass: HomeAssistant, expected_state: str
+) -> None:
+    """Test sensor datetime device classes."""
+    await async_trigger(hass, TEST_STATE_SENSOR, "anything")
 
-    await hass.async_block_till_done()
+    state = hass.states.get(TEST_SENSOR.entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
-    now = dt_util.now()
 
-    with patch("homeassistant.util.dt.now", return_value=now):
-        hass.bus.async_fire("test_event")
-        await hass.async_block_till_done()
+@pytest.mark.parametrize(("count", "config"), [(1, {"device_class": "date"})])
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("state_template", "expected_state"),
+    [
+        ("invalid", STATE_UNKNOWN),
+        ("{{ utcnow().date() }}", "2026-05-04"),
+    ],
+)
+@pytest.mark.usefixtures("setup_state_sensor")
+@pytest.mark.freeze_time("2026-05-04 00:00:00+00:00")
+async def test_sensor_date_device_class(
+    hass: HomeAssistant, expected_state: str
+) -> None:
+    """Test sensor date device class."""
+    await async_trigger(hass, TEST_STATE_SENSOR, "anything")
 
-    date_state = hass.states.get("sensor.date_entity")
-    assert date_state is not None
-    assert date_state.state == STATE_UNKNOWN
-
-    ts_state = hass.states.get("sensor.timestamp_entity")
-    assert ts_state is not None
-    assert ts_state.state == STATE_UNKNOWN
+    state = hass.states.get(TEST_SENSOR.entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, "template")])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Account for new uptime device_class in template sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/169687
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
