### PR TITLE
Add data_description blocks to dnsip strings

### DIFF
--- a/homeassistant/components/dnsip/strings.json
+++ b/homeassistant/components/dnsip/strings.json
@@ -9,11 +9,18 @@
     "step": {
       "user": {
         "data": {
-          "hostname": "The hostname for which to perform the DNS query",
-          "port": "Port for IPV4 lookup",
-          "port_ipv6": "Port for IPV6 lookup",
-          "resolver": "Resolver for IPV4 lookup",
-          "resolver_ipv6": "Resolver for IPV6 lookup"
+          "hostname": "Hostname",
+          "port": "IPv4 port",
+          "port_ipv6": "IPv6 port",
+          "resolver": "IPv4 resolver",
+          "resolver_ipv6": "IPv6 resolver"
+        },
+        "data_description": {
+          "hostname": "The hostname for which to perform the DNS query.",
+          "port": "Port used for the IPv4 lookup.",
+          "port_ipv6": "Port used for the IPv6 lookup.",
+          "resolver": "Resolver used for the IPv4 lookup.",
+          "resolver_ipv6": "Resolver used for the IPv6 lookup."
         }
       }
     }
@@ -50,6 +57,12 @@
           "port_ipv6": "[%key:component::dnsip::config::step::user::data::port_ipv6%]",
           "resolver": "[%key:component::dnsip::config::step::user::data::resolver%]",
           "resolver_ipv6": "[%key:component::dnsip::config::step::user::data::resolver_ipv6%]"
+        },
+        "data_description": {
+          "port": "[%key:component::dnsip::config::step::user::data_description::port%]",
+          "port_ipv6": "[%key:component::dnsip::config::step::user::data_description::port_ipv6%]",
+          "resolver": "[%key:component::dnsip::config::step::user::data_description::resolver%]",
+          "resolver_ipv6": "[%key:component::dnsip::config::step::user::data_description::resolver_ipv6%]"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Split out from #169688 per @gjohansson-ST's request.

Adds `data_description` blocks to the `config.step.user` and `options.step.init` form steps. The existing descriptive text in the `data` blocks is shortened to proper field labels, with the descriptive text moved to `data_description` (helper text below each field).

Required so #169688 can claim `config-flow: done` in the quality scale, which activates the strict translation check requiring a `data_description` for every form field.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #169688

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
