### PR TITLE
Remove location_name property from mobile_app device tracker

### DIFF
--- a/homeassistant/components/mobile_app/device_tracker.py
+++ b/homeassistant/components/mobile_app/device_tracker.py
@@ -13,10 +13,7 @@ from homeassistant.components.device_tracker import (
     ATTR_LOCATION_NAME,
     TrackerEntity,
 )
-from homeassistant.components.zone import (
-    ENTITY_ID_FORMAT as ZONE_ENTITY_ID_FORMAT,
-    HOME_ZONE,
-)
+from homeassistant.components.zone import ENTITY_ID_FORMAT as ZONE_ENTITY_ID_FORMAT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
@@ -24,9 +21,8 @@ from homeassistant.const import (
     ATTR_GPS_ACCURACY,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    STATE_HOME,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -97,6 +93,15 @@ async def async_setup_entry(
     async_add_entities([entity])
 
 
+def _zone_state(hass: HomeAssistant, data: dict[str, Any]) -> State | None:
+    """Return the state of the zone matching the location name in data, if any."""
+    if not (location_name := data.get(ATTR_LOCATION_NAME)):
+        return None
+    # If a location name is set, set the location to the center of the zone
+    # to allow the `in_zones` attribute to be populated by the base class.
+    return hass.states.get(ZONE_ENTITY_ID_FORMAT.format(location_name))
+
+
 class MobileAppEntity(TrackerEntity, RestoreEntity):
     """Represent a tracked device."""
 
@@ -129,13 +134,17 @@ class MobileAppEntity(TrackerEntity, RestoreEntity):
     @property
     def location_accuracy(self) -> float:
         """Return the gps accuracy of the device."""
+        if ATTR_GPS not in self._data:
+            return 0
         return self._data.get(ATTR_GPS_ACCURACY, 0)
 
     @property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         if (gps := self._data.get(ATTR_GPS)) is None:
-            return None
+            if not (zone_state := _zone_state(self.hass, self._data)):
+                return None
+            return zone_state.attributes.get(ATTR_LATITUDE)
 
         return gps[0]
 
@@ -143,22 +152,11 @@ class MobileAppEntity(TrackerEntity, RestoreEntity):
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         if (gps := self._data.get(ATTR_GPS)) is None:
-            return None
+            if not (zone_state := _zone_state(self.hass, self._data)):
+                return None
+            return zone_state.attributes.get(ATTR_LONGITUDE)
 
         return gps[1]
-
-    @property
-    def location_name(self) -> str | None:
-        """Return a location name for the current location of the device."""
-        if location_name := self._data.get(ATTR_LOCATION_NAME):
-            if location_name == HOME_ZONE:
-                return STATE_HOME
-            if zone_state := self.hass.states.get(
-                ZONE_ENTITY_ID_FORMAT.format(location_name)
-            ):
-                return zone_state.name
-            return location_name
-        return None
 
     @property
     def name(self) -> str:

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -55,9 +55,9 @@ async def setup_zone(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("extra_webhook_data", "expected_attributes", "expected_state"),
     [
-        # Send coordinates + location_name: Location name has precedence
+        # Send coordinates + location_name: Coordinates have precedence
         (
-            {"gps": [10, 20], "location_name": "home"},
+            {"gps": [10, 20], "gps_accuracy": 30, "location_name": "home"},
             {
                 "latitude": 10,
                 "longitude": 20,
@@ -67,7 +67,7 @@ async def setup_zone(hass: HomeAssistant) -> None:
             "home",
         ),
         (
-            {"gps": [20, 30], "location_name": "office"},
+            {"gps": [20, 30], "gps_accuracy": 30, "location_name": "office"},
             {
                 "latitude": 20,
                 "longitude": 30,
@@ -77,7 +77,7 @@ async def setup_zone(hass: HomeAssistant) -> None:
             "Office",
         ),
         (
-            {"gps": [30, 40], "location_name": "school"},
+            {"gps": [30, 40], "gps_accuracy": 30, "location_name": "school"},
             {
                 "latitude": 30,
                 "longitude": 40,
@@ -86,30 +86,88 @@ async def setup_zone(hass: HomeAssistant) -> None:
             },
             "School",
         ),
-        # Send wrong coordinates + location_name: Location name has precedence
+        # Send wrong coordinates + location_name: Coordinates have precedence
         (
-            {"gps": [10, 10], "location_name": "home"},
+            {"gps": [10, 10], "gps_accuracy": 30, "location_name": "home"},
             {"latitude": 10, "longitude": 10, "gps_accuracy": 30, "in_zones": []},
+            "not_home",
+        ),
+        (
+            {"gps": [10, 10], "gps_accuracy": 30, "location_name": "office"},
+            {"latitude": 10, "longitude": 10, "gps_accuracy": 30, "in_zones": []},
+            "not_home",
+        ),
+        (
+            {"gps": [10, 10], "gps_accuracy": 30, "location_name": "school"},
+            {"latitude": 10, "longitude": 10, "gps_accuracy": 30, "in_zones": []},
+            "not_home",
+        ),
+        # Send location_name only
+        (
+            {"location_name": "home"},
+            {
+                "latitude": 10,
+                "longitude": 20,
+                "gps_accuracy": 0,
+                "in_zones": ["zone.home"],
+            },
             "home",
         ),
         (
-            {"gps": [10, 10], "location_name": "office"},
-            {"latitude": 10, "longitude": 10, "gps_accuracy": 30, "in_zones": []},
+            {"location_name": "office"},
+            {
+                "latitude": 20,
+                "longitude": 30,
+                "gps_accuracy": 0,
+                "in_zones": ["zone.office"],
+            },
             "Office",
         ),
         (
-            {"gps": [10, 10], "location_name": "school"},
-            {"latitude": 10, "longitude": 10, "gps_accuracy": 30, "in_zones": []},
+            {"location_name": "school"},
+            {
+                "latitude": 30,
+                "longitude": 40,
+                "gps_accuracy": 0,
+                "in_zones": ["zone.school"],
+            },
             "School",
         ),
-        # Send location_name only
-        ({"location_name": "home"}, {"in_zones": []}, "home"),
-        ({"location_name": "office"}, {"in_zones": []}, "Office"),
-        ({"location_name": "school"}, {"in_zones": []}, "School"),
-        ({"location_name": "no_such_zone"}, {"in_zones": []}, "no_such_zone"),
+        ({"location_name": "no_such_zone"}, {"in_zones": []}, "unknown"),
+        # Send location_name and accuracy
+        (
+            {"location_name": "home", "gps_accuracy": 30},
+            {
+                "latitude": 10,
+                "longitude": 20,
+                "gps_accuracy": 0,
+                "in_zones": ["zone.home"],
+            },
+            "home",
+        ),
+        (
+            {"location_name": "office", "gps_accuracy": 30},
+            {
+                "latitude": 20,
+                "longitude": 30,
+                "gps_accuracy": 0,
+                "in_zones": ["zone.office"],
+            },
+            "Office",
+        ),
+        (
+            {"location_name": "school", "gps_accuracy": 30},
+            {
+                "latitude": 30,
+                "longitude": 40,
+                "gps_accuracy": 0,
+                "in_zones": ["zone.school"],
+            },
+            "School",
+        ),
         # Send coordinates only - location is determined by coordinates
         (
-            {"gps": [10, 20]},
+            {"gps": [10, 20], "gps_accuracy": 30},
             {
                 "latitude": 10,
                 "longitude": 20,
@@ -119,7 +177,7 @@ async def setup_zone(hass: HomeAssistant) -> None:
             "home",
         ),
         (
-            {"gps": [20, 30]},
+            {"gps": [20, 30], "gps_accuracy": 30},
             {
                 "latitude": 20,
                 "longitude": 30,
@@ -129,7 +187,7 @@ async def setup_zone(hass: HomeAssistant) -> None:
             "Office",
         ),
         (
-            {"gps": [30, 40]},
+            {"gps": [30, 40], "gps_accuracy": 30},
             {
                 "latitude": 30,
                 "longitude": 40,
@@ -154,7 +212,6 @@ async def test_sending_location(
         json={
             "type": "update_location",
             "data": {
-                "gps_accuracy": 30,
                 "battery": 40,
                 "altitude": 50,
                 "course": 60,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `location_name` property from `mobile_app` device tracker, and instead use the `location_name` sent by the apps to determine coordinates.

Rationale: The `location_name` sent by both the Android and iOS is always the object ID of the current zone. With this change, the coordinates will be set to the center of the zone, which makes functionality which requires coordinates, for example the `in_zones` state attribute work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
