### PR TITLE
Restore OwnTracks custom device tracker attributes

### DIFF
--- a/homeassistant/components/owntracks/const.py
+++ b/homeassistant/components/owntracks/const.py
@@ -1,4 +1,12 @@
 """Constants for OwnTracks."""
 
-DOMAIN = "owntracks"
-ATTR_UPDATE_TIMESTAMP = "update_timestamp"
+from typing import Final
+
+ATTR_ADDRESS: Final = "address"
+ATTR_BATTERY_STATUS: Final = "battery_status"
+ATTR_COURSE: Final = "course"
+ATTR_TID: Final = "tid"
+ATTR_UPDATE_TIMESTAMP: Final = "update_timestamp"
+ATTR_VELOCITY: Final = "velocity"
+
+DOMAIN: Final = "owntracks"

--- a/homeassistant/components/owntracks/const.py
+++ b/homeassistant/components/owntracks/const.py
@@ -2,11 +2,11 @@
 
 from typing import Final
 
+DOMAIN: Final = "owntracks"
+
 ATTR_ADDRESS: Final = "address"
 ATTR_BATTERY_STATUS: Final = "battery_status"
 ATTR_COURSE: Final = "course"
 ATTR_TID: Final = "tid"
 ATTR_UPDATE_TIMESTAMP: Final = "update_timestamp"
 ATTR_VELOCITY: Final = "velocity"
-
-DOMAIN: Final = "owntracks"

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -21,8 +21,26 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import (
+    ATTR_ADDRESS,
+    ATTR_BATTERY_STATUS,
+    ATTR_COURSE,
+    ATTR_TID,
+    ATTR_UPDATE_TIMESTAMP,
+    ATTR_VELOCITY,
+    DOMAIN,
+)
+
+_RESTORED_OWNTRACKS_ATTRIBUTES: tuple[str, ...] = (
+    ATTR_ADDRESS,
+    ATTR_BATTERY_STATUS,
+    ATTR_COURSE,
+    ATTR_TID,
+    ATTR_UPDATE_TIMESTAMP,
+    ATTR_VELOCITY,
+)
 
 
 async def async_setup_entry(
@@ -141,12 +159,19 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
             return
 
         attr = state.attributes
+        attributes = {
+            key: attr[key] for key in _RESTORED_OWNTRACKS_ATTRIBUTES if key in attr
+        }
+        if isinstance(update_timestamp := attributes.get(ATTR_UPDATE_TIMESTAMP), str):
+            attributes[ATTR_UPDATE_TIMESTAMP] = dt_util.parse_datetime(update_timestamp)
+
         self._data = {
             "host_name": state.name,
             "gps": (attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE)),
             "gps_accuracy": attr.get(ATTR_GPS_ACCURACY),
             "battery": attr.get(ATTR_BATTERY_LEVEL),
             "source_type": attr.get(ATTR_SOURCE_TYPE),
+            "attributes": attributes,
         }
 
     @callback

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -11,7 +11,14 @@ from homeassistant.components.device_tracker import SourceType
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_HOME
 from homeassistant.util import decorator, dt as dt_util, slugify
 
-from .const import ATTR_UPDATE_TIMESTAMP
+from .const import (
+    ATTR_ADDRESS,
+    ATTR_BATTERY_STATUS,
+    ATTR_COURSE,
+    ATTR_TID,
+    ATTR_UPDATE_TIMESTAMP,
+    ATTR_VELOCITY,
+)
 from .helper import supports_encryption
 
 _LOGGER = logging.getLogger(__name__)
@@ -72,15 +79,15 @@ def _parse_see_args(message, subscribe_topic):
     if "batt" in message:
         kwargs["battery"] = message["batt"]
     if "vel" in message:
-        kwargs["attributes"]["velocity"] = message["vel"]
+        kwargs["attributes"][ATTR_VELOCITY] = message["vel"]
     if "tid" in message:
-        kwargs["attributes"]["tid"] = message["tid"]
+        kwargs["attributes"][ATTR_TID] = message["tid"]
     if "addr" in message:
-        kwargs["attributes"]["address"] = message["addr"]
+        kwargs["attributes"][ATTR_ADDRESS] = message["addr"]
     if "cog" in message:
-        kwargs["attributes"]["course"] = message["cog"]
+        kwargs["attributes"][ATTR_COURSE] = message["cog"]
     if "bs" in message:
-        kwargs["attributes"]["battery_status"] = message["bs"]
+        kwargs["attributes"][ATTR_BATTERY_STATUS] = message["bs"]
     if "t" in message:
         if message["t"] in ("c", "u"):
             kwargs["source_type"] = SourceType.GPS

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -13,7 +13,14 @@ import pytest
 
 from homeassistant.components import owntracks
 from homeassistant.components.device_tracker.legacy import Device
-from homeassistant.components.owntracks.const import ATTR_UPDATE_TIMESTAMP
+from homeassistant.components.owntracks.const import (
+    ATTR_ADDRESS,
+    ATTR_BATTERY_STATUS,
+    ATTR_COURSE,
+    ATTR_TID,
+    ATTR_UPDATE_TIMESTAMP,
+    ATTR_VELOCITY,
+)
 from homeassistant.const import STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -141,6 +148,14 @@ DEFAULT_BEACON_TRANSITION_MESSAGE = {
 
 # Location messages
 LOCATION_MESSAGE = DEFAULT_LOCATION_MESSAGE
+
+LOCATION_MESSAGE_WITH_CUSTOM_ATTRIBUTES = build_message(
+    {
+        "addr": "123 Main Street",
+        "bs": 3,
+    },
+    LOCATION_MESSAGE,
+)
 
 LOCATION_MESSAGE_INACCURATE = build_message(
     {
@@ -1601,7 +1616,7 @@ async def test_restore_state(
     client = await hass_client()
     resp = await client.post(
         "/api/webhook/owntracks_test",
-        json=LOCATION_MESSAGE,
+        json=LOCATION_MESSAGE_WITH_CUSTOM_ATTRIBUTES,
         headers={"X-Limit-u": "Paulus", "X-Limit-d": "Pixel"},
     )
     assert resp.status == 200
@@ -1624,6 +1639,18 @@ async def test_restore_state(
     assert state_1.attributes["longitude"] == state_2.attributes["longitude"]
     assert state_1.attributes["battery_level"] == state_2.attributes["battery_level"]
     assert state_1.attributes["source_type"] == state_2.attributes["source_type"]
+    assert state_1.attributes[ATTR_TID] == state_2.attributes[ATTR_TID]
+    assert state_1.attributes[ATTR_VELOCITY] == state_2.attributes[ATTR_VELOCITY]
+    assert state_1.attributes[ATTR_COURSE] == state_2.attributes[ATTR_COURSE]
+    assert state_1.attributes[ATTR_ADDRESS] == state_2.attributes[ATTR_ADDRESS]
+    assert (
+        state_1.attributes[ATTR_UPDATE_TIMESTAMP]
+        == state_2.attributes[ATTR_UPDATE_TIMESTAMP]
+    )
+    assert (
+        state_1.attributes[ATTR_BATTERY_STATUS]
+        == state_2.attributes[ATTR_BATTERY_STATUS]
+    )
 
 
 async def test_returns_empty_friends(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Restore OwnTracks custom `device_tracker` state attributes after Home Assistant reloads the integration or restores the entity state.

Home Assistant's restore state helper provides the previous entity state, and the OwnTracks device tracker already uses that restored state to rebuild core tracker attributes such as GPS coordinates, accuracy, battery level, and source type. OwnTracks-specific attributes parsed from location messages, such as `tid`, `velocity`, `course`, `address`, `battery_status`, and `update_timestamp`, were not restored.

This PR keeps the existing core tracker restore behavior and also restores the OwnTracks-specific attributes currently parsed by the integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
