### PR TITLE
Add OpenAQ integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -440,6 +440,7 @@ homeassistant.components.onkyo.*
 homeassistant.components.open_meteo.*
 homeassistant.components.open_router.*
 homeassistant.components.openai_conversation.*
+homeassistant.components.openaq.*
 homeassistant.components.openevse.*
 homeassistant.components.openexchangerates.*
 homeassistant.components.opensky.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1320,6 +1320,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/open_router/ @joostlek @ab3lson
 /homeassistant/components/openai_conversation/ @Shulyaka
 /tests/components/openai_conversation/ @Shulyaka
+/homeassistant/components/openaq/ @jeeftor
+/tests/components/openaq/ @jeeftor
 /homeassistant/components/opendisplay/ @g4bri3lDev
 /tests/components/opendisplay/ @g4bri3lDev
 /homeassistant/components/openerz/ @misialq

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1355,6 +1355,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/open_router/ @joostlek @ab3lson
 /homeassistant/components/openai_conversation/ @Shulyaka
 /tests/components/openai_conversation/ @Shulyaka
+/homeassistant/components/openaq/ @jeeftor
+/tests/components/openaq/ @jeeftor
 /homeassistant/components/opendisplay/ @g4bri3lDev
 /tests/components/opendisplay/ @g4bri3lDev
 /homeassistant/components/openerz/ @misialq

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -1,0 +1,53 @@
+"""The OpenAQ integration."""
+
+import asyncio
+
+from openaq import AsyncOpenAQ
+
+from homeassistant.const import CONF_API_KEY, Platform
+from homeassistant.core import HomeAssistant
+
+from .const import SUBENTRY_TYPE_LOCATION
+from .coordinator import (
+    OpenAQConfigEntry,
+    OpenAQDataUpdateCoordinator,
+    OpenAQRuntimeData,
+)
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
+    """Set up OpenAQ from a config entry."""
+    client = AsyncOpenAQ(api_key=entry.data[CONF_API_KEY])
+    coordinators: dict[str, OpenAQDataUpdateCoordinator] = {}
+
+    for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_LOCATION):
+        coordinators[subentry.subentry_id] = OpenAQDataUpdateCoordinator(
+            hass, entry, subentry, client
+        )
+
+    await asyncio.gather(
+        *(
+            coordinator.async_config_entry_first_refresh()
+            for coordinator in coordinators.values()
+        )
+    )
+
+    entry.runtime_data = OpenAQRuntimeData(client=client, coordinators=coordinators)
+    entry.async_on_unload(entry.add_update_listener(async_update_entry))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_update_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> None:
+    """Update the config entry."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok and (runtime_data := getattr(entry, "runtime_data", None)):
+        await runtime_data.client.close()
+    return unload_ok

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -2,8 +2,6 @@
 
 import asyncio
 
-from openaq import AsyncOpenAQ
-
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
 
@@ -12,6 +10,7 @@ from .coordinator import (
     OpenAQConfigEntry,
     OpenAQDataUpdateCoordinator,
     OpenAQRuntimeData,
+    async_create_openaq_client,
 )
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -19,7 +18,7 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
     """Set up OpenAQ from a config entry."""
-    client = AsyncOpenAQ(api_key=entry.data[CONF_API_KEY])
+    client = await async_create_openaq_client(hass, entry.data[CONF_API_KEY])
     coordinators: dict[str, OpenAQDataUpdateCoordinator] = {}
 
     for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_LOCATION):

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -27,12 +27,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
             hass, entry, subentry, client
         )
 
-    await asyncio.gather(
-        *(
-            coordinator.async_config_entry_first_refresh()
-            for coordinator in coordinators.values()
+    try:
+        await asyncio.gather(
+            *(
+                coordinator.async_config_entry_first_refresh()
+                for coordinator in coordinators.values()
+            )
         )
-    )
+    except Exception:
+        await client.close()
+        raise
 
     entry.runtime_data = OpenAQRuntimeData(client=client, coordinators=coordinators)
     entry.async_on_unload(entry.add_update_listener(async_update_entry))

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -20,11 +20,12 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
     """Set up OpenAQ from a config entry."""
     client = await async_create_openaq_client(hass, entry.data[CONF_API_KEY])
+    client_lock = asyncio.Lock()
     coordinators: dict[str, OpenAQDataUpdateCoordinator] = {}
 
     for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_LOCATION):
         coordinators[subentry.subentry_id] = OpenAQDataUpdateCoordinator(
-            hass, entry, subentry, client
+            hass, entry, subentry, client, client_lock
         )
 
     try:
@@ -32,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
             for coordinator in coordinators.values():
                 tg.create_task(coordinator.async_config_entry_first_refresh())
     except ExceptionGroup as err:
-        await client.close()
+        await hass.async_add_executor_job(client.close)
         if (subgroup := err.subgroup(ConfigEntryNotReady)) is not None:
             raise subgroup.exceptions[0] from err
         raise
@@ -52,5 +53,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> b
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        await entry.runtime_data.client.close()
+        await hass.async_add_executor_job(entry.runtime_data.client.close)
     return unload_ok

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -27,9 +27,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
         )
 
     try:
-        async with asyncio.TaskGroup() as tg:
-            for coordinator in coordinators.values():
-                tg.create_task(coordinator.async_config_entry_first_refresh())
+        await asyncio.gather(
+            *[
+                coordinator.async_config_entry_first_refresh()
+                for coordinator in coordinators.values()
+            ]
+        )
     except Exception:
         await client.close()
         raise

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -34,10 +34,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
                 tg.create_task(coordinator.async_config_entry_first_refresh())
     except ExceptionGroup as err:
         await hass.async_add_executor_job(client.close)
-        if (subgroup := err.subgroup(ConfigEntryAuthFailed)) is not None:
-            raise subgroup.exceptions[0] from err
-        if (subgroup := err.subgroup(ConfigEntryNotReady)) is not None:
-            raise subgroup.exceptions[0] from err
+        if (auth_subgroup := err.subgroup(ConfigEntryAuthFailed)) is not None:
+            raise auth_subgroup.exceptions[0] from err
+        if (not_ready_subgroup := err.subgroup(ConfigEntryNotReady)) is not None:
+            raise not_ready_subgroup.exceptions[0] from err
         raise
 
     entry.runtime_data = OpenAQRuntimeData(client=client, coordinators=coordinators)

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -27,14 +27,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
         )
 
     try:
-        try:
-            async with asyncio.TaskGroup() as tg:
-                for coordinator in coordinators.values():
-                    tg.create_task(coordinator.async_config_entry_first_refresh())
-        except ExceptionGroup as err:
-            raise err.exceptions[0] from err
-    except Exception:
+        async with asyncio.TaskGroup() as tg:
+            for coordinator in coordinators.values():
+                tg.create_task(coordinator.async_config_entry_first_refresh())
+    except ExceptionGroup as err:
         await client.close()
+        if (subgroup := err.subgroup(ConfigEntryNotReady)) is not None:
+            raise subgroup.exceptions[0] from err
         raise
 
     entry.runtime_data = OpenAQRuntimeData(client=client, coordinators=coordinators)

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -27,12 +27,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
         )
 
     try:
-        await asyncio.gather(
-            *(
-                coordinator.async_config_entry_first_refresh()
-                for coordinator in coordinators.values()
-            )
-        )
+        async with asyncio.TaskGroup() as tg:
+            for coordinator in coordinators.values():
+                tg.create_task(coordinator.async_config_entry_first_refresh())
     except Exception:
         await client.close()
         raise

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .const import SUBENTRY_TYPE_LOCATION
 from .coordinator import (
@@ -34,6 +34,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
                 tg.create_task(coordinator.async_config_entry_first_refresh())
     except ExceptionGroup as err:
         await hass.async_add_executor_job(client.close)
+        if (subgroup := err.subgroup(ConfigEntryAuthFailed)) is not None:
+            raise subgroup.exceptions[0] from err
         if (subgroup := err.subgroup(ConfigEntryNotReady)) is not None:
             raise subgroup.exceptions[0] from err
         raise

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import SUBENTRY_TYPE_LOCATION
 from .coordinator import (

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -27,12 +27,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
         )
 
     try:
-        await asyncio.gather(
-            *[
-                coordinator.async_config_entry_first_refresh()
-                for coordinator in coordinators.values()
-            ]
-        )
+        try:
+            async with asyncio.TaskGroup() as tg:
+                for coordinator in coordinators.values():
+                    tg.create_task(coordinator.async_config_entry_first_refresh())
+        except ExceptionGroup as err:
+            raise err.exceptions[0] from err
     except Exception:
         await client.close()
         raise
@@ -51,6 +51,6 @@ async def async_update_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> N
 async def async_unload_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok and (runtime_data := getattr(entry, "runtime_data", None)):
-        await runtime_data.client.close()
+    if unload_ok:
+        await entry.runtime_data.client.close()
     return unload_ok

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -1,10 +1,8 @@
 """The OpenAQ integration."""
 
-import asyncio
-
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import SUBENTRY_TYPE_LOCATION
 from .coordinator import (
@@ -20,24 +18,18 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
     """Set up OpenAQ from a config entry."""
     client = await async_create_openaq_client(hass, entry.data[CONF_API_KEY])
-    client_lock = asyncio.Lock()
     coordinators: dict[str, OpenAQDataUpdateCoordinator] = {}
 
     for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_LOCATION):
         coordinators[subentry.subentry_id] = OpenAQDataUpdateCoordinator(
-            hass, entry, subentry, client, client_lock
+            hass, entry, subentry, client
         )
 
     try:
-        async with asyncio.TaskGroup() as tg:
-            for coordinator in coordinators.values():
-                tg.create_task(coordinator.async_config_entry_first_refresh())
-    except ExceptionGroup as err:
+        for coordinator in coordinators.values():
+            await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady:
         await hass.async_add_executor_job(client.close)
-        if (auth_subgroup := err.subgroup(ConfigEntryAuthFailed)) is not None:
-            raise auth_subgroup.exceptions[0] from err
-        if (not_ready_subgroup := err.subgroup(ConfigEntryNotReady)) is not None:
-            raise not_ready_subgroup.exceptions[0] from err
         raise
 
     entry.runtime_data = OpenAQRuntimeData(client=client, coordinators=coordinators)

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -35,7 +35,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bo
         await hass.async_add_executor_job(client.close)
         raise
 
-    entry.runtime_data = OpenAQRuntimeData(client=client, coordinators=coordinators)
+    entry.runtime_data = OpenAQRuntimeData(
+        client=client, client_lock=client_lock, coordinators=coordinators
+    )
     entry.async_on_unload(entry.add_update_listener(async_update_entry))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -50,5 +52,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> b
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        await hass.async_add_executor_job(entry.runtime_data.client.close)
+        async with entry.runtime_data.client_lock:
+            await hass.async_add_executor_job(entry.runtime_data.client.close)
     return unload_ok

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -1,5 +1,7 @@
 """The OpenAQ integration."""
 
+import asyncio
+
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -18,11 +20,12 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
     """Set up OpenAQ from a config entry."""
     client = await async_create_openaq_client(hass, entry.data[CONF_API_KEY])
+    client_lock = asyncio.Lock()
     coordinators: dict[str, OpenAQDataUpdateCoordinator] = {}
 
     for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_LOCATION):
         coordinators[subentry.subentry_id] = OpenAQDataUpdateCoordinator(
-            hass, entry, subentry, client
+            hass, entry, subentry, client, client_lock
         )
 
     try:

--- a/homeassistant/components/openaq/__init__.py
+++ b/homeassistant/components/openaq/__init__.py
@@ -11,7 +11,7 @@ from .coordinator import (
     OpenAQConfigEntry,
     OpenAQDataUpdateCoordinator,
     OpenAQRuntimeData,
-    async_create_openaq_client,
+    create_openaq_client,
 )
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -19,7 +19,7 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: OpenAQConfigEntry) -> bool:
     """Set up OpenAQ from a config entry."""
-    client = await async_create_openaq_client(hass, entry.data[CONF_API_KEY])
+    client = create_openaq_client(entry.data[CONF_API_KEY])
     client_lock = asyncio.Lock()
     coordinators: dict[str, OpenAQDataUpdateCoordinator] = {}
 

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -57,7 +57,11 @@ from .const import (
     MAX_RADIUS,
     SUBENTRY_TYPE_LOCATION,
 )
-from .coordinator import async_create_openaq_client, get_openaq_value
+from .coordinator import (
+    async_create_openaq_client,
+    get_openaq_value,
+    normalize_parameter,
+)
 from .sensor import SENSOR_DESCRIPTIONS
 
 _LOGGER = logging.getLogger(__name__)
@@ -159,14 +163,6 @@ def _search_radii(max_radius: int) -> tuple[int, ...]:
     return tuple(radii)
 
 
-def _normalize_parameter(parameter: object) -> str | None:
-    """Normalize an OpenAQ parameter object to its canonical name."""
-    name = get_openaq_value(parameter, "name")
-    if isinstance(name, str):
-        return name.lower().replace(".", "").replace("_", "")
-    return None
-
-
 def _supported_parameters(location: object) -> tuple[str, ...]:
     """Return supported sensor parameters for an OpenAQ location."""
     sensors = get_openaq_value(location, "sensors")
@@ -175,7 +171,7 @@ def _supported_parameters(location: object) -> tuple[str, ...]:
 
     parameters: set[str] = set()
     for sensor in sensors:
-        parameter_name = _normalize_parameter(get_openaq_value(sensor, "parameter"))
+        parameter_name = normalize_parameter(get_openaq_value(sensor, "parameter"))
         if parameter_name in SENSOR_DESCRIPTIONS:
             parameters.add(parameter_name)
     return tuple(sorted(parameters))

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for the OpenAQ integration."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import logging
 from math import inf

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -323,6 +323,8 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                         if location_data is None:
                             continue
                         locations.setdefault(location_data.location_id, location_data)
+            except ApiKeyMissingError, ForbiddenError, NotAuthorizedError:
+                errors["base"] = "invalid_auth"
             except HTTPRateLimitError, RateLimitError:
                 errors["base"] = "rate_limited"
             except (

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -5,22 +5,17 @@ import logging
 from math import inf
 from typing import Any
 
+import httpx
 from openaq import (
     ApiKeyMissingError,
     AsyncOpenAQ,
-    BadGatewayError,
-    BadRequestError,
     ForbiddenError,
-    GatewayTimeoutError,
     HTTPRateLimitError,
     NotAuthorizedError,
-    NotFoundError,
     RateLimitError,
-    ServerError,
-    ServiceUnavailableError,
-    TimeoutError as OpenAQTimeoutError,
-    ValidationError,
 )
+from openaq.shared.exceptions import APIError
+from openaq.shared.responses import Location
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -57,11 +52,7 @@ from .const import (
     MAX_RADIUS,
     SUBENTRY_TYPE_LOCATION,
 )
-from .coordinator import (
-    async_create_openaq_client,
-    get_openaq_value,
-    normalize_parameter,
-)
+from .coordinator import async_create_openaq_client, normalize_parameter
 from .sensor import SENSOR_DESCRIPTIONS
 
 _LOGGER = logging.getLogger(__name__)
@@ -127,28 +118,17 @@ async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> None:
         raise InvalidAuth from err
     except (HTTPRateLimitError, RateLimitError) as err:
         raise RateLimited from err
-    except (
-        BadGatewayError,
-        BadRequestError,
-        GatewayTimeoutError,
-        NotFoundError,
-        OpenAQTimeoutError,
-        ServerError,
-        ServiceUnavailableError,
-        ValidationError,
-    ) as err:
+    except (APIError, httpx.HTTPError) as err:
         raise CannotConnect from err
     finally:
         await client.close()
 
 
-def _location_title(location: object) -> str:
+def _location_title(location: Location) -> str:
     """Return a display title for an OpenAQ location."""
-    name = get_openaq_value(location, "name")
-    locality = get_openaq_value(location, "locality")
-    if isinstance(locality, str) and locality and locality != name:
-        return f"{name}, {locality}"
-    return str(name)
+    if location.locality and location.locality != location.name:
+        return f"{location.name}, {location.locality}"
+    return location.name
 
 
 def _search_radii(max_radius: int) -> tuple[int, ...]:
@@ -163,26 +143,19 @@ def _search_radii(max_radius: int) -> tuple[int, ...]:
     return tuple(radii)
 
 
-def _supported_parameters(location: object) -> tuple[str, ...]:
+def _supported_parameters(location: Location) -> tuple[str, ...]:
     """Return supported sensor parameters for an OpenAQ location."""
-    sensors = get_openaq_value(location, "sensors")
-    if not isinstance(sensors, list):
-        return ()
-
     parameters: set[str] = set()
-    for sensor in sensors:
-        parameter_name = normalize_parameter(get_openaq_value(sensor, "parameter"))
+    for sensor in location.sensors:
+        parameter_name = normalize_parameter(sensor.parameter)
         if parameter_name in SENSOR_DESCRIPTIONS:
             parameters.add(parameter_name)
     return tuple(sorted(parameters))
 
 
-def _location_distance(location: object) -> float | None:
+def _location_distance(location: Location) -> float | None:
     """Return the location distance in meters."""
-    distance = get_openaq_value(location, "distance")
-    if isinstance(distance, bool) or not isinstance(distance, (int, float)):
-        return None
-    return float(distance)
+    return location.distance
 
 
 def _location_sort_key(
@@ -197,18 +170,14 @@ def _location_sort_key(
     )
 
 
-def _location_from_result(location: object) -> OpenAQLocationFlowData | None:
+def _location_from_result(location: Location) -> OpenAQLocationFlowData | None:
     """Return flow data for a useful OpenAQ location result."""
-    location_id = get_openaq_value(location, "id")
-    if not isinstance(location_id, int):
-        return None
-
     supported_parameters = _supported_parameters(location)
     if not supported_parameters:
         return None
 
     return OpenAQLocationFlowData(
-        location_id=location_id,
+        location_id=location.id,
         title=_location_title(location),
         supported_parameters=supported_parameters,
         distance=_location_distance(location),
@@ -244,8 +213,7 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            await self.async_set_unique_id(DOMAIN)
-            self._abort_if_unique_id_configured()
+            self._async_abort_entries_match({CONF_API_KEY: user_input[CONF_API_KEY]})
             try:
                 await validate_input(self.hass, user_input)
             except CannotConnect:
@@ -278,30 +246,32 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
-        """Handle adding an OpenAQ location."""
-        return await self.async_step_map()
-
-    async def async_step_map(
-        self, user_input: dict[str, Any] | None = None
-    ) -> SubentryFlowResult:
         """Find OpenAQ locations near a map point."""
         errors: dict[str, str] = {}
         if user_input is not None:
+            selected_location = user_input[CONF_LOCATION]
             coordinates = (
-                user_input[CONF_LOCATION][CONF_LATITUDE],
-                user_input[CONF_LOCATION][CONF_LONGITUDE],
+                selected_location[CONF_LATITUDE],
+                selected_location[CONF_LONGITUDE],
+            )
+            max_radius = max(
+                1,
+                min(
+                    int(selected_location.get(CONF_RADIUS, DEFAULT_RADIUS)),
+                    MAX_RADIUS,
+                ),
             )
             client = await _get_client(self.hass, self._get_entry().data[CONF_API_KEY])
             try:
                 locations: dict[int, OpenAQLocationFlowData] = {}
-                for radius in _search_radii(user_input[CONF_RADIUS]):
+                for radius in _search_radii(max_radius):
                     response = await client.locations.list(
                         coordinates=coordinates,
                         radius=radius,
                         limit=user_input[CONF_LIMIT],
                     )
-                    for location in response.results:
-                        location_data = _location_from_result(location)
+                    for result_location in response.results:
+                        location_data = _location_from_result(result_location)
                         if location_data is None:
                             continue
                         locations.setdefault(location_data.location_id, location_data)
@@ -309,16 +279,7 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                 errors["base"] = "invalid_auth"
             except HTTPRateLimitError, RateLimitError:
                 errors["base"] = "rate_limited"
-            except (
-                BadGatewayError,
-                BadRequestError,
-                GatewayTimeoutError,
-                NotFoundError,
-                OpenAQTimeoutError,
-                ServerError,
-                ServiceUnavailableError,
-                ValidationError,
-            ):
+            except APIError, httpx.HTTPError:
                 errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
@@ -338,15 +299,12 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                 await client.close()
 
         return self.async_show_form(
-            step_id="map",
+            step_id="user",
             data_schema=self.add_suggested_values_to_schema(
                 vol.Schema(
                     {
                         vol.Required(CONF_LOCATION): LocationSelector(
-                            LocationSelectorConfig(radius=False)
-                        ),
-                        vol.Required(CONF_RADIUS, default=DEFAULT_RADIUS): vol.All(
-                            vol.Coerce(int), vol.Range(min=1, max=MAX_RADIUS)
+                            LocationSelectorConfig(radius=True)
                         ),
                         vol.Required(
                             CONF_LIMIT, default=DEFAULT_LOCATION_LIMIT
@@ -357,6 +315,7 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                     CONF_LOCATION: {
                         CONF_LATITUDE: self.hass.config.latitude,
                         CONF_LONGITUDE: self.hass.config.longitude,
+                        CONF_RADIUS: DEFAULT_RADIUS,
                     }
                 },
             ),

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -59,7 +59,7 @@ from .const import (
     MAX_RADIUS,
     SUBENTRY_TYPE_LOCATION,
 )
-from .coordinator import async_create_openaq_client, format_openaq_url, get_openaq_value
+from .coordinator import async_create_openaq_client, get_openaq_value
 from .sensor import SENSOR_DESCRIPTIONS
 
 _LOGGER = logging.getLogger(__name__)
@@ -301,18 +301,6 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
             try:
                 locations: dict[int, OpenAQLocationFlowData] = {}
                 for radius in _search_radii(user_input[CONF_RADIUS]):
-                    _LOGGER.debug(
-                        "Querying OpenAQ URL: %s",
-                        format_openaq_url(
-                            "/locations",
-                            {
-                                "page": 1,
-                                "limit": user_input[CONF_LIMIT],
-                                "radius": radius,
-                                "coordinates": coordinates,
-                            },
-                        ),
-                    )
                     response = await client.locations.list(
                         coordinates=coordinates,
                         radius=radius,

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+from math import inf
 from typing import Any
 
 from openaq import (
@@ -58,12 +59,27 @@ from .const import (
     MAX_RADIUS,
     SUBENTRY_TYPE_LOCATION,
 )
-from .coordinator import get_openaq_value
+from .coordinator import async_create_openaq_client, format_openaq_url, get_openaq_value
+from .sensor import SENSOR_DESCRIPTIONS
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
-LOCATION_ID_DATA_SCHEMA = vol.Schema({vol.Required(CONF_LOCATION_ID): int})
+LOCATION_SEARCH_RADII = (5000, 10000, MAX_RADIUS)
+MAX_LOCATION_OPTIONS = 5
+SENSOR_DISPLAY_NAMES = {
+    "bc": "Black carbon",
+    "co": "Carbon monoxide",
+    "co2": "Carbon dioxide",
+    "no": "Nitrogen monoxide",
+    "no2": "Nitrogen dioxide",
+    "nox": "Nitrogen oxides",
+    "o3": "Ozone",
+    "pm1": "PM1",
+    "pm10": "PM10",
+    "pm25": "PM2.5",
+    "so2": "Sulphur dioxide",
+}
 
 
 @dataclass(slots=True)
@@ -72,16 +88,37 @@ class OpenAQLocationFlowData:
 
     location_id: int
     title: str
+    supported_parameters: tuple[str, ...] = ()
+    distance: float | None = None
+
+    @property
+    def select_label(self) -> str:
+        """Return a label for the location selector."""
+        if not self.supported_parameters:
+            return self.title
+
+        sensor_names = sorted(
+            SENSOR_DISPLAY_NAMES[parameter] for parameter in self.supported_parameters
+        )
+        sensor_count = len(sensor_names)
+        sensor_word = "sensor" if sensor_count == 1 else "sensors"
+        distance = "unknown distance"
+        if self.distance is not None:
+            distance = f"{self.distance / 1000:.1f} km"
+        return (
+            f"{self.title} - {sensor_count} {sensor_word}: "
+            f"{', '.join(sensor_names)} - {distance}"
+        )
 
 
-def _get_client(api_key: str) -> AsyncOpenAQ:
+async def _get_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
     """Return an OpenAQ client."""
-    return AsyncOpenAQ(api_key=api_key)
+    return await async_create_openaq_client(hass, api_key)
 
 
 async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> None:
     """Validate the user input allows us to connect."""
-    client = _get_client(data[CONF_API_KEY])
+    client = await _get_client(_hass, data[CONF_API_KEY])
     try:
         await client.parameters.list(limit=1)
     except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:
@@ -110,6 +147,78 @@ def _location_title(location: object) -> str:
     if isinstance(locality, str) and locality and locality != name:
         return f"{name}, {locality}"
     return str(name)
+
+
+def _search_radii(max_radius: int) -> tuple[int, ...]:
+    """Return progressive search radii capped by the selected maximum radius."""
+    radii: list[int] = []
+    for radius in LOCATION_SEARCH_RADII:
+        search_radius = min(radius, max_radius)
+        if search_radius not in radii:
+            radii.append(search_radius)
+        if search_radius == max_radius:
+            break
+    return tuple(radii)
+
+
+def _normalize_parameter(parameter: object) -> str | None:
+    """Normalize an OpenAQ parameter object to its canonical name."""
+    name = get_openaq_value(parameter, "name")
+    if isinstance(name, str):
+        return name.lower().replace(".", "").replace("_", "")
+    return None
+
+
+def _supported_parameters(location: object) -> tuple[str, ...]:
+    """Return supported sensor parameters for an OpenAQ location."""
+    sensors = get_openaq_value(location, "sensors")
+    if not isinstance(sensors, list):
+        return ()
+
+    parameters: set[str] = set()
+    for sensor in sensors:
+        parameter_name = _normalize_parameter(get_openaq_value(sensor, "parameter"))
+        if parameter_name in SENSOR_DESCRIPTIONS:
+            parameters.add(parameter_name)
+    return tuple(sorted(parameters))
+
+
+def _location_distance(location: object) -> float | None:
+    """Return the location distance in meters."""
+    distance = get_openaq_value(location, "distance")
+    if isinstance(distance, bool) or not isinstance(distance, (int, float)):
+        return None
+    return float(distance)
+
+
+def _location_sort_key(
+    location: OpenAQLocationFlowData,
+) -> tuple[int, float, str, int]:
+    """Return the ranking key for an OpenAQ location."""
+    return (
+        -len(location.supported_parameters),
+        location.distance if location.distance is not None else inf,
+        location.title,
+        location.location_id,
+    )
+
+
+def _location_from_result(location: object) -> OpenAQLocationFlowData | None:
+    """Return flow data for a useful OpenAQ location result."""
+    location_id = get_openaq_value(location, "id")
+    if not isinstance(location_id, int):
+        return None
+
+    supported_parameters = _supported_parameters(location)
+    if not supported_parameters:
+        return None
+
+    return OpenAQLocationFlowData(
+        location_id=location_id,
+        title=_location_title(location),
+        supported_parameters=supported_parameters,
+        distance=_location_distance(location),
+    )
 
 
 def _is_location_configured(hass: HomeAssistant, location_id: int) -> bool:
@@ -175,11 +284,8 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
-        """Select how to add an OpenAQ location."""
-        return self.async_show_menu(
-            step_id="user",
-            menu_options=["map", CONF_LOCATION_ID],
-        )
+        """Handle adding an OpenAQ location."""
+        return await self.async_step_map()
 
     async def async_step_map(
         self, user_input: dict[str, Any] | None = None
@@ -187,16 +293,36 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
         """Find OpenAQ locations near a map point."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            client = _get_client(self._get_entry().data[CONF_API_KEY])
+            coordinates = (
+                user_input[CONF_LOCATION][CONF_LATITUDE],
+                user_input[CONF_LOCATION][CONF_LONGITUDE],
+            )
+            client = await _get_client(self.hass, self._get_entry().data[CONF_API_KEY])
             try:
-                response = await client.locations.list(
-                    coordinates=(
-                        user_input[CONF_LOCATION][CONF_LATITUDE],
-                        user_input[CONF_LOCATION][CONF_LONGITUDE],
-                    ),
-                    radius=user_input[CONF_RADIUS],
-                    limit=user_input[CONF_LIMIT],
-                )
+                locations: dict[int, OpenAQLocationFlowData] = {}
+                for radius in _search_radii(user_input[CONF_RADIUS]):
+                    _LOGGER.debug(
+                        "Querying OpenAQ URL: %s",
+                        format_openaq_url(
+                            "/locations",
+                            {
+                                "page": 1,
+                                "limit": user_input[CONF_LIMIT],
+                                "radius": radius,
+                                "coordinates": coordinates,
+                            },
+                        ),
+                    )
+                    response = await client.locations.list(
+                        coordinates=coordinates,
+                        radius=radius,
+                        limit=user_input[CONF_LIMIT],
+                    )
+                    for location in response.results:
+                        location_data = _location_from_result(location)
+                        if location_data is None:
+                            continue
+                        locations.setdefault(location_data.location_id, location_data)
             except HTTPRateLimitError, RateLimitError:
                 errors["base"] = "rate_limited"
             except (
@@ -214,15 +340,12 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                self._locations = {}
-                for location in response.results:
-                    location_id = get_openaq_value(location, "id")
-                    if not isinstance(location_id, int):
-                        continue
-                    self._locations[str(location_id)] = OpenAQLocationFlowData(
-                        location_id=location_id,
-                        title=_location_title(location),
-                    )
+                self._locations = {
+                    str(location.location_id): location
+                    for location in sorted(locations.values(), key=_location_sort_key)[
+                        :MAX_LOCATION_OPTIONS
+                    ]
+                }
                 if not self._locations:
                     errors["base"] = "no_locations_found"
                 else:
@@ -273,7 +396,7 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                         SelectSelectorConfig(
                             options=[
                                 SelectOptionDict(
-                                    value=location_id, label=location.title
+                                    value=location_id, label=location.select_label
                                 )
                                 for location_id, location in self._locations.items()
                             ],
@@ -282,52 +405,6 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                     )
                 }
             ),
-        )
-
-    async def async_step_location_id(
-        self, user_input: dict[str, Any] | None = None
-    ) -> SubentryFlowResult:
-        """Add an OpenAQ location by location ID."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            location_id = user_input[CONF_LOCATION_ID]
-            if _is_location_configured(self.hass, location_id):
-                return self.async_abort(reason="already_configured")
-            client = _get_client(self._get_entry().data[CONF_API_KEY])
-            try:
-                response = await client.locations.get(location_id)
-            except HTTPRateLimitError, RateLimitError:
-                errors["base"] = "rate_limited"
-            except NotFoundError:
-                errors["base"] = "invalid_location"
-            except (
-                BadGatewayError,
-                BadRequestError,
-                GatewayTimeoutError,
-                OpenAQTimeoutError,
-                ServerError,
-                ServiceUnavailableError,
-                ValidationError,
-            ):
-                errors["base"] = "cannot_connect"
-            except Exception:
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
-            else:
-                location = response.results[0]
-                return self._async_create_location_entry(
-                    OpenAQLocationFlowData(
-                        location_id=location_id,
-                        title=_location_title(location),
-                    )
-                )
-            finally:
-                await client.close()
-
-        return self.async_show_form(
-            step_id=CONF_LOCATION_ID,
-            data_schema=LOCATION_ID_DATA_SCHEMA,
-            errors=errors,
         )
 
     def _async_create_location_entry(

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -1,0 +1,353 @@
+"""Config flow for the OpenAQ integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from openaq import (
+    ApiKeyMissingError,
+    AsyncOpenAQ,
+    BadGatewayError,
+    BadRequestError,
+    ForbiddenError,
+    GatewayTimeoutError,
+    HTTPRateLimitError,
+    NotAuthorizedError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+    ServiceUnavailableError,
+    TimeoutError as OpenAQTimeoutError,
+    ValidationError,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
+)
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LOCATION,
+    CONF_LONGITUDE,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.selector import (
+    LocationSelector,
+    LocationSelectorConfig,
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import (
+    CONF_LIMIT,
+    CONF_LOCATION_ID,
+    CONF_RADIUS,
+    DEFAULT_LOCATION_LIMIT,
+    DEFAULT_RADIUS,
+    DOMAIN,
+    MAX_RADIUS,
+    SUBENTRY_TYPE_LOCATION,
+)
+from .coordinator import get_openaq_value
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
+LOCATION_ID_DATA_SCHEMA = vol.Schema({vol.Required(CONF_LOCATION_ID): int})
+
+
+@dataclass(slots=True)
+class OpenAQLocationFlowData:
+    """OpenAQ location data stored during the subentry flow."""
+
+    location_id: int
+    title: str
+
+
+def _get_client(api_key: str) -> AsyncOpenAQ:
+    """Return an OpenAQ client."""
+    return AsyncOpenAQ(api_key=api_key)
+
+
+async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> None:
+    """Validate the user input allows us to connect."""
+    client = _get_client(data[CONF_API_KEY])
+    try:
+        await client.parameters.list(limit=1)
+    except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:
+        raise InvalidAuth from err
+    except (HTTPRateLimitError, RateLimitError) as err:
+        raise RateLimited from err
+    except (
+        BadGatewayError,
+        BadRequestError,
+        GatewayTimeoutError,
+        NotFoundError,
+        OpenAQTimeoutError,
+        ServerError,
+        ServiceUnavailableError,
+        ValidationError,
+    ) as err:
+        raise CannotConnect from err
+    finally:
+        await client.close()
+
+
+def _location_title(location: object) -> str:
+    """Return a display title for an OpenAQ location."""
+    name = get_openaq_value(location, "name")
+    locality = get_openaq_value(location, "locality")
+    if isinstance(locality, str) and locality and locality != name:
+        return f"{name}, {locality}"
+    return str(name)
+
+
+def _is_location_configured(hass: HomeAssistant, location_id: int) -> bool:
+    """Return whether an OpenAQ location is already configured."""
+    unique_id = str(location_id)
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        for subentry in entry.subentries.values():
+            if subentry.unique_id == unique_id:
+                return True
+    return False
+
+
+class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for OpenAQ."""
+
+    VERSION = 1
+
+    @classmethod
+    @callback
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Return subentries supported by this integration."""
+        return {SUBENTRY_TYPE_LOCATION: OpenAQLocationSubentryFlow}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_API_KEY: user_input[CONF_API_KEY]})
+            try:
+                await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except RateLimited:
+                errors["base"] = "rate_limited"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title="OpenAQ",
+                    data={CONF_API_KEY: user_input[CONF_API_KEY]},
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+
+class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
+    """Handle an OpenAQ location subentry flow."""
+
+    _locations: dict[str, OpenAQLocationFlowData]
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Select how to add an OpenAQ location."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["map", CONF_LOCATION_ID],
+        )
+
+    async def async_step_map(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Find OpenAQ locations near a map point."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            client = _get_client(self._get_entry().data[CONF_API_KEY])
+            try:
+                response = await client.locations.list(
+                    coordinates=(
+                        user_input[CONF_LOCATION][CONF_LATITUDE],
+                        user_input[CONF_LOCATION][CONF_LONGITUDE],
+                    ),
+                    radius=user_input[CONF_RADIUS],
+                    limit=user_input[CONF_LIMIT],
+                )
+            except HTTPRateLimitError, RateLimitError:
+                errors["base"] = "rate_limited"
+            except (
+                BadGatewayError,
+                BadRequestError,
+                GatewayTimeoutError,
+                NotFoundError,
+                OpenAQTimeoutError,
+                ServerError,
+                ServiceUnavailableError,
+                ValidationError,
+            ):
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self._locations = {}
+                for location in response.results:
+                    location_id = get_openaq_value(location, "id")
+                    if not isinstance(location_id, int):
+                        continue
+                    self._locations[str(location_id)] = OpenAQLocationFlowData(
+                        location_id=location_id,
+                        title=_location_title(location),
+                    )
+                if not self._locations:
+                    errors["base"] = "no_locations_found"
+                else:
+                    return await self.async_step_select()
+            finally:
+                await client.close()
+
+        return self.async_show_form(
+            step_id="map",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(CONF_LOCATION): LocationSelector(
+                            LocationSelectorConfig(radius=False)
+                        ),
+                        vol.Required(CONF_RADIUS, default=DEFAULT_RADIUS): vol.All(
+                            vol.Coerce(int), vol.Range(min=1, max=MAX_RADIUS)
+                        ),
+                        vol.Required(
+                            CONF_LIMIT, default=DEFAULT_LOCATION_LIMIT
+                        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+                    }
+                ),
+                {
+                    CONF_LOCATION: {
+                        CONF_LATITUDE: self.hass.config.latitude,
+                        CONF_LONGITUDE: self.hass.config.longitude,
+                    }
+                },
+            ),
+            errors=errors,
+        )
+
+    async def async_step_select(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Select one of the found OpenAQ locations."""
+        if user_input is not None:
+            return self._async_create_location_entry(
+                self._locations[user_input[CONF_LOCATION_ID]]
+            )
+
+        return self.async_show_form(
+            step_id="select",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_LOCATION_ID): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                SelectOptionDict(
+                                    value=location_id, label=location.title
+                                )
+                                for location_id, location in self._locations.items()
+                            ],
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            ),
+        )
+
+    async def async_step_location_id(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Add an OpenAQ location by location ID."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            location_id = user_input[CONF_LOCATION_ID]
+            if _is_location_configured(self.hass, location_id):
+                return self.async_abort(reason="already_configured")
+            client = _get_client(self._get_entry().data[CONF_API_KEY])
+            try:
+                response = await client.locations.get(location_id)
+            except HTTPRateLimitError, RateLimitError:
+                errors["base"] = "rate_limited"
+            except (
+                BadGatewayError,
+                BadRequestError,
+                GatewayTimeoutError,
+                NotFoundError,
+                OpenAQTimeoutError,
+                ServerError,
+                ServiceUnavailableError,
+                ValidationError,
+            ):
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                location = response.results[0]
+                return self._async_create_location_entry(
+                    OpenAQLocationFlowData(
+                        location_id=location_id,
+                        title=_location_title(location),
+                    )
+                )
+            finally:
+                await client.close()
+
+        return self.async_show_form(
+            step_id=CONF_LOCATION_ID,
+            data_schema=LOCATION_ID_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    def _async_create_location_entry(
+        self, location: OpenAQLocationFlowData
+    ) -> SubentryFlowResult:
+        """Create an OpenAQ location subentry."""
+        if _is_location_configured(self.hass, location.location_id):
+            return self.async_abort(reason="already_configured")
+        return self.async_create_entry(
+            title=location.title,
+            data={CONF_LOCATION_ID: location.location_id},
+            unique_id=str(location.location_id),
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""
+
+
+class RateLimited(HomeAssistantError):
+    """Error to indicate the API rate limit was exceeded."""

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -141,7 +141,8 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            self._async_abort_entries_match({CONF_API_KEY: user_input[CONF_API_KEY]})
+            await self.async_set_unique_id(DOMAIN)
+            self._abort_if_unique_id_configured()
             try:
                 await validate_input(self.hass, user_input)
             except CannotConnect:
@@ -297,11 +298,12 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                 response = await client.locations.get(location_id)
             except HTTPRateLimitError, RateLimitError:
                 errors["base"] = "rate_limited"
+            except NotFoundError:
+                errors["base"] = "invalid_location"
             except (
                 BadGatewayError,
                 BadRequestError,
                 GatewayTimeoutError,
-                NotFoundError,
                 OpenAQTimeoutError,
                 ServerError,
                 ServiceUnavailableError,

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -58,18 +58,11 @@ STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
 LOCATION_FETCH_LIMIT = 100
 LOCATION_SEARCH_RADII = (5000, 10000, MAX_RADIUS)
 MAX_LOCATION_OPTIONS = 10
-SENSOR_DISPLAY_NAMES = {
-    "bc": "Black carbon",
-    "co": "Carbon monoxide",
-    "co2": "Carbon dioxide",
-    "no": "Nitrogen monoxide",
-    "no2": "Nitrogen dioxide",
-    "nox": "Nitrogen oxides",
-    "o3": "Ozone",
+PARAMETER_DISPLAY_CODES = {
     "pm1": "PM1",
     "pm10": "PM10",
     "pm25": "PM2.5",
-    "so2": "Sulphur dioxide",
+    "nox": "NOx",
 }
 
 
@@ -88,18 +81,14 @@ class OpenAQLocationFlowData:
         if not self.supported_parameters:
             return self.title
 
-        sensor_names = sorted(
-            SENSOR_DISPLAY_NAMES[parameter] for parameter in self.supported_parameters
+        parameter_codes = sorted(
+            PARAMETER_DISPLAY_CODES.get(parameter, parameter.upper())
+            for parameter in self.supported_parameters
         )
-        sensor_count = len(sensor_names)
-        sensor_word = "sensor" if sensor_count == 1 else "sensors"
-        distance = "unknown distance"
+        label = f"{self.title} ({', '.join(parameter_codes)})"
         if self.distance is not None:
-            distance = f"{self.distance / 1000:.1f} km"
-        return (
-            f"{self.title} - {sensor_count} {sensor_word}: "
-            f"{', '.join(sensor_names)} - {distance}"
-        )
+            label = f"{label} - {self.distance / 1000:.1f} km"
+        return label
 
 
 async def _get_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -1,12 +1,12 @@
 """Config flow for the OpenAQ integration."""
 
 from dataclasses import dataclass
+from functools import partial
 import logging
 from math import inf
 from typing import Any
 
-from openaq import AsyncOpenAQ
-from openaq.shared.responses import Location
+from openaq.core.responses import Location
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -84,11 +84,6 @@ class OpenAQLocationFlowData:
         return label
 
 
-async def _get_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
-    """Return an OpenAQ client."""
-    return await async_create_openaq_client(hass, api_key)
-
-
 def _location_title(location: Location) -> str:
     """Return a display title for an OpenAQ location."""
     if location.locality and location.locality != location.name:
@@ -118,11 +113,6 @@ def _supported_parameters(location: Location) -> tuple[str, ...]:
     return tuple(sorted(parameters))
 
 
-def _location_distance(location: Location) -> float | None:
-    """Return the location distance in meters."""
-    return location.distance
-
-
 def _location_sort_key(
     location: OpenAQLocationFlowData,
 ) -> tuple[float, int, str, int]:
@@ -145,7 +135,7 @@ def _location_from_result(location: Location) -> OpenAQLocationFlowData | None:
         location_id=location.id,
         title=_location_title(location),
         supported_parameters=supported_parameters,
-        distance=_location_distance(location),
+        distance=location.distance,
     )
 
 
@@ -180,11 +170,15 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._async_abort_entries_match({CONF_API_KEY: user_input[CONF_API_KEY]})
             try:
-                client = await _get_client(self.hass, user_input[CONF_API_KEY])
+                client = await async_create_openaq_client(
+                    self.hass, user_input[CONF_API_KEY]
+                )
                 try:
-                    await client.parameters.list(limit=1)
+                    await self.hass.async_add_executor_job(
+                        partial(client.parameters.list, limit=1)
+                    )
                 finally:
-                    await client.close()
+                    await self.hass.async_add_executor_job(client.close)
             except OPENAQ_AUTH_EXCEPTIONS:
                 errors["base"] = "invalid_auth"
             except OPENAQ_RATE_LIMIT_EXCEPTIONS:
@@ -230,14 +224,19 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                     MAX_RADIUS,
                 ),
             )
-            client = await _get_client(self.hass, self._get_entry().data[CONF_API_KEY])
+            client = await async_create_openaq_client(
+                self.hass, self._get_entry().data[CONF_API_KEY]
+            )
             try:
                 locations: dict[int, OpenAQLocationFlowData] = {}
                 for radius in _search_radii(max_radius):
-                    response = await client.locations.list(
-                        coordinates=coordinates,
-                        radius=radius,
-                        limit=LOCATION_FETCH_LIMIT,
+                    response = await self.hass.async_add_executor_job(
+                        partial(
+                            client.locations.list,
+                            coordinates=coordinates,
+                            radius=radius,
+                            limit=LOCATION_FETCH_LIMIT,
+                        )
                     )
                     for result_location in response.results:
                         location_data = _location_from_result(result_location)
@@ -267,7 +266,7 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                 else:
                     return await self.async_step_select()
             finally:
-                await client.close()
+                await self.hass.async_add_executor_job(client.close)
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -57,7 +57,7 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
 LOCATION_FETCH_LIMIT = 100
 LOCATION_SEARCH_RADII = (5000, 10000, MAX_RADIUS)
-MAX_LOCATION_OPTIONS = 5
+MAX_LOCATION_OPTIONS = 10
 SENSOR_DISPLAY_NAMES = {
     "bc": "Black carbon",
     "co": "Carbon monoxide",

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from functools import partial
 import logging
 from math import inf
-from typing import Any
+from typing import Any, override
 
 from openaq.core.responses import Location
 import voluptuous as vol
@@ -156,12 +156,14 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this integration."""
         return {SUBENTRY_TYPE_LOCATION: OpenAQLocationSubentryFlow}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -45,7 +45,6 @@ from homeassistant.helpers.selector import (
 from .const import (
     CONF_LOCATION_ID,
     CONF_RADIUS,
-    DEFAULT_RADIUS,
     DOMAIN,
     MAX_RADIUS,
     SUBENTRY_TYPE_LOCATION,
@@ -256,7 +255,7 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
             max_radius = max(
                 1,
                 min(
-                    int(selected_location.get(CONF_RADIUS, DEFAULT_RADIUS)),
+                    int(selected_location.get(CONF_RADIUS, MAX_RADIUS)),
                     MAX_RADIUS,
                 ),
             )
@@ -313,7 +312,7 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                     CONF_LOCATION: {
                         CONF_LATITUDE: self.hass.config.latitude,
                         CONF_LONGITUDE: self.hass.config.longitude,
-                        CONF_RADIUS: DEFAULT_RADIUS,
+                        CONF_RADIUS: MAX_RADIUS,
                     }
                 },
             ),

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -5,16 +5,7 @@ import logging
 from math import inf
 from typing import Any
 
-import httpx
-from openaq import (
-    ApiKeyMissingError,
-    AsyncOpenAQ,
-    ForbiddenError,
-    HTTPRateLimitError,
-    NotAuthorizedError,
-    RateLimitError,
-)
-from openaq.shared.exceptions import APIError
+from openaq import AsyncOpenAQ
 from openaq.shared.responses import Location
 import voluptuous as vol
 
@@ -33,7 +24,6 @@ from homeassistant.const import (
     CONF_RADIUS,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import (
     LocationSelector,
     LocationSelectorConfig,
@@ -43,7 +33,15 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import CONF_LOCATION_ID, DOMAIN, MAX_RADIUS, SUBENTRY_TYPE_LOCATION
+from .const import (
+    CONF_LOCATION_ID,
+    DOMAIN,
+    MAX_RADIUS,
+    OPENAQ_API_EXCEPTIONS,
+    OPENAQ_AUTH_EXCEPTIONS,
+    OPENAQ_RATE_LIMIT_EXCEPTIONS,
+    SUBENTRY_TYPE_LOCATION,
+)
 from .coordinator import async_create_openaq_client, normalize_parameter
 from .sensor import SENSOR_DESCRIPTIONS
 
@@ -89,21 +87,6 @@ class OpenAQLocationFlowData:
 async def _get_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
     """Return an OpenAQ client."""
     return await async_create_openaq_client(hass, api_key)
-
-
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
-    """Validate the user input allows us to connect."""
-    client = await _get_client(hass, data[CONF_API_KEY])
-    try:
-        await client.parameters.list(limit=1)
-    except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:
-        raise InvalidAuth from err
-    except (HTTPRateLimitError, RateLimitError) as err:
-        raise RateLimited from err
-    except (APIError, httpx.HTTPError) as err:
-        raise CannotConnect from err
-    finally:
-        await client.close()
 
 
 def _location_title(location: Location) -> str:
@@ -197,13 +180,17 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._async_abort_entries_match({CONF_API_KEY: user_input[CONF_API_KEY]})
             try:
-                await validate_input(self.hass, user_input)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
+                client = await _get_client(self.hass, user_input[CONF_API_KEY])
+                try:
+                    await client.parameters.list(limit=1)
+                finally:
+                    await client.close()
+            except OPENAQ_AUTH_EXCEPTIONS:
                 errors["base"] = "invalid_auth"
-            except RateLimited:
+            except OPENAQ_RATE_LIMIT_EXCEPTIONS:
                 errors["base"] = "rate_limited"
+            except OPENAQ_API_EXCEPTIONS:
+                errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -259,11 +246,11 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                         ):
                             continue
                         locations.setdefault(location_data.location_id, location_data)
-            except ApiKeyMissingError, ForbiddenError, NotAuthorizedError:
+            except OPENAQ_AUTH_EXCEPTIONS:
                 errors["base"] = "invalid_auth"
-            except HTTPRateLimitError, RateLimitError:
+            except OPENAQ_RATE_LIMIT_EXCEPTIONS:
                 errors["base"] = "rate_limited"
-            except APIError, httpx.HTTPError:
+            except OPENAQ_API_EXCEPTIONS:
                 errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
@@ -342,15 +329,3 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
             data={CONF_LOCATION_ID: location.location_id},
             unique_id=str(location.location_id),
         )
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""
-
-
-class RateLimited(HomeAssistantError):
-    """Error to indicate the API rate limit was exceeded."""

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from functools import partial
-import logging
 from math import inf
 from typing import Any, override
 
@@ -36,6 +35,7 @@ from homeassistant.helpers.selector import (
 from .const import (
     CONF_LOCATION_ID,
     DOMAIN,
+    LOGGER,
     MAX_RADIUS,
     OPENAQ_API_EXCEPTIONS,
     OPENAQ_AUTH_EXCEPTIONS,
@@ -44,8 +44,6 @@ from .const import (
 )
 from .coordinator import async_create_openaq_client, normalize_parameter
 from .sensor import SENSOR_DESCRIPTIONS
-
-_LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
 LOCATION_FETCH_LIMIT = 100
@@ -187,8 +185,8 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "rate_limited"
             except OPENAQ_API_EXCEPTIONS:
                 errors["base"] = "cannot_connect"
-            except Exception:
-                _LOGGER.exception("Unexpected exception")
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
                 return self.async_create_entry(
@@ -253,8 +251,8 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                 errors["base"] = "rate_limited"
             except OPENAQ_API_EXCEPTIONS:
                 errors["base"] = "cannot_connect"
-            except Exception:
-                _LOGGER.exception("Unexpected exception")
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
                 self._locations = {
@@ -282,9 +280,17 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                 ),
                 {
                     CONF_LOCATION: {
-                        CONF_LATITUDE: self.hass.config.latitude,
-                        CONF_LONGITUDE: self.hass.config.longitude,
-                        CONF_RADIUS: MAX_RADIUS,
+                        CONF_LATITUDE: user_input[CONF_LOCATION][CONF_LATITUDE]
+                        if user_input is not None
+                        else self.hass.config.latitude,
+                        CONF_LONGITUDE: user_input[CONF_LOCATION][CONF_LONGITUDE]
+                        if user_input is not None
+                        else self.hass.config.longitude,
+                        CONF_RADIUS: user_input[CONF_LOCATION].get(
+                            CONF_RADIUS, MAX_RADIUS
+                        )
+                        if user_input is not None
+                        else MAX_RADIUS,
                     }
                 },
             ),

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LOCATION,
     CONF_LONGITUDE,
+    CONF_RADIUS,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -42,13 +43,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import (
-    CONF_LOCATION_ID,
-    CONF_RADIUS,
-    DOMAIN,
-    MAX_RADIUS,
-    SUBENTRY_TYPE_LOCATION,
-)
+from .const import CONF_LOCATION_ID, DOMAIN, MAX_RADIUS, SUBENTRY_TYPE_LOCATION
 from .coordinator import async_create_openaq_client, normalize_parameter
 from .sensor import SENSOR_DESCRIPTIONS
 

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -43,10 +43,8 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
-    CONF_LIMIT,
     CONF_LOCATION_ID,
     CONF_RADIUS,
-    DEFAULT_LOCATION_LIMIT,
     DEFAULT_RADIUS,
     DOMAIN,
     MAX_RADIUS,
@@ -58,6 +56,7 @@ from .sensor import SENSOR_DESCRIPTIONS
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
+LOCATION_FETCH_LIMIT = 100
 LOCATION_SEARCH_RADII = (5000, 10000, MAX_RADIUS)
 MAX_LOCATION_OPTIONS = 5
 SENSOR_DISPLAY_NAMES = {
@@ -160,11 +159,11 @@ def _location_distance(location: Location) -> float | None:
 
 def _location_sort_key(
     location: OpenAQLocationFlowData,
-) -> tuple[int, float, str, int]:
+) -> tuple[float, int, str, int]:
     """Return the ranking key for an OpenAQ location."""
     return (
-        -len(location.supported_parameters),
         location.distance if location.distance is not None else inf,
+        -len(location.supported_parameters),
         location.title,
         location.location_id,
     )
@@ -268,11 +267,13 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                     response = await client.locations.list(
                         coordinates=coordinates,
                         radius=radius,
-                        limit=user_input[CONF_LIMIT],
+                        limit=LOCATION_FETCH_LIMIT,
                     )
                     for result_location in response.results:
                         location_data = _location_from_result(result_location)
-                        if location_data is None:
+                        if location_data is None or _is_location_configured(
+                            self.hass, location_data.location_id
+                        ):
                             continue
                         locations.setdefault(location_data.location_id, location_data)
             except ApiKeyMissingError, ForbiddenError, NotAuthorizedError:
@@ -306,9 +307,6 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                         vol.Required(CONF_LOCATION): LocationSelector(
                             LocationSelectorConfig(radius=True)
                         ),
-                        vol.Required(
-                            CONF_LIMIT, default=DEFAULT_LOCATION_LIMIT
-                        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
                     }
                 ),
                 {

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -96,9 +96,9 @@ async def _get_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
     return await async_create_openaq_client(hass, api_key)
 
 
-async def validate_input(_hass: HomeAssistant, data: dict[str, Any]) -> None:
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     """Validate the user input allows us to connect."""
-    client = await _get_client(_hass, data[CONF_API_KEY])
+    client = await _get_client(hass, data[CONF_API_KEY])
     try:
         await client.parameters.list(limit=1)
     except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the OpenAQ integration."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import partial
 from math import inf
@@ -55,6 +56,26 @@ PARAMETER_DISPLAY_CODES = {
     "pm25": "PM2.5",
     "nox": "NOx",
 }
+
+
+async def _async_validate_api_key(hass: HomeAssistant, api_key: str) -> str | None:
+    """Validate an OpenAQ API key and return an error key if validation fails."""
+    try:
+        client = await async_create_openaq_client(hass, api_key)
+        try:
+            await hass.async_add_executor_job(partial(client.parameters.list, limit=1))
+        finally:
+            await hass.async_add_executor_job(client.close)
+    except OPENAQ_AUTH_EXCEPTIONS:
+        return "invalid_auth"
+    except OPENAQ_RATE_LIMIT_EXCEPTIONS:
+        return "rate_limited"
+    except OPENAQ_API_EXCEPTIONS:
+        return "cannot_connect"
+    except Exception:  # noqa: BLE001
+        LOGGER.exception("Unexpected exception")
+        return "unknown"
+    return None
 
 
 @dataclass(slots=True)
@@ -169,25 +190,10 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             self._async_abort_entries_match({CONF_API_KEY: user_input[CONF_API_KEY]})
-            try:
-                client = await async_create_openaq_client(
-                    self.hass, user_input[CONF_API_KEY]
-                )
-                try:
-                    await self.hass.async_add_executor_job(
-                        partial(client.parameters.list, limit=1)
-                    )
-                finally:
-                    await self.hass.async_add_executor_job(client.close)
-            except OPENAQ_AUTH_EXCEPTIONS:
-                errors["base"] = "invalid_auth"
-            except OPENAQ_RATE_LIMIT_EXCEPTIONS:
-                errors["base"] = "rate_limited"
-            except OPENAQ_API_EXCEPTIONS:
-                errors["base"] = "cannot_connect"
-            except Exception:  # noqa: BLE001
-                LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+            if error := await _async_validate_api_key(
+                self.hass, user_input[CONF_API_KEY]
+            ):
+                errors["base"] = error
             else:
                 return self.async_create_entry(
                     title="OpenAQ",
@@ -196,6 +202,34 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle a reauthentication request."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication with a new API key."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if error := await _async_validate_api_key(
+                self.hass, user_input[CONF_API_KEY]
+            ):
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -40,10 +40,10 @@ from .const import (
     OPENAQ_API_EXCEPTIONS,
     OPENAQ_AUTH_EXCEPTIONS,
     OPENAQ_RATE_LIMIT_EXCEPTIONS,
+    PARAMETER_DEVICE_CLASSES,
     SUBENTRY_TYPE_LOCATION,
 )
 from .coordinator import create_openaq_client, normalize_parameter
-from .sensor import SENSOR_DESCRIPTIONS
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
 LOCATION_FETCH_LIMIT = 100
@@ -131,7 +131,7 @@ def _supported_parameters(location: Location) -> tuple[str, ...]:
     parameters: set[str] = set()
     for sensor in location.sensors:
         parameter_name = normalize_parameter(sensor.parameter)
-        if parameter_name in SENSOR_DESCRIPTIONS:
+        if parameter_name in PARAMETER_DEVICE_CLASSES:
             parameters.add(parameter_name)
     return tuple(sorted(parameters))
 
@@ -236,13 +236,12 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
             )
             try:
                 locations: dict[int, OpenAQLocationFlowData] = {}
-                responses = await self.hass.async_add_executor_job(
+                for result_locations in await self.hass.async_add_executor_job(
                     _search_locations,
                     self._get_entry().data[CONF_API_KEY],
                     coordinates,
                     _search_radii(max_radius),
-                )
-                for result_locations in responses:
+                ):
                     for result_location in result_locations:
                         location_data = _location_from_result(result_location)
                         if location_data is None or _is_location_configured(
@@ -250,6 +249,8 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                         ):
                             continue
                         locations.setdefault(location_data.location_id, location_data)
+                    if len(locations) >= MAX_LOCATION_OPTIONS:
+                        break
             except OPENAQ_AUTH_EXCEPTIONS:
                 errors["base"] = "invalid_auth"
             except OPENAQ_RATE_LIMIT_EXCEPTIONS:
@@ -288,9 +289,7 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                         CONF_LONGITUDE: user_input[CONF_LOCATION][CONF_LONGITUDE]
                         if user_input is not None
                         else self.hass.config.longitude,
-                        CONF_RADIUS: user_input[CONF_LOCATION].get(
-                            CONF_RADIUS, MAX_RADIUS
-                        )
+                        CONF_RADIUS: max_radius
                         if user_input is not None
                         else MAX_RADIUS,
                     }
@@ -341,7 +340,9 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
 
 
 def _search_locations(
-    api_key: str, coordinates: tuple[float, float], radii: tuple[int, ...]
+    api_key: str,
+    coordinates: tuple[float, float],
+    radii: tuple[int, ...],
 ) -> list[Sequence[Location]]:
     """Search all requested radii with a temporary OpenAQ client."""
     client = create_openaq_client(api_key)

--- a/homeassistant/components/openaq/config_flow.py
+++ b/homeassistant/components/openaq/config_flow.py
@@ -1,8 +1,7 @@
 """Config flow for the OpenAQ integration."""
 
-from collections.abc import Mapping
+from collections.abc import Sequence
 from dataclasses import dataclass
-from functools import partial
 from math import inf
 from typing import Any, override
 
@@ -43,7 +42,7 @@ from .const import (
     OPENAQ_RATE_LIMIT_EXCEPTIONS,
     SUBENTRY_TYPE_LOCATION,
 )
-from .coordinator import async_create_openaq_client, normalize_parameter
+from .coordinator import create_openaq_client, normalize_parameter
 from .sensor import SENSOR_DESCRIPTIONS
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
@@ -61,11 +60,7 @@ PARAMETER_DISPLAY_CODES = {
 async def _async_validate_api_key(hass: HomeAssistant, api_key: str) -> str | None:
     """Validate an OpenAQ API key and return an error key if validation fails."""
     try:
-        client = await async_create_openaq_client(hass, api_key)
-        try:
-            await hass.async_add_executor_job(partial(client.parameters.list, limit=1))
-        finally:
-            await hass.async_add_executor_job(client.close)
+        await hass.async_add_executor_job(_validate_api_key, api_key)
     except OPENAQ_AUTH_EXCEPTIONS:
         return "invalid_auth"
     except OPENAQ_RATE_LIMIT_EXCEPTIONS:
@@ -76,6 +71,15 @@ async def _async_validate_api_key(hass: HomeAssistant, api_key: str) -> str | No
         LOGGER.exception("Unexpected exception")
         return "unknown"
     return None
+
+
+def _validate_api_key(api_key: str) -> None:
+    """Validate an API key with a temporary OpenAQ client."""
+    client = create_openaq_client(api_key)
+    try:
+        client.parameters.list(limit=1)
+    finally:
+        client.close()
 
 
 @dataclass(slots=True)
@@ -206,34 +210,6 @@ class OpenAQConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_reauth(
-        self, entry_data: Mapping[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle a reauthentication request."""
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reauthentication with a new API key."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            if error := await _async_validate_api_key(
-                self.hass, user_input[CONF_API_KEY]
-            ):
-                errors["base"] = error
-            else:
-                return self.async_update_reload_and_abort(
-                    self._get_reauth_entry(),
-                    data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
-                )
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=STEP_USER_DATA_SCHEMA,
-            errors=errors,
-        )
-
 
 class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
     """Handle an OpenAQ location subentry flow."""
@@ -258,21 +234,16 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                     MAX_RADIUS,
                 ),
             )
-            client = await async_create_openaq_client(
-                self.hass, self._get_entry().data[CONF_API_KEY]
-            )
             try:
                 locations: dict[int, OpenAQLocationFlowData] = {}
-                for radius in _search_radii(max_radius):
-                    response = await self.hass.async_add_executor_job(
-                        partial(
-                            client.locations.list,
-                            coordinates=coordinates,
-                            radius=radius,
-                            limit=LOCATION_FETCH_LIMIT,
-                        )
-                    )
-                    for result_location in response.results:
+                responses = await self.hass.async_add_executor_job(
+                    _search_locations,
+                    self._get_entry().data[CONF_API_KEY],
+                    coordinates,
+                    _search_radii(max_radius),
+                )
+                for result_locations in responses:
+                    for result_location in result_locations:
                         location_data = _location_from_result(result_location)
                         if location_data is None or _is_location_configured(
                             self.hass, location_data.location_id
@@ -299,9 +270,6 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
                     errors["base"] = "no_locations_found"
                 else:
                     return await self.async_step_select()
-            finally:
-                await self.hass.async_add_executor_job(client.close)
-
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
@@ -370,3 +338,19 @@ class OpenAQLocationSubentryFlow(ConfigSubentryFlow):
             data={CONF_LOCATION_ID: location.location_id},
             unique_id=str(location.location_id),
         )
+
+
+def _search_locations(
+    api_key: str, coordinates: tuple[float, float], radii: tuple[int, ...]
+) -> list[Sequence[Location]]:
+    """Search all requested radii with a temporary OpenAQ client."""
+    client = create_openaq_client(api_key)
+    try:
+        return [
+            client.locations.list(
+                coordinates=coordinates, radius=radius, limit=LOCATION_FETCH_LIMIT
+            ).results
+            for radius in radii
+        ]
+    finally:
+        client.close()

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -1,0 +1,18 @@
+"""Constants for the OpenAQ integration."""
+
+import logging
+from typing import Final
+
+DOMAIN = "openaq"
+
+LOGGER = logging.getLogger(__package__)
+
+ATTRIBUTION: Final = "Data provided by OpenAQ"
+CONF_LIMIT: Final = "limit"
+CONF_LOCATION_ID: Final = "location_id"
+CONF_RADIUS: Final = "radius"
+
+DEFAULT_LOCATION_LIMIT: Final = 25
+DEFAULT_RADIUS: Final = 10000
+MAX_RADIUS: Final = 25000
+SUBENTRY_TYPE_LOCATION: Final = "location"

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -10,7 +10,7 @@ from openaq import (
     NotAuthorizedError,
     RateLimitError,
 )
-from openaq.core.exceptions import APIError, OpenAQError
+from openaq.core.exceptions import APIError
 
 DOMAIN = "openaq"
 
@@ -29,4 +29,3 @@ OPENAQ_AUTH_EXCEPTIONS: Final = (
 )
 OPENAQ_RATE_LIMIT_EXCEPTIONS: Final = (HTTPRateLimitError, RateLimitError)
 OPENAQ_API_EXCEPTIONS: Final = (APIError, OSError)
-OPENAQ_UPDATE_EXCEPTIONS: Final = (APIError, OpenAQError, OSError)

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -8,11 +8,9 @@ DOMAIN = "openaq"
 LOGGER = logging.getLogger(__package__)
 
 ATTRIBUTION: Final = "Data provided by OpenAQ"
-CONF_LIMIT: Final = "limit"
 CONF_LOCATION_ID: Final = "location_id"
 CONF_RADIUS: Final = "radius"
 
-DEFAULT_LOCATION_LIMIT: Final = 25
 DEFAULT_RADIUS: Final = 10000
 MAX_RADIUS: Final = 25000
 SUBENTRY_TYPE_LOCATION: Final = "location"

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -3,6 +3,16 @@
 import logging
 from typing import Final
 
+import httpx
+from openaq import (
+    ApiKeyMissingError,
+    ForbiddenError,
+    HTTPRateLimitError,
+    NotAuthorizedError,
+    RateLimitError,
+)
+from openaq.shared.exceptions import APIError, OpenAQError
+
 DOMAIN = "openaq"
 
 LOGGER = logging.getLogger(__package__)
@@ -12,3 +22,12 @@ CONF_LOCATION_ID: Final = "location_id"
 
 MAX_RADIUS: Final = 25000
 SUBENTRY_TYPE_LOCATION: Final = "location"
+
+OPENAQ_AUTH_EXCEPTIONS: Final = (
+    ApiKeyMissingError,
+    ForbiddenError,
+    NotAuthorizedError,
+)
+OPENAQ_RATE_LIMIT_EXCEPTIONS: Final = (HTTPRateLimitError, RateLimitError)
+OPENAQ_API_EXCEPTIONS: Final = (APIError, httpx.HTTPError)
+OPENAQ_UPDATE_EXCEPTIONS: Final = (APIError, OpenAQError, httpx.HTTPError)

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -19,6 +19,9 @@ LOGGER = logging.getLogger(__package__)
 ATTRIBUTION: Final = "Data provided by OpenAQ"
 CONF_LOCATION_ID: Final = "location_id"
 
+OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER: Final = "μg/m³"
+OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER: Final = "mg/m³"
+
 MAX_RADIUS: Final = 25000
 SUBENTRY_TYPE_LOCATION: Final = "location"
 

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -12,20 +12,12 @@ from openaq import (
 )
 from openaq.core.exceptions import APIError
 
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-)
-
 DOMAIN = "openaq"
 
 LOGGER = logging.getLogger(__package__)
 
 ATTRIBUTION: Final = "Data provided by OpenAQ"
 CONF_LOCATION_ID: Final = "location_id"
-
-OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER: Final = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER: Final = CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER
 
 MAX_RADIUS: Final = 25000
 SUBENTRY_TYPE_LOCATION: Final = "location"

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -11,6 +11,5 @@ ATTRIBUTION: Final = "Data provided by OpenAQ"
 CONF_LOCATION_ID: Final = "location_id"
 CONF_RADIUS: Final = "radius"
 
-DEFAULT_RADIUS: Final = 10000
 MAX_RADIUS: Final = 25000
 SUBENTRY_TYPE_LOCATION: Final = "location"

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -9,7 +9,6 @@ LOGGER = logging.getLogger(__package__)
 
 ATTRIBUTION: Final = "Data provided by OpenAQ"
 CONF_LOCATION_ID: Final = "location_id"
-CONF_RADIUS: Final = "radius"
 
 MAX_RADIUS: Final = 25000
 SUBENTRY_TYPE_LOCATION: Final = "location"

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Final
 
-import httpx
 from openaq import (
     ApiKeyMissingError,
     ForbiddenError,
@@ -11,7 +10,7 @@ from openaq import (
     NotAuthorizedError,
     RateLimitError,
 )
-from openaq.shared.exceptions import APIError, OpenAQError
+from openaq.core.exceptions import APIError, OpenAQError
 
 DOMAIN = "openaq"
 
@@ -29,5 +28,5 @@ OPENAQ_AUTH_EXCEPTIONS: Final = (
     NotAuthorizedError,
 )
 OPENAQ_RATE_LIMIT_EXCEPTIONS: Final = (HTTPRateLimitError, RateLimitError)
-OPENAQ_API_EXCEPTIONS: Final = (APIError, httpx.HTTPError)
-OPENAQ_UPDATE_EXCEPTIONS: Final = (APIError, OpenAQError, httpx.HTTPError)
+OPENAQ_API_EXCEPTIONS: Final = (APIError, OSError)
+OPENAQ_UPDATE_EXCEPTIONS: Final = (APIError, OpenAQError, OSError)

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -12,6 +12,11 @@ from openaq import (
 )
 from openaq.core.exceptions import APIError
 
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+)
+
 DOMAIN = "openaq"
 
 LOGGER = logging.getLogger(__package__)
@@ -19,8 +24,8 @@ LOGGER = logging.getLogger(__package__)
 ATTRIBUTION: Final = "Data provided by OpenAQ"
 CONF_LOCATION_ID: Final = "location_id"
 
-OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER: Final = "μg/m³"
-OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER: Final = "mg/m³"
+OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER: Final = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER: Final = CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER
 
 MAX_RADIUS: Final = 25000
 SUBENTRY_TYPE_LOCATION: Final = "location"

--- a/homeassistant/components/openaq/const.py
+++ b/homeassistant/components/openaq/const.py
@@ -1,5 +1,7 @@
 """Constants for the OpenAQ integration."""
 
+from http.client import HTTPException
+from json import JSONDecodeError
 import logging
 from typing import Final
 
@@ -11,6 +13,8 @@ from openaq import (
     RateLimitError,
 )
 from openaq.core.exceptions import APIError
+
+from homeassistant.components.sensor import SensorDeviceClass
 
 DOMAIN = "openaq"
 
@@ -28,4 +32,23 @@ OPENAQ_AUTH_EXCEPTIONS: Final = (
     NotAuthorizedError,
 )
 OPENAQ_RATE_LIMIT_EXCEPTIONS: Final = (HTTPRateLimitError, RateLimitError)
-OPENAQ_API_EXCEPTIONS: Final = (APIError, OSError)
+OPENAQ_API_EXCEPTIONS: Final = (
+    APIError,
+    OSError,
+    HTTPException,
+    JSONDecodeError,
+)
+
+PARAMETER_DEVICE_CLASSES: dict[str, SensorDeviceClass | None] = {
+    "pm1": SensorDeviceClass.PM1,
+    "pm25": SensorDeviceClass.PM25,
+    "pm10": SensorDeviceClass.PM10,
+    "co": SensorDeviceClass.CO,
+    "co2": SensorDeviceClass.CO2,
+    "no2": SensorDeviceClass.NITROGEN_DIOXIDE,
+    "o3": SensorDeviceClass.OZONE,
+    "so2": SensorDeviceClass.SULPHUR_DIOXIDE,
+    "no": SensorDeviceClass.NITROGEN_MONOXIDE,
+    "nox": None,
+    "bc": None,
+}

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -1,5 +1,6 @@
 """Data coordinator for the OpenAQ integration."""
 
+import asyncio
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
@@ -129,7 +130,7 @@ def get_openaq_value(data: object, *names: str) -> Any:
     return None
 
 
-def _normalize_parameter(parameter: object) -> str | None:
+def normalize_parameter(parameter: object) -> str | None:
     """Normalize an OpenAQ parameter object to its canonical name."""
     name = get_openaq_value(parameter, "name")
     if isinstance(name, str):
@@ -191,7 +192,7 @@ def _sensor_metadata_by_id(
     for sensor in sensors:
         sensor_id = _normalize_sensor_id(get_openaq_value(sensor, "id"))
         parameter = get_openaq_value(sensor, "parameter")
-        parameter_name = _normalize_parameter(parameter)
+        parameter_name = normalize_parameter(parameter)
         if sensor_id is None or parameter_name is None:
             continue
         metadata[sensor_id] = (
@@ -222,7 +223,7 @@ def normalize_latest_measurements(
 
     for sensor in sensors:
         parameter = get_openaq_value(sensor, "parameter")
-        parameter_name = _normalize_parameter(parameter)
+        parameter_name = normalize_parameter(parameter)
         latest = get_openaq_value(sensor, "latest")
         value = (
             _as_float(get_openaq_value(latest, "value")) if latest is not None else None
@@ -265,9 +266,11 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
         try:
-            location_response = await self.client.locations.get(self.location_id)
-            latest_response = await self.client.locations.latest(self.location_id)
-            sensors_response = await self.client.locations.sensors(self.location_id)
+            location_response, latest_response, sensors_response = await asyncio.gather(
+                self.client.locations.get(self.location_id),
+                self.client.locations.latest(self.location_id),
+                self.client.locations.sensors(self.location_id),
+            )
         except (
             BadGatewayError,
             BadRequestError,
@@ -317,4 +320,5 @@ __all__ = [
     "create_openaq_client",
     "get_openaq_value",
     "normalize_latest_measurements",
+    "normalize_parameter",
 ]

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from types import MappingProxyType
-from typing import Any
+from typing import Any, cast
 
+import httpx
 from openaq import (
     ApiKeyMissingError,
     AsyncOpenAQ,
@@ -24,7 +25,7 @@ from openaq import (
     TimeoutError as OpenAQTimeoutError,
     ValidationError,
 )
-from openaq._async.transport import AsyncTransport
+from openaq.shared.transport import check_response
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import (
@@ -32,6 +33,7 @@ from homeassistant.const import (
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import location as location_util
 
@@ -79,14 +81,44 @@ class OpenAQRuntimeData:
 type OpenAQConfigEntry = ConfigEntry[OpenAQRuntimeData]
 
 
-def create_openaq_client(api_key: str) -> AsyncOpenAQ:
-    """Create an OpenAQ client with an independent transport."""
-    return AsyncOpenAQ(api_key=api_key, transport=AsyncTransport())
+class HomeAssistantOpenAQTransport:
+    """OpenAQ transport using Home Assistant's shared httpx client."""
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        """Initialize the transport."""
+        self.client = client
+
+    async def send_request(
+        self,
+        method: str,
+        url: str,
+        params: httpx.QueryParams | Mapping[str, str | int | float | bool] | None,
+        headers: httpx.Headers | Mapping[str, str],
+    ) -> httpx.Response:
+        """Send a request through Home Assistant's shared httpx client."""
+        response = await self.client.request(
+            method=method,
+            url=url,
+            params=params,
+            headers=headers,
+        )
+        return check_response(response)
+
+    async def close(self) -> None:
+        """Keep the shared Home Assistant httpx client open."""
+
+
+def create_openaq_client(api_key: str, httpx_client: httpx.AsyncClient) -> AsyncOpenAQ:
+    """Create an OpenAQ client with a Home Assistant managed transport."""
+    return AsyncOpenAQ(
+        api_key=api_key,
+        transport=cast(Any, HomeAssistantOpenAQTransport(httpx_client)),
+    )
 
 
 async def async_create_openaq_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
-    """Create an OpenAQ client without blocking the event loop."""
-    return await hass.async_add_executor_job(create_openaq_client, api_key)
+    """Create an OpenAQ client."""
+    return create_openaq_client(api_key, get_async_client(hass))
 
 
 def get_openaq_value(data: object, *names: str) -> Any:
@@ -277,6 +309,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
 
 
 __all__ = [
+    "HomeAssistantOpenAQTransport",
     "OpenAQConfigEntry",
     "OpenAQDataUpdateCoordinator",
     "OpenAQLocationData",

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -26,12 +26,25 @@ from openaq import (
 )
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_LOCATION_ID, DOMAIN, LOGGER
 
 UPDATE_INTERVAL = timedelta(minutes=10)
+
+OPENAQ_UNIT_ALIASES = {
+    "µg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "µg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "mg/m3": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+}
 
 
 @dataclass(slots=True)
@@ -97,6 +110,13 @@ def _as_float(value: object) -> float | None:
     return float(value)
 
 
+def _normalize_unit(unit: object) -> str | None:
+    """Normalize an OpenAQ unit string to Home Assistant's canonical unit."""
+    if not isinstance(unit, str):
+        return None
+    return OPENAQ_UNIT_ALIASES.get(unit, unit)
+
+
 def _sensor_metadata_by_id(
     sensors: Sequence[object],
 ) -> dict[int, tuple[str, str | None]]:
@@ -108,8 +128,10 @@ def _sensor_metadata_by_id(
         parameter_name = _normalize_parameter(parameter)
         if sensor_id is None or parameter_name is None:
             continue
-        unit = get_openaq_value(parameter, "units")
-        metadata[sensor_id] = (parameter_name, unit if isinstance(unit, str) else None)
+        metadata[sensor_id] = (
+            parameter_name,
+            _normalize_unit(get_openaq_value(parameter, "units")),
+        )
     return metadata
 
 
@@ -142,9 +164,10 @@ def normalize_latest_measurements(
         )
         if parameter_name is None or parameter_name in measurements or value is None:
             continue
-        unit = get_openaq_value(parameter, "units")
         measurements[parameter_name] = OpenAQMeasurement(
-            parameter_name, value, unit if isinstance(unit, str) else None
+            parameter_name,
+            value,
+            _normalize_unit(get_openaq_value(parameter, "units")),
         )
 
     return MappingProxyType(measurements)
@@ -199,6 +222,12 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 translation_domain=DOMAIN,
                 translation_key="unable_to_fetch",
             ) from err
+
+        if not location_response.results:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unable_to_fetch",
+            )
 
         location = location_response.results[0]
         return OpenAQLocationData(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from types import MappingProxyType
 from typing import Any
+from urllib.parse import urlencode
 
 from openaq import (
     ApiKeyMissingError,
@@ -24,6 +25,8 @@ from openaq import (
     TimeoutError as OpenAQTimeoutError,
     ValidationError,
 )
+from openaq._async.transport import AsyncTransport
+from openaq.shared.client import DEFAULT_BASE_URL
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import (
@@ -32,6 +35,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import location as location_util
 
 from .const import CONF_LOCATION_ID, DOMAIN, LOGGER
 
@@ -62,6 +66,7 @@ class OpenAQLocationData:
 
     location_id: int
     name: str
+    distance_to_home: float | None
     measurements: MappingProxyType[str, OpenAQMeasurement]
 
 
@@ -74,6 +79,46 @@ class OpenAQRuntimeData:
 
 
 type OpenAQConfigEntry = ConfigEntry[OpenAQRuntimeData]
+
+
+type OpenAQScalarQueryValue = str | int | float | bool
+type OpenAQQueryValue = (
+    OpenAQScalarQueryValue
+    | list[OpenAQScalarQueryValue]
+    | tuple[OpenAQScalarQueryValue, ...]
+)
+
+
+def create_openaq_client(api_key: str) -> AsyncOpenAQ:
+    """Create an OpenAQ client with an independent transport."""
+    return AsyncOpenAQ(api_key=api_key, transport=AsyncTransport())
+
+
+async def async_create_openaq_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
+    """Create an OpenAQ client without blocking the event loop."""
+    return await hass.async_add_executor_job(create_openaq_client, api_key)
+
+
+def format_openaq_url(
+    path: str, params: Mapping[str, OpenAQQueryValue | None] | None = None
+) -> str:
+    """Format an OpenAQ API URL for debug logging."""
+    url = f"{DEFAULT_BASE_URL.rstrip('/')}/{path.lstrip('/')}"
+    if not params:
+        return url
+
+    query_params: dict[str, str | int | float | bool] = {}
+    for key, value in params.items():
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple)):
+            query_params[key] = ",".join(str(item) for item in value)
+        else:
+            query_params[key] = value
+
+    if not query_params:
+        return url
+    return f"{url}?{urlencode(query_params)}"
 
 
 def get_openaq_value(data: object, *names: str) -> Any:
@@ -115,6 +160,59 @@ def _normalize_unit(unit: object) -> str | None:
     if not isinstance(unit, str):
         return None
     return OPENAQ_UNIT_ALIASES.get(unit, unit)
+
+
+def _coordinate_value(coordinates: object, name: str) -> float | None:
+    """Return a numeric coordinate value."""
+    value = get_openaq_value(coordinates, name)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _distance_to_home(hass: HomeAssistant, location: object) -> float | None:
+    """Return the distance in meters from Home Assistant to the OpenAQ location."""
+    coordinates = get_openaq_value(location, "coordinates")
+    latitude = _coordinate_value(coordinates, "latitude")
+    longitude = _coordinate_value(coordinates, "longitude")
+    if latitude is None or longitude is None:
+        return None
+    return location_util.distance(
+        hass.config.latitude,
+        hass.config.longitude,
+        latitude,
+        longitude,
+    )
+
+
+def _debug_sensor_summary(sensors: Sequence[object]) -> list[dict[str, object]]:
+    """Return a compact sensor summary for debug logging."""
+    summary: list[dict[str, object]] = []
+    for sensor in sensors:
+        parameter = get_openaq_value(sensor, "parameter")
+        latest = get_openaq_value(sensor, "latest")
+        summary.append(
+            {
+                "id": get_openaq_value(sensor, "id"),
+                "parameter": get_openaq_value(parameter, "name"),
+                "units": get_openaq_value(parameter, "units"),
+                "latest": get_openaq_value(latest, "value")
+                if latest is not None
+                else None,
+            }
+        )
+    return summary
+
+
+def _debug_latest_summary(latest_results: Sequence[object]) -> list[dict[str, object]]:
+    """Return a compact latest measurement summary for debug logging."""
+    return [
+        {
+            "sensor_id": get_openaq_value(latest, "sensors_id", "sensorsId"),
+            "value": get_openaq_value(latest, "value"),
+        }
+        for latest in latest_results
+    ]
 
 
 def _sensor_metadata_by_id(
@@ -200,9 +298,31 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
         try:
+            LOGGER.debug(
+                "Querying OpenAQ URL: %s",
+                format_openaq_url(f"/locations/{self.location_id}"),
+            )
             location_response = await self.client.locations.get(self.location_id)
+            LOGGER.debug(
+                "Querying OpenAQ URL: %s",
+                format_openaq_url(f"/locations/{self.location_id}/latest"),
+            )
             latest_response = await self.client.locations.latest(self.location_id)
+            LOGGER.debug(
+                "Querying OpenAQ URL: %s",
+                format_openaq_url(f"/locations/{self.location_id}/sensors"),
+            )
             sensors_response = await self.client.locations.sensors(self.location_id)
+            LOGGER.debug(
+                "OpenAQ latest response for location %s: %s",
+                self.location_id,
+                _debug_latest_summary(latest_response.results),
+            )
+            LOGGER.debug(
+                "OpenAQ sensors response for location %s: %s",
+                self.location_id,
+                _debug_sensor_summary(sensors_response.results),
+            )
         except (
             BadGatewayError,
             BadRequestError,
@@ -230,12 +350,19 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
             )
 
         location = location_response.results[0]
+        measurements = normalize_latest_measurements(
+            latest_response.results, sensors_response.results
+        )
+        LOGGER.debug(
+            "Normalized OpenAQ measurements for location %s: %s",
+            self.location_id,
+            sorted(measurements),
+        )
         return OpenAQLocationData(
             location_id=self.location_id,
             name=str(get_openaq_value(location, "name")),
-            measurements=normalize_latest_measurements(
-                latest_response.results, sensors_response.results
-            ),
+            distance_to_home=_distance_to_home(self.hass, location),
+            measurements=measurements,
         )
 
 
@@ -245,6 +372,9 @@ __all__ = [
     "OpenAQLocationData",
     "OpenAQMeasurement",
     "OpenAQRuntimeData",
+    "async_create_openaq_client",
+    "create_openaq_client",
+    "format_openaq_url",
     "get_openaq_value",
     "normalize_latest_measurements",
 ]

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -1,7 +1,5 @@
 """Data coordinator for the OpenAQ integration."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -262,15 +262,37 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         self.client = client
         self.subentry = subentry
         self.location_id: int = subentry.data[CONF_LOCATION_ID]
+        self._location: object | None = None
+        self._sensors: Sequence[object] | None = None
 
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
+        location: object
+        sensors: Sequence[object]
         try:
-            location_response, latest_response, sensors_response = await asyncio.gather(
-                self.client.locations.get(self.location_id),
-                self.client.locations.latest(self.location_id),
-                self.client.locations.sensors(self.location_id),
-            )
+            if self._location is None or self._sensors is None:
+                (
+                    location_response,
+                    latest_response,
+                    sensors_response,
+                ) = await asyncio.gather(
+                    self.client.locations.get(self.location_id),
+                    self.client.locations.latest(self.location_id),
+                    self.client.locations.sensors(self.location_id),
+                )
+                if not location_response.results:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="unable_to_fetch",
+                    )
+                location = location_response.results[0]
+                sensors = sensors_response.results
+                self._location = location
+                self._sensors = sensors
+            else:
+                location = self._location
+                sensors = self._sensors
+                latest_response = await self.client.locations.latest(self.location_id)
         except (
             BadGatewayError,
             BadRequestError,
@@ -291,16 +313,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 translation_key="unable_to_fetch",
             ) from err
 
-        if not location_response.results:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="unable_to_fetch",
-            )
-
-        location = location_response.results[0]
-        measurements = normalize_latest_measurements(
-            latest_response.results, sensors_response.results
-        )
+        measurements = normalize_latest_measurements(latest_response.results, sensors)
         return OpenAQLocationData(
             location_id=self.location_id,
             name=str(get_openaq_value(location, "name")),

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -1,0 +1,221 @@
+"""Data coordinator for the OpenAQ integration."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from types import MappingProxyType
+from typing import Any
+
+from openaq import (
+    ApiKeyMissingError,
+    AsyncOpenAQ,
+    BadGatewayError,
+    BadRequestError,
+    ForbiddenError,
+    GatewayTimeoutError,
+    HTTPRateLimitError,
+    NotAuthorizedError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+    ServiceUnavailableError,
+    TimeoutError as OpenAQTimeoutError,
+    ValidationError,
+)
+
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import CONF_LOCATION_ID, DOMAIN, LOGGER
+
+UPDATE_INTERVAL = timedelta(minutes=10)
+
+
+@dataclass(slots=True)
+class OpenAQMeasurement:
+    """Latest OpenAQ measurement for a parameter."""
+
+    parameter: str
+    value: float
+    unit: str | None
+
+
+@dataclass(slots=True)
+class OpenAQLocationData:
+    """Latest OpenAQ data for a configured location."""
+
+    location_id: int
+    name: str
+    measurements: MappingProxyType[str, OpenAQMeasurement]
+
+
+@dataclass(slots=True)
+class OpenAQRuntimeData:
+    """Runtime data for the OpenAQ integration."""
+
+    client: AsyncOpenAQ
+    coordinators: dict[str, OpenAQDataUpdateCoordinator]
+
+
+type OpenAQConfigEntry = ConfigEntry[OpenAQRuntimeData]
+
+
+def get_openaq_value(data: object, *names: str) -> Any:
+    """Get a value from an SDK object or a dict-like test object."""
+    for name in names:
+        if isinstance(data, dict) and name in data:
+            return data[name]
+        if hasattr(data, name):
+            return getattr(data, name)
+    return None
+
+
+def _normalize_parameter(parameter: object) -> str | None:
+    """Normalize an OpenAQ parameter object to its canonical name."""
+    name = get_openaq_value(parameter, "name")
+    if isinstance(name, str):
+        return name.lower().replace(".", "").replace("_", "")
+    return None
+
+
+def _normalize_sensor_id(value: object) -> int | None:
+    """Normalize an OpenAQ sensor id to an integer."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    return None
+
+
+def _as_float(value: object) -> float | None:
+    """Return value as a float when it is a numeric sensor value."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _sensor_metadata_by_id(
+    sensors: Sequence[object],
+) -> dict[int, tuple[str, str | None]]:
+    """Return parameter metadata keyed by OpenAQ sensor id."""
+    metadata: dict[int, tuple[str, str | None]] = {}
+    for sensor in sensors:
+        sensor_id = _normalize_sensor_id(get_openaq_value(sensor, "id"))
+        parameter = get_openaq_value(sensor, "parameter")
+        parameter_name = _normalize_parameter(parameter)
+        if sensor_id is None or parameter_name is None:
+            continue
+        unit = get_openaq_value(parameter, "units")
+        metadata[sensor_id] = (parameter_name, unit if isinstance(unit, str) else None)
+    return metadata
+
+
+def normalize_latest_measurements(
+    latest_results: Sequence[object], sensors: Sequence[object]
+) -> MappingProxyType[str, OpenAQMeasurement]:
+    """Normalize OpenAQ latest measurements by parameter name."""
+    sensor_metadata = _sensor_metadata_by_id(sensors)
+    measurements: dict[str, OpenAQMeasurement] = {}
+
+    for latest in latest_results:
+        sensor_id = _normalize_sensor_id(
+            get_openaq_value(latest, "sensors_id", "sensorsId")
+        )
+        value = _as_float(get_openaq_value(latest, "value"))
+        if sensor_id is None or value is None:
+            continue
+        if sensor_id not in sensor_metadata:
+            LOGGER.debug("Ignoring OpenAQ measurement for unknown sensor %s", sensor_id)
+            continue
+        parameter, unit = sensor_metadata[sensor_id]
+        measurements[parameter] = OpenAQMeasurement(parameter, value, unit)
+
+    for sensor in sensors:
+        parameter = get_openaq_value(sensor, "parameter")
+        parameter_name = _normalize_parameter(parameter)
+        latest = get_openaq_value(sensor, "latest")
+        value = (
+            _as_float(get_openaq_value(latest, "value")) if latest is not None else None
+        )
+        if parameter_name is None or parameter_name in measurements or value is None:
+            continue
+        unit = get_openaq_value(parameter, "units")
+        measurements[parameter_name] = OpenAQMeasurement(
+            parameter_name, value, unit if isinstance(unit, str) else None
+        )
+
+    return MappingProxyType(measurements)
+
+
+class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
+    """Coordinator for fetching OpenAQ location data."""
+
+    config_entry: OpenAQConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OpenAQConfigEntry,
+        subentry: ConfigSubentry,
+        client: AsyncOpenAQ,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN}_{subentry.subentry_id}",
+            update_interval=UPDATE_INTERVAL,
+        )
+        self.client = client
+        self.subentry = subentry
+        self.location_id: int = subentry.data[CONF_LOCATION_ID]
+
+    async def _async_update_data(self) -> OpenAQLocationData:
+        """Fetch data from OpenAQ."""
+        try:
+            location_response = await self.client.locations.get(self.location_id)
+            latest_response = await self.client.locations.latest(self.location_id)
+            sensors_response = await self.client.locations.sensors(self.location_id)
+        except (
+            BadGatewayError,
+            BadRequestError,
+            ApiKeyMissingError,
+            ForbiddenError,
+            GatewayTimeoutError,
+            HTTPRateLimitError,
+            NotFoundError,
+            NotAuthorizedError,
+            OpenAQTimeoutError,
+            RateLimitError,
+            ServerError,
+            ServiceUnavailableError,
+            ValidationError,
+        ) as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unable_to_fetch",
+            ) from err
+
+        location = location_response.results[0]
+        return OpenAQLocationData(
+            location_id=self.location_id,
+            name=str(get_openaq_value(location, "name")),
+            measurements=normalize_latest_measurements(
+                latest_response.results, sensors_response.results
+            ),
+        )
+
+
+__all__ = [
+    "OpenAQConfigEntry",
+    "OpenAQDataUpdateCoordinator",
+    "OpenAQLocationData",
+    "OpenAQMeasurement",
+    "OpenAQRuntimeData",
+    "get_openaq_value",
+    "normalize_latest_measurements",
+]

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -8,21 +8,15 @@ from types import MappingProxyType
 from typing import Any, cast
 
 import httpx
-from openaq import (
-    ApiKeyMissingError,
-    AsyncOpenAQ,
-    BadGatewayError,
-    BadRequestError,
-    ForbiddenError,
-    GatewayTimeoutError,
-    HTTPRateLimitError,
-    NotAuthorizedError,
-    NotFoundError,
-    RateLimitError,
-    ServerError,
-    ServiceUnavailableError,
-    TimeoutError as OpenAQTimeoutError,
-    ValidationError,
+from openaq import AsyncOpenAQ
+from openaq.shared.exceptions import APIError, OpenAQError
+from openaq.shared.responses import (
+    Coordinates,
+    Latest,
+    Location,
+    Parameter,
+    ParameterBase,
+    Sensor,
 )
 from openaq.shared.transport import check_response
 
@@ -104,13 +98,14 @@ class HomeAssistantOpenAQTransport:
         return check_response(response)
 
     async def close(self) -> None:
-        """Keep the shared Home Assistant httpx client open."""
+        """The OpenAQ SDK calls this when closing, but Home Assistant owns the shared httpx client."""
 
 
 def create_openaq_client(api_key: str, httpx_client: httpx.AsyncClient) -> AsyncOpenAQ:
     """Create an OpenAQ client with a Home Assistant managed transport."""
     return AsyncOpenAQ(
         api_key=api_key,
+        # Avoid importing the SDK's private transport type just for this cast.
         transport=cast(Any, HomeAssistantOpenAQTransport(httpx_client)),
     )
 
@@ -120,31 +115,9 @@ async def async_create_openaq_client(hass: HomeAssistant, api_key: str) -> Async
     return create_openaq_client(api_key, get_async_client(hass))
 
 
-def get_openaq_value(data: object, *names: str) -> Any:
-    """Get a value from an SDK object or a dict-like test object."""
-    for name in names:
-        if isinstance(data, dict) and name in data:
-            return data[name]
-        if hasattr(data, name):
-            return getattr(data, name)
-    return None
-
-
-def normalize_parameter(parameter: object) -> str | None:
+def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     """Normalize an OpenAQ parameter object to its canonical name."""
-    name = get_openaq_value(parameter, "name")
-    if isinstance(name, str):
-        return name.lower().replace(".", "").replace("_", "")
-    return None
-
-
-def _normalize_sensor_id(value: object) -> int | None:
-    """Normalize an OpenAQ sensor id to an integer."""
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.isdecimal():
-        return int(value)
-    return None
+    return parameter.name.lower().replace(".", "").replace("_", "")
 
 
 def _as_float(value: object) -> float | None:
@@ -161,19 +134,11 @@ def _normalize_unit(unit: object) -> str | None:
     return OPENAQ_UNIT_ALIASES.get(unit, unit)
 
 
-def _coordinate_value(coordinates: object, name: str) -> float | None:
-    """Return a numeric coordinate value."""
-    value = get_openaq_value(coordinates, name)
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    return float(value)
-
-
-def _distance_to_home(hass: HomeAssistant, location: object) -> float | None:
+def _distance_to_home(hass: HomeAssistant, location: Location) -> float | None:
     """Return the distance in meters from Home Assistant to the OpenAQ location."""
-    coordinates = get_openaq_value(location, "coordinates")
-    latitude = _coordinate_value(coordinates, "latitude")
-    longitude = _coordinate_value(coordinates, "longitude")
+    coordinates: Coordinates = location.coordinates
+    latitude = _as_float(coordinates.latitude)
+    longitude = _as_float(coordinates.longitude)
     if latitude is None or longitude is None:
         return None
     return location_util.distance(
@@ -185,56 +150,33 @@ def _distance_to_home(hass: HomeAssistant, location: object) -> float | None:
 
 
 def _sensor_metadata_by_id(
-    sensors: Sequence[object],
+    sensors: Sequence[Sensor],
 ) -> dict[int, tuple[str, str | None]]:
     """Return parameter metadata keyed by OpenAQ sensor id."""
     metadata: dict[int, tuple[str, str | None]] = {}
     for sensor in sensors:
-        sensor_id = _normalize_sensor_id(get_openaq_value(sensor, "id"))
-        parameter = get_openaq_value(sensor, "parameter")
+        parameter = sensor.parameter
         parameter_name = normalize_parameter(parameter)
-        if sensor_id is None or parameter_name is None:
-            continue
-        metadata[sensor_id] = (
+        metadata[sensor.id] = (
             parameter_name,
-            _normalize_unit(get_openaq_value(parameter, "units")),
+            _normalize_unit(parameter.units),
         )
     return metadata
 
 
 def normalize_latest_measurements(
-    latest_results: Sequence[object], sensors: Sequence[object]
+    latest_results: Sequence[Latest], sensors: Sequence[Sensor]
 ) -> MappingProxyType[str, OpenAQMeasurement]:
     """Normalize OpenAQ latest measurements by parameter name."""
     sensor_metadata = _sensor_metadata_by_id(sensors)
     measurements: dict[str, OpenAQMeasurement] = {}
 
     for latest in latest_results:
-        sensor_id = _normalize_sensor_id(
-            get_openaq_value(latest, "sensors_id", "sensorsId")
-        )
-        value = _as_float(get_openaq_value(latest, "value"))
-        if sensor_id is None or value is None:
+        value = _as_float(latest.value)
+        if value is None or latest.sensors_id not in sensor_metadata:
             continue
-        if sensor_id not in sensor_metadata:
-            continue
-        parameter, unit = sensor_metadata[sensor_id]
+        parameter, unit = sensor_metadata[latest.sensors_id]
         measurements[parameter] = OpenAQMeasurement(parameter, value, unit)
-
-    for sensor in sensors:
-        parameter = get_openaq_value(sensor, "parameter")
-        parameter_name = normalize_parameter(parameter)
-        latest = get_openaq_value(sensor, "latest")
-        value = (
-            _as_float(get_openaq_value(latest, "value")) if latest is not None else None
-        )
-        if parameter_name is None or parameter_name in measurements or value is None:
-            continue
-        measurements[parameter_name] = OpenAQMeasurement(
-            parameter_name,
-            value,
-            _normalize_unit(get_openaq_value(parameter, "units")),
-        )
 
     return MappingProxyType(measurements)
 
@@ -262,13 +204,13 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         self.client = client
         self.subentry = subentry
         self.location_id: int = subentry.data[CONF_LOCATION_ID]
-        self._location: object | None = None
-        self._sensors: Sequence[object] | None = None
+        self._location: Location | None = None
+        self._sensors: Sequence[Sensor] | None = None
 
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
-        location: object
-        sensors: Sequence[object]
+        location: Location
+        sensors: Sequence[Sensor]
         try:
             if self._location is None or self._sensors is None:
                 (
@@ -293,21 +235,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 location = self._location
                 sensors = self._sensors
                 latest_response = await self.client.locations.latest(self.location_id)
-        except (
-            BadGatewayError,
-            BadRequestError,
-            ApiKeyMissingError,
-            ForbiddenError,
-            GatewayTimeoutError,
-            HTTPRateLimitError,
-            NotFoundError,
-            NotAuthorizedError,
-            OpenAQTimeoutError,
-            RateLimitError,
-            ServerError,
-            ServiceUnavailableError,
-            ValidationError,
-        ) as err:
+        except (APIError, OpenAQError, httpx.HTTPError) as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="unable_to_fetch",
@@ -316,22 +244,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         measurements = normalize_latest_measurements(latest_response.results, sensors)
         return OpenAQLocationData(
             location_id=self.location_id,
-            name=str(get_openaq_value(location, "name")),
+            name=location.name,
             distance_to_home=_distance_to_home(self.hass, location),
             measurements=measurements,
         )
-
-
-__all__ = [
-    "HomeAssistantOpenAQTransport",
-    "OpenAQConfigEntry",
-    "OpenAQDataUpdateCoordinator",
-    "OpenAQLocationData",
-    "OpenAQMeasurement",
-    "OpenAQRuntimeData",
-    "async_create_openaq_client",
-    "create_openaq_client",
-    "get_openaq_value",
-    "normalize_latest_measurements",
-    "normalize_parameter",
-]

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from types import MappingProxyType
 from typing import Any
-from urllib.parse import urlencode
 
 from openaq import (
     ApiKeyMissingError,
@@ -26,7 +25,6 @@ from openaq import (
     ValidationError,
 )
 from openaq._async.transport import AsyncTransport
-from openaq.shared.client import DEFAULT_BASE_URL
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import (
@@ -81,14 +79,6 @@ class OpenAQRuntimeData:
 type OpenAQConfigEntry = ConfigEntry[OpenAQRuntimeData]
 
 
-type OpenAQScalarQueryValue = str | int | float | bool
-type OpenAQQueryValue = (
-    OpenAQScalarQueryValue
-    | list[OpenAQScalarQueryValue]
-    | tuple[OpenAQScalarQueryValue, ...]
-)
-
-
 def create_openaq_client(api_key: str) -> AsyncOpenAQ:
     """Create an OpenAQ client with an independent transport."""
     return AsyncOpenAQ(api_key=api_key, transport=AsyncTransport())
@@ -97,28 +87,6 @@ def create_openaq_client(api_key: str) -> AsyncOpenAQ:
 async def async_create_openaq_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
     """Create an OpenAQ client without blocking the event loop."""
     return await hass.async_add_executor_job(create_openaq_client, api_key)
-
-
-def format_openaq_url(
-    path: str, params: Mapping[str, OpenAQQueryValue | None] | None = None
-) -> str:
-    """Format an OpenAQ API URL for debug logging."""
-    url = f"{DEFAULT_BASE_URL.rstrip('/')}/{path.lstrip('/')}"
-    if not params:
-        return url
-
-    query_params: dict[str, str | int | float | bool] = {}
-    for key, value in params.items():
-        if value is None:
-            continue
-        if isinstance(value, (list, tuple)):
-            query_params[key] = ",".join(str(item) for item in value)
-        else:
-            query_params[key] = value
-
-    if not query_params:
-        return url
-    return f"{url}?{urlencode(query_params)}"
 
 
 def get_openaq_value(data: object, *names: str) -> Any:
@@ -185,36 +153,6 @@ def _distance_to_home(hass: HomeAssistant, location: object) -> float | None:
     )
 
 
-def _debug_sensor_summary(sensors: Sequence[object]) -> list[dict[str, object]]:
-    """Return a compact sensor summary for debug logging."""
-    summary: list[dict[str, object]] = []
-    for sensor in sensors:
-        parameter = get_openaq_value(sensor, "parameter")
-        latest = get_openaq_value(sensor, "latest")
-        summary.append(
-            {
-                "id": get_openaq_value(sensor, "id"),
-                "parameter": get_openaq_value(parameter, "name"),
-                "units": get_openaq_value(parameter, "units"),
-                "latest": get_openaq_value(latest, "value")
-                if latest is not None
-                else None,
-            }
-        )
-    return summary
-
-
-def _debug_latest_summary(latest_results: Sequence[object]) -> list[dict[str, object]]:
-    """Return a compact latest measurement summary for debug logging."""
-    return [
-        {
-            "sensor_id": get_openaq_value(latest, "sensors_id", "sensorsId"),
-            "value": get_openaq_value(latest, "value"),
-        }
-        for latest in latest_results
-    ]
-
-
 def _sensor_metadata_by_id(
     sensors: Sequence[object],
 ) -> dict[int, tuple[str, str | None]]:
@@ -248,7 +186,6 @@ def normalize_latest_measurements(
         if sensor_id is None or value is None:
             continue
         if sensor_id not in sensor_metadata:
-            LOGGER.debug("Ignoring OpenAQ measurement for unknown sensor %s", sensor_id)
             continue
         parameter, unit = sensor_metadata[sensor_id]
         measurements[parameter] = OpenAQMeasurement(parameter, value, unit)
@@ -298,31 +235,9 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
         try:
-            LOGGER.debug(
-                "Querying OpenAQ URL: %s",
-                format_openaq_url(f"/locations/{self.location_id}"),
-            )
             location_response = await self.client.locations.get(self.location_id)
-            LOGGER.debug(
-                "Querying OpenAQ URL: %s",
-                format_openaq_url(f"/locations/{self.location_id}/latest"),
-            )
             latest_response = await self.client.locations.latest(self.location_id)
-            LOGGER.debug(
-                "Querying OpenAQ URL: %s",
-                format_openaq_url(f"/locations/{self.location_id}/sensors"),
-            )
             sensors_response = await self.client.locations.sensors(self.location_id)
-            LOGGER.debug(
-                "OpenAQ latest response for location %s: %s",
-                self.location_id,
-                _debug_latest_summary(latest_response.results),
-            )
-            LOGGER.debug(
-                "OpenAQ sensors response for location %s: %s",
-                self.location_id,
-                _debug_sensor_summary(sensors_response.results),
-            )
         except (
             BadGatewayError,
             BadRequestError,
@@ -353,11 +268,6 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         measurements = normalize_latest_measurements(
             latest_response.results, sensors_response.results
         )
-        LOGGER.debug(
-            "Normalized OpenAQ measurements for location %s: %s",
-            self.location_id,
-            sorted(measurements),
-        )
         return OpenAQLocationData(
             location_id=self.location_id,
             name=str(get_openaq_value(location, "name")),
@@ -374,7 +284,6 @@ __all__ = [
     "OpenAQRuntimeData",
     "async_create_openaq_client",
     "create_openaq_client",
-    "format_openaq_url",
     "get_openaq_value",
     "normalize_latest_measurements",
 ]

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -124,7 +124,7 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     return parameter.name.lower().replace(".", "").replace("_", "")
 
 
-def _as_float(value: float | None) -> float | None:
+def _as_float(value: float | int | None) -> float | None:
     """Return value as a float when it is a numeric sensor value."""
     if isinstance(value, (float, int)):
         return float(value)

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from types import MappingProxyType
-from typing import TypeVar, override
+from typing import NoReturn, TypeVar, override
 
 from openaq import OpenAQ
 from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
@@ -179,7 +179,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         async with self._client_lock:
             return await self.hass.async_add_executor_job(target, *args)
 
-    def _raise_update_failed(self, err: Exception) -> None:
+    def _raise_update_failed(self, err: Exception) -> NoReturn:
         """Raise a translated update failure."""
         if isinstance(err, OPENAQ_AUTH_EXCEPTIONS):
             raise ConfigEntryAuthFailed(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -179,15 +179,10 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         async with self._client_lock:
             return await self.hass.async_add_executor_job(target, *args)
 
-    def _raise_update_failed(self, err: Exception, *, first_refresh: bool) -> None:
+    def _raise_update_failed(self, err: Exception) -> None:
         """Raise a translated update failure."""
         if isinstance(err, OPENAQ_AUTH_EXCEPTIONS):
-            if first_refresh:
-                raise ConfigEntryAuthFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="authentication_failed",
-                ) from err
-            raise UpdateFailed(
+            raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="authentication_failed",
             ) from err
@@ -213,7 +208,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     self.client.locations.sensors, self.location_id
                 )
             except Exception as err:  # noqa: BLE001
-                self._raise_update_failed(err, first_refresh=True)
+                self._raise_update_failed(err)
             if not location_response.results:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
@@ -231,7 +226,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     self.client.locations.latest, self.location_id
                 )
             except Exception as err:  # noqa: BLE001
-                self._raise_update_failed(err, first_refresh=False)
+                self._raise_update_failed(err)
 
         measurements = normalize_latest_measurements(latest_response.results, sensors)
         return OpenAQLocationData(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -214,15 +214,33 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         sensors: Sequence[Sensor]
         try:
             if self._location is None or self._sensors is None:
-                (
-                    location_response,
-                    latest_response,
-                    sensors_response,
-                ) = await asyncio.gather(
-                    self.client.locations.get(self.location_id),
-                    self.client.locations.latest(self.location_id),
-                    self.client.locations.sensors(self.location_id),
-                )
+                try:
+                    async with asyncio.TaskGroup() as tg:
+                        location_task = tg.create_task(
+                            self.client.locations.get(self.location_id)
+                        )
+                        latest_task = tg.create_task(
+                            self.client.locations.latest(self.location_id)
+                        )
+                        sensors_task = tg.create_task(
+                            self.client.locations.sensors(self.location_id)
+                        )
+                except* (
+                    ApiKeyMissingError,
+                    ForbiddenError,
+                    NotAuthorizedError,
+                ) as err:
+                    raise HomeAssistantError(
+                        f"Authentication failed for location {self.location_id}: {err}"
+                    ) from err.exceptions[0]
+                except* (APIError, OpenAQError, httpx.HTTPError) as err:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="unable_to_fetch",
+                    ) from err.exceptions[0]
+                location_response = location_task.result()
+                latest_response = latest_task.result()
+                sensors_response = sensors_task.result()
                 if not location_response.results:
                     raise UpdateFailed(
                         translation_domain=DOMAIN,

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -10,32 +10,26 @@ from typing import NoReturn, TypeVar, override
 from openaq import OpenAQ
 from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
 
+from homeassistant import const as ha_const
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CONF_LOCATION_ID,
-    DOMAIN,
-    LOGGER,
-    OPENAQ_AUTH_EXCEPTIONS,
-    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
-)
+from .const import CONF_LOCATION_ID, DOMAIN, LOGGER, OPENAQ_AUTH_EXCEPTIONS
 
 UPDATE_INTERVAL = timedelta(minutes=10)
 _T = TypeVar("_T")
 
 OPENAQ_UNIT_ALIASES = {
-    "µg/m³": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    "µg/m3": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m³": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m3": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m³": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m3": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    "mg/m³": OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
-    "mg/m3": OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
+    "µg/m³": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "µg/m3": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m³": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m3": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m³": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m3": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "mg/m³": ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    "mg/m3": ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 }
 
 

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -41,7 +41,9 @@ OPENAQ_UNIT_ALIASES = {
     "µg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     "ug/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     "ug/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     "μg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "mg/m³": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
     "mg/m3": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 }
 
@@ -230,8 +232,8 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     first_exception = err.exceptions[0]
                     if isinstance(first_exception, AUTH_EXCEPTIONS):
                         raise UpdateFailed(
-                            f"Authentication failed for location {self.location_id}: "
-                            f"{first_exception}"
+                            translation_domain=DOMAIN,
+                            translation_key="authentication_failed",
                         ) from first_exception
                     raise UpdateFailed(
                         translation_domain=DOMAIN,
@@ -255,7 +257,8 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 latest_response = await self.client.locations.latest(self.location_id)
         except AUTH_EXCEPTIONS as err:
             raise UpdateFailed(
-                f"Authentication failed for location {self.location_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="authentication_failed",
             ) from err
         except API_EXCEPTIONS as err:
             raise UpdateFailed(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -175,6 +175,18 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         async with self._client_lock:
             return await self.hass.async_add_executor_job(target, *args)
 
+    def _raise_update_failed(self, err: Exception) -> None:
+        """Raise a translated update failure."""
+        if isinstance(err, OPENAQ_AUTH_EXCEPTIONS):
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="authentication_failed",
+            ) from err
+        raise UpdateFailed(
+            translation_domain=DOMAIN,
+            translation_key="unable_to_fetch",
+        ) from err
+
     @override
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
@@ -191,16 +203,8 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 sensors_response = await self._async_run_openaq_job(
                     self.client.locations.sensors, self.location_id
                 )
-            except OPENAQ_AUTH_EXCEPTIONS as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="authentication_failed",
-                ) from err
-            except Exception as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="unable_to_fetch",
-                ) from err
+            except Exception as err:  # noqa: BLE001
+                self._raise_update_failed(err)
             if not location_response.results:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
@@ -217,16 +221,8 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 latest_response = await self._async_run_openaq_job(
                     self.client.locations.latest, self.location_id
                 )
-            except OPENAQ_AUTH_EXCEPTIONS as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="authentication_failed",
-                ) from err
-            except Exception as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="unable_to_fetch",
-                ) from err
+            except Exception as err:  # noqa: BLE001
+                self._raise_update_failed(err)
 
         measurements = normalize_latest_measurements(latest_response.results, sensors)
         return OpenAQLocationData(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -10,8 +10,8 @@ from typing import NoReturn, TypeVar, override
 from openaq import OpenAQ
 from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
 
-from homeassistant import const as ha_const
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.const import UnitOfDensity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -22,14 +22,14 @@ UPDATE_INTERVAL = timedelta(minutes=10)
 _T = TypeVar("_T")
 
 OPENAQ_UNIT_ALIASES = {
-    "µg/m³": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "µg/m3": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m³": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m3": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m³": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m3": ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "mg/m³": ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    "mg/m3": ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    "µg/m³": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+    "µg/m3": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+    "ug/m³": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+    "ug/m3": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+    "μg/m³": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+    "μg/m3": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+    "mg/m³": UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER,
+    "mg/m3": UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER,
 }
 
 

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -121,7 +121,7 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     return parameter.name.lower().replace(".", "").replace("_", "")
 
 
-def _as_float(value: float | int | None) -> float | None:
+def _as_float(value: float | None) -> float | None:
     """Return value as a float when it is a numeric sensor value."""
     if isinstance(value, (float, int)):
         return float(value)

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -121,9 +121,9 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     return parameter.name.lower().replace(".", "").replace("_", "")
 
 
-def _as_float(value: float | None) -> float | None:
+def _as_float(value: float | int | None) -> float | None:
     """Return value as a float when it is a numeric sensor value."""
-    if isinstance(value, float | int):
+    if isinstance(value, (float, int)):
         return float(value)
     return None
 

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -18,13 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CONF_LOCATION_ID,
-    DOMAIN,
-    LOGGER,
-    OPENAQ_AUTH_EXCEPTIONS,
-    OPENAQ_UPDATE_EXCEPTIONS,
-)
+from .const import CONF_LOCATION_ID, DOMAIN, LOGGER, OPENAQ_AUTH_EXCEPTIONS
 
 UPDATE_INTERVAL = timedelta(minutes=10)
 _T = TypeVar("_T")
@@ -226,11 +220,6 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
                     translation_key="authentication_failed",
-                ) from err
-            except OPENAQ_UPDATE_EXCEPTIONS as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="unable_to_fetch",
                 ) from err
             except Exception as err:
                 raise UpdateFailed(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import location as location_util
@@ -123,9 +123,9 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
 
 def _as_float(value: float | None) -> float | None:
     """Return value as a float when it is a numeric sensor value."""
-    if value is None or isinstance(value, bool):
-        return None
-    return float(value)
+    if isinstance(value, float | int):
+        return float(value)
+    return None
 
 
 def _normalize_unit(unit: str | None) -> str | None:
@@ -237,7 +237,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 sensors = self._sensors
                 latest_response = await self.client.locations.latest(self.location_id)
         except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:
-            raise ConfigEntryError(
+            raise HomeAssistantError(
                 f"Authentication failed for location {self.location_id}: {err}"
             ) from err
         except (APIError, OpenAQError, httpx.HTTPError) as err:

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 from typing import Any, cast
 
 import httpx
-from openaq import AsyncOpenAQ
+from openaq import ApiKeyMissingError, AsyncOpenAQ, ForbiddenError, NotAuthorizedError
 from openaq.shared.exceptions import APIError, OpenAQError
 from openaq.shared.responses import (
     Coordinates,
@@ -26,6 +26,7 @@ from homeassistant.const import (
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import location as location_util
@@ -120,16 +121,16 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     return parameter.name.lower().replace(".", "").replace("_", "")
 
 
-def _as_float(value: object) -> float | None:
+def _as_float(value: float | None) -> float | None:
     """Return value as a float when it is a numeric sensor value."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if value is None or isinstance(value, bool):
         return None
     return float(value)
 
 
-def _normalize_unit(unit: object) -> str | None:
+def _normalize_unit(unit: str | None) -> str | None:
     """Normalize an OpenAQ unit string to Home Assistant's canonical unit."""
-    if not isinstance(unit, str):
+    if unit is None:
         return None
     return OPENAQ_UNIT_ALIASES.get(unit, unit)
 
@@ -235,6 +236,10 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 location = self._location
                 sensors = self._sensors
                 latest_response = await self.client.locations.latest(self.location_id)
+        except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:
+            raise ConfigEntryError(
+                f"Authentication failed for location {self.location_id}: {err}"
+            ) from err
         except (APIError, OpenAQError, httpx.HTTPError) as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -233,11 +233,6 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                             f"Authentication failed for location {self.location_id}: "
                             f"{first_exception}"
                         ) from first_exception
-                    if isinstance(first_exception, API_EXCEPTIONS):
-                        raise UpdateFailed(
-                            translation_domain=DOMAIN,
-                            translation_key="unable_to_fetch",
-                        ) from first_exception
                     raise UpdateFailed(
                         translation_domain=DOMAIN,
                         translation_key="unable_to_fetch",

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -1,23 +1,14 @@
 """Data coordinator for the OpenAQ integration."""
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from types import MappingProxyType
-from typing import Any, cast
+from typing import TypeVar
 
-import httpx
-from openaq import AsyncOpenAQ
-from openaq.shared.responses import (
-    Coordinates,
-    Latest,
-    Location,
-    Parameter,
-    ParameterBase,
-    Sensor,
-)
-from openaq.shared.transport import check_response
+from openaq import OpenAQ
+from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import (
@@ -25,9 +16,7 @@ from homeassistant.const import (
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import location as location_util
 
 from .const import (
     CONF_LOCATION_ID,
@@ -38,6 +27,7 @@ from .const import (
 )
 
 UPDATE_INTERVAL = timedelta(minutes=10)
+_T = TypeVar("_T")
 
 OPENAQ_UNIT_ALIASES = {
     "µg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -61,12 +51,20 @@ class OpenAQMeasurement:
 
 
 @dataclass(slots=True)
+class OpenAQSensorMetadata:
+    """OpenAQ sensor metadata for a parameter."""
+
+    parameter: str
+    unit: str | None
+
+
+@dataclass(slots=True)
 class OpenAQLocationData:
     """Latest OpenAQ data for a configured location."""
 
     location_id: int
     name: str
-    distance_to_home: float | None
+    sensor_metadata: MappingProxyType[str, OpenAQSensorMetadata]
     measurements: MappingProxyType[str, OpenAQMeasurement]
 
 
@@ -74,64 +72,26 @@ class OpenAQLocationData:
 class OpenAQRuntimeData:
     """Runtime data for the OpenAQ integration."""
 
-    client: AsyncOpenAQ
+    client: OpenAQ
     coordinators: dict[str, OpenAQDataUpdateCoordinator]
 
 
 type OpenAQConfigEntry = ConfigEntry[OpenAQRuntimeData]
 
 
-class HomeAssistantOpenAQTransport:
-    """OpenAQ transport using Home Assistant's shared httpx client."""
-
-    def __init__(self, client: httpx.AsyncClient) -> None:
-        """Initialize the transport."""
-        self.client = client
-
-    async def send_request(
-        self,
-        method: str,
-        url: str,
-        params: httpx.QueryParams | Mapping[str, str | int | float | bool] | None,
-        headers: httpx.Headers | Mapping[str, str],
-    ) -> httpx.Response:
-        """Send a request through Home Assistant's shared httpx client."""
-        response = await self.client.request(
-            method=method,
-            url=url,
-            params=params,
-            headers=headers,
-        )
-        return check_response(response)
-
-    async def close(self) -> None:
-        """The OpenAQ SDK calls this when closing, but Home Assistant owns the shared httpx client."""
-
-
-def create_openaq_client(api_key: str, httpx_client: httpx.AsyncClient) -> AsyncOpenAQ:
-    """Create an OpenAQ client with a Home Assistant managed transport."""
-    return AsyncOpenAQ(
-        api_key=api_key,
-        # Avoid importing the SDK's private transport type just for this cast.
-        transport=cast(Any, HomeAssistantOpenAQTransport(httpx_client)),
-    )
-
-
-async def async_create_openaq_client(hass: HomeAssistant, api_key: str) -> AsyncOpenAQ:
+def create_openaq_client(api_key: str) -> OpenAQ:
     """Create an OpenAQ client."""
-    return create_openaq_client(api_key, get_async_client(hass))
+    return OpenAQ(api_key=api_key)
+
+
+async def async_create_openaq_client(hass: HomeAssistant, api_key: str) -> OpenAQ:
+    """Create an OpenAQ client."""
+    return await hass.async_add_executor_job(create_openaq_client, api_key)
 
 
 def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     """Normalize an OpenAQ parameter object to its canonical name."""
     return parameter.name.lower().replace(".", "").replace("_", "")
-
-
-def _as_float(value: float | None) -> float | None:
-    """Return value as a float when it is a numeric sensor value."""
-    if isinstance(value, (float, int)):
-        return float(value)
-    return None
 
 
 def _normalize_unit(unit: str | None) -> str | None:
@@ -141,34 +101,31 @@ def _normalize_unit(unit: str | None) -> str | None:
     return OPENAQ_UNIT_ALIASES.get(unit, unit)
 
 
-def _distance_to_home(hass: HomeAssistant, location: Location) -> float | None:
-    """Return the distance in meters from Home Assistant to the OpenAQ location."""
-    coordinates: Coordinates = location.coordinates
-    latitude = _as_float(coordinates.latitude)
-    longitude = _as_float(coordinates.longitude)
-    if latitude is None or longitude is None:
-        return None
-    return location_util.distance(
-        hass.config.latitude,
-        hass.config.longitude,
-        latitude,
-        longitude,
-    )
-
-
 def _sensor_metadata_by_id(
     sensors: Sequence[Sensor],
-) -> dict[int, tuple[str, str | None]]:
+) -> dict[int, OpenAQSensorMetadata]:
     """Return parameter metadata keyed by OpenAQ sensor id."""
-    metadata: dict[int, tuple[str, str | None]] = {}
+    metadata: dict[int, OpenAQSensorMetadata] = {}
     for sensor in sensors:
         parameter = sensor.parameter
         parameter_name = normalize_parameter(parameter)
-        metadata[sensor.id] = (
-            parameter_name,
-            _normalize_unit(parameter.units),
+        metadata[sensor.id] = OpenAQSensorMetadata(
+            parameter=parameter_name,
+            unit=_normalize_unit(parameter.units),
         )
     return metadata
+
+
+def normalize_sensor_metadata(
+    sensors: Sequence[Sensor],
+) -> MappingProxyType[str, OpenAQSensorMetadata]:
+    """Normalize OpenAQ sensor metadata by parameter name."""
+    return MappingProxyType(
+        {
+            metadata.parameter: metadata
+            for metadata in _sensor_metadata_by_id(sensors).values()
+        }
+    )
 
 
 def normalize_latest_measurements(
@@ -179,32 +136,14 @@ def normalize_latest_measurements(
     measurements: dict[str, OpenAQMeasurement] = {}
 
     for latest in latest_results:
-        value = _as_float(latest.value)
-        if value is None or latest.sensors_id not in sensor_metadata:
+        if latest.value is None or latest.sensors_id not in sensor_metadata:
             continue
-        parameter, unit = sensor_metadata[latest.sensors_id]
-        measurements[parameter] = OpenAQMeasurement(parameter, value, unit)
+        metadata = sensor_metadata[latest.sensors_id]
+        measurements[metadata.parameter] = OpenAQMeasurement(
+            metadata.parameter, float(latest.value), metadata.unit
+        )
 
     return MappingProxyType(measurements)
-
-
-def _first_exception(exc: BaseException) -> BaseException:
-    """Return the first nested exception."""
-    if isinstance(exc, BaseExceptionGroup):
-        return _first_exception(exc.exceptions[0])
-    return exc
-
-
-def _exception_group_cause(
-    err: ExceptionGroup, exception_types: tuple[type[Exception], ...] | None = None
-) -> BaseException:
-    """Return the exception to chain from an exception group."""
-    if (
-        exception_types is not None
-        and (subgroup := err.subgroup(exception_types)) is not None
-    ):
-        return _first_exception(subgroup)
-    return _first_exception(err)
 
 
 class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
@@ -217,7 +156,8 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         hass: HomeAssistant,
         config_entry: OpenAQConfigEntry,
         subentry: ConfigSubentry,
-        client: AsyncOpenAQ,
+        client: OpenAQ,
+        client_lock: asyncio.Lock | None = None,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -228,10 +168,18 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
             update_interval=UPDATE_INTERVAL,
         )
         self.client = client
+        self._client_lock = client_lock or asyncio.Lock()
         self.subentry = subentry
         self.location_id: int = subentry.data[CONF_LOCATION_ID]
         self._location: Location | None = None
         self._sensors: Sequence[Sensor] | None = None
+
+    async def _async_run_openaq_job(
+        self, target: Callable[..., _T], *args: object
+    ) -> _T:
+        """Run a blocking OpenAQ SDK call."""
+        async with self._client_lock:
+            return await self.hass.async_add_executor_job(target, *args)
 
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
@@ -239,43 +187,41 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         sensors: Sequence[Sensor]
         if self._location is None or self._sensors is None:
             try:
-                async with asyncio.TaskGroup() as tg:
-                    location_task = tg.create_task(
-                        self.client.locations.get(self.location_id)
-                    )
-                    latest_task = tg.create_task(
-                        self.client.locations.latest(self.location_id)
-                    )
-                    sensors_task = tg.create_task(
-                        self.client.locations.sensors(self.location_id)
-                    )
-            except ExceptionGroup as err:
-                if err.subgroup(OPENAQ_AUTH_EXCEPTIONS) is not None:
-                    raise UpdateFailed(
-                        translation_domain=DOMAIN,
-                        translation_key="authentication_failed",
-                    ) from _exception_group_cause(err, OPENAQ_AUTH_EXCEPTIONS)
+                location_response = await self._async_run_openaq_job(
+                    self.client.locations.get, self.location_id
+                )
+                latest_response = await self._async_run_openaq_job(
+                    self.client.locations.latest, self.location_id
+                )
+                sensors_response = await self._async_run_openaq_job(
+                    self.client.locations.sensors, self.location_id
+                )
+            except OPENAQ_AUTH_EXCEPTIONS as err:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="authentication_failed",
+                ) from err
+            except Exception as err:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
                     translation_key="unable_to_fetch",
-                ) from _exception_group_cause(err)
-            location_response = location_task.result()
-            latest_response = latest_task.result()
-            sensors_response = sensors_task.result()
+                ) from err
             if not location_response.results:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
                     translation_key="unable_to_fetch",
                 )
-            self._location = location_response.results[0]
-            self._sensors = sensors_response.results
-            location = self._location
-            sensors = self._sensors
+            location = location_response.results[0]
+            sensors = sensors_response.results
+            self._location = location
+            self._sensors = sensors
         else:
             location = self._location
             sensors = self._sensors
             try:
-                latest_response = await self.client.locations.latest(self.location_id)
+                latest_response = await self._async_run_openaq_job(
+                    self.client.locations.latest, self.location_id
+                )
             except OPENAQ_AUTH_EXCEPTIONS as err:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
@@ -286,11 +232,16 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     translation_domain=DOMAIN,
                     translation_key="unable_to_fetch",
                 ) from err
+            except Exception as err:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="unable_to_fetch",
+                ) from err
 
         measurements = normalize_latest_measurements(latest_response.results, sensors)
         return OpenAQLocationData(
             location_id=self.location_id,
             name=location.name,
-            distance_to_home=_distance_to_home(self.hass, location),
+            sensor_metadata=normalize_sensor_metadata(sensors),
             measurements=measurements,
         )

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -26,7 +26,6 @@ from homeassistant.const import (
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import location as location_util
@@ -230,7 +229,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     ForbiddenError,
                     NotAuthorizedError,
                 ) as err:
-                    raise HomeAssistantError(
+                    raise UpdateFailed(
                         f"Authentication failed for location {self.location_id}: {err}"
                     ) from err.exceptions[0]
                 except* (APIError, OpenAQError, httpx.HTTPError) as err:
@@ -255,7 +254,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 sensors = self._sensors
                 latest_response = await self.client.locations.latest(self.location_id)
         except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:
-            raise HomeAssistantError(
+            raise UpdateFailed(
                 f"Authentication failed for location {self.location_id}: {err}"
             ) from err
         except (APIError, OpenAQError, httpx.HTTPError) as err:

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -229,16 +229,15 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                             self.client.locations.sensors(self.location_id)
                         )
                 except ExceptionGroup as err:
-                    first_exception = err.exceptions[0]
-                    if isinstance(first_exception, AUTH_EXCEPTIONS):
+                    if err.subgroup(AUTH_EXCEPTIONS) is not None:
                         raise UpdateFailed(
                             translation_domain=DOMAIN,
                             translation_key="authentication_failed",
-                        ) from first_exception
+                        ) from err
                     raise UpdateFailed(
                         translation_domain=DOMAIN,
                         translation_key="unable_to_fetch",
-                    ) from first_exception
+                    ) from err
                 location_response = location_task.result()
                 latest_response = latest_task.result()
                 sensors_response = sensors_task.result()

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from types import MappingProxyType
-from typing import TypeVar
+from typing import TypeVar, override
 
 from openaq import OpenAQ
 from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
@@ -175,6 +175,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         async with self._client_lock:
             return await self.hass.async_add_executor_job(target, *args)
 
+    @override
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
         location: Location

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -8,8 +8,7 @@ from types import MappingProxyType
 from typing import Any, cast
 
 import httpx
-from openaq import ApiKeyMissingError, AsyncOpenAQ, ForbiddenError, NotAuthorizedError
-from openaq.shared.exceptions import APIError, OpenAQError
+from openaq import AsyncOpenAQ
 from openaq.shared.responses import (
     Coordinates,
     Latest,
@@ -30,11 +29,15 @@ from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import location as location_util
 
-from .const import CONF_LOCATION_ID, DOMAIN, LOGGER
+from .const import (
+    CONF_LOCATION_ID,
+    DOMAIN,
+    LOGGER,
+    OPENAQ_AUTH_EXCEPTIONS,
+    OPENAQ_UPDATE_EXCEPTIONS,
+)
 
 UPDATE_INTERVAL = timedelta(minutes=10)
-AUTH_EXCEPTIONS = (ApiKeyMissingError, ForbiddenError, NotAuthorizedError)
-API_EXCEPTIONS = (APIError, OpenAQError, httpx.HTTPError)
 
 OPENAQ_UNIT_ALIASES = {
     "µg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -124,7 +127,7 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     return parameter.name.lower().replace(".", "").replace("_", "")
 
 
-def _as_float(value: float | int | None) -> float | None:
+def _as_float(value: float | None) -> float | None:
     """Return value as a float when it is a numeric sensor value."""
     if isinstance(value, (float, int)):
         return float(value)
@@ -185,6 +188,25 @@ def normalize_latest_measurements(
     return MappingProxyType(measurements)
 
 
+def _first_exception(exc: BaseException) -> BaseException:
+    """Return the first nested exception."""
+    if isinstance(exc, BaseExceptionGroup):
+        return _first_exception(exc.exceptions[0])
+    return exc
+
+
+def _exception_group_cause(
+    err: ExceptionGroup, exception_types: tuple[type[Exception], ...] | None = None
+) -> BaseException:
+    """Return the exception to chain from an exception group."""
+    if (
+        exception_types is not None
+        and (subgroup := err.subgroup(exception_types)) is not None
+    ):
+        return _first_exception(subgroup)
+    return _first_exception(err)
+
+
 class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
     """Coordinator for fetching OpenAQ location data."""
 
@@ -215,53 +237,55 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         """Fetch data from OpenAQ."""
         location: Location
         sensors: Sequence[Sensor]
-        try:
-            if self._location is None or self._sensors is None:
-                try:
-                    async with asyncio.TaskGroup() as tg:
-                        location_task = tg.create_task(
-                            self.client.locations.get(self.location_id)
-                        )
-                        latest_task = tg.create_task(
-                            self.client.locations.latest(self.location_id)
-                        )
-                        sensors_task = tg.create_task(
-                            self.client.locations.sensors(self.location_id)
-                        )
-                except ExceptionGroup as err:
-                    if err.subgroup(AUTH_EXCEPTIONS) is not None:
-                        raise UpdateFailed(
-                            translation_domain=DOMAIN,
-                            translation_key="authentication_failed",
-                        ) from err
-                    raise UpdateFailed(
-                        translation_domain=DOMAIN,
-                        translation_key="unable_to_fetch",
-                    ) from err
-                location_response = location_task.result()
-                latest_response = latest_task.result()
-                sensors_response = sensors_task.result()
-                if not location_response.results:
-                    raise UpdateFailed(
-                        translation_domain=DOMAIN,
-                        translation_key="unable_to_fetch",
+        if self._location is None or self._sensors is None:
+            try:
+                async with asyncio.TaskGroup() as tg:
+                    location_task = tg.create_task(
+                        self.client.locations.get(self.location_id)
                     )
-                self._location = location_response.results[0]
-                self._sensors = sensors_response.results
-            else:
-                location = self._location
-                sensors = self._sensors
+                    latest_task = tg.create_task(
+                        self.client.locations.latest(self.location_id)
+                    )
+                    sensors_task = tg.create_task(
+                        self.client.locations.sensors(self.location_id)
+                    )
+            except ExceptionGroup as err:
+                if err.subgroup(OPENAQ_AUTH_EXCEPTIONS) is not None:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="authentication_failed",
+                    ) from _exception_group_cause(err, OPENAQ_AUTH_EXCEPTIONS)
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="unable_to_fetch",
+                ) from _exception_group_cause(err)
+            location_response = location_task.result()
+            latest_response = latest_task.result()
+            sensors_response = sensors_task.result()
+            if not location_response.results:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="unable_to_fetch",
+                )
+            self._location = location_response.results[0]
+            self._sensors = sensors_response.results
+            location = self._location
+            sensors = self._sensors
+        else:
+            location = self._location
+            sensors = self._sensors
+            try:
                 latest_response = await self.client.locations.latest(self.location_id)
-        except AUTH_EXCEPTIONS as err:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="authentication_failed",
-            ) from err
-        except API_EXCEPTIONS as err:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="unable_to_fetch",
-            ) from err
+            except OPENAQ_AUTH_EXCEPTIONS as err:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="authentication_failed",
+                ) from err
+            except OPENAQ_UPDATE_EXCEPTIONS as err:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="unable_to_fetch",
+                ) from err
 
         measurements = normalize_latest_measurements(latest_response.results, sensors)
         return OpenAQLocationData(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -246,10 +246,8 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                         translation_domain=DOMAIN,
                         translation_key="unable_to_fetch",
                     )
-                location = location_response.results[0]
-                sensors = sensors_response.results
-                self._location = location
-                self._sensors = sensors
+                self._location = location_response.results[0]
+                self._sensors = sensors_response.results
             else:
                 location = self._location
                 sensors = self._sensors

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -33,6 +33,8 @@ from homeassistant.util import location as location_util
 from .const import CONF_LOCATION_ID, DOMAIN, LOGGER
 
 UPDATE_INTERVAL = timedelta(minutes=10)
+AUTH_EXCEPTIONS = (ApiKeyMissingError, ForbiddenError, NotAuthorizedError)
+API_EXCEPTIONS = (APIError, OpenAQError, httpx.HTTPError)
 
 OPENAQ_UNIT_ALIASES = {
     "µg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -224,19 +226,22 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                         sensors_task = tg.create_task(
                             self.client.locations.sensors(self.location_id)
                         )
-                except* (
-                    ApiKeyMissingError,
-                    ForbiddenError,
-                    NotAuthorizedError,
-                ) as err:
-                    raise UpdateFailed(
-                        f"Authentication failed for location {self.location_id}: {err}"
-                    ) from err.exceptions[0]
-                except* (APIError, OpenAQError, httpx.HTTPError) as err:
+                except ExceptionGroup as err:
+                    first_exception = err.exceptions[0]
+                    if isinstance(first_exception, AUTH_EXCEPTIONS):
+                        raise UpdateFailed(
+                            f"Authentication failed for location {self.location_id}: "
+                            f"{first_exception}"
+                        ) from first_exception
+                    if isinstance(first_exception, API_EXCEPTIONS):
+                        raise UpdateFailed(
+                            translation_domain=DOMAIN,
+                            translation_key="unable_to_fetch",
+                        ) from first_exception
                     raise UpdateFailed(
                         translation_domain=DOMAIN,
                         translation_key="unable_to_fetch",
-                    ) from err.exceptions[0]
+                    ) from first_exception
                 location_response = location_task.result()
                 latest_response = latest_task.result()
                 sensors_response = sensors_task.result()
@@ -253,11 +258,11 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                 location = self._location
                 sensors = self._sensors
                 latest_response = await self.client.locations.latest(self.location_id)
-        except (ApiKeyMissingError, ForbiddenError, NotAuthorizedError) as err:
+        except AUTH_EXCEPTIONS as err:
             raise UpdateFailed(
                 f"Authentication failed for location {self.location_id}: {err}"
             ) from err
-        except (APIError, OpenAQError, httpx.HTTPError) as err:
+        except API_EXCEPTIONS as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="unable_to_fetch",

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -11,27 +11,31 @@ from openaq import OpenAQ
 from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-)
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_LOCATION_ID, DOMAIN, LOGGER, OPENAQ_AUTH_EXCEPTIONS
+from .const import (
+    CONF_LOCATION_ID,
+    DOMAIN,
+    LOGGER,
+    OPENAQ_AUTH_EXCEPTIONS,
+    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
+)
 
 UPDATE_INTERVAL = timedelta(minutes=10)
 _T = TypeVar("_T")
 
 OPENAQ_UNIT_ALIASES = {
-    "µg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "µg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "mg/m³": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    "mg/m3": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    "µg/m³": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    "µg/m3": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m³": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m3": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m³": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m3": OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    "mg/m³": OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
+    "mg/m3": OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
 }
 
 
@@ -175,9 +179,14 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         async with self._client_lock:
             return await self.hass.async_add_executor_job(target, *args)
 
-    def _raise_update_failed(self, err: Exception) -> None:
+    def _raise_update_failed(self, err: Exception, *, first_refresh: bool) -> None:
         """Raise a translated update failure."""
         if isinstance(err, OPENAQ_AUTH_EXCEPTIONS):
+            if first_refresh:
+                raise ConfigEntryAuthFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="authentication_failed",
+                ) from err
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="authentication_failed",
@@ -204,7 +213,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     self.client.locations.sensors, self.location_id
                 )
             except Exception as err:  # noqa: BLE001
-                self._raise_update_failed(err)
+                self._raise_update_failed(err, first_refresh=True)
             if not location_response.results:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
@@ -222,7 +231,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     self.client.locations.latest, self.location_id
                 )
             except Exception as err:  # noqa: BLE001
-                self._raise_update_failed(err)
+                self._raise_update_failed(err, first_refresh=False)
 
         measurements = normalize_latest_measurements(latest_response.results, sensors)
         return OpenAQLocationData(

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -13,10 +13,9 @@ from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Se
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import UnitOfDensity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_LOCATION_ID, DOMAIN, LOGGER, OPENAQ_AUTH_EXCEPTIONS
+from .const import CONF_LOCATION_ID, DOMAIN, LOGGER
 
 UPDATE_INTERVAL = timedelta(minutes=10)
 _T = TypeVar("_T")
@@ -175,11 +174,6 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
 
     def _raise_update_failed(self, err: Exception) -> NoReturn:
         """Raise a translated update failure."""
-        if isinstance(err, OPENAQ_AUTH_EXCEPTIONS):
-            raise ConfigEntryAuthFailed(
-                translation_domain=DOMAIN,
-                translation_key="authentication_failed",
-            ) from err
         raise UpdateFailed(
             translation_domain=DOMAIN,
             translation_key="unable_to_fetch",
@@ -192,40 +186,50 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         sensors: Sequence[Sensor]
         if self._location is None or self._sensors is None:
             try:
-                location_response = await self._async_run_openaq_job(
-                    self.client.locations.get, self.location_id
-                )
-                latest_response = await self._async_run_openaq_job(
-                    self.client.locations.latest, self.location_id
-                )
-                sensors_response = await self._async_run_openaq_job(
-                    self.client.locations.sensors, self.location_id
+                (
+                    location_results,
+                    latest_results,
+                    sensors,
+                ) = await self._async_run_openaq_job(
+                    _fetch_initial_location_data, self.client, self.location_id
                 )
             except Exception as err:  # noqa: BLE001
                 self._raise_update_failed(err)
-            if not location_response.results:
+            if not location_results:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
                     translation_key="unable_to_fetch",
                 )
-            location = location_response.results[0]
-            sensors = sensors_response.results
+            location = location_results[0]
             self._location = location
             self._sensors = sensors
         else:
             location = self._location
             sensors = self._sensors
             try:
-                latest_response = await self._async_run_openaq_job(
-                    self.client.locations.latest, self.location_id
-                )
+                latest_results = (
+                    await self._async_run_openaq_job(
+                        self.client.locations.latest, self.location_id
+                    )
+                ).results
             except Exception as err:  # noqa: BLE001
                 self._raise_update_failed(err)
 
-        measurements = normalize_latest_measurements(latest_response.results, sensors)
+        measurements = normalize_latest_measurements(latest_results, sensors)
         return OpenAQLocationData(
             location_id=self.location_id,
             name=location.name,
             sensor_metadata=normalize_sensor_metadata(sensors),
             measurements=measurements,
         )
+
+
+def _fetch_initial_location_data(
+    client: OpenAQ, location_id: int
+) -> tuple[Sequence[Location], Sequence[Latest], Sequence[Sensor]]:
+    """Fetch all SDK data required for an initial location refresh."""
+    return (
+        client.locations.get(location_id).results,
+        client.locations.latest(location_id).results,
+        client.locations.sensors(location_id).results,
+    )

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -64,6 +64,7 @@ class OpenAQRuntimeData:
     """Runtime data for the OpenAQ integration."""
 
     client: OpenAQ
+    client_lock: asyncio.Lock
     coordinators: dict[str, OpenAQDataUpdateCoordinator]
 
 

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -10,6 +10,7 @@ from typing import override
 from openaq import OpenAQ
 from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
 
+from homeassistant.components.sensor import DEVICE_CLASS_UNITS
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import UnitOfDensity
 from homeassistant.core import HomeAssistant
@@ -22,6 +23,7 @@ from .const import (
     OPENAQ_API_EXCEPTIONS,
     OPENAQ_AUTH_EXCEPTIONS,
     OPENAQ_RATE_LIMIT_EXCEPTIONS,
+    PARAMETER_DEVICE_CLASSES,
 )
 
 UPDATE_INTERVAL = timedelta(minutes=10)
@@ -48,7 +50,7 @@ class OpenAQLocationData:
 
     location_id: int
     name: str
-    sensor_metadata: MappingProxyType[str, str | None]
+    sensor_metadata: MappingProxyType[str, str]
     measurements: MappingProxyType[str, float]
 
 
@@ -66,12 +68,7 @@ type OpenAQConfigEntry = ConfigEntry[OpenAQRuntimeData]
 
 def create_openaq_client(api_key: str) -> OpenAQ:
     """Create an OpenAQ client."""
-    return OpenAQ(api_key=api_key)
-
-
-async def async_create_openaq_client(hass: HomeAssistant, api_key: str) -> OpenAQ:
-    """Create an OpenAQ client."""
-    return await hass.async_add_executor_job(create_openaq_client, api_key)
+    return OpenAQ(api_key=api_key, auto_wait=False)
 
 
 def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
@@ -81,18 +78,23 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
 
 def _build_sensor_metadata(
     sensors: Sequence[Sensor],
-) -> tuple[dict[int, str], MappingProxyType[str, str | None]]:
+) -> tuple[dict[int, str], MappingProxyType[str, str]]:
     """Return sensor parameter name and unit mappings keyed by sensor id."""
     by_id: dict[int, str] = {}
-    units: dict[str, str | None] = {}
+    units: dict[str, str] = {}
 
     for sensor in sensors:
         parameter = normalize_parameter(sensor.parameter)
+        if parameter not in PARAMETER_DEVICE_CLASSES:
+            continue
+        unit = OPENAQ_UNIT_ALIASES.get(sensor.parameter.units, sensor.parameter.units)
+        device_class = PARAMETER_DEVICE_CLASSES[parameter]
+        if device_class is not None:
+            valid_units = DEVICE_CLASS_UNITS.get(device_class)
+            if valid_units is not None and unit not in valid_units:
+                continue
         by_id[sensor.id] = parameter
-        unit = sensor.parameter.units
-        units[parameter] = (
-            OPENAQ_UNIT_ALIASES.get(unit, unit) if unit is not None else None
-        )
+        units[parameter] = unit
 
     return by_id, MappingProxyType(units)
 
@@ -105,10 +107,10 @@ def normalize_latest_measurements(
     measurements: dict[str, float] = {}
 
     for latest in latest_results:
-        if latest.value is None or latest.sensors_id not in sensors_by_id:
+        if latest.sensors_id not in sensors_by_id:
             continue
         parameter = sensors_by_id[latest.sensors_id]
-        measurements[parameter] = float(latest.value)
+        measurements[parameter] = latest.value
 
     return MappingProxyType(measurements)
 
@@ -135,7 +137,7 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         config_entry: OpenAQConfigEntry,
         subentry: ConfigSubentry,
         client: OpenAQ,
-        client_lock: asyncio.Lock | None = None,
+        client_lock: asyncio.Lock,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -146,18 +148,17 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
             update_interval=UPDATE_INTERVAL,
         )
         self.client = client
-        self._client_lock = client_lock or asyncio.Lock()
+        self._client_lock = client_lock
         self.subentry = subentry
         self.location_id: int = subentry.data[CONF_LOCATION_ID]
         self._location: Location | None = None
-        self._sensors: Sequence[Sensor] | None = None
+        self._sensors_by_id: dict[int, str] | None = None
+        self._sensor_metadata: MappingProxyType[str, str] | None = None
 
     @override
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
-        location: Location
-        sensors: Sequence[Sensor]
-        if self._location is None or self._sensors is None:
+        if self._location is None:
             async with self._client_lock:
                 try:
                     (
@@ -177,12 +178,9 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                     translation_domain=DOMAIN,
                     translation_key="unable_to_fetch",
                 )
-            location = location_results[0]
-            self._location = location
-            self._sensors = sensors
+            self._location = location_results[0]
+            self._sensors_by_id, self._sensor_metadata = _build_sensor_metadata(sensors)
         else:
-            location = self._location
-            sensors = self._sensors
             async with self._client_lock:
                 try:
                     latest_results = (
@@ -196,11 +194,14 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
                         translation_key="unable_to_fetch",
                     ) from err
 
-        by_id, sensor_metadata = _build_sensor_metadata(sensors)
-        measurements = normalize_latest_measurements(latest_results, by_id)
+        assert self._sensors_by_id is not None
+        assert self._sensor_metadata is not None
+        measurements = normalize_latest_measurements(
+            latest_results, self._sensors_by_id
+        )
         return OpenAQLocationData(
             location_id=self.location_id,
-            name=location.name,
-            sensor_metadata=sensor_metadata,
+            name=self._location.name,
+            sensor_metadata=self._sensor_metadata,
             measurements=measurements,
         )

--- a/homeassistant/components/openaq/coordinator.py
+++ b/homeassistant/components/openaq/coordinator.py
@@ -1,11 +1,11 @@
 """Data coordinator for the OpenAQ integration."""
 
 import asyncio
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from types import MappingProxyType
-from typing import NoReturn, TypeVar, override
+from typing import override
 
 from openaq import OpenAQ
 from openaq.core.responses import Latest, Location, Parameter, ParameterBase, Sensor
@@ -15,10 +15,20 @@ from homeassistant.const import UnitOfDensity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_LOCATION_ID, DOMAIN, LOGGER
+from .const import (
+    CONF_LOCATION_ID,
+    DOMAIN,
+    LOGGER,
+    OPENAQ_API_EXCEPTIONS,
+    OPENAQ_AUTH_EXCEPTIONS,
+    OPENAQ_RATE_LIMIT_EXCEPTIONS,
+)
 
 UPDATE_INTERVAL = timedelta(minutes=10)
-_T = TypeVar("_T")
+
+OPENAQ_FETCH_EXCEPTIONS = (
+    OPENAQ_AUTH_EXCEPTIONS + OPENAQ_RATE_LIMIT_EXCEPTIONS + OPENAQ_API_EXCEPTIONS
+)
 
 OPENAQ_UNIT_ALIASES = {
     "µg/m³": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
@@ -33,30 +43,13 @@ OPENAQ_UNIT_ALIASES = {
 
 
 @dataclass(slots=True)
-class OpenAQMeasurement:
-    """Latest OpenAQ measurement for a parameter."""
-
-    parameter: str
-    value: float
-    unit: str | None
-
-
-@dataclass(slots=True)
-class OpenAQSensorMetadata:
-    """OpenAQ sensor metadata for a parameter."""
-
-    parameter: str
-    unit: str | None
-
-
-@dataclass(slots=True)
 class OpenAQLocationData:
     """Latest OpenAQ data for a configured location."""
 
     location_id: int
     name: str
-    sensor_metadata: MappingProxyType[str, OpenAQSensorMetadata]
-    measurements: MappingProxyType[str, OpenAQMeasurement]
+    sensor_metadata: MappingProxyType[str, str | None]
+    measurements: MappingProxyType[str, float]
 
 
 @dataclass(slots=True)
@@ -86,56 +79,49 @@ def normalize_parameter(parameter: Parameter | ParameterBase) -> str:
     return parameter.name.lower().replace(".", "").replace("_", "")
 
 
-def _normalize_unit(unit: str | None) -> str | None:
-    """Normalize an OpenAQ unit string to Home Assistant's canonical unit."""
-    if unit is None:
-        return None
-    return OPENAQ_UNIT_ALIASES.get(unit, unit)
-
-
-def _sensor_metadata_by_id(
+def _build_sensor_metadata(
     sensors: Sequence[Sensor],
-) -> dict[int, OpenAQSensorMetadata]:
-    """Return parameter metadata keyed by OpenAQ sensor id."""
-    metadata: dict[int, OpenAQSensorMetadata] = {}
+) -> tuple[dict[int, str], MappingProxyType[str, str | None]]:
+    """Return sensor parameter name and unit mappings keyed by sensor id."""
+    by_id: dict[int, str] = {}
+    units: dict[str, str | None] = {}
+
     for sensor in sensors:
-        parameter = sensor.parameter
-        parameter_name = normalize_parameter(parameter)
-        metadata[sensor.id] = OpenAQSensorMetadata(
-            parameter=parameter_name,
-            unit=_normalize_unit(parameter.units),
+        parameter = normalize_parameter(sensor.parameter)
+        by_id[sensor.id] = parameter
+        unit = sensor.parameter.units
+        units[parameter] = (
+            OPENAQ_UNIT_ALIASES.get(unit, unit) if unit is not None else None
         )
-    return metadata
 
-
-def normalize_sensor_metadata(
-    sensors: Sequence[Sensor],
-) -> MappingProxyType[str, OpenAQSensorMetadata]:
-    """Normalize OpenAQ sensor metadata by parameter name."""
-    return MappingProxyType(
-        {
-            metadata.parameter: metadata
-            for metadata in _sensor_metadata_by_id(sensors).values()
-        }
-    )
+    return by_id, MappingProxyType(units)
 
 
 def normalize_latest_measurements(
-    latest_results: Sequence[Latest], sensors: Sequence[Sensor]
-) -> MappingProxyType[str, OpenAQMeasurement]:
+    latest_results: Sequence[Latest],
+    sensors_by_id: dict[int, str],
+) -> MappingProxyType[str, float]:
     """Normalize OpenAQ latest measurements by parameter name."""
-    sensor_metadata = _sensor_metadata_by_id(sensors)
-    measurements: dict[str, OpenAQMeasurement] = {}
+    measurements: dict[str, float] = {}
 
     for latest in latest_results:
-        if latest.value is None or latest.sensors_id not in sensor_metadata:
+        if latest.value is None or latest.sensors_id not in sensors_by_id:
             continue
-        metadata = sensor_metadata[latest.sensors_id]
-        measurements[metadata.parameter] = OpenAQMeasurement(
-            metadata.parameter, float(latest.value), metadata.unit
-        )
+        parameter = sensors_by_id[latest.sensors_id]
+        measurements[parameter] = float(latest.value)
 
     return MappingProxyType(measurements)
+
+
+def _fetch_initial_location_data(
+    client: OpenAQ, location_id: int
+) -> tuple[Sequence[Location], Sequence[Latest], Sequence[Sensor]]:
+    """Fetch all SDK data required for an initial location refresh."""
+    return (
+        client.locations.get(location_id).results,
+        client.locations.latest(location_id).results,
+        client.locations.sensors(location_id).results,
+    )
 
 
 class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
@@ -166,36 +152,26 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         self._location: Location | None = None
         self._sensors: Sequence[Sensor] | None = None
 
-    async def _async_run_openaq_job(
-        self, target: Callable[..., _T], *args: object
-    ) -> _T:
-        """Run a blocking OpenAQ SDK call."""
-        async with self._client_lock:
-            return await self.hass.async_add_executor_job(target, *args)
-
-    def _raise_update_failed(self, err: Exception) -> NoReturn:
-        """Raise a translated update failure."""
-        raise UpdateFailed(
-            translation_domain=DOMAIN,
-            translation_key="unable_to_fetch",
-        ) from err
-
     @override
     async def _async_update_data(self) -> OpenAQLocationData:
         """Fetch data from OpenAQ."""
         location: Location
         sensors: Sequence[Sensor]
         if self._location is None or self._sensors is None:
-            try:
-                (
-                    location_results,
-                    latest_results,
-                    sensors,
-                ) = await self._async_run_openaq_job(
-                    _fetch_initial_location_data, self.client, self.location_id
-                )
-            except Exception as err:  # noqa: BLE001
-                self._raise_update_failed(err)
+            async with self._client_lock:
+                try:
+                    (
+                        location_results,
+                        latest_results,
+                        sensors,
+                    ) = await self.hass.async_add_executor_job(
+                        _fetch_initial_location_data, self.client, self.location_id
+                    )
+                except OPENAQ_FETCH_EXCEPTIONS as err:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="unable_to_fetch",
+                    ) from err
             if not location_results:
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
@@ -207,30 +183,24 @@ class OpenAQDataUpdateCoordinator(DataUpdateCoordinator[OpenAQLocationData]):
         else:
             location = self._location
             sensors = self._sensors
-            try:
-                latest_results = (
-                    await self._async_run_openaq_job(
-                        self.client.locations.latest, self.location_id
-                    )
-                ).results
-            except Exception as err:  # noqa: BLE001
-                self._raise_update_failed(err)
+            async with self._client_lock:
+                try:
+                    latest_results = (
+                        await self.hass.async_add_executor_job(
+                            self.client.locations.latest, self.location_id
+                        )
+                    ).results
+                except OPENAQ_FETCH_EXCEPTIONS as err:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="unable_to_fetch",
+                    ) from err
 
-        measurements = normalize_latest_measurements(latest_results, sensors)
+        by_id, sensor_metadata = _build_sensor_metadata(sensors)
+        measurements = normalize_latest_measurements(latest_results, by_id)
         return OpenAQLocationData(
             location_id=self.location_id,
             name=location.name,
-            sensor_metadata=normalize_sensor_metadata(sensors),
+            sensor_metadata=sensor_metadata,
             measurements=measurements,
         )
-
-
-def _fetch_initial_location_data(
-    client: OpenAQ, location_id: int
-) -> tuple[Sequence[Location], Sequence[Latest], Sequence[Sensor]]:
-    """Fetch all SDK data required for an initial location refresh."""
-    return (
-        client.locations.get(location_id).results,
-        client.locations.latest(location_id).results,
-        client.locations.sensors(location_id).results,
-    )

--- a/homeassistant/components/openaq/icons.json
+++ b/homeassistant/components/openaq/icons.json
@@ -1,0 +1,12 @@
+{
+  "entity": {
+    "sensor": {
+      "bc": {
+        "default": "mdi:molecule"
+      },
+      "nox": {
+        "default": "mdi:molecule"
+      }
+    }
+  }
+}

--- a/homeassistant/components/openaq/manifest.json
+++ b/homeassistant/components/openaq/manifest.json
@@ -3,7 +3,6 @@
   "name": "OpenAQ",
   "codeowners": ["@jeeftor"],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/openaq",
   "integration_type": "service",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/openaq/manifest.json
+++ b/homeassistant/components/openaq/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "openaq",
+  "name": "OpenAQ",
+  "codeowners": ["@jeeftor"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://www.home-assistant.io/integrations/openaq",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "quality_scale": "no_score",
+  "requirements": ["openaq==0.7.0"]
+}

--- a/homeassistant/components/openaq/manifest.json
+++ b/homeassistant/components/openaq/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/openaq",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "quality_scale": "no_score",
+  "quality_scale": "bronze",
   "requirements": ["openaq==0.7.0"]
 }

--- a/homeassistant/components/openaq/manifest.json
+++ b/homeassistant/components/openaq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["openaq==1.0.0rc4"]
+  "requirements": ["openaq==1.0.3"]
 }

--- a/homeassistant/components/openaq/manifest.json
+++ b/homeassistant/components/openaq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["openaq==0.7.0"]
+  "requirements": ["openaq==1.0.0rc4"]
 }

--- a/homeassistant/components/openaq/manifest.json
+++ b/homeassistant/components/openaq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["openaq==1.0.3"]
+  "requirements": ["openaq==1.1.0"]
 }

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -16,15 +16,9 @@ rules:
   docs-actions:
     status: exempt
     comment: Integration registers no actions.
-  docs-high-level-description:
-    status: todo
-    comment: Pending the separate OpenAQ documentation PR.
-  docs-installation-instructions:
-    status: todo
-    comment: Pending the separate OpenAQ documentation PR.
-  docs-removal-instructions:
-    status: todo
-    comment: Pending the separate OpenAQ documentation PR.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
   entity-event-setup:
     status: exempt
     comment: Integration does not subscribe to entity events.
@@ -40,8 +34,8 @@ rules:
     status: exempt
     comment: Integration registers no actions.
   config-entry-unloading: done
-  docs-configuration-parameters: todo
-  docs-installation-parameters: todo
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: todo
@@ -58,12 +52,12 @@ rules:
   discovery:
     status: exempt
     comment: Integration requires an API key and selected monitoring locations.
-  docs-data-update: todo
+  docs-data-update: done
   docs-examples: todo
-  docs-known-limitations: todo
-  docs-supported-devices: todo
-  docs-supported-functions: todo
-  docs-troubleshooting: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
   docs-use-cases: todo
   dynamic-devices: todo
   entity-category: todo

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -6,9 +6,7 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage:
-    status: todo
-    comment: Subentry API error branches still need full config flow test coverage.
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -4,9 +4,7 @@ rules:
     status: exempt
     comment: Integration registers no actions.
   appropriate-polling: done
-  brands:
-    status: todo
-    comment: Pending the separate OpenAQ brands PR.
+  brands: done
   common-modules: done
   config-flow-test-coverage:
     status: todo

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -1,0 +1,82 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration registers no actions.
+  appropriate-polling: done
+  brands:
+    status: todo
+    comment: Pending the separate OpenAQ brands PR.
+  common-modules: done
+  config-flow-test-coverage:
+    status: todo
+    comment: Subentry API error branches still need full config flow test coverage.
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration registers no actions.
+  docs-high-level-description:
+    status: todo
+    comment: Pending the separate OpenAQ documentation PR.
+  docs-installation-instructions:
+    status: todo
+    comment: Pending the separate OpenAQ documentation PR.
+  docs-removal-instructions:
+    status: todo
+    comment: Pending the separate OpenAQ documentation PR.
+  entity-event-setup:
+    status: exempt
+    comment: Integration does not subscribe to entity events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: Integration registers no actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: Integration does not use discovery.
+  discovery:
+    status: exempt
+    comment: Integration requires an API key and selected monitoring locations.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: done
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -47,7 +47,7 @@ rules:
     comment: Integration does not use discovery.
   discovery:
     status: exempt
-    comment: Integration requires an API key and selected monitoring locations.
+    comment: OpenAQ is a cloud data service; monitoring locations are selected from the API and are not discoverable via Home Assistant discovery protocols.
   docs-data-update: done
   docs-examples: todo
   docs-known-limitations: done

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -12,9 +12,15 @@ rules:
   docs-actions:
     status: exempt
     comment: Integration registers no actions.
+  docs-conditions:
+    status: exempt
+    comment: Integration provides no conditions.
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: Integration provides no triggers.
   entity-event-setup:
     status: exempt
     comment: Integration does not subscribe to entity events.

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -12,15 +12,9 @@ rules:
   docs-actions:
     status: exempt
     comment: Integration registers no actions.
-  docs-conditions:
-    status: exempt
-    comment: Integration provides no conditions.
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
-  docs-triggers:
-    status: exempt
-    comment: Integration provides no triggers.
   entity-event-setup:
     status: exempt
     comment: Integration does not subscribe to entity events.

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -67,6 +67,6 @@ rules:
   stale-devices: todo
 
   # Platinum
-  async-dependency: done
+  async-dependency: todo
   inject-websession: todo
   strict-typing: todo

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
   integration-owner: done
   log-when-unavailable: todo
   parallel-updates: todo
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -12,9 +12,11 @@ rules:
   docs-actions:
     status: exempt
     comment: Integration registers no actions.
+  docs-conditions: done
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
+  docs-triggers: done
   entity-event-setup:
     status: exempt
     comment: Integration does not subscribe to entity events.

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -36,8 +36,8 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
-  parallel-updates: todo
+  log-when-unavailable: done
+  parallel-updates: done
   reauthentication-flow: todo
   test-coverage: todo
 
@@ -71,4 +71,4 @@ rules:
   # Platinum
   async-dependency: todo
   inject-websession: todo
-  strict-typing: todo
+  strict-typing: done

--- a/homeassistant/components/openaq/quality_scale.yaml
+++ b/homeassistant/components/openaq/quality_scale.yaml
@@ -38,7 +38,7 @@ rules:
   integration-owner: done
   log-when-unavailable: todo
   parallel-updates: todo
-  reauthentication-flow: done
+  reauthentication-flow: todo
   test-coverage: todo
 
   # Gold

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -1,0 +1,178 @@
+"""Support for OpenAQ sensors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_PARTS_PER_BILLION,
+    CONCENTRATION_PARTS_PER_MILLION,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTRIBUTION, DOMAIN
+from .coordinator import (
+    OpenAQConfigEntry,
+    OpenAQDataUpdateCoordinator,
+    OpenAQLocationData,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+UNIT_MAP = {
+    "µg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "µg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "ug/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "μg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "mg/m³": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    "mg/m3": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    "ppm": CONCENTRATION_PARTS_PER_MILLION,
+    "ppb": CONCENTRATION_PARTS_PER_BILLION,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpenAQSensorEntityDescription(SensorEntityDescription):
+    """Description for an OpenAQ sensor entity."""
+
+
+SENSOR_DESCRIPTIONS: dict[str, OpenAQSensorEntityDescription] = {
+    "pm1": OpenAQSensorEntityDescription(
+        key="pm1",
+        translation_key="pm1",
+        device_class=SensorDeviceClass.PM1,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "pm25": OpenAQSensorEntityDescription(
+        key="pm25",
+        translation_key="pm25",
+        device_class=SensorDeviceClass.PM25,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "pm10": OpenAQSensorEntityDescription(
+        key="pm10",
+        translation_key="pm10",
+        device_class=SensorDeviceClass.PM10,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "co": OpenAQSensorEntityDescription(
+        key="co",
+        translation_key="co",
+        device_class=SensorDeviceClass.CO,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "co2": OpenAQSensorEntityDescription(
+        key="co2",
+        translation_key="co2",
+        device_class=SensorDeviceClass.CO2,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "no2": OpenAQSensorEntityDescription(
+        key="no2",
+        translation_key="no2",
+        device_class=SensorDeviceClass.NITROGEN_DIOXIDE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "o3": OpenAQSensorEntityDescription(
+        key="o3",
+        translation_key="o3",
+        device_class=SensorDeviceClass.OZONE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "so2": OpenAQSensorEntityDescription(
+        key="so2",
+        translation_key="so2",
+        device_class=SensorDeviceClass.SULPHUR_DIOXIDE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "no": OpenAQSensorEntityDescription(
+        key="no",
+        translation_key="no",
+        device_class=SensorDeviceClass.NITROGEN_MONOXIDE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "nox": OpenAQSensorEntityDescription(
+        key="nox",
+        translation_key="nox",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "bc": OpenAQSensorEntityDescription(
+        key="bc",
+        translation_key="bc",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: OpenAQConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up OpenAQ sensors."""
+    for subentry_id, coordinator in entry.runtime_data.coordinators.items():
+        async_add_entities(
+            (
+                OpenAQSensor(coordinator, SENSOR_DESCRIPTIONS[parameter])
+                for parameter in coordinator.data.measurements
+                if parameter in SENSOR_DESCRIPTIONS
+            ),
+            config_subentry_id=subentry_id,
+        )
+        for parameter in coordinator.data.measurements:
+            if parameter not in SENSOR_DESCRIPTIONS:
+                _LOGGER.debug("Ignoring unsupported OpenAQ parameter: %s", parameter)
+
+
+class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity):
+    """Representation of an OpenAQ sensor."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    entity_description: OpenAQSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: OpenAQDataUpdateCoordinator,
+        entity_description: OpenAQSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{coordinator.location_id}_{entity_description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, str(coordinator.location_id))},
+            name=coordinator.data.name,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the sensor value."""
+        return self.coordinator.data.measurements[self.entity_description.key].value
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the native unit of measurement."""
+        unit = self.coordinator.data.measurements[self.entity_description.key].unit
+        if unit is None:
+            return None
+        return UNIT_MAP.get(unit, unit)
+
+
+__all__ = ["SENSOR_DESCRIPTIONS", "OpenAQLocationData", "OpenAQSensor"]

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -11,11 +11,13 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.const import EntityCategory, UnitOfLength
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import ATTRIBUTION, DOMAIN
 from .coordinator import (
@@ -25,6 +27,8 @@ from .coordinator import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+DISTANCE_FROM_HOME = "distance_from_home"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -38,66 +42,89 @@ SENSOR_DESCRIPTIONS: dict[str, OpenAQSensorEntityDescription] = {
         translation_key="pm1",
         device_class=SensorDeviceClass.PM1,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "pm25": OpenAQSensorEntityDescription(
         key="pm25",
         translation_key="pm25",
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "pm10": OpenAQSensorEntityDescription(
         key="pm10",
         translation_key="pm10",
         device_class=SensorDeviceClass.PM10,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "co": OpenAQSensorEntityDescription(
         key="co",
         translation_key="co",
         device_class=SensorDeviceClass.CO,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
     ),
     "co2": OpenAQSensorEntityDescription(
         key="co2",
         translation_key="co2",
         device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "no2": OpenAQSensorEntityDescription(
         key="no2",
         translation_key="no2",
         device_class=SensorDeviceClass.NITROGEN_DIOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "o3": OpenAQSensorEntityDescription(
         key="o3",
         translation_key="o3",
         device_class=SensorDeviceClass.OZONE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "so2": OpenAQSensorEntityDescription(
         key="so2",
         translation_key="so2",
         device_class=SensorDeviceClass.SULPHUR_DIOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "no": OpenAQSensorEntityDescription(
         key="no",
         translation_key="no",
         device_class=SensorDeviceClass.NITROGEN_MONOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "nox": OpenAQSensorEntityDescription(
         key="nox",
         translation_key="nox",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     "bc": OpenAQSensorEntityDescription(
         key="bc",
         translation_key="bc",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
 }
+
+DISTANCE_SENSOR_DESCRIPTION = OpenAQSensorEntityDescription(
+    key=DISTANCE_FROM_HOME,
+    translation_key=DISTANCE_FROM_HOME,
+    name="Distance from Home Assistant",
+    device_class=SensorDeviceClass.DISTANCE,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    entity_registry_enabled_default=False,
+    native_unit_of_measurement=UnitOfLength.KILOMETERS,
+    state_class=SensorStateClass.MEASUREMENT,
+    suggested_display_precision=1,
+)
 
 
 async def async_setup_entry(
@@ -108,11 +135,12 @@ async def async_setup_entry(
     """Set up OpenAQ sensors."""
     for subentry_id, coordinator in entry.runtime_data.coordinators.items():
         async_add_entities(
-            (
+            [
                 OpenAQSensor(coordinator, SENSOR_DESCRIPTIONS[parameter])
                 for parameter in coordinator.data.measurements
                 if parameter in SENSOR_DESCRIPTIONS
-            ),
+            ]
+            + [OpenAQSensor(coordinator, DISTANCE_SENSOR_DESCRIPTION)],
             config_subentry_id=subentry_id,
         )
         for parameter in coordinator.data.measurements:
@@ -145,6 +173,16 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
     @property
     def native_value(self) -> StateType:
         """Return the sensor value."""
+        if self.entity_description.key == DISTANCE_FROM_HOME:
+            distance_to_home = self.coordinator.data.distance_to_home
+            if distance_to_home is None:
+                return None
+            return DistanceConverter.convert(
+                distance_to_home,
+                UnitOfLength.METERS,
+                self.hass.config.units.length_unit,
+            )
+
         measurement = self.coordinator.data.measurements.get(
             self.entity_description.key
         )
@@ -153,6 +191,9 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
+        if self.entity_description.key == DISTANCE_FROM_HOME:
+            return self.hass.config.units.length_unit
+
         measurement = self.coordinator.data.measurements.get(
             self.entity_description.key
         )

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import logging
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -25,8 +24,6 @@ from .coordinator import (
     OpenAQDataUpdateCoordinator,
     OpenAQLocationData,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 DISTANCE_FROM_HOME = "distance_from_home"
 
@@ -143,9 +140,6 @@ async def async_setup_entry(
             + [OpenAQSensor(coordinator, DISTANCE_SENSOR_DESCRIPTION)],
             config_subentry_id=subentry_id,
         )
-        for parameter in coordinator.data.measurements:
-            if parameter not in SENSOR_DESCRIPTIONS:
-                _LOGGER.debug("Ignoring unsupported OpenAQ parameter: %s", parameter)
 
 
 class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity):

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -164,12 +164,20 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
     @property
     def native_value(self) -> StateType:
         """Return the sensor value."""
-        return self.coordinator.data.measurements[self.entity_description.key].value
+        measurement = self.coordinator.data.measurements.get(
+            self.entity_description.key
+        )
+        return measurement.value if measurement is not None else None
 
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
-        unit = self.coordinator.data.measurements[self.entity_description.key].unit
+        measurement = self.coordinator.data.measurements.get(
+            self.entity_description.key
+        )
+        if measurement is None:
+            return None
+        unit = measurement.unit
         if unit is None:
             return None
         return UNIT_MAP.get(unit, unit)

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -1,7 +1,5 @@
 """Support for OpenAQ sensors."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -14,14 +14,9 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import ATTRIBUTION, DOMAIN
-from .coordinator import (
-    OpenAQConfigEntry,
-    OpenAQDataUpdateCoordinator,
-    OpenAQLocationData,
-)
+from .coordinator import OpenAQConfigEntry, OpenAQDataUpdateCoordinator
 
 DISTANCE_FROM_HOME = "distance_from_home"
 
@@ -34,63 +29,54 @@ class OpenAQSensorEntityDescription(SensorEntityDescription):
 SENSOR_DESCRIPTIONS: dict[str, OpenAQSensorEntityDescription] = {
     "pm1": OpenAQSensorEntityDescription(
         key="pm1",
-        translation_key="pm1",
         device_class=SensorDeviceClass.PM1,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "pm25": OpenAQSensorEntityDescription(
         key="pm25",
-        translation_key="pm25",
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "pm10": OpenAQSensorEntityDescription(
         key="pm10",
-        translation_key="pm10",
         device_class=SensorDeviceClass.PM10,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "co": OpenAQSensorEntityDescription(
         key="co",
-        translation_key="co",
         device_class=SensorDeviceClass.CO,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
     "co2": OpenAQSensorEntityDescription(
         key="co2",
-        translation_key="co2",
         device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "no2": OpenAQSensorEntityDescription(
         key="no2",
-        translation_key="no2",
         device_class=SensorDeviceClass.NITROGEN_DIOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "o3": OpenAQSensorEntityDescription(
         key="o3",
-        translation_key="o3",
         device_class=SensorDeviceClass.OZONE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "so2": OpenAQSensorEntityDescription(
         key="so2",
-        translation_key="so2",
         device_class=SensorDeviceClass.SULPHUR_DIOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "no": OpenAQSensorEntityDescription(
         key="no",
-        translation_key="no",
         device_class=SensorDeviceClass.NITROGEN_MONOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
@@ -109,18 +95,6 @@ SENSOR_DESCRIPTIONS: dict[str, OpenAQSensorEntityDescription] = {
     ),
 }
 
-DISTANCE_SENSOR_DESCRIPTION = OpenAQSensorEntityDescription(
-    key=DISTANCE_FROM_HOME,
-    translation_key=DISTANCE_FROM_HOME,
-    name="Distance from Home Assistant",
-    device_class=SensorDeviceClass.DISTANCE,
-    entity_category=EntityCategory.DIAGNOSTIC,
-    entity_registry_enabled_default=False,
-    native_unit_of_measurement=UnitOfLength.KILOMETERS,
-    state_class=SensorStateClass.MEASUREMENT,
-    suggested_display_precision=1,
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -135,9 +109,18 @@ async def async_setup_entry(
                 for parameter in coordinator.data.measurements
                 if parameter in SENSOR_DESCRIPTIONS
             ]
-            + [OpenAQSensor(coordinator, DISTANCE_SENSOR_DESCRIPTION)],
+            + [OpenAQDistanceSensor(coordinator)],
             config_subentry_id=subentry_id,
         )
+
+
+def _device_info(coordinator: OpenAQDataUpdateCoordinator) -> DeviceInfo:
+    """Return device info for an OpenAQ location."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, str(coordinator.location_id))},
+        name=coordinator.data.name,
+        entry_type=DeviceEntryType.SERVICE,
+    )
 
 
 class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity):
@@ -156,25 +139,11 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._attr_unique_id = f"{coordinator.location_id}_{entity_description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, str(coordinator.location_id))},
-            name=coordinator.data.name,
-            entry_type=DeviceEntryType.SERVICE,
-        )
+        self._attr_device_info = _device_info(coordinator)
 
     @property
     def native_value(self) -> StateType:
         """Return the sensor value."""
-        if self.entity_description.key == DISTANCE_FROM_HOME:
-            distance_to_home = self.coordinator.data.distance_to_home
-            if distance_to_home is None:
-                return None
-            return DistanceConverter.convert(
-                distance_to_home,
-                UnitOfLength.METERS,
-                self.hass.config.units.length_unit,
-            )
-
         measurement = self.coordinator.data.measurements.get(
             self.entity_description.key
         )
@@ -183,9 +152,6 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
-        if self.entity_description.key == DISTANCE_FROM_HOME:
-            return self.hass.config.units.length_unit
-
         measurement = self.coordinator.data.measurements.get(
             self.entity_description.key
         )
@@ -194,4 +160,25 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         return measurement.unit
 
 
-__all__ = ["SENSOR_DESCRIPTIONS", "OpenAQLocationData", "OpenAQSensor"]
+class OpenAQDistanceSensor(SensorEntity):
+    """Representation of a static OpenAQ distance sensor."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_has_entity_name = True
+    _attr_name = "Distance from Home Assistant"
+    _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
+    _attr_should_poll = False
+    _attr_suggested_display_precision = 1
+    _attr_translation_key = DISTANCE_FROM_HOME
+
+    def __init__(self, coordinator: OpenAQDataUpdateCoordinator) -> None:
+        """Initialize the sensor."""
+        self._attr_unique_id = f"{coordinator.location_id}_{DISTANCE_FROM_HOME}"
+        self._attr_device_info = _device_info(coordinator)
+        distance_to_home = coordinator.data.distance_to_home
+        self._attr_native_value = (
+            None if distance_to_home is None else distance_to_home / 1000
+        )

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -11,12 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_BILLION,
-    CONCENTRATION_PARTS_PER_MILLION,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -31,19 +25,6 @@ from .coordinator import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-UNIT_MAP = {
-    "µg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "µg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "ug/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m³": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "μg/m3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "mg/m³": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    "mg/m3": CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    "ppm": CONCENTRATION_PARTS_PER_MILLION,
-    "ppb": CONCENTRATION_PARTS_PER_BILLION,
-}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -177,10 +158,7 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         )
         if measurement is None:
             return None
-        unit = measurement.unit
-        if unit is None:
-            return None
-        return UNIT_MAP.get(unit, unit)
+        return measurement.unit
 
 
 __all__ = ["SENSOR_DESCRIPTIONS", "OpenAQLocationData", "OpenAQSensor"]

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -1,7 +1,5 @@
 """Support for OpenAQ sensors."""
 
-from dataclasses import dataclass
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -21,73 +19,68 @@ from .coordinator import OpenAQConfigEntry, OpenAQDataUpdateCoordinator
 DISTANCE_FROM_HOME = "distance_from_home"
 
 
-@dataclass(frozen=True, kw_only=True)
-class OpenAQSensorEntityDescription(SensorEntityDescription):
-    """Description for an OpenAQ sensor entity."""
-
-
-SENSOR_DESCRIPTIONS: dict[str, OpenAQSensorEntityDescription] = {
-    "pm1": OpenAQSensorEntityDescription(
+SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
+    "pm1": SensorEntityDescription(
         key="pm1",
         device_class=SensorDeviceClass.PM1,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "pm25": OpenAQSensorEntityDescription(
+    "pm25": SensorEntityDescription(
         key="pm25",
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "pm10": OpenAQSensorEntityDescription(
+    "pm10": SensorEntityDescription(
         key="pm10",
         device_class=SensorDeviceClass.PM10,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "co": OpenAQSensorEntityDescription(
+    "co": SensorEntityDescription(
         key="co",
         device_class=SensorDeviceClass.CO,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
-    "co2": OpenAQSensorEntityDescription(
+    "co2": SensorEntityDescription(
         key="co2",
         device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "no2": OpenAQSensorEntityDescription(
+    "no2": SensorEntityDescription(
         key="no2",
         device_class=SensorDeviceClass.NITROGEN_DIOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "o3": OpenAQSensorEntityDescription(
+    "o3": SensorEntityDescription(
         key="o3",
         device_class=SensorDeviceClass.OZONE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "so2": OpenAQSensorEntityDescription(
+    "so2": SensorEntityDescription(
         key="so2",
         device_class=SensorDeviceClass.SULPHUR_DIOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "no": OpenAQSensorEntityDescription(
+    "no": SensorEntityDescription(
         key="no",
         device_class=SensorDeviceClass.NITROGEN_MONOXIDE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "nox": OpenAQSensorEntityDescription(
+    "nox": SensorEntityDescription(
         key="nox",
         translation_key="nox",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
-    "bc": OpenAQSensorEntityDescription(
+    "bc": SensorEntityDescription(
         key="bc",
         translation_key="bc",
         state_class=SensorStateClass.MEASUREMENT,
@@ -128,12 +121,12 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
 
     _attr_attribution = ATTRIBUTION
     _attr_has_entity_name = True
-    entity_description: OpenAQSensorEntityDescription
+    entity_description: SensorEntityDescription
 
     def __init__(
         self,
         coordinator: OpenAQDataUpdateCoordinator,
-        entity_description: OpenAQSensorEntityDescription,
+        entity_description: SensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -158,15 +158,16 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         return measurement.unit
 
 
-class OpenAQDistanceSensor(SensorEntity):
-    """Representation of a static OpenAQ distance sensor."""
+class OpenAQDistanceSensor(
+    CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity
+):
+    """Representation of an OpenAQ distance sensor."""
 
     _attr_attribution = ATTRIBUTION
     _attr_device_class = SensorDeviceClass.DISTANCE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
     _attr_has_entity_name = True
-    _attr_name = "Distance from Home Assistant"
     _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
     _attr_should_poll = False
     _attr_suggested_display_precision = 1
@@ -174,9 +175,12 @@ class OpenAQDistanceSensor(SensorEntity):
 
     def __init__(self, coordinator: OpenAQDataUpdateCoordinator) -> None:
         """Initialize the sensor."""
+        super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.location_id}_{DISTANCE_FROM_HOME}"
         self._attr_device_info = _device_info(coordinator)
-        distance_to_home = coordinator.data.distance_to_home
-        self._attr_native_value = (
-            None if distance_to_home is None else distance_to_home / 1000
-        )
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the distance to Home Assistant."""
+        distance_to_home = self.coordinator.data.distance_to_home
+        return None if distance_to_home is None else distance_to_home / 1000

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -1,5 +1,7 @@
 """Support for OpenAQ sensors."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -130,6 +132,7 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         self._attr_device_info = _device_info(coordinator)
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the sensor value."""
         measurement = self.coordinator.data.measurements.get(
@@ -138,6 +141,7 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         return measurement.value if measurement is not None else None
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
         metadata = self.coordinator.data.sensor_metadata.get(

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -6,7 +6,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import EntityCategory, UnitOfLength
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -15,9 +14,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, DOMAIN
 from .coordinator import OpenAQConfigEntry, OpenAQDataUpdateCoordinator
-
-DISTANCE_FROM_HOME = "distance_from_home"
-
 
 SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     "pm1": SensorEntityDescription(
@@ -99,10 +95,9 @@ async def async_setup_entry(
         async_add_entities(
             [
                 OpenAQSensor(coordinator, SENSOR_DESCRIPTIONS[parameter])
-                for parameter in coordinator.data.measurements
+                for parameter in coordinator.data.sensor_metadata
                 if parameter in SENSOR_DESCRIPTIONS
-            ]
-            + [OpenAQDistanceSensor(coordinator)],
+            ],
             config_subentry_id=subentry_id,
         )
 
@@ -145,36 +140,9 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
-        measurement = self.coordinator.data.measurements.get(
+        metadata = self.coordinator.data.sensor_metadata.get(
             self.entity_description.key
         )
-        if measurement is None:
+        if metadata is None:
             return None
-        return measurement.unit
-
-
-class OpenAQDistanceSensor(
-    CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity
-):
-    """Representation of an OpenAQ distance sensor."""
-
-    _attr_attribution = ATTRIBUTION
-    _attr_device_class = SensorDeviceClass.DISTANCE
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_entity_registry_enabled_default = False
-    _attr_has_entity_name = True
-    _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
-    _attr_suggested_display_precision = 1
-    _attr_translation_key = DISTANCE_FROM_HOME
-
-    def __init__(self, coordinator: OpenAQDataUpdateCoordinator) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.location_id}_{DISTANCE_FROM_HOME}"
-        self._attr_device_info = _device_info(coordinator)
-
-    @property
-    def native_value(self) -> StateType:
-        """Return the distance to Home Assistant."""
-        distance_to_home = self.coordinator.data.distance_to_home
-        return None if distance_to_home is None else distance_to_home / 1000
+        return metadata.unit

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -83,11 +83,13 @@ SENSOR_DESCRIPTIONS: dict[str, OpenAQSensorEntityDescription] = {
     ),
     "nox": OpenAQSensorEntityDescription(
         key="nox",
+        translation_key="nox",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "bc": OpenAQSensorEntityDescription(
         key="bc",
+        translation_key="bc",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -164,7 +164,6 @@ class OpenAQDistanceSensor(
     _attr_entity_registry_enabled_default = False
     _attr_has_entity_name = True
     _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
-    _attr_should_poll = False
     _attr_suggested_display_precision = 1
     _attr_translation_key = DISTANCE_FROM_HOME
 

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -83,13 +83,11 @@ SENSOR_DESCRIPTIONS: dict[str, OpenAQSensorEntityDescription] = {
     ),
     "nox": OpenAQSensorEntityDescription(
         key="nox",
-        translation_key="nox",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     "bc": OpenAQSensorEntityDescription(
         key="bc",
-        translation_key="bc",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -144,9 +144,4 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
     @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
-        metadata = self.coordinator.data.sensor_metadata.get(
-            self.entity_description.key
-        )
-        if metadata is None:
-            return None
-        return metadata.unit
+        return self.coordinator.data.sensor_metadata[self.entity_description.key].unit

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -104,21 +104,11 @@ async def async_setup_entry(
         )
 
 
-def _device_info(coordinator: OpenAQDataUpdateCoordinator) -> DeviceInfo:
-    """Return device info for an OpenAQ location."""
-    return DeviceInfo(
-        identifiers={(DOMAIN, str(coordinator.location_id))},
-        name=coordinator.data.name,
-        entry_type=DeviceEntryType.SERVICE,
-    )
-
-
 class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity):
     """Representation of an OpenAQ sensor."""
 
     _attr_attribution = ATTRIBUTION
     _attr_has_entity_name = True
-    entity_description: SensorEntityDescription
 
     def __init__(
         self,
@@ -129,19 +119,20 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._attr_unique_id = f"{coordinator.location_id}_{entity_description.key}"
-        self._attr_device_info = _device_info(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, str(coordinator.location_id))},
+            name=coordinator.data.name,
+            entry_type=DeviceEntryType.SERVICE,
+        )
 
     @property
     @override
     def native_value(self) -> StateType:
         """Return the sensor value."""
-        measurement = self.coordinator.data.measurements.get(
-            self.entity_description.key
-        )
-        return measurement.value if measurement is not None else None
+        return self.coordinator.data.measurements.get(self.entity_description.key)
 
     @property
     @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
-        return self.coordinator.data.sensor_metadata[self.entity_description.key].unit
+        return self.coordinator.data.sensor_metadata[self.entity_description.key]

--- a/homeassistant/components/openaq/sensor.py
+++ b/homeassistant/components/openaq/sensor.py
@@ -17,6 +17,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import ATTRIBUTION, DOMAIN
 from .coordinator import OpenAQConfigEntry, OpenAQDataUpdateCoordinator
 
+PARALLEL_UPDATES = 0
+
 SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     "pm1": SensorEntityDescription(
         key="pm1",
@@ -119,6 +121,9 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._attr_unique_id = f"{coordinator.location_id}_{entity_description.key}"
+        self._attr_native_unit_of_measurement = coordinator.data.sensor_metadata[
+            entity_description.key
+        ]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(coordinator.location_id))},
             name=coordinator.data.name,
@@ -130,9 +135,3 @@ class OpenAQSensor(CoordinatorEntity[OpenAQDataUpdateCoordinator], SensorEntity)
     def native_value(self) -> StateType:
         """Return the sensor value."""
         return self.coordinator.data.measurements.get(self.entity_description.key)
-
-    @property
-    @override
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the native unit of measurement."""
-        return self.coordinator.data.sensor_metadata[self.entity_description.key]

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -1,18 +1,18 @@
 {
   "config": {
     "abort": {
-      "already_configured": "This service is already configured"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "rate_limited": "OpenAQ rate limit exceeded. Try again later.",
-      "unknown": "Unexpected error"
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "user": {
         "data": {
-          "api_key": "API key"
+          "api_key": "[%key:common::config_flow::data::api_key%]"
         },
         "data_description": {
           "api_key": "API key for OpenAQ"
@@ -23,33 +23,29 @@
   "config_subentries": {
     "location": {
       "abort": {
-        "already_configured": "This monitoring location is already configured"
+        "already_configured": "[%key:common::config_flow::abort::already_configured_location%]"
       },
       "entry_type": "Monitoring location",
       "error": {
-        "cannot_connect": "Failed to connect",
-        "invalid_auth": "Invalid authentication",
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
         "no_locations_found": "No OpenAQ monitoring locations were found nearby.",
-        "rate_limited": "OpenAQ rate limit exceeded. Try again later.",
-        "unknown": "Unexpected error"
+        "rate_limited": "[%key:component::openaq::config::error::rate_limited%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "initiate_flow": {
         "user": "Add monitoring location"
       },
       "step": {
-        "map": {
-          "data": {
-            "limit": "Maximum locations",
-            "location": "Location",
-            "radius": "Search radius"
-          },
-          "data_description": {
-            "radius": "Search radius in meters, up to 25000"
-          }
-        },
         "select": {
           "data": {
-            "location_id": "Monitoring location"
+            "location_id": "[%key:component::openaq::config_subentries::location::entry_type%]"
+          }
+        },
+        "user": {
+          "data": {
+            "limit": "Maximum locations",
+            "location": "[%key:common::config_flow::data::location%]"
           }
         }
       }
@@ -60,38 +56,11 @@
       "bc": {
         "name": "Black carbon"
       },
-      "co": {
-        "name": "Carbon monoxide"
-      },
-      "co2": {
-        "name": "Carbon dioxide"
-      },
       "distance_from_home": {
         "name": "Distance from Home Assistant"
       },
-      "no": {
-        "name": "Nitrogen monoxide"
-      },
-      "no2": {
-        "name": "Nitrogen dioxide"
-      },
       "nox": {
         "name": "Nitrogen oxides"
-      },
-      "o3": {
-        "name": "Ozone"
-      },
-      "pm1": {
-        "name": "PM1"
-      },
-      "pm10": {
-        "name": "PM10"
-      },
-      "pm25": {
-        "name": "PM2.5"
-      },
-      "so2": {
-        "name": "Sulphur dioxide"
       }
     }
   },

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -1,0 +1,115 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "This service is already configured"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "rate_limited": "OpenAQ rate limit exceeded. Try again later.",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "api_key": "API key"
+        },
+        "data_description": {
+          "api_key": "API key for OpenAQ"
+        }
+      }
+    }
+  },
+  "config_subentries": {
+    "location": {
+      "abort": {
+        "already_configured": "This service is already configured"
+      },
+      "entry_type": "Monitoring location",
+      "error": {
+        "cannot_connect": "Failed to connect",
+        "no_locations_found": "No OpenAQ monitoring locations were found nearby.",
+        "rate_limited": "OpenAQ rate limit exceeded. Try again later.",
+        "unknown": "Unexpected error"
+      },
+      "initiate_flow": {
+        "user": "Add monitoring location"
+      },
+      "step": {
+        "location_id": {
+          "data": {
+            "location_id": "Location ID"
+          },
+          "data_description": {
+            "location_id": "The OpenAQ location ID"
+          }
+        },
+        "map": {
+          "data": {
+            "limit": "Maximum locations",
+            "location": "Location",
+            "radius": "Search radius"
+          },
+          "data_description": {
+            "radius": "Search radius in meters, up to 25000"
+          }
+        },
+        "select": {
+          "data": {
+            "location_id": "Monitoring location"
+          }
+        },
+        "user": {
+          "description": "How do you want to select an OpenAQ monitoring location?",
+          "menu_options": {
+            "location_id": "Location ID",
+            "map": "Location"
+          },
+          "title": "Add monitoring location"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "bc": {
+        "name": "Black carbon"
+      },
+      "co": {
+        "name": "Carbon monoxide"
+      },
+      "co2": {
+        "name": "Carbon dioxide"
+      },
+      "no": {
+        "name": "Nitrogen monoxide"
+      },
+      "no2": {
+        "name": "Nitrogen dioxide"
+      },
+      "nox": {
+        "name": "Nitrogen oxides"
+      },
+      "o3": {
+        "name": "Ozone"
+      },
+      "pm1": {
+        "name": "PM1"
+      },
+      "pm10": {
+        "name": "PM10"
+      },
+      "pm25": {
+        "name": "PM2.5"
+      },
+      "so2": {
+        "name": "Sulphur dioxide"
+      }
+    }
+  },
+  "exceptions": {
+    "unable_to_fetch": {
+      "message": "Unable to fetch data from OpenAQ"
+    }
+  }
+}

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -28,6 +28,7 @@
       "entry_type": "Monitoring location",
       "error": {
         "cannot_connect": "Failed to connect",
+        "invalid_auth": "Invalid authentication",
         "no_locations_found": "No OpenAQ monitoring locations were found nearby.",
         "rate_limited": "OpenAQ rate limit exceeded. Try again later.",
         "unknown": "Unexpected error"

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -23,11 +23,12 @@
   "config_subentries": {
     "location": {
       "abort": {
-        "already_configured": "This service is already configured"
+        "already_configured": "This monitoring location is already configured"
       },
       "entry_type": "Monitoring location",
       "error": {
         "cannot_connect": "Failed to connect",
+        "invalid_location": "Invalid OpenAQ location ID",
         "no_locations_found": "No OpenAQ monitoring locations were found nearby.",
         "rate_limited": "OpenAQ rate limit exceeded. Try again later.",
         "unknown": "Unexpected error"

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -28,7 +28,6 @@
       "entry_type": "Monitoring location",
       "error": {
         "cannot_connect": "Failed to connect",
-        "invalid_location": "Invalid OpenAQ location ID",
         "no_locations_found": "No OpenAQ monitoring locations were found nearby.",
         "rate_limited": "OpenAQ rate limit exceeded. Try again later.",
         "unknown": "Unexpected error"
@@ -37,14 +36,6 @@
         "user": "Add monitoring location"
       },
       "step": {
-        "location_id": {
-          "data": {
-            "location_id": "Location ID"
-          },
-          "data_description": {
-            "location_id": "The OpenAQ location ID"
-          }
-        },
         "map": {
           "data": {
             "limit": "Maximum locations",
@@ -59,14 +50,6 @@
           "data": {
             "location_id": "Monitoring location"
           }
-        },
-        "user": {
-          "description": "How do you want to select an OpenAQ monitoring location?",
-          "menu_options": {
-            "location_id": "Location ID",
-            "map": "Location"
-          },
-          "title": "Add monitoring location"
         }
       }
     }
@@ -81,6 +64,9 @@
       },
       "co2": {
         "name": "Carbon dioxide"
+      },
+      "distance_from_home": {
+        "name": "Distance from Home Assistant"
       },
       "no": {
         "name": "Nitrogen monoxide"

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -65,6 +65,9 @@
     }
   },
   "exceptions": {
+    "authentication_failed": {
+      "message": "Authentication failed while fetching OpenAQ data"
+    },
     "unable_to_fetch": {
       "message": "Unable to fetch data from OpenAQ"
     }

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -44,7 +44,6 @@
         },
         "user": {
           "data": {
-            "limit": "Maximum locations",
             "location": "[%key:common::config_flow::data::location%]"
           }
         }

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -10,6 +11,14 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "api_key": "API key for OpenAQ"
+        }
+      },
       "user": {
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]"

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -45,7 +45,8 @@
         "user": {
           "data": {
             "location": "[%key:common::config_flow::data::location%]"
-          }
+          },
+          "description": "Select a monitoring location."
         }
       }
     }

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -56,9 +56,6 @@
       "bc": {
         "name": "Black carbon"
       },
-      "distance_from_home": {
-        "name": "Distance from Home Assistant"
-      },
       "nox": {
         "name": "Nitrogen oxides"
       }

--- a/homeassistant/components/openaq/strings.json
+++ b/homeassistant/components/openaq/strings.json
@@ -1,8 +1,7 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -11,14 +10,6 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
-      "reauth_confirm": {
-        "data": {
-          "api_key": "[%key:common::config_flow::data::api_key%]"
-        },
-        "data_description": {
-          "api_key": "API key for OpenAQ"
-        }
-      },
       "user": {
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]"
@@ -71,9 +62,6 @@
     }
   },
   "exceptions": {
-    "authentication_failed": {
-      "message": "Authentication failed while fetching OpenAQ data"
-    },
     "unable_to_fetch": {
       "message": "Unable to fetch data from OpenAQ"
     }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -554,6 +554,7 @@ FLOWS = {
         "open_meteo",
         "open_router",
         "openai_conversation",
+        "openaq",
         "opendisplay",
         "openevse",
         "openexchangerates",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -570,6 +570,7 @@ FLOWS = {
         "open_meteo",
         "open_router",
         "openai_conversation",
+        "openaq",
         "opendisplay",
         "openevse",
         "openexchangerates",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5077,6 +5077,12 @@
       "config_flow": false,
       "iot_class": "cloud_push"
     },
+    "openaq": {
+      "name": "OpenAQ",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "opendisplay": {
       "name": "OpenDisplay",
       "integration_type": "device",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5232,6 +5232,12 @@
       "config_flow": false,
       "iot_class": "cloud_push"
     },
+    "openaq": {
+      "name": "OpenAQ",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "opendisplay": {
       "name": "OpenDisplay",
       "integration_type": "device",

--- a/mypy.ini
+++ b/mypy.ini
@@ -4158,6 +4158,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.openaq.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.openevse.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1781,7 +1781,7 @@ open-meteo==0.3.2
 openai==2.45.0
 
 # homeassistant.components.openaq
-openaq==1.0.3
+openaq==1.1.0
 
 # homeassistant.components.openerz
 openerz-api==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1781,7 +1781,7 @@ open-meteo==0.3.2
 openai==2.45.0
 
 # homeassistant.components.openaq
-openaq==1.0.0rc4
+openaq==1.0.3
 
 # homeassistant.components.openerz
 openerz-api==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1781,7 +1781,7 @@ open-meteo==0.3.2
 openai==2.45.0
 
 # homeassistant.components.openaq
-openaq==0.7.0
+openaq==1.0.0rc4
 
 # homeassistant.components.openerz
 openerz-api==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1780,6 +1780,9 @@ open-meteo==0.3.2
 # homeassistant.components.ovhcloud_ai_endpoints
 openai==2.45.0
 
+# homeassistant.components.openaq
+openaq==0.7.0
+
 # homeassistant.components.openerz
 openerz-api==0.3.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1826,6 +1826,9 @@ open-meteo==0.3.2
 # homeassistant.components.ovhcloud_ai_endpoints
 openai==3.10.0
 
+# homeassistant.components.openaq
+openaq==0.7.0
+
 # homeassistant.components.openerz
 openerz-api==0.3.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1827,7 +1827,7 @@ open-meteo==0.3.2
 openai==3.10.0
 
 # homeassistant.components.openaq
-openaq==1.0.3
+openaq==1.1.0
 
 # homeassistant.components.openerz
 openerz-api==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1827,7 +1827,7 @@ open-meteo==0.3.2
 openai==3.10.0
 
 # homeassistant.components.openaq
-openaq==0.7.0
+openaq==1.0.0rc4
 
 # homeassistant.components.openerz
 openerz-api==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1827,7 +1827,7 @@ open-meteo==0.3.2
 openai==3.10.0
 
 # homeassistant.components.openaq
-openaq==1.0.0rc4
+openaq==1.0.3
 
 # homeassistant.components.openerz
 openerz-api==0.3.0

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1614,7 +1614,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "oncue",
     "ondilo_ico",
     "onvif",
-    "openaq",
     "open_meteo",
     "openalpr_cloud",
     "openerz",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1614,6 +1614,7 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "oncue",
     "ondilo_ico",
     "onvif",
+    "openaq",
     "open_meteo",
     "openalpr_cloud",
     "openerz",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1597,6 +1597,7 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "oncue",
     "ondilo_ico",
     "onvif",
+    "openaq",
     "open_meteo",
     "openalpr_cloud",
     "openerz",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1597,7 +1597,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "oncue",
     "ondilo_ico",
     "onvif",
-    "openaq",
     "open_meteo",
     "openalpr_cloud",
     "openerz",

--- a/tests/components/imgw_pib/conftest.py
+++ b/tests/components/imgw_pib/conftest.py
@@ -1,7 +1,6 @@
 """Common fixtures for the IMGW-PIB tests."""
 
 from collections.abc import Generator
-import copy
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -66,7 +65,7 @@ def mock_imgw_pib_client() -> Generator[AsyncMock]:
         ),
     ):
         client = mock_client.create.return_value
-        client.get_hydrological_data.return_value = copy.deepcopy(HYDROLOGICAL_DATA)
+        client.get_hydrological_data.return_value = HYDROLOGICAL_DATA
         client.hydrological_stations = {"123": "River Name (Station Name)"}
 
         yield client

--- a/tests/components/imgw_pib/conftest.py
+++ b/tests/components/imgw_pib/conftest.py
@@ -1,6 +1,7 @@
 """Common fixtures for the IMGW-PIB tests."""
 
 from collections.abc import Generator
+import copy
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -65,7 +66,7 @@ def mock_imgw_pib_client() -> Generator[AsyncMock]:
         ),
     ):
         client = mock_client.create.return_value
-        client.get_hydrological_data.return_value = HYDROLOGICAL_DATA
+        client.get_hydrological_data.return_value = copy.deepcopy(HYDROLOGICAL_DATA)
         client.hydrological_stations = {"123": "River Name (Station Name)"}
 
         yield client

--- a/tests/components/openaq/__init__.py
+++ b/tests/components/openaq/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for the OpenAQ integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the OpenAQ integration."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -2,8 +2,24 @@
 
 from collections.abc import Generator
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
+from openaq.shared.responses import (
+    Coordinates,
+    CountryBase,
+    Datetime,
+    InstrumentBase,
+    Latest,
+    LatestBase,
+    Location,
+    OwnerBase,
+    Parameter,
+    ParameterBase,
+    ProviderBase,
+    Sensor,
+    SensorBase,
+)
 import pytest
 
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
@@ -16,6 +32,7 @@ API_KEY = "test-api-key"
 LOCATION_ID = 2178
 LOCATION_NAME = "Del Norte"
 SUBENTRY_ID = "ABCDEF"
+DATETIME = Datetime(utc="2026-05-08T00:00:00Z", local="2026-05-07T18:00:00-06:00")
 
 
 def make_response(results: list[object]) -> SimpleNamespace:
@@ -30,29 +47,56 @@ def make_location(
     coordinates: tuple[float, float] = (35.1, -106.6),
     distance: float | None = 0.0,
     sensor_parameters: tuple[str, ...] = ("pm25",),
-) -> SimpleNamespace:
+) -> Location:
     """Return an OpenAQ location."""
-    return SimpleNamespace(
+    return Location(
         id=location_id,
         name=name,
         locality=locality,
-        coordinates=SimpleNamespace(
-            latitude=coordinates[0],
-            longitude=coordinates[1],
-        ),
-        distance=distance,
+        timezone="America/Denver",
+        country=CountryBase(id=1, code="US", name="United States"),
+        owner=OwnerBase(id=1, name="OpenAQ"),
+        provider=ProviderBase(id=1, name="OpenAQ"),
+        is_mobile=False,
+        is_monitor=True,
+        instruments=[InstrumentBase(id=1, name="Monitor")],
         sensors=[
-            make_sensor(sensor_id, parameter)
+            make_sensor_base(sensor_id, parameter)
             for sensor_id, parameter in enumerate(sensor_parameters, start=1)
         ],
+        coordinates=Coordinates(latitude=coordinates[0], longitude=coordinates[1]),
+        bounds=(-106.6, 35.1, -106.6, 35.1),
+        distance=distance,
+        datetime_first=DATETIME,
+        datetime_last=DATETIME,
     )
 
 
 def make_parameter(
     name: str, units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-) -> SimpleNamespace:
+) -> Parameter:
     """Return an OpenAQ parameter."""
-    return SimpleNamespace(name=name, units=units)
+    return Parameter(id=1, name=name, units=units)
+
+
+def make_parameter_base(
+    name: str, units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+) -> ParameterBase:
+    """Return an OpenAQ base parameter."""
+    return ParameterBase(id=1, name=name, units=units, display_name=None)
+
+
+def make_sensor_base(
+    sensor_id: int,
+    parameter: str,
+    units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+) -> SensorBase:
+    """Return an OpenAQ base sensor."""
+    return SensorBase(
+        id=sensor_id,
+        name=parameter,
+        parameter=make_parameter_base(parameter, units),
+    )
 
 
 def make_sensor(
@@ -60,19 +104,34 @@ def make_sensor(
     parameter: str,
     units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     value: float | None = None,
-) -> SimpleNamespace:
+) -> Sensor:
     """Return an OpenAQ sensor."""
-    latest = None if value is None else SimpleNamespace(value=value)
-    return SimpleNamespace(
+    latest = (
+        None
+        if value is None
+        else LatestBase(
+            datetime=DATETIME,
+            value=value,
+            coordinates=Coordinates(latitude=35.1, longitude=-106.6),
+        )
+    )
+    return Sensor(
         id=sensor_id,
+        name=parameter,
         parameter=make_parameter(parameter, units),
         latest=latest,
     )
 
 
-def make_latest(sensor_id: int, value: float | None) -> SimpleNamespace:
+def make_latest(sensor_id: int, value: float | None) -> Latest:
     """Return an OpenAQ latest measurement."""
-    return SimpleNamespace(sensors_id=sensor_id, value=value)
+    return Latest(
+        datetime=DATETIME,
+        value=cast(float, value),
+        coordinates=Coordinates(latitude=35.1, longitude=-106.6),
+        sensors_id=sensor_id,
+        locations_id=LOCATION_ID,
+    )
 
 
 @pytest.fixture

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -24,10 +24,28 @@ def make_response(results: list[object]) -> SimpleNamespace:
 
 
 def make_location(
-    location_id: int = LOCATION_ID, name: str = LOCATION_NAME
+    location_id: int = LOCATION_ID,
+    name: str = LOCATION_NAME,
+    locality: str | None = "Albuquerque",
+    coordinates: tuple[float, float] = (35.1, -106.6),
+    distance: float | None = 0.0,
+    sensor_parameters: tuple[str, ...] = ("pm25",),
 ) -> SimpleNamespace:
     """Return an OpenAQ location."""
-    return SimpleNamespace(id=location_id, name=name, locality="Albuquerque")
+    return SimpleNamespace(
+        id=location_id,
+        name=name,
+        locality=locality,
+        coordinates=SimpleNamespace(
+            latitude=coordinates[0],
+            longitude=coordinates[1],
+        ),
+        distance=distance,
+        sensors=[
+            make_sensor(sensor_id, parameter)
+            for sensor_id, parameter in enumerate(sensor_parameters, start=1)
+        ],
+    )
 
 
 def make_parameter(
@@ -90,9 +108,12 @@ def mock_config_entry() -> MockConfigEntry:
 def mock_openaq_client() -> Generator[AsyncMock]:
     """Mock the OpenAQ client."""
     with (
-        patch("homeassistant.components.openaq.AsyncOpenAQ") as mock_init,
         patch(
-            "homeassistant.components.openaq.config_flow.AsyncOpenAQ",
+            "homeassistant.components.openaq.async_create_openaq_client",
+            new_callable=AsyncMock,
+        ) as mock_init,
+        patch(
+            "homeassistant.components.openaq.config_flow.async_create_openaq_client",
             new=mock_init,
         ),
     ):

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.config_entries import ConfigSubentryData
-from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, CONF_API_KEY
 
 from tests.common import MockConfigEntry
 
@@ -30,13 +30,18 @@ def make_location(
     return SimpleNamespace(id=location_id, name=name, locality="Albuquerque")
 
 
-def make_parameter(name: str, units: str = "µg/m³") -> SimpleNamespace:
+def make_parameter(
+    name: str, units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+) -> SimpleNamespace:
     """Return an OpenAQ parameter."""
     return SimpleNamespace(name=name, units=units)
 
 
 def make_sensor(
-    sensor_id: int, parameter: str, units: str = "µg/m³", value: float | None = None
+    sensor_id: int,
+    parameter: str,
+    units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    value: float | None = None,
 ) -> SimpleNamespace:
     """Return an OpenAQ sensor."""
     latest = None if value is None else SimpleNamespace(value=value)

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -1,0 +1,137 @@
+"""Common fixtures for the OpenAQ tests."""
+
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
+from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.const import CONF_API_KEY
+
+from tests.common import MockConfigEntry
+
+API_KEY = "test-api-key"
+LOCATION_ID = 2178
+LOCATION_NAME = "Del Norte"
+SUBENTRY_ID = "ABCDEF"
+
+
+def make_response(results: list[object]) -> SimpleNamespace:
+    """Return an OpenAQ SDK response."""
+    return SimpleNamespace(results=results)
+
+
+def make_location(
+    location_id: int = LOCATION_ID, name: str = LOCATION_NAME
+) -> SimpleNamespace:
+    """Return an OpenAQ location."""
+    return SimpleNamespace(id=location_id, name=name, locality="Albuquerque")
+
+
+def make_parameter(name: str, units: str = "µg/m³") -> SimpleNamespace:
+    """Return an OpenAQ parameter."""
+    return SimpleNamespace(name=name, units=units)
+
+
+def make_sensor(
+    sensor_id: int, parameter: str, units: str = "µg/m³", value: float | None = None
+) -> SimpleNamespace:
+    """Return an OpenAQ sensor."""
+    latest = None if value is None else SimpleNamespace(value=value)
+    return SimpleNamespace(
+        id=sensor_id,
+        parameter=make_parameter(parameter, units),
+        latest=latest,
+    )
+
+
+def make_latest(sensor_id: int, value: float | None) -> SimpleNamespace:
+    """Return an OpenAQ latest measurement."""
+    return SimpleNamespace(sensors_id=sensor_id, value=value)
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.openaq.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return an OpenAQ config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: API_KEY},
+        subentries_data=[
+            ConfigSubentryData(
+                data={CONF_LOCATION_ID: LOCATION_ID},
+                subentry_id=SUBENTRY_ID,
+                subentry_type="location",
+                title=LOCATION_NAME,
+                unique_id=str(LOCATION_ID),
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def mock_openaq_client() -> Generator[AsyncMock]:
+    """Mock the OpenAQ client."""
+    with (
+        patch("homeassistant.components.openaq.AsyncOpenAQ") as mock_init,
+        patch(
+            "homeassistant.components.openaq.config_flow.AsyncOpenAQ",
+            new=mock_init,
+        ),
+    ):
+        client = mock_init.return_value
+        client.close = AsyncMock()
+        client.parameters = SimpleNamespace()
+        client.locations = SimpleNamespace()
+        client.parameters.list = AsyncMock()
+        client.locations.get = AsyncMock()
+        client.locations.list = AsyncMock()
+        client.locations.latest = AsyncMock()
+        client.locations.sensors = AsyncMock()
+        client.parameters.list.return_value = make_response([])
+        client.locations.get.return_value = make_response([make_location()])
+        client.locations.list.return_value = make_response([make_location()])
+        client.locations.latest.return_value = make_response(
+            [
+                make_latest(1, 8.5),
+                make_latest(2, 12.1),
+                make_latest(3, 33.2),
+                make_latest(4, 0.4),
+                make_latest(5, 415),
+                make_latest(6, 15),
+                make_latest(7, 22),
+                make_latest(8, 4),
+                make_latest(9, 6),
+                make_latest(10, 17),
+                make_latest(11, 0.9),
+                make_latest(12, 123),
+            ]
+        )
+        client.locations.sensors.return_value = make_response(
+            [
+                make_sensor(1, "pm1"),
+                make_sensor(2, "pm25"),
+                make_sensor(3, "pm10"),
+                make_sensor(4, "co", "ppm"),
+                make_sensor(5, "co2", "ppm"),
+                make_sensor(6, "no2", "ppb"),
+                make_sensor(7, "o3", "ppb"),
+                make_sensor(8, "so2", "ppb"),
+                make_sensor(9, "no", "ppb"),
+                make_sensor(10, "nox", "ppb"),
+                make_sensor(11, "bc"),
+                make_sensor(12, "unsupported"),
+            ]
+        )
+        yield client

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -68,6 +68,7 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         title="OpenAQ",
         data={CONF_API_KEY: API_KEY},
+        unique_id=DOMAIN,
         subentries_data=[
             ConfigSubentryData(
                 data={CONF_LOCATION_ID: LOCATION_ID},

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -22,9 +22,13 @@ from openaq.core.responses import (
 )
 import pytest
 
-from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
+from homeassistant.components.openaq.const import (
+    CONF_LOCATION_ID,
+    DOMAIN,
+    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+)
 from homeassistant.config_entries import ConfigSubentryDataWithId
-from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, CONF_API_KEY
+from homeassistant.const import CONF_API_KEY
 
 from tests.common import MockConfigEntry
 
@@ -73,14 +77,14 @@ def make_location(
 
 
 def make_parameter(
-    name: str, units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    name: str, units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER
 ) -> Parameter:
     """Return an OpenAQ parameter."""
     return Parameter(id=1, name=name, units=units)
 
 
 def make_parameter_base(
-    name: str, units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    name: str, units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER
 ) -> ParameterBase:
     """Return an OpenAQ base parameter."""
     return ParameterBase(id=1, name=name, units=units, display_name=None)
@@ -89,7 +93,7 @@ def make_parameter_base(
 def make_sensor_base(
     sensor_id: int,
     parameter: str,
-    units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
 ) -> SensorBase:
     """Return an OpenAQ base sensor."""
     return SensorBase(
@@ -102,7 +106,7 @@ def make_sensor_base(
 def make_sensor(
     sensor_id: int,
     parameter: str,
-    units: str = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
     value: float | None = None,
 ) -> Sensor:
     """Return an OpenAQ sensor."""

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -22,10 +22,9 @@ from openaq.core.responses import (
 )
 import pytest
 
-from homeassistant import const as ha_const
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.config_entries import ConfigSubentryDataWithId
-from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONF_API_KEY, UnitOfDensity
 
 from tests.common import MockConfigEntry
 
@@ -74,14 +73,14 @@ def make_location(
 
 
 def make_parameter(
-    name: str, units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    name: str, units: str = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
 ) -> Parameter:
     """Return an OpenAQ parameter."""
     return Parameter(id=1, name=name, units=units)
 
 
 def make_parameter_base(
-    name: str, units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    name: str, units: str = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
 ) -> ParameterBase:
     """Return an OpenAQ base parameter."""
     return ParameterBase(id=1, name=name, units=units, display_name=None)
@@ -90,7 +89,7 @@ def make_parameter_base(
 def make_sensor_base(
     sensor_id: int,
     parameter: str,
-    units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    units: str = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
 ) -> SensorBase:
     """Return an OpenAQ base sensor."""
     return SensorBase(
@@ -103,7 +102,7 @@ def make_sensor_base(
 def make_sensor(
     sensor_id: int,
     parameter: str,
-    units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    units: str = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
     value: float | None = None,
 ) -> Sensor:
     """Return an OpenAQ sensor."""

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -22,11 +22,8 @@ from openaq.core.responses import (
 )
 import pytest
 
-from homeassistant.components.openaq.const import (
-    CONF_LOCATION_ID,
-    DOMAIN,
-    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-)
+from homeassistant import const as ha_const
+from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.config_entries import ConfigSubentryDataWithId
 from homeassistant.const import CONF_API_KEY
 
@@ -77,14 +74,14 @@ def make_location(
 
 
 def make_parameter(
-    name: str, units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER
+    name: str, units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 ) -> Parameter:
     """Return an OpenAQ parameter."""
     return Parameter(id=1, name=name, units=units)
 
 
 def make_parameter_base(
-    name: str, units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER
+    name: str, units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 ) -> ParameterBase:
     """Return an OpenAQ base parameter."""
     return ParameterBase(id=1, name=name, units=units, display_name=None)
@@ -93,7 +90,7 @@ def make_parameter_base(
 def make_sensor_base(
     sensor_id: int,
     parameter: str,
-    units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
 ) -> SensorBase:
     """Return an OpenAQ base sensor."""
     return SensorBase(
@@ -106,7 +103,7 @@ def make_sensor_base(
 def make_sensor(
     sensor_id: int,
     parameter: str,
-    units: str = OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    units: str = ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     value: float | None = None,
 ) -> Sensor:
     """Return an OpenAQ sensor."""

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -3,9 +3,9 @@
 from collections.abc import Generator
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from openaq.shared.responses import (
+from openaq.core.responses import (
     Coordinates,
     CountryBase,
     Datetime,
@@ -23,7 +23,7 @@ from openaq.shared.responses import (
 import pytest
 
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
-from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.config_entries import ConfigSubentryDataWithId
 from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, CONF_API_KEY
 
 from tests.common import MockConfigEntry
@@ -152,7 +152,7 @@ def mock_config_entry() -> MockConfigEntry:
         data={CONF_API_KEY: API_KEY},
         unique_id=DOMAIN,
         subentries_data=[
-            ConfigSubentryData(
+            ConfigSubentryDataWithId(
                 data={CONF_LOCATION_ID: LOCATION_ID},
                 subentry_id=SUBENTRY_ID,
                 subentry_type="location",
@@ -164,7 +164,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_openaq_client() -> Generator[AsyncMock]:
+def mock_openaq_client() -> Generator[MagicMock]:
     """Mock the OpenAQ client."""
     with (
         patch(
@@ -177,14 +177,14 @@ def mock_openaq_client() -> Generator[AsyncMock]:
         ),
     ):
         client = mock_init.return_value
-        client.close = AsyncMock()
+        client.close = MagicMock()
         client.parameters = SimpleNamespace()
         client.locations = SimpleNamespace()
-        client.parameters.list = AsyncMock()
-        client.locations.get = AsyncMock()
-        client.locations.list = AsyncMock()
-        client.locations.latest = AsyncMock()
-        client.locations.sensors = AsyncMock()
+        client.parameters.list = MagicMock()
+        client.locations.get = MagicMock()
+        client.locations.list = MagicMock()
+        client.locations.latest = MagicMock()
+        client.locations.sensors = MagicMock()
         client.parameters.list.return_value = make_response([])
         client.locations.get.return_value = make_response([make_location()])
         client.locations.list.return_value = make_response([make_location()])

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Generator
 from types import SimpleNamespace
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from openaq.core.responses import (
@@ -123,11 +122,11 @@ def make_sensor(
     )
 
 
-def make_latest(sensor_id: int, value: float | None) -> Latest:
+def make_latest(sensor_id: int, value: float) -> Latest:
     """Return an OpenAQ latest measurement."""
     return Latest(
         datetime=DATETIME,
-        value=cast(float, value),
+        value=value,
         coordinates=Coordinates(latitude=35.1, longitude=-106.6),
         sensors_id=sensor_id,
         locations_id=LOCATION_ID,
@@ -166,58 +165,58 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 def mock_openaq_client() -> Generator[MagicMock]:
     """Mock the OpenAQ client."""
+    client = MagicMock()
+    client.close = MagicMock()
+    client.parameters = SimpleNamespace()
+    client.locations = SimpleNamespace()
+    client.parameters.list = MagicMock()
+    client.locations.get = MagicMock()
+    client.locations.list = MagicMock()
+    client.locations.latest = MagicMock()
+    client.locations.sensors = MagicMock()
+    client.parameters.list.return_value = make_response([])
+    client.locations.get.return_value = make_response([make_location()])
+    client.locations.list.return_value = make_response([make_location()])
+    client.locations.latest.return_value = make_response(
+        [
+            make_latest(1, 8.5),
+            make_latest(2, 12.1),
+            make_latest(3, 33.2),
+            make_latest(4, 0.4),
+            make_latest(5, 415),
+            make_latest(6, 15),
+            make_latest(7, 22),
+            make_latest(8, 4),
+            make_latest(9, 6),
+            make_latest(10, 17),
+            make_latest(11, 0.9),
+            make_latest(12, 123),
+        ]
+    )
+    client.locations.sensors.return_value = make_response(
+        [
+            make_sensor(1, "pm1"),
+            make_sensor(2, "pm25"),
+            make_sensor(3, "pm10"),
+            make_sensor(4, "co", "ppm"),
+            make_sensor(5, "co2", "ppm"),
+            make_sensor(6, "no2", "ppb"),
+            make_sensor(7, "o3", "ppb"),
+            make_sensor(8, "so2", "ppb"),
+            make_sensor(9, "no", "ppb"),
+            make_sensor(10, "nox", "ppb"),
+            make_sensor(11, "bc"),
+            make_sensor(12, "unsupported"),
+        ]
+    )
     with (
         patch(
-            "homeassistant.components.openaq.async_create_openaq_client",
-            new_callable=AsyncMock,
-        ) as mock_init,
-    ):
-        client = mock_init.return_value
-        client.close = MagicMock()
-        client.parameters = SimpleNamespace()
-        client.locations = SimpleNamespace()
-        client.parameters.list = MagicMock()
-        client.locations.get = MagicMock()
-        client.locations.list = MagicMock()
-        client.locations.latest = MagicMock()
-        client.locations.sensors = MagicMock()
-        client.parameters.list.return_value = make_response([])
-        client.locations.get.return_value = make_response([make_location()])
-        client.locations.list.return_value = make_response([make_location()])
-        client.locations.latest.return_value = make_response(
-            [
-                make_latest(1, 8.5),
-                make_latest(2, 12.1),
-                make_latest(3, 33.2),
-                make_latest(4, 0.4),
-                make_latest(5, 415),
-                make_latest(6, 15),
-                make_latest(7, 22),
-                make_latest(8, 4),
-                make_latest(9, 6),
-                make_latest(10, 17),
-                make_latest(11, 0.9),
-                make_latest(12, 123),
-            ]
-        )
-        client.locations.sensors.return_value = make_response(
-            [
-                make_sensor(1, "pm1"),
-                make_sensor(2, "pm25"),
-                make_sensor(3, "pm10"),
-                make_sensor(4, "co", "ppm"),
-                make_sensor(5, "co2", "ppm"),
-                make_sensor(6, "no2", "ppb"),
-                make_sensor(7, "o3", "ppb"),
-                make_sensor(8, "so2", "ppb"),
-                make_sensor(9, "no", "ppb"),
-                make_sensor(10, "nox", "ppb"),
-                make_sensor(11, "bc"),
-                make_sensor(12, "unsupported"),
-            ]
-        )
-        with patch(
+            "homeassistant.components.openaq.create_openaq_client",
+            return_value=client,
+        ),
+        patch(
             "homeassistant.components.openaq.config_flow.create_openaq_client",
             return_value=client,
-        ):
-            yield client
+        ),
+    ):
+        yield client

--- a/tests/components/openaq/conftest.py
+++ b/tests/components/openaq/conftest.py
@@ -171,10 +171,6 @@ def mock_openaq_client() -> Generator[MagicMock]:
             "homeassistant.components.openaq.async_create_openaq_client",
             new_callable=AsyncMock,
         ) as mock_init,
-        patch(
-            "homeassistant.components.openaq.config_flow.async_create_openaq_client",
-            new=mock_init,
-        ),
     ):
         client = mock_init.return_value
         client.close = MagicMock()
@@ -220,4 +216,8 @@ def mock_openaq_client() -> Generator[MagicMock]:
                 make_sensor(12, "unsupported"),
             ]
         )
-        yield client
+        with patch(
+            "homeassistant.components.openaq.config_flow.create_openaq_client",
+            return_value=client,
+        ):
+            yield client

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -94,7 +94,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'co2',
+    'translation_key': None,
     'unique_id': '2178_co2',
     'unit_of_measurement': 'ppm',
   })
@@ -153,7 +153,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'co',
+    'translation_key': None,
     'unique_id': '2178_co',
     'unit_of_measurement': 'ppm',
   })
@@ -181,9 +181,7 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
+    'capabilities': None,
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -223,7 +221,6 @@
       'attribution': 'Data provided by OpenAQ',
       'device_class': 'distance',
       'friendly_name': 'Del Norte Distance from Home Assistant',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
@@ -271,7 +268,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'no2',
+    'translation_key': None,
     'unique_id': '2178_no2',
     'unit_of_measurement': 'ppb',
   })
@@ -330,7 +327,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'no',
+    'translation_key': None,
     'unique_id': '2178_no',
     'unit_of_measurement': 'ppb',
   })
@@ -447,7 +444,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'o3',
+    'translation_key': None,
     'unique_id': '2178_o3',
     'unit_of_measurement': 'ppb',
   })
@@ -506,7 +503,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'pm1',
+    'translation_key': None,
     'unique_id': '2178_pm1',
     'unit_of_measurement': 'μg/m³',
   })
@@ -565,7 +562,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'pm10',
+    'translation_key': None,
     'unique_id': '2178_pm10',
     'unit_of_measurement': 'μg/m³',
   })
@@ -624,7 +621,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'pm25',
+    'translation_key': None,
     'unique_id': '2178_pm25',
     'unit_of_measurement': 'μg/m³',
   })
@@ -683,7 +680,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'so2',
+    'translation_key': None,
     'unique_id': '2178_so2',
     'unit_of_measurement': 'ppb',
   })

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -1,0 +1,615 @@
+# serializer version: 1
+# name: test_sensor_snapshot[sensor.del_norte_black_carbon-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_black_carbon',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Black carbon',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Black carbon',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bc',
+    'unique_id': '2178_bc',
+    'unit_of_measurement': 'μg/m³',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_black_carbon-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'friendly_name': 'Del Norte Black carbon',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'μg/m³',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_black_carbon',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.9',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_carbon_dioxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_carbon_dioxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Carbon dioxide',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.CO2: 'carbon_dioxide'>,
+    'original_icon': None,
+    'original_name': 'Carbon dioxide',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'co2',
+    'unique_id': '2178_co2',
+    'unit_of_measurement': 'ppm',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_carbon_dioxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'carbon_dioxide',
+      'friendly_name': 'Del Norte Carbon dioxide',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_carbon_dioxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '415.0',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_carbon_monoxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_carbon_monoxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Carbon monoxide',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.CO: 'carbon_monoxide'>,
+    'original_icon': None,
+    'original_name': 'Carbon monoxide',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'co',
+    'unique_id': '2178_co',
+    'unit_of_measurement': 'ppm',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_carbon_monoxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'carbon_monoxide',
+      'friendly_name': 'Del Norte Carbon monoxide',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_carbon_monoxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.4',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_dioxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_nitrogen_dioxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Nitrogen dioxide',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.NITROGEN_DIOXIDE: 'nitrogen_dioxide'>,
+    'original_icon': None,
+    'original_name': 'Nitrogen dioxide',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'no2',
+    'unique_id': '2178_no2',
+    'unit_of_measurement': 'ppb',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_dioxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'nitrogen_dioxide',
+      'friendly_name': 'Del Norte Nitrogen dioxide',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppb',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_nitrogen_dioxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15.0',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_monoxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_nitrogen_monoxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Nitrogen monoxide',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.NITROGEN_MONOXIDE: 'nitrogen_monoxide'>,
+    'original_icon': None,
+    'original_name': 'Nitrogen monoxide',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'no',
+    'unique_id': '2178_no',
+    'unit_of_measurement': 'ppb',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_monoxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'nitrogen_monoxide',
+      'friendly_name': 'Del Norte Nitrogen monoxide',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppb',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_nitrogen_monoxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.0',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_nitrogen_oxides',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Nitrogen oxides',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Nitrogen oxides',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'nox',
+    'unique_id': '2178_nox',
+    'unit_of_measurement': 'ppb',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'friendly_name': 'Del Norte Nitrogen oxides',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppb',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_nitrogen_oxides',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '17.0',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_ozone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_ozone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ozone',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.OZONE: 'ozone'>,
+    'original_icon': None,
+    'original_name': 'Ozone',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'o3',
+    'unique_id': '2178_o3',
+    'unit_of_measurement': 'ppb',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_ozone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'ozone',
+      'friendly_name': 'Del Norte Ozone',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppb',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_ozone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '22.0',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_pm1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_pm1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PM1',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PM1: 'pm1'>,
+    'original_icon': None,
+    'original_name': 'PM1',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pm1',
+    'unique_id': '2178_pm1',
+    'unit_of_measurement': 'μg/m³',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_pm1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'pm1',
+      'friendly_name': 'Del Norte PM1',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'μg/m³',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_pm1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8.5',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_pm10-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_pm10',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PM10',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PM10: 'pm10'>,
+    'original_icon': None,
+    'original_name': 'PM10',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pm10',
+    'unique_id': '2178_pm10',
+    'unit_of_measurement': 'μg/m³',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_pm10-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'pm10',
+      'friendly_name': 'Del Norte PM10',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'μg/m³',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_pm10',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '33.2',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_pm2_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_pm2_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PM2.5',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PM25: 'pm25'>,
+    'original_icon': None,
+    'original_name': 'PM2.5',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pm25',
+    'unique_id': '2178_pm25',
+    'unit_of_measurement': 'μg/m³',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_pm2_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'pm25',
+      'friendly_name': 'Del Norte PM2.5',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'μg/m³',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_pm2_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12.1',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_sulphur_dioxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_sulphur_dioxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Sulphur dioxide',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SULPHUR_DIOXIDE: 'sulphur_dioxide'>,
+    'original_icon': None,
+    'original_name': 'Sulphur dioxide',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'so2',
+    'unique_id': '2178_so2',
+    'unit_of_measurement': 'ppb',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_sulphur_dioxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'sulphur_dioxide',
+      'friendly_name': 'Del Norte Sulphur dioxide',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppb',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_sulphur_dioxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4.0',
+  })
+# ---

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -25,6 +25,9 @@
     'name': None,
     'object_id_base': 'Black carbon',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': None,
     'original_icon': None,
@@ -80,6 +83,9 @@
     'name': None,
     'object_id_base': 'Carbon dioxide',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.CO2: 'carbon_dioxide'>,
     'original_icon': None,
@@ -136,6 +142,9 @@
     'name': None,
     'object_id_base': 'Carbon monoxide',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.CO: 'carbon_monoxide'>,
     'original_icon': None,
@@ -166,6 +175,65 @@
     'state': '0.4',
   })
 # ---
+# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Distance from Home Assistant',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+    'original_icon': None,
+    'original_name': 'Distance from Home Assistant',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'distance_from_home',
+    'unique_id': '2178_distance_from_home',
+    'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'device_class': 'distance',
+      'friendly_name': 'Del Norte Distance from Home Assistant',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1011.981016',
+  })
+# ---
 # name: test_sensor_snapshot[sensor.del_norte_nitrogen_dioxide-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -192,6 +260,9 @@
     'name': None,
     'object_id_base': 'Nitrogen dioxide',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.NITROGEN_DIOXIDE: 'nitrogen_dioxide'>,
     'original_icon': None,
@@ -248,6 +319,9 @@
     'name': None,
     'object_id_base': 'Nitrogen monoxide',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.NITROGEN_MONOXIDE: 'nitrogen_monoxide'>,
     'original_icon': None,
@@ -304,6 +378,9 @@
     'name': None,
     'object_id_base': 'Nitrogen oxides',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': None,
     'original_icon': None,
@@ -359,6 +436,9 @@
     'name': None,
     'object_id_base': 'Ozone',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.OZONE: 'ozone'>,
     'original_icon': None,
@@ -415,6 +495,9 @@
     'name': None,
     'object_id_base': 'PM1',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.PM1: 'pm1'>,
     'original_icon': None,
@@ -471,6 +554,9 @@
     'name': None,
     'object_id_base': 'PM10',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.PM10: 'pm10'>,
     'original_icon': None,
@@ -527,6 +613,9 @@
     'name': None,
     'object_id_base': 'PM2.5',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.PM25: 'pm25'>,
     'original_icon': None,
@@ -583,6 +672,9 @@
     'name': None,
     'object_id_base': 'Sulphur dioxide',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.SULPHUR_DIOXIDE: 'sulphur_dioxide'>,
     'original_icon': None,

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -175,62 +175,6 @@
     'state': '0.4',
   })
 # ---
-# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Distance from Home Assistant',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
-    'original_icon': None,
-    'original_name': 'Distance from Home Assistant',
-    'platform': 'openaq',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'distance_from_home',
-    'unique_id': '2178_distance_from_home',
-    'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-  })
-# ---
-# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'distance',
-      'friendly_name': 'Del Norte Distance from Home Assistant',
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1011.981016',
-  })
-# ---
 # name: test_sensor_snapshot[sensor.del_norte_nitrogen_dioxide-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor_snapshot[sensor.del_norte_black_carbon-entry]
+# name: test_sensor_snapshot[sensor.del_norte-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.del_norte_black_carbon',
+    'entity_id': 'sensor.del_norte',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,7 +23,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Black carbon',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -31,26 +31,84 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Black carbon',
+    'original_name': None,
     'platform': 'openaq',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'bc',
+    'translation_key': None,
+    'unique_id': '2178_nox',
+    'unit_of_measurement': 'ppb',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'friendly_name': 'Del Norte',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppb',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '17.0',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
     'unique_id': '2178_bc',
     'unit_of_measurement': 'μg/m³',
   })
 # ---
-# name: test_sensor_snapshot[sensor.del_norte_black_carbon-state]
+# name: test_sensor_snapshot[sensor.del_norte_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenAQ',
-      'friendly_name': 'Del Norte Black carbon',
+      'friendly_name': 'Del Norte',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'μg/m³',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.del_norte_black_carbon',
+    'entity_id': 'sensor.del_norte_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -347,64 +405,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '6.0',
-  })
-# ---
-# name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.del_norte_nitrogen_oxides',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Nitrogen oxides',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Nitrogen oxides',
-    'platform': 'openaq',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'nox',
-    'unique_id': '2178_nox',
-    'unit_of_measurement': 'ppb',
-  })
-# ---
-# name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'friendly_name': 'Del Norte Nitrogen oxides',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppb',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.del_norte_nitrogen_oxides',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '17.0',
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_ozone-entry]

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -233,7 +233,7 @@
     'state': '0.4',
   })
 # ---
-# name: test_sensor_snapshot[sensor.del_norte_distance-entry]
+# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -247,7 +247,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.del_norte_distance',
+    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -273,7 +273,7 @@
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
-# name: test_sensor_snapshot[sensor.del_norte_distance-state]
+# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenAQ',
@@ -282,7 +282,7 @@
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.del_norte_distance',
+    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -38,16 +38,16 @@
     'supported_features': 0,
     'translation_key': 'bc',
     'unique_id': '2178_bc',
-    'unit_of_measurement': 'μg/m³',
+    'unit_of_measurement': <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_black_carbon-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'friendly_name': 'Del Norte Black carbon',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'μg/m³',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Black carbon',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_black_carbon',
@@ -64,7 +64,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -102,11 +102,11 @@
 # name: test_sensor_snapshot[sensor.del_norte_carbon_dioxide-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'carbon_dioxide',
-      'friendly_name': 'Del Norte Carbon dioxide',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppm',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'carbon_dioxide',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Carbon dioxide',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'ppm',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_carbon_dioxide',
@@ -123,7 +123,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -161,11 +161,11 @@
 # name: test_sensor_snapshot[sensor.del_norte_carbon_monoxide-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'carbon_monoxide',
-      'friendly_name': 'Del Norte Carbon monoxide',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppm',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'carbon_monoxide',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Carbon monoxide',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'ppm',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_carbon_monoxide',
@@ -182,7 +182,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -220,11 +220,11 @@
 # name: test_sensor_snapshot[sensor.del_norte_nitrogen_dioxide-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'nitrogen_dioxide',
-      'friendly_name': 'Del Norte Nitrogen dioxide',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppb',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'nitrogen_dioxide',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Nitrogen dioxide',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'ppb',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_nitrogen_dioxide',
@@ -241,7 +241,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -279,11 +279,11 @@
 # name: test_sensor_snapshot[sensor.del_norte_nitrogen_monoxide-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'nitrogen_monoxide',
-      'friendly_name': 'Del Norte Nitrogen monoxide',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppb',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'nitrogen_monoxide',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Nitrogen monoxide',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'ppb',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_nitrogen_monoxide',
@@ -300,7 +300,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -338,10 +338,10 @@
 # name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'friendly_name': 'Del Norte Nitrogen oxides',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppb',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Nitrogen oxides',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'ppb',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_nitrogen_oxides',
@@ -358,7 +358,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -396,11 +396,11 @@
 # name: test_sensor_snapshot[sensor.del_norte_ozone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'ozone',
-      'friendly_name': 'Del Norte Ozone',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppb',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'ozone',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Ozone',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'ppb',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_ozone',
@@ -417,7 +417,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -449,17 +449,17 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': '2178_pm1',
-    'unit_of_measurement': 'μg/m³',
+    'unit_of_measurement': <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_pm1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'pm1',
-      'friendly_name': 'Del Norte PM1',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'μg/m³',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'pm1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte PM1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_pm1',
@@ -476,7 +476,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -508,17 +508,17 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': '2178_pm10',
-    'unit_of_measurement': 'μg/m³',
+    'unit_of_measurement': <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_pm10-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'pm10',
-      'friendly_name': 'Del Norte PM10',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'μg/m³',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'pm10',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte PM10',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_pm10',
@@ -535,7 +535,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -567,17 +567,17 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': '2178_pm25',
-    'unit_of_measurement': 'μg/m³',
+    'unit_of_measurement': <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_pm2_5-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'pm25',
-      'friendly_name': 'Del Norte PM2.5',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'μg/m³',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'pm25',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte PM2.5',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_pm2_5',
@@ -594,7 +594,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -632,11 +632,11 @@
 # name: test_sensor_snapshot[sensor.del_norte_sulphur_dioxide-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'device_class': 'sulphur_dioxide',
-      'friendly_name': 'Del Norte Sulphur dioxide',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppb',
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by OpenAQ',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'sulphur_dioxide',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Del Norte Sulphur dioxide',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'ppb',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.del_norte_sulphur_dioxide',

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -233,7 +233,7 @@
     'state': '0.4',
   })
 # ---
-# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-entry]
+# name: test_sensor_snapshot[sensor.del_norte_distance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -247,7 +247,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
+    'entity_id': 'sensor.del_norte_distance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -255,7 +255,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Distance from Home Assistant',
+    'object_id_base': 'Distance',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -263,7 +263,7 @@
     }),
     'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
     'original_icon': None,
-    'original_name': 'Distance from Home Assistant',
+    'original_name': 'Distance',
     'platform': 'openaq',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -273,16 +273,16 @@
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
-# name: test_sensor_snapshot[sensor.del_norte_distance_from_home_assistant-state]
+# name: test_sensor_snapshot[sensor.del_norte_distance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenAQ',
       'device_class': 'distance',
-      'friendly_name': 'Del Norte Distance from Home Assistant',
+      'friendly_name': 'Del Norte Distance',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.del_norte_distance_from_home_assistant',
+    'entity_id': 'sensor.del_norte_distance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -197,7 +197,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Distance',
+    'object_id_base': 'Distance from Home Assistant',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -205,7 +205,7 @@
     }),
     'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
     'original_icon': None,
-    'original_name': 'Distance',
+    'original_name': 'Distance from Home Assistant',
     'platform': 'openaq',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -220,7 +220,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenAQ',
       'device_class': 'distance',
-      'friendly_name': 'Del Norte Distance',
+      'friendly_name': 'Del Norte Distance from Home Assistant',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -64,7 +64,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -123,7 +123,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -182,7 +182,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -241,7 +241,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -300,7 +300,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -358,7 +358,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -417,7 +417,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -476,7 +476,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -535,7 +535,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -594,7 +594,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor_snapshot[sensor.del_norte-entry]
+# name: test_sensor_snapshot[sensor.del_norte_black_carbon-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.del_norte',
+    'entity_id': 'sensor.del_norte_black_carbon',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,7 +23,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Black carbon',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -31,84 +31,26 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Black carbon',
     'platform': 'openaq',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '2178_nox',
-    'unit_of_measurement': 'ppb',
-  })
-# ---
-# name: test_sensor_snapshot[sensor.del_norte-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by OpenAQ',
-      'friendly_name': 'Del Norte',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ppb',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.del_norte',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '17.0',
-  })
-# ---
-# name: test_sensor_snapshot[sensor.del_norte_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.del_norte_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'openaq',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'bc',
     'unique_id': '2178_bc',
     'unit_of_measurement': 'μg/m³',
   })
 # ---
-# name: test_sensor_snapshot[sensor.del_norte_2-state]
+# name: test_sensor_snapshot[sensor.del_norte_black_carbon-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenAQ',
-      'friendly_name': 'Del Norte',
+      'friendly_name': 'Del Norte Black carbon',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'μg/m³',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.del_norte_2',
+    'entity_id': 'sensor.del_norte_black_carbon',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -405,6 +347,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '6.0',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.del_norte_nitrogen_oxides',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Nitrogen oxides',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Nitrogen oxides',
+    'platform': 'openaq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'nox',
+    'unique_id': '2178_nox',
+    'unit_of_measurement': 'ppb',
+  })
+# ---
+# name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenAQ',
+      'friendly_name': 'Del Norte Nitrogen oxides',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppb',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.del_norte_nitrogen_oxides',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '17.0',
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_ozone-entry]

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -64,7 +64,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -123,7 +123,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -182,7 +182,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -241,7 +241,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -300,7 +300,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -358,7 +358,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -417,7 +417,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -476,7 +476,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -535,7 +535,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -594,7 +594,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,

--- a/tests/components/openaq/snapshots/test_sensor.ambr
+++ b/tests/components/openaq/snapshots/test_sensor.ambr
@@ -113,7 +113,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '415.0',
+    'state': '415',
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_carbon_monoxide-entry]
@@ -231,7 +231,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '15.0',
+    'state': '15',
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_nitrogen_monoxide-entry]
@@ -290,7 +290,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '6.0',
+    'state': '6',
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_nitrogen_oxides-entry]
@@ -348,7 +348,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '17.0',
+    'state': '17',
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_ozone-entry]
@@ -407,7 +407,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '22.0',
+    'state': '22',
   })
 # ---
 # name: test_sensor_snapshot[sensor.del_norte_pm1-entry]
@@ -643,6 +643,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '4.0',
+    'state': '4',
   })
 # ---

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -1,14 +1,15 @@
 """Test the OpenAQ config flow."""
 
+from collections.abc import Sequence
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from typing import cast
+from unittest.mock import AsyncMock, call
 
 from openaq import (
     BadGatewayError,
     GatewayTimeoutError,
     HTTPRateLimitError,
     NotAuthorizedError,
-    NotFoundError,
 )
 import pytest
 
@@ -26,11 +27,21 @@ from homeassistant.const import (
     CONF_API_KEY,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import FlowResult, FlowResultType
+from homeassistant.helpers.selector import SelectOptionDict, SelectSelector
 
 from .conftest import API_KEY, LOCATION_ID, make_location, make_response
 
 from tests.common import MockConfigEntry
+
+
+def _get_select_options(result: FlowResult) -> Sequence[SelectOptionDict]:
+    """Return select options from a flow result."""
+    data_schema = result["data_schema"]
+    assert data_schema is not None
+    selector = next(iter(data_schema.schema.values()))
+    assert isinstance(selector, SelectSelector)
+    return cast(Sequence[SelectOptionDict], selector.config["options"])
 
 
 async def test_user_flow_success(
@@ -126,11 +137,6 @@ async def test_location_subentry_map_flow(
         (mock_config_entry.entry_id, "location"),
         context={"source": config_entries.SOURCE_USER},
     )
-    assert result["type"] is FlowResultType.MENU
-
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": "map"}
-    )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "map"
 
@@ -175,9 +181,6 @@ async def test_location_subentry_map_flow_without_locality(
         context={"source": config_entries.SOURCE_USER},
     )
     result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": "map"}
-    )
-    result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
             ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
@@ -194,6 +197,211 @@ async def test_location_subentry_map_flow_without_locality(
     assert result["title"] == "Albuquerque"
 
 
+async def test_location_subentry_map_flow_sorts_by_sensor_count_before_distance(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search ranks useful locations by sensor count before distance."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.side_effect = [
+        make_response(
+            [
+                make_location(
+                    location_id=9998,
+                    name="Nearby",
+                    locality="Nearby",
+                    distance=1000,
+                    sensor_parameters=("o3",),
+                )
+            ]
+        ),
+        make_response(
+            [
+                make_location(
+                    location_id=9999,
+                    name="Pinecliff",
+                    locality="Pinecliff",
+                    distance=6000,
+                    sensor_parameters=("pm1", "pm10", "pm25"),
+                )
+            ]
+        ),
+    ]
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 10000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select"
+    assert _get_select_options(result) == [
+        SelectOptionDict(
+            value="9999",
+            label="Pinecliff - 3 sensors: PM1, PM10, PM2.5 - 6.0 km",
+        ),
+        SelectOptionDict(value="9998", label="Nearby - 1 sensor: Ozone - 1.0 km"),
+    ]
+    assert mock_openaq_client.locations.list.await_args_list == [
+        call(coordinates=(35.1, -106.6), radius=5000, limit=10),
+        call(coordinates=(35.1, -106.6), radius=10000, limit=10),
+    ]
+
+
+async def test_location_subentry_map_flow_limits_to_top_five_locations(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search only shows the top five useful locations."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [
+            make_location(location_id=9991, name="Location 1", distance=100),
+            make_location(location_id=9992, name="Location 2", distance=200),
+            make_location(location_id=9993, name="Location 3", distance=300),
+            make_location(location_id=9994, name="Location 4", distance=400),
+            make_location(location_id=9995, name="Location 5", distance=500),
+            make_location(location_id=9996, name="Location 6", distance=600),
+        ]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert [option["value"] for option in _get_select_options(result)] == [
+        "9991",
+        "9992",
+        "9993",
+        "9994",
+        "9995",
+    ]
+
+
+async def test_location_subentry_map_flow_omits_locations_without_supported_sensors(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search omits locations with only unsupported sensors."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [
+            make_location(
+                location_id=9998,
+                name="Unsupported",
+                sensor_parameters=("temperature",),
+            ),
+            make_location(location_id=9999, name="Supported"),
+        ]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert [option["value"] for option in _get_select_options(result)] == ["9999"]
+
+
+async def test_location_subentry_map_flow_deduplicates_locations_across_radius_searches(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search deduplicates location IDs across radius searches."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.side_effect = [
+        make_response([make_location(location_id=9998, name="Duplicate")]),
+        make_response(
+            [
+                make_location(location_id=9998, name="Duplicate"),
+                make_location(location_id=9999, name="Other"),
+            ]
+        ),
+    ]
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 10000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert [option["value"] for option in _get_select_options(result)] == [
+        "9998",
+        "9999",
+    ]
+
+
+async def test_location_subentry_map_flow_expands_radius_for_useful_locations(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search expands the radius when nearby results are not useful."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.side_effect = [
+        make_response(
+            [
+                make_location(
+                    location_id=9998,
+                    name="Unsupported",
+                    sensor_parameters=("temperature",),
+                )
+            ]
+        ),
+        make_response([make_location(location_id=9999, name="Supported")]),
+    ]
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 10000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert [option["value"] for option in _get_select_options(result)] == ["9999"]
+    assert mock_openaq_client.locations.list.await_args_list == [
+        call(coordinates=(35.1, -106.6), radius=5000, limit=10),
+        call(coordinates=(35.1, -106.6), radius=10000, limit=10),
+    ]
+
+
 async def test_location_subentry_no_locations_found(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
@@ -206,10 +414,6 @@ async def test_location_subentry_no_locations_found(
         (mock_config_entry.entry_id, "location"),
         context={"source": config_entries.SOURCE_USER},
     )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": "map"}
-    )
-
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
@@ -238,10 +442,6 @@ async def test_location_subentry_invalid_map_location_id(
         (mock_config_entry.entry_id, "location"),
         context={"source": config_entries.SOURCE_USER},
     )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": "map"}
-    )
-
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
@@ -279,10 +479,6 @@ async def test_location_subentry_map_flow_errors(
         context={"source": config_entries.SOURCE_USER},
     )
     result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": "map"}
-    )
-
-    result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
             ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
@@ -296,116 +492,6 @@ async def test_location_subentry_map_flow_errors(
     assert result["errors"] == {"base": error}
 
 
-async def test_location_subentry_location_id_flow(
-    hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test adding an OpenAQ location by location ID."""
-    mock_config_entry.add_to_hass(hass)
-    result = await hass.config_entries.subentries.async_init(
-        (mock_config_entry.entry_id, "location"),
-        context={"source": config_entries.SOURCE_USER},
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == CONF_LOCATION_ID
-
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {CONF_LOCATION_ID: 9999}
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == {CONF_LOCATION_ID: 9999}
-    assert list(mock_config_entry.subentries.values())[1].unique_id == "9999"
-    mock_openaq_client.locations.get.assert_awaited_once_with(9999)
-
-
-async def test_location_subentry_location_id_not_found(
-    hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test adding an invalid OpenAQ location ID."""
-    mock_config_entry.add_to_hass(hass)
-    mock_openaq_client.locations.get.side_effect = NotFoundError("Location not found")
-    result = await hass.config_entries.subentries.async_init(
-        (mock_config_entry.entry_id, "location"),
-        context={"source": config_entries.SOURCE_USER},
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
-    )
-
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {CONF_LOCATION_ID: 9999}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == CONF_LOCATION_ID
-    assert result["errors"] == {"base": "invalid_location"}
-
-
-@pytest.mark.parametrize(
-    ("exception", "error"),
-    [
-        (HTTPRateLimitError("Rate limited"), "rate_limited"),
-        (BadGatewayError("Bad gateway"), "cannot_connect"),
-        (Exception("Unexpected"), "unknown"),
-    ],
-)
-async def test_location_subentry_location_id_flow_errors(
-    hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    exception: Exception,
-    error: str,
-) -> None:
-    """Test location ID API errors."""
-    mock_config_entry.add_to_hass(hass)
-    mock_openaq_client.locations.get.side_effect = exception
-    result = await hass.config_entries.subentries.async_init(
-        (mock_config_entry.entry_id, "location"),
-        context={"source": config_entries.SOURCE_USER},
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
-    )
-
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {CONF_LOCATION_ID: 9999}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == CONF_LOCATION_ID
-    assert result["errors"] == {"base": error}
-
-
-async def test_duplicate_location_subentry(
-    hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test duplicate OpenAQ location subentries abort."""
-    mock_config_entry.add_to_hass(hass)
-    result = await hass.config_entries.subentries.async_init(
-        (mock_config_entry.entry_id, "location"),
-        context={"source": config_entries.SOURCE_USER},
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
-    )
-
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {CONF_LOCATION_ID: LOCATION_ID}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
 async def test_duplicate_location_subentry_from_map_selection(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
@@ -417,9 +503,6 @@ async def test_duplicate_location_subentry_from_map_selection(
     result = await hass.config_entries.subentries.async_init(
         (mock_config_entry.entry_id, "location"),
         context={"source": config_entries.SOURCE_USER},
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": "map"}
     )
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
@@ -456,11 +539,16 @@ async def test_duplicate_location_subentry_across_entries(
         context={"source": config_entries.SOURCE_USER},
     )
     result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
     )
 
     result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {CONF_LOCATION_ID: LOCATION_ID}
+        result["flow_id"], {CONF_LOCATION_ID: str(LOCATION_ID)}
     )
 
     assert result["type"] is FlowResultType.ABORT

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import AsyncMock
 
-from openaq import GatewayTimeoutError, HTTPRateLimitError, NotAuthorizedError
+from openaq import (
+    GatewayTimeoutError,
+    HTTPRateLimitError,
+    NotAuthorizedError,
+    NotFoundError,
+)
 import pytest
 
 from homeassistant import config_entries
@@ -44,6 +49,7 @@ async def test_user_flow_success(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "OpenAQ"
     assert result["data"] == {CONF_API_KEY: API_KEY}
+    assert result["result"].unique_id == DOMAIN
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -91,16 +97,17 @@ async def test_duplicate_parent_entry(
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test duplicate API key setup aborts."""
+    """Test duplicate parent setup aborts."""
     mock_config_entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
-        data={CONF_API_KEY: API_KEY},
+        data={CONF_API_KEY: "other-api-key"},
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    mock_openaq_client.parameters.list.assert_not_awaited()
 
 
 async def test_location_subentry_map_flow(
@@ -206,6 +213,31 @@ async def test_location_subentry_location_id_flow(
     assert result["data"] == {CONF_LOCATION_ID: 9999}
     assert list(mock_config_entry.subentries.values())[1].unique_id == "9999"
     mock_openaq_client.locations.get.assert_awaited_once_with(9999)
+
+
+async def test_location_subentry_location_id_not_found(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test adding an invalid OpenAQ location ID."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.get.side_effect = NotFoundError("Location not found")
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: 9999}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_LOCATION_ID
+    assert result["errors"] == {"base": "invalid_location"}
 
 
 async def test_duplicate_location_subentry(

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 from openaq import (
+    BadGatewayError,
     GatewayTimeoutError,
     HTTPRateLimitError,
     NotAuthorizedError,
@@ -188,6 +189,46 @@ async def test_location_subentry_no_locations_found(
     assert result["errors"] == {"base": "no_locations_found"}
 
 
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (HTTPRateLimitError("Rate limited"), "rate_limited"),
+        (BadGatewayError("Bad gateway"), "cannot_connect"),
+        (Exception("Unexpected"), "unknown"),
+    ],
+)
+async def test_location_subentry_map_flow_errors(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test map search API errors."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.side_effect = exception
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": "map"}
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "map"
+    assert result["errors"] == {"base": error}
+
+
 async def test_location_subentry_location_id_flow(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
@@ -238,6 +279,41 @@ async def test_location_subentry_location_id_not_found(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == CONF_LOCATION_ID
     assert result["errors"] == {"base": "invalid_location"}
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (HTTPRateLimitError("Rate limited"), "rate_limited"),
+        (BadGatewayError("Bad gateway"), "cannot_connect"),
+        (Exception("Unexpected"), "unknown"),
+    ],
+)
+async def test_location_subentry_location_id_flow_errors(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test location ID API errors."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.get.side_effect = exception
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: 9999}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_LOCATION_ID
+    assert result["errors"] == {"base": error}
 
 
 async def test_duplicate_location_subentry(

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the OpenAQ config flow."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from openaq import (
@@ -159,6 +160,40 @@ async def test_location_subentry_map_flow(
     )
 
 
+async def test_location_subentry_map_flow_without_locality(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test adding an OpenAQ location without a separate locality."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [make_location(location_id=9999, name="Albuquerque")]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": "map"}
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: "9999"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Albuquerque"
+
+
 async def test_location_subentry_no_locations_found(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
@@ -167,6 +202,38 @@ async def test_location_subentry_no_locations_found(
     """Test map search with no matching OpenAQ locations."""
     mock_config_entry.add_to_hass(hass)
     mock_openaq_client.locations.list.return_value = make_response([])
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": "map"}
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "map"
+    assert result["errors"] == {"base": "no_locations_found"}
+
+
+async def test_location_subentry_invalid_map_location_id(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search ignores locations without integer IDs."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [SimpleNamespace(id="bad", name="Bad", locality="Albuquerque")]
+    )
     result = await hass.config_entries.subentries.async_init(
         (mock_config_entry.entry_id, "location"),
         context={"source": config_entries.SOURCE_USER},
@@ -333,6 +400,38 @@ async def test_duplicate_location_subentry(
 
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"], {CONF_LOCATION_ID: LOCATION_ID}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_duplicate_location_subentry_from_map_selection(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate OpenAQ location selected from map aborts."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response([make_location()])
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": "map"}
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: str(LOCATION_ID)}
     )
 
     assert result["type"] is FlowResultType.ABORT

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -23,6 +23,7 @@ from openaq import (
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components.openaq.config_flow import OpenAQLocationFlowData
 from homeassistant.components.openaq.const import (
     CONF_LIMIT,
     CONF_LOCATION_ID,
@@ -265,6 +266,38 @@ async def test_location_subentry_map_flow_sorts_by_sensor_count_before_distance(
     ]
 
 
+async def test_location_subentry_map_flow_labels_unknown_distance(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search labels locations with invalid distances."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [make_location(location_id=9999, distance=True)]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert _get_select_options(result) == [
+        SelectOptionDict(
+            value="9999",
+            label="Del Norte, Albuquerque - 1 sensor: PM2.5 - unknown distance",
+        )
+    ]
+
+
 async def test_location_subentry_map_flow_limits_to_top_five_locations(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
@@ -463,6 +496,41 @@ async def test_location_subentry_invalid_map_location_id(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "map"
     assert result["errors"] == {"base": "no_locations_found"}
+
+
+async def test_location_subentry_invalid_map_sensors(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search ignores locations without sensor lists."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [SimpleNamespace(id=9999, name="Bad", locality="Albuquerque", sensors=None)]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "map"
+    assert result["errors"] == {"base": "no_locations_found"}
+
+
+def test_location_select_label_without_supported_parameters() -> None:
+    """Test location select label with no supported parameters."""
+    location = OpenAQLocationFlowData(location_id=9999, title="Del Norte")
+
+    assert location.select_label == "Del Norte"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -1,25 +1,18 @@
 """Test the OpenAQ config flow."""
 
 from collections.abc import Sequence
-from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, call
 
+import httpx
 from openaq import (
     ApiKeyMissingError,
-    BadGatewayError,
-    BadRequestError,
     ForbiddenError,
-    GatewayTimeoutError,
     HTTPRateLimitError,
     NotAuthorizedError,
-    NotFoundError,
     RateLimitError,
-    ServerError,
-    ServiceUnavailableError,
-    TimeoutError as OpenAQTimeoutError,
-    ValidationError,
 )
+from openaq.shared.exceptions import APIError
 import pytest
 
 from homeassistant import config_entries
@@ -72,7 +65,6 @@ async def test_user_flow_success(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "OpenAQ"
     assert result["data"] == {CONF_API_KEY: API_KEY}
-    assert result["result"].unique_id == DOMAIN
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -80,8 +72,9 @@ async def test_user_flow_success(
     ("exception", "error"),
     [
         (NotAuthorizedError("Invalid API key"), "invalid_auth"),
-        (GatewayTimeoutError("Timeout"), "cannot_connect"),
         (HTTPRateLimitError("Rate limited"), "rate_limited"),
+        (APIError("API error"), "cannot_connect"),
+        (httpx.ConnectError("Connection error"), "cannot_connect"),
         (Exception("Unexpected"), "unknown"),
     ],
 )
@@ -120,17 +113,38 @@ async def test_duplicate_parent_entry(
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test duplicate parent setup aborts."""
+    """Test duplicate parent setup aborts for the same API key."""
     mock_config_entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
-        data={CONF_API_KEY: "other-api-key"},
+        data={CONF_API_KEY: API_KEY},
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     mock_openaq_client.parameters.list.assert_not_awaited()
+
+
+async def test_different_api_key_parent_entry(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a parent entry can be added for a different API key."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.async_block_till_done()
+    mock_setup_entry.reset_mock()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_API_KEY: "other-api-key"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_API_KEY: "other-api-key"}
 
 
 async def test_location_subentry_map_flow(
@@ -148,13 +162,16 @@ async def test_location_subentry_map_flow(
         context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "map"
+    assert result["step_id"] == "user"
 
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -193,8 +210,11 @@ async def test_location_subentry_map_flow_without_locality(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -245,8 +265,11 @@ async def test_location_subentry_map_flow_sorts_by_sensor_count_before_distance(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 10000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 10000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -271,10 +294,10 @@ async def test_location_subentry_map_flow_labels_unknown_distance(
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test map search labels locations with invalid distances."""
+    """Test map search labels locations with unknown distances."""
     mock_config_entry.add_to_hass(hass)
     mock_openaq_client.locations.list.return_value = make_response(
-        [make_location(location_id=9999, distance=True)]
+        [make_location(location_id=9999, distance=None)]
     )
     result = await hass.config_entries.subentries.async_init(
         (mock_config_entry.entry_id, "location"),
@@ -284,8 +307,11 @@ async def test_location_subentry_map_flow_labels_unknown_distance(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -322,8 +348,11 @@ async def test_location_subentry_map_flow_limits_to_top_five_locations(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -361,8 +390,11 @@ async def test_location_subentry_map_flow_omits_locations_without_supported_sens
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -393,8 +425,11 @@ async def test_location_subentry_map_flow_deduplicates_locations_across_radius_s
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 10000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 10000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -431,8 +466,11 @@ async def test_location_subentry_map_flow_expands_radius_for_useful_locations(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 10000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 10000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -459,70 +497,17 @@ async def test_location_subentry_no_locations_found(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "map"
-    assert result["errors"] == {"base": "no_locations_found"}
-
-
-async def test_location_subentry_invalid_map_location_id(
-    hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test map search ignores locations without integer IDs."""
-    mock_config_entry.add_to_hass(hass)
-    mock_openaq_client.locations.list.return_value = make_response(
-        [SimpleNamespace(id="bad", name="Bad", locality="Albuquerque")]
-    )
-    result = await hass.config_entries.subentries.async_init(
-        (mock_config_entry.entry_id, "location"),
-        context={"source": config_entries.SOURCE_USER},
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"],
-        {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
-            CONF_LIMIT: 10,
-        },
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "map"
-    assert result["errors"] == {"base": "no_locations_found"}
-
-
-async def test_location_subentry_invalid_map_sensors(
-    hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test map search ignores locations without sensor lists."""
-    mock_config_entry.add_to_hass(hass)
-    mock_openaq_client.locations.list.return_value = make_response(
-        [SimpleNamespace(id=9999, name="Bad", locality="Albuquerque", sensors=None)]
-    )
-    result = await hass.config_entries.subentries.async_init(
-        (mock_config_entry.entry_id, "location"),
-        context={"source": config_entries.SOURCE_USER},
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"],
-        {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
-            CONF_LIMIT: 10,
-        },
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "map"
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "no_locations_found"}
 
 
@@ -541,14 +526,8 @@ def test_location_select_label_without_supported_parameters() -> None:
         (NotAuthorizedError("Invalid API key"), "invalid_auth"),
         (HTTPRateLimitError("Rate limited"), "rate_limited"),
         (RateLimitError("Rate limited"), "rate_limited"),
-        (BadGatewayError("Bad gateway"), "cannot_connect"),
-        (BadRequestError("Bad request"), "cannot_connect"),
-        (GatewayTimeoutError("Timeout"), "cannot_connect"),
-        (NotFoundError("Not found"), "cannot_connect"),
-        (OpenAQTimeoutError("Timeout"), "cannot_connect"),
-        (ServerError("Server error"), "cannot_connect"),
-        (ServiceUnavailableError("Service unavailable"), "cannot_connect"),
-        (ValidationError("Validation error"), "cannot_connect"),
+        (APIError("API error"), "cannot_connect"),
+        (httpx.ConnectError("Connection error"), "cannot_connect"),
         (Exception("Unexpected"), "unknown"),
     ],
 )
@@ -569,14 +548,17 @@ async def test_location_subentry_map_flow_errors(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "map"
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": error}
 
 
@@ -595,8 +577,11 @@ async def test_duplicate_location_subentry_from_map_selection(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )
@@ -629,8 +614,11 @@ async def test_duplicate_location_subentry_across_entries(
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
-            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
-            CONF_RADIUS: 5000,
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
             CONF_LIMIT: 10,
         },
     )

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -1,0 +1,260 @@
+"""Test the OpenAQ config flow."""
+
+from unittest.mock import AsyncMock
+
+from openaq import GatewayTimeoutError, HTTPRateLimitError, NotAuthorizedError
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.openaq.const import (
+    CONF_LIMIT,
+    CONF_LOCATION_ID,
+    CONF_RADIUS,
+    DOMAIN,
+)
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LOCATION,
+    ATTR_LONGITUDE,
+    CONF_API_KEY,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import API_KEY, LOCATION_ID, make_location, make_response
+
+from tests.common import MockConfigEntry
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_openaq_client: AsyncMock
+) -> None:
+    """Test successful API key setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_API_KEY: API_KEY}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "OpenAQ"
+    assert result["data"] == {CONF_API_KEY: API_KEY}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (NotAuthorizedError("Invalid API key"), "invalid_auth"),
+        (GatewayTimeoutError("Timeout"), "cannot_connect"),
+        (HTTPRateLimitError("Rate limited"), "rate_limited"),
+        (Exception("Unexpected"), "unknown"),
+    ],
+)
+async def test_user_flow_errors(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_openaq_client: AsyncMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test API key setup errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    mock_openaq_client.parameters.list.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_API_KEY: API_KEY}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_openaq_client.parameters.list.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_API_KEY: API_KEY}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_duplicate_parent_entry(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate API key setup aborts."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_API_KEY: API_KEY},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_location_subentry_map_flow(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test adding an OpenAQ location via map search."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [make_location(location_id=9999, name="South Valley")]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": "map"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "map"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: "9999"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "South Valley, Albuquerque"
+    assert result["data"] == {CONF_LOCATION_ID: 9999}
+    assert list(mock_config_entry.subentries.values())[1].unique_id == "9999"
+    mock_openaq_client.locations.list.assert_awaited_once_with(
+        coordinates=(35.1, -106.6),
+        radius=5000,
+        limit=10,
+    )
+
+
+async def test_location_subentry_no_locations_found(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search with no matching OpenAQ locations."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response([])
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": "map"}
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {ATTR_LATITUDE: 35.1, ATTR_LONGITUDE: -106.6},
+            CONF_RADIUS: 5000,
+            CONF_LIMIT: 10,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "map"
+    assert result["errors"] == {"base": "no_locations_found"}
+
+
+async def test_location_subentry_location_id_flow(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test adding an OpenAQ location by location ID."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == CONF_LOCATION_ID
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: 9999}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_LOCATION_ID: 9999}
+    assert list(mock_config_entry.subentries.values())[1].unique_id == "9999"
+    mock_openaq_client.locations.get.assert_awaited_once_with(9999)
+
+
+async def test_duplicate_location_subentry(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate OpenAQ location subentries abort."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: LOCATION_ID}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_duplicate_location_subentry_across_entries(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate OpenAQ location subentries across entries abort."""
+    mock_config_entry.add_to_hass(hass)
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: "other-api-key"},
+    )
+    second_entry.add_to_hass(hass)
+    result = await hass.config_entries.subentries.async_init(
+        (second_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {"next_step_id": CONF_LOCATION_ID}
+    )
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: LOCATION_ID}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -6,10 +6,19 @@ from typing import cast
 from unittest.mock import AsyncMock, call
 
 from openaq import (
+    ApiKeyMissingError,
     BadGatewayError,
+    BadRequestError,
+    ForbiddenError,
     GatewayTimeoutError,
     HTTPRateLimitError,
     NotAuthorizedError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+    ServiceUnavailableError,
+    TimeoutError as OpenAQTimeoutError,
+    ValidationError,
 )
 import pytest
 
@@ -459,8 +468,19 @@ async def test_location_subentry_invalid_map_location_id(
 @pytest.mark.parametrize(
     ("exception", "error"),
     [
+        (ApiKeyMissingError("Missing API key"), "invalid_auth"),
+        (ForbiddenError("Forbidden"), "invalid_auth"),
+        (NotAuthorizedError("Invalid API key"), "invalid_auth"),
         (HTTPRateLimitError("Rate limited"), "rate_limited"),
+        (RateLimitError("Rate limited"), "rate_limited"),
         (BadGatewayError("Bad gateway"), "cannot_connect"),
+        (BadRequestError("Bad request"), "cannot_connect"),
+        (GatewayTimeoutError("Timeout"), "cannot_connect"),
+        (NotFoundError("Not found"), "cannot_connect"),
+        (OpenAQTimeoutError("Timeout"), "cannot_connect"),
+        (ServerError("Server error"), "cannot_connect"),
+        (ServiceUnavailableError("Service unavailable"), "cannot_connect"),
+        (ValidationError("Validation error"), "cannot_connect"),
         (Exception("Unexpected"), "unknown"),
     ],
 )

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -159,6 +159,61 @@ async def test_different_api_key_parent_entry(
     assert result["data"] == {CONF_API_KEY: "other-api-key"}
 
 
+async def test_reauth_success(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_openaq_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test successful API key reauthentication."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_API_KEY: "new-api-key"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data == {CONF_API_KEY: "new-api-key"}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (NotAuthorizedError("Invalid API key"), "invalid_auth"),
+        (HTTPRateLimitError("Rate limited"), "rate_limited"),
+        (APIError("API error"), "cannot_connect"),
+        (OSError("Connection error"), "cannot_connect"),
+        (Exception("Unexpected"), "unknown"),
+    ],
+)
+async def test_reauth_errors(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test API key reauthentication errors."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reauth_flow(hass)
+    mock_openaq_client.parameters.list.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_API_KEY: "new-api-key"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+
 async def test_location_subentry_map_flow(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -318,6 +318,42 @@ async def test_location_subentry_map_flow_labels_unknown_distance(
     ]
 
 
+async def test_location_subentry_map_flow_sorts_locations_by_distance(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test map search presents locations ordered by distance."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [
+            make_location(location_id=9993, name="Far", distance=3000),
+            make_location(location_id=9991, name="Near", distance=1000),
+            make_location(location_id=9992, name="Middle", distance=2000),
+        ]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
+        },
+    )
+
+    assert [option["value"] for option in _get_select_options(result)] == [
+        "9991",
+        "9992",
+        "9993",
+    ]
+
+
 async def test_location_subentry_map_flow_limits_to_top_five_locations(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -20,7 +20,12 @@ from homeassistant.components.openaq.config_flow import (
     LOCATION_FETCH_LIMIT,
     OpenAQLocationFlowData,
 )
-from homeassistant.components.openaq.const import CONF_LOCATION_ID, CONF_RADIUS, DOMAIN
+from homeassistant.components.openaq.const import (
+    CONF_LOCATION_ID,
+    CONF_RADIUS,
+    DOMAIN,
+    MAX_RADIUS,
+)
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LOCATION,
@@ -43,6 +48,15 @@ def _get_select_options(result: FlowResult) -> Sequence[SelectOptionDict]:
     selector = next(iter(data_schema.schema.values()))
     assert isinstance(selector, SelectSelector)
     return cast(Sequence[SelectOptionDict], selector.config["options"])
+
+
+def _get_suggested_values(result: FlowResult) -> dict[str, object]:
+    """Return suggested values from a flow result."""
+    data_schema = result["data_schema"]
+    assert data_schema is not None
+    marker = next(iter(data_schema.schema))
+    assert marker == ATTR_LOCATION
+    return cast(dict[str, object], marker.description["suggested_value"])
 
 
 async def test_user_flow_success(
@@ -161,6 +175,11 @@ async def test_location_subentry_map_flow(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+    assert _get_suggested_values(result) == {
+        ATTR_LATITUDE: hass.config.latitude,
+        ATTR_LONGITUDE: hass.config.longitude,
+        CONF_RADIUS: MAX_RADIUS,
+    }
 
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"],

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -16,13 +16,11 @@ from openaq.shared.exceptions import APIError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.openaq.config_flow import OpenAQLocationFlowData
-from homeassistant.components.openaq.const import (
-    CONF_LIMIT,
-    CONF_LOCATION_ID,
-    CONF_RADIUS,
-    DOMAIN,
+from homeassistant.components.openaq.config_flow import (
+    LOCATION_FETCH_LIMIT,
+    OpenAQLocationFlowData,
 )
+from homeassistant.components.openaq.const import CONF_LOCATION_ID, CONF_RADIUS, DOMAIN
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LOCATION,
@@ -33,7 +31,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult, FlowResultType
 from homeassistant.helpers.selector import SelectOptionDict, SelectSelector
 
-from .conftest import API_KEY, LOCATION_ID, make_location, make_response
+from .conftest import API_KEY, make_location, make_response
 
 from tests.common import MockConfigEntry
 
@@ -172,7 +170,6 @@ async def test_location_subentry_map_flow(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
     assert result["type"] is FlowResultType.FORM
@@ -189,7 +186,7 @@ async def test_location_subentry_map_flow(
     mock_openaq_client.locations.list.assert_awaited_once_with(
         coordinates=(35.1, -106.6),
         radius=5000,
-        limit=10,
+        limit=LOCATION_FETCH_LIMIT,
     )
 
 
@@ -215,7 +212,6 @@ async def test_location_subentry_map_flow_without_locality(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
@@ -227,12 +223,12 @@ async def test_location_subentry_map_flow_without_locality(
     assert result["title"] == "Albuquerque"
 
 
-async def test_location_subentry_map_flow_sorts_by_sensor_count_before_distance(
+async def test_location_subentry_map_flow_sorts_by_distance_before_sensor_count(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test map search ranks useful locations by sensor count before distance."""
+    """Test map search ranks useful locations by distance before sensor count."""
     mock_config_entry.add_to_hass(hass)
     mock_openaq_client.locations.list.side_effect = [
         make_response(
@@ -270,22 +266,21 @@ async def test_location_subentry_map_flow_sorts_by_sensor_count_before_distance(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 10000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "select"
     assert _get_select_options(result) == [
+        SelectOptionDict(value="9998", label="Nearby - 1 sensor: Ozone - 1.0 km"),
         SelectOptionDict(
             value="9999",
             label="Pinecliff - 3 sensors: PM1, PM10, PM2.5 - 6.0 km",
         ),
-        SelectOptionDict(value="9998", label="Nearby - 1 sensor: Ozone - 1.0 km"),
     ]
     assert mock_openaq_client.locations.list.await_args_list == [
-        call(coordinates=(35.1, -106.6), radius=5000, limit=10),
-        call(coordinates=(35.1, -106.6), radius=10000, limit=10),
+        call(coordinates=(35.1, -106.6), radius=5000, limit=LOCATION_FETCH_LIMIT),
+        call(coordinates=(35.1, -106.6), radius=10000, limit=LOCATION_FETCH_LIMIT),
     ]
 
 
@@ -312,7 +307,6 @@ async def test_location_subentry_map_flow_labels_unknown_distance(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
@@ -353,7 +347,6 @@ async def test_location_subentry_map_flow_limits_to_top_five_locations(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
@@ -395,7 +388,6 @@ async def test_location_subentry_map_flow_omits_locations_without_supported_sens
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
@@ -430,7 +422,6 @@ async def test_location_subentry_map_flow_deduplicates_locations_across_radius_s
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 10000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
@@ -471,14 +462,13 @@ async def test_location_subentry_map_flow_expands_radius_for_useful_locations(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 10000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
     assert [option["value"] for option in _get_select_options(result)] == ["9999"]
     assert mock_openaq_client.locations.list.await_args_list == [
-        call(coordinates=(35.1, -106.6), radius=5000, limit=10),
-        call(coordinates=(35.1, -106.6), radius=10000, limit=10),
+        call(coordinates=(35.1, -106.6), radius=5000, limit=LOCATION_FETCH_LIMIT),
+        call(coordinates=(35.1, -106.6), radius=10000, limit=LOCATION_FETCH_LIMIT),
     ]
 
 
@@ -502,7 +492,6 @@ async def test_location_subentry_no_locations_found(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
@@ -553,7 +542,6 @@ async def test_location_subentry_map_flow_errors(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
@@ -562,14 +550,19 @@ async def test_location_subentry_map_flow_errors(
     assert result["errors"] == {"base": error}
 
 
-async def test_duplicate_location_subentry_from_map_selection(
+async def test_location_subentry_map_flow_omits_configured_locations(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test duplicate OpenAQ location selected from map aborts."""
+    """Test map search omits already configured OpenAQ locations."""
     mock_config_entry.add_to_hass(hass)
-    mock_openaq_client.locations.list.return_value = make_response([make_location()])
+    mock_openaq_client.locations.list.return_value = make_response(
+        [
+            make_location(),
+            make_location(location_id=9999, name="New location"),
+        ]
+    )
     result = await hass.config_entries.subentries.async_init(
         (mock_config_entry.entry_id, "location"),
         context={"source": config_entries.SOURCE_USER},
@@ -582,16 +575,12 @@ async def test_duplicate_location_subentry_from_map_selection(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {CONF_LOCATION_ID: str(LOCATION_ID)}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select"
+    assert [option["value"] for option in _get_select_options(result)] == ["9999"]
 
 
 async def test_duplicate_location_subentry_across_entries(
@@ -599,7 +588,7 @@ async def test_duplicate_location_subentry_across_entries(
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test duplicate OpenAQ location subentries across entries abort."""
+    """Test duplicate OpenAQ location subentries are omitted across entries."""
     mock_config_entry.add_to_hass(hass)
     second_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -619,13 +608,9 @@ async def test_duplicate_location_subentry_across_entries(
                 ATTR_LONGITUDE: -106.6,
                 CONF_RADIUS: 5000,
             },
-            CONF_LIMIT: 10,
         },
     )
 
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], {CONF_LOCATION_ID: str(LOCATION_ID)}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "no_locations_found"}

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -2,9 +2,8 @@
 
 from collections.abc import Sequence
 from typing import cast
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
-import httpx
 from openaq import (
     ApiKeyMissingError,
     ForbiddenError,
@@ -12,7 +11,7 @@ from openaq import (
     NotAuthorizedError,
     RateLimitError,
 )
-from openaq.shared.exceptions import APIError
+from openaq.core.exceptions import APIError
 import pytest
 
 from homeassistant import config_entries
@@ -21,7 +20,7 @@ from homeassistant.components.openaq.config_flow import (
     OpenAQLocationFlowData,
 )
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN, MAX_RADIUS
-from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.config_entries import ConfigSubentryDataWithId
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LOCATION,
@@ -30,7 +29,7 @@ from homeassistant.const import (
     CONF_RADIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult, FlowResultType
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.selector import SelectOptionDict, SelectSelector
 
 from .conftest import API_KEY, make_location, make_response
@@ -38,7 +37,9 @@ from .conftest import API_KEY, make_location, make_response
 from tests.common import MockConfigEntry
 
 
-def _get_select_options(result: FlowResult) -> Sequence[SelectOptionDict]:
+def _get_select_options(
+    result: config_entries.SubentryFlowResult,
+) -> Sequence[SelectOptionDict]:
     """Return select options from a flow result."""
     data_schema = result["data_schema"]
     assert data_schema is not None
@@ -47,7 +48,9 @@ def _get_select_options(result: FlowResult) -> Sequence[SelectOptionDict]:
     return cast(Sequence[SelectOptionDict], selector.config["options"])
 
 
-def _get_suggested_values(result: FlowResult) -> dict[str, object]:
+def _get_suggested_values(
+    result: config_entries.SubentryFlowResult,
+) -> dict[str, object]:
     """Return suggested values from a flow result."""
     data_schema = result["data_schema"]
     assert data_schema is not None
@@ -57,7 +60,7 @@ def _get_suggested_values(result: FlowResult) -> dict[str, object]:
 
 
 async def test_user_flow_success(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_openaq_client: AsyncMock
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_openaq_client: MagicMock
 ) -> None:
     """Test successful API key setup."""
     result = await hass.config_entries.flow.async_init(
@@ -83,14 +86,14 @@ async def test_user_flow_success(
         (NotAuthorizedError("Invalid API key"), "invalid_auth"),
         (HTTPRateLimitError("Rate limited"), "rate_limited"),
         (APIError("API error"), "cannot_connect"),
-        (httpx.ConnectError("Connection error"), "cannot_connect"),
+        (OSError("Connection error"), "cannot_connect"),
         (Exception("Unexpected"), "unknown"),
     ],
 )
 async def test_user_flow_errors(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     exception: Exception,
     error: str,
 ) -> None:
@@ -119,7 +122,7 @@ async def test_user_flow_errors(
 
 async def test_duplicate_parent_entry(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test duplicate parent setup aborts for the same API key."""
@@ -132,13 +135,13 @@ async def test_duplicate_parent_entry(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    mock_openaq_client.parameters.list.assert_not_awaited()
+    mock_openaq_client.parameters.list.assert_not_called()
 
 
 async def test_different_api_key_parent_entry(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test a parent entry can be added for a different API key."""
@@ -158,7 +161,7 @@ async def test_different_api_key_parent_entry(
 
 async def test_location_subentry_map_flow(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test adding an OpenAQ location via map search."""
@@ -199,7 +202,7 @@ async def test_location_subentry_map_flow(
     assert result["title"] == "South Valley, Albuquerque"
     assert result["data"] == {CONF_LOCATION_ID: 9999}
     assert list(mock_config_entry.subentries.values())[1].unique_id == "9999"
-    mock_openaq_client.locations.list.assert_awaited_once_with(
+    mock_openaq_client.locations.list.assert_called_once_with(
         coordinates=(35.1, -106.6),
         radius=5000,
         limit=LOCATION_FETCH_LIMIT,
@@ -208,7 +211,7 @@ async def test_location_subentry_map_flow(
 
 async def test_location_subentry_map_flow_without_locality(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test adding an OpenAQ location without a separate locality."""
@@ -241,7 +244,7 @@ async def test_location_subentry_map_flow_without_locality(
 
 async def test_location_subentry_select_aborts_when_location_was_just_configured(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test select aborts if the chosen location was configured during the flow."""
@@ -268,7 +271,7 @@ async def test_location_subentry_select_aborts_when_location_was_just_configured
         title="OpenAQ",
         data={CONF_API_KEY: "other-api-key"},
         subentries_data=[
-            ConfigSubentryData(
+            ConfigSubentryDataWithId(
                 data={CONF_LOCATION_ID: 9999},
                 subentry_id="GHIJKL",
                 subentry_type="location",
@@ -289,7 +292,7 @@ async def test_location_subentry_select_aborts_when_location_was_just_configured
 
 async def test_location_subentry_map_flow_sorts_by_distance_before_sensor_count(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search ranks useful locations by distance before sensor count."""
@@ -342,7 +345,7 @@ async def test_location_subentry_map_flow_sorts_by_distance_before_sensor_count(
             label="Pinecliff (PM1, PM10, PM2.5) - 6.0 km",
         ),
     ]
-    assert mock_openaq_client.locations.list.await_args_list == [
+    assert mock_openaq_client.locations.list.call_args_list == [
         call(coordinates=(35.1, -106.6), radius=5000, limit=LOCATION_FETCH_LIMIT),
         call(coordinates=(35.1, -106.6), radius=10000, limit=LOCATION_FETCH_LIMIT),
     ]
@@ -350,7 +353,7 @@ async def test_location_subentry_map_flow_sorts_by_distance_before_sensor_count(
 
 async def test_location_subentry_map_flow_omits_unknown_distance(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search omits unknown distances from location labels."""
@@ -384,7 +387,7 @@ async def test_location_subentry_map_flow_omits_unknown_distance(
 
 async def test_location_subentry_map_flow_sorts_locations_by_distance(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search presents locations ordered by distance."""
@@ -420,7 +423,7 @@ async def test_location_subentry_map_flow_sorts_locations_by_distance(
 
 async def test_location_subentry_map_flow_limits_to_top_ten_locations(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search only shows the top ten useful locations."""
@@ -471,7 +474,7 @@ async def test_location_subentry_map_flow_limits_to_top_ten_locations(
 
 async def test_location_subentry_map_flow_omits_locations_without_supported_sensors(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search omits locations with only unsupported sensors."""
@@ -506,7 +509,7 @@ async def test_location_subentry_map_flow_omits_locations_without_supported_sens
 
 async def test_location_subentry_map_flow_deduplicates_locations_across_radius_searches(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search deduplicates location IDs across radius searches."""
@@ -543,7 +546,7 @@ async def test_location_subentry_map_flow_deduplicates_locations_across_radius_s
 
 async def test_location_subentry_map_flow_expands_radius_for_useful_locations(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search expands the radius when nearby results are not useful."""
@@ -576,7 +579,7 @@ async def test_location_subentry_map_flow_expands_radius_for_useful_locations(
     )
 
     assert [option["value"] for option in _get_select_options(result)] == ["9999"]
-    assert mock_openaq_client.locations.list.await_args_list == [
+    assert mock_openaq_client.locations.list.call_args_list == [
         call(coordinates=(35.1, -106.6), radius=5000, limit=LOCATION_FETCH_LIMIT),
         call(coordinates=(35.1, -106.6), radius=10000, limit=LOCATION_FETCH_LIMIT),
     ]
@@ -584,7 +587,7 @@ async def test_location_subentry_map_flow_expands_radius_for_useful_locations(
 
 async def test_location_subentry_no_locations_found(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search with no matching OpenAQ locations."""
@@ -626,13 +629,13 @@ def test_location_select_label_without_supported_parameters() -> None:
         (HTTPRateLimitError("Rate limited"), "rate_limited"),
         (RateLimitError("Rate limited"), "rate_limited"),
         (APIError("API error"), "cannot_connect"),
-        (httpx.ConnectError("Connection error"), "cannot_connect"),
+        (OSError("Connection error"), "cannot_connect"),
         (Exception("Unexpected"), "unknown"),
     ],
 )
 async def test_location_subentry_map_flow_errors(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     exception: Exception,
     error: str,
@@ -662,7 +665,7 @@ async def test_location_subentry_map_flow_errors(
 
 async def test_location_subentry_map_flow_omits_configured_locations(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test map search omits already configured OpenAQ locations."""
@@ -695,7 +698,7 @@ async def test_location_subentry_map_flow_omits_configured_locations(
 
 async def test_duplicate_location_subentry_across_entries(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test duplicate OpenAQ location subentries are omitted across entries."""

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -291,10 +291,10 @@ async def test_location_subentry_map_flow_sorts_by_distance_before_sensor_count(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "select"
     assert _get_select_options(result) == [
-        SelectOptionDict(value="9998", label="Nearby - 1 sensor: Ozone - 1.0 km"),
+        SelectOptionDict(value="9998", label="Nearby (O3) - 1.0 km"),
         SelectOptionDict(
             value="9999",
-            label="Pinecliff - 3 sensors: PM1, PM10, PM2.5 - 6.0 km",
+            label="Pinecliff (PM1, PM10, PM2.5) - 6.0 km",
         ),
     ]
     assert mock_openaq_client.locations.list.await_args_list == [
@@ -303,12 +303,12 @@ async def test_location_subentry_map_flow_sorts_by_distance_before_sensor_count(
     ]
 
 
-async def test_location_subentry_map_flow_labels_unknown_distance(
+async def test_location_subentry_map_flow_omits_unknown_distance(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test map search labels locations with unknown distances."""
+    """Test map search omits unknown distances from location labels."""
     mock_config_entry.add_to_hass(hass)
     mock_openaq_client.locations.list.return_value = make_response(
         [make_location(location_id=9999, distance=None)]
@@ -332,7 +332,7 @@ async def test_location_subentry_map_flow_labels_unknown_distance(
     assert _get_select_options(result) == [
         SelectOptionDict(
             value="9999",
-            label="Del Norte, Albuquerque - 1 sensor: PM2.5 - unknown distance",
+            label="Del Norte, Albuquerque (PM2.5)",
         )
     ]
 

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -26,6 +26,7 @@ from homeassistant.components.openaq.const import (
     DOMAIN,
     MAX_RADIUS,
 )
+from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LOCATION,
@@ -240,6 +241,54 @@ async def test_location_subentry_map_flow_without_locality(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Albuquerque"
+
+
+async def test_location_subentry_select_aborts_when_location_was_just_configured(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test select aborts if the chosen location was configured during the flow."""
+    mock_config_entry.add_to_hass(hass)
+    mock_openaq_client.locations.list.return_value = make_response(
+        [make_location(location_id=9999, name="South Valley")]
+    )
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, "location"),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {
+            ATTR_LOCATION: {
+                ATTR_LATITUDE: 35.1,
+                ATTR_LONGITUDE: -106.6,
+                CONF_RADIUS: 5000,
+            },
+        },
+    )
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: "other-api-key"},
+        subentries_data=[
+            ConfigSubentryData(
+                data={CONF_LOCATION_ID: 9999},
+                subentry_id="GHIJKL",
+                subentry_type="location",
+                title="South Valley",
+                unique_id="9999",
+            )
+        ],
+    )
+    second_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LOCATION_ID: "9999"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_location_subentry_map_flow_sorts_by_distance_before_sensor_count(

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -611,6 +611,11 @@ async def test_location_subentry_no_locations_found(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "no_locations_found"}
+    assert _get_suggested_values(result) == {
+        ATTR_LATITUDE: 35.1,
+        ATTR_LONGITUDE: -106.6,
+        CONF_RADIUS: 5000,
+    }
 
 
 def test_location_select_label_without_supported_parameters() -> None:

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -20,18 +20,14 @@ from homeassistant.components.openaq.config_flow import (
     LOCATION_FETCH_LIMIT,
     OpenAQLocationFlowData,
 )
-from homeassistant.components.openaq.const import (
-    CONF_LOCATION_ID,
-    CONF_RADIUS,
-    DOMAIN,
-    MAX_RADIUS,
-)
+from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN, MAX_RADIUS
 from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LOCATION,
     ATTR_LONGITUDE,
     CONF_API_KEY,
+    CONF_RADIUS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult, FlowResultType

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -373,12 +373,12 @@ async def test_location_subentry_map_flow_sorts_locations_by_distance(
     ]
 
 
-async def test_location_subentry_map_flow_limits_to_top_five_locations(
+async def test_location_subentry_map_flow_limits_to_top_ten_locations(
     hass: HomeAssistant,
     mock_openaq_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test map search only shows the top five useful locations."""
+    """Test map search only shows the top ten useful locations."""
     mock_config_entry.add_to_hass(hass)
     mock_openaq_client.locations.list.return_value = make_response(
         [
@@ -388,6 +388,11 @@ async def test_location_subentry_map_flow_limits_to_top_five_locations(
             make_location(location_id=9994, name="Location 4", distance=400),
             make_location(location_id=9995, name="Location 5", distance=500),
             make_location(location_id=9996, name="Location 6", distance=600),
+            make_location(location_id=9997, name="Location 7", distance=700),
+            make_location(location_id=9998, name="Location 8", distance=800),
+            make_location(location_id=9999, name="Location 9", distance=900),
+            make_location(location_id=10000, name="Location 10", distance=1000),
+            make_location(location_id=10001, name="Location 11", distance=1100),
         ]
     )
     result = await hass.config_entries.subentries.async_init(
@@ -411,6 +416,11 @@ async def test_location_subentry_map_flow_limits_to_top_five_locations(
         "9993",
         "9994",
         "9995",
+        "9996",
+        "9997",
+        "9998",
+        "9999",
+        "10000",
     ]
 
 

--- a/tests/components/openaq/test_config_flow.py
+++ b/tests/components/openaq/test_config_flow.py
@@ -78,6 +78,7 @@ async def test_user_flow_success(
     assert result["title"] == "OpenAQ"
     assert result["data"] == {CONF_API_KEY: API_KEY}
     assert len(mock_setup_entry.mock_calls) == 1
+    mock_openaq_client.close.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -118,6 +119,7 @@ async def test_user_flow_errors(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_openaq_client.close.call_count == 2
 
 
 async def test_duplicate_parent_entry(
@@ -157,61 +159,6 @@ async def test_different_api_key_parent_entry(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_API_KEY: "other-api-key"}
-
-
-async def test_reauth_success(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_openaq_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test successful API key reauthentication."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await mock_config_entry.start_reauth_flow(hass)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reauth_confirm"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_API_KEY: "new-api-key"}
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reauth_successful"
-    assert mock_config_entry.data == {CONF_API_KEY: "new-api-key"}
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-@pytest.mark.parametrize(
-    ("exception", "error"),
-    [
-        (NotAuthorizedError("Invalid API key"), "invalid_auth"),
-        (HTTPRateLimitError("Rate limited"), "rate_limited"),
-        (APIError("API error"), "cannot_connect"),
-        (OSError("Connection error"), "cannot_connect"),
-        (Exception("Unexpected"), "unknown"),
-    ],
-)
-async def test_reauth_errors(
-    hass: HomeAssistant,
-    mock_openaq_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    exception: Exception,
-    error: str,
-) -> None:
-    """Test API key reauthentication errors."""
-    mock_config_entry.add_to_hass(hass)
-    result = await mock_config_entry.start_reauth_flow(hass)
-    mock_openaq_client.parameters.list.side_effect = exception
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_API_KEY: "new-api-key"}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": error}
 
 
 async def test_location_subentry_map_flow(
@@ -262,6 +209,7 @@ async def test_location_subentry_map_flow(
         radius=5000,
         limit=LOCATION_FETCH_LIMIT,
     )
+    mock_openaq_client.close.assert_called_once()
 
 
 async def test_location_subentry_map_flow_without_locality(
@@ -721,6 +669,7 @@ async def test_location_subentry_map_flow_errors(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": error}
+    mock_openaq_client.close.assert_called_once()
 
 
 async def test_location_subentry_map_flow_omits_configured_locations(

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -1,6 +1,6 @@
 """Test OpenAQ data coordinator helpers."""
 
-from types import MappingProxyType, SimpleNamespace
+from types import MappingProxyType
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -10,7 +10,6 @@ from homeassistant.components.openaq.coordinator import (
     OpenAQMeasurement,
     async_create_openaq_client,
     create_openaq_client,
-    get_openaq_value,
     normalize_latest_measurements,
 )
 from homeassistant.const import (
@@ -83,29 +82,17 @@ async def test_async_create_openaq_client_uses_shared_httpx_client(
         await httpx_client.aclose()
 
 
-def test_get_openaq_value_dict() -> None:
-    """Test getting OpenAQ values from dict data."""
-    data = {"id": 123}
-
-    assert get_openaq_value(data, "id") == 123
-    assert get_openaq_value(data, "missing") is None
-
-
-def test_normalize_latest_measurements_ignores_invalid_data() -> None:
-    """Test normalizing latest measurements ignores invalid API data."""
+def test_normalize_latest_measurements() -> None:
+    """Test normalizing latest measurements by sensor metadata."""
     measurements = normalize_latest_measurements(
         [
-            make_latest("1", 8.5),
-            make_latest("unknown", 12.1),
+            make_latest(1, 8.5),
             make_latest(999, 44.1),
-            make_latest(2, True),
-            make_latest(3, 33.2),
+            make_latest(2, None),
         ],
         [
-            make_sensor("1", "pm2.5", "µg/m3"),
+            make_sensor(1, "pm2.5", "µg/m3"),
             make_sensor(2, "pm10"),
-            make_sensor(3, "no_units", 123),
-            SimpleNamespace(id=4, parameter=SimpleNamespace()),
         ],
     )
 
@@ -116,20 +103,15 @@ def test_normalize_latest_measurements_ignores_invalid_data() -> None:
                 value=8.5,
                 unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             ),
-            "nounits": OpenAQMeasurement(
-                parameter="nounits",
-                value=33.2,
-                unit=None,
-            ),
         }
     )
 
 
-def test_normalize_latest_measurements_uses_sensor_latest() -> None:
-    """Test normalizing measurements from sensor latest data."""
+def test_normalize_latest_measurements_normalizes_unit_aliases() -> None:
+    """Test normalizing measurement unit aliases."""
     measurements = normalize_latest_measurements(
-        [],
-        [make_sensor(1, "pm10", "mg/m3", value=12.1)],
+        [make_latest(1, 12.1)],
+        [make_sensor(1, "pm10", "mg/m3")],
     )
 
     assert measurements == MappingProxyType(

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -2,6 +2,8 @@
 
 from types import MappingProxyType, SimpleNamespace
 
+import httpx
+
 from homeassistant.components.openaq.coordinator import (
     OpenAQMeasurement,
     create_openaq_client,
@@ -16,17 +18,17 @@ from homeassistant.const import (
 from .conftest import make_latest, make_sensor
 
 
-async def test_create_openaq_client_uses_fresh_transport() -> None:
-    """Test OpenAQ clients do not share a closable transport."""
-    client = create_openaq_client("api-key")
-    other_client = create_openaq_client("api-key")
+async def test_create_openaq_client_keeps_shared_httpx_client_open() -> None:
+    """Test closing the OpenAQ client does not close the shared httpx client."""
+    httpx_client = httpx.AsyncClient()
+    client = create_openaq_client("api-key", httpx_client)
 
     try:
-        assert client.transport is not other_client.transport
+        assert client.transport.client is httpx_client
         await client.close()
-        assert not other_client.transport.client.is_closed
+        assert not httpx_client.is_closed
     finally:
-        await other_client.close()
+        await httpx_client.aclose()
 
 
 def test_get_openaq_value_dict() -> None:

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -1,11 +1,14 @@
 """Test OpenAQ data coordinator helpers."""
 
 from types import MappingProxyType, SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import httpx
 
 from homeassistant.components.openaq.coordinator import (
+    HomeAssistantOpenAQTransport,
     OpenAQMeasurement,
+    async_create_openaq_client,
     create_openaq_client,
     get_openaq_value,
     normalize_latest_measurements,
@@ -14,8 +17,38 @@ from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
 )
+from homeassistant.core import HomeAssistant
 
 from .conftest import make_latest, make_sensor
+
+
+async def test_transport_sends_request_with_shared_httpx_client() -> None:
+    """Test the transport sends requests with the shared httpx client."""
+    response = httpx.Response(
+        200,
+        json={"results": []},
+        request=httpx.Request("GET", "https://api.openaq.org/v3/locations"),
+    )
+    httpx_client = AsyncMock(spec=httpx.AsyncClient)
+    httpx_client.request.return_value = response
+
+    transport = HomeAssistantOpenAQTransport(httpx_client)
+
+    assert (
+        await transport.send_request(
+            "GET",
+            "https://api.openaq.org/v3/locations",
+            params={"limit": 1},
+            headers={"X-API-Key": "api-key"},
+        )
+        is response
+    )
+    httpx_client.request.assert_awaited_once_with(
+        method="GET",
+        url="https://api.openaq.org/v3/locations",
+        params={"limit": 1},
+        headers={"X-API-Key": "api-key"},
+    )
 
 
 async def test_create_openaq_client_keeps_shared_httpx_client_open() -> None:
@@ -27,6 +60,25 @@ async def test_create_openaq_client_keeps_shared_httpx_client_open() -> None:
         assert client.transport.client is httpx_client
         await client.close()
         assert not httpx_client.is_closed
+    finally:
+        await httpx_client.aclose()
+
+
+async def test_async_create_openaq_client_uses_shared_httpx_client(
+    hass: HomeAssistant,
+) -> None:
+    """Test creating an OpenAQ client from Home Assistant."""
+    httpx_client = httpx.AsyncClient()
+
+    try:
+        with patch(
+            "homeassistant.components.openaq.coordinator.get_async_client",
+            return_value=httpx_client,
+        ):
+            client = await async_create_openaq_client(hass, "api-key")
+
+        assert client.transport.client is httpx_client
+        await client.close()
     finally:
         await httpx_client.aclose()
 
@@ -45,6 +97,7 @@ def test_normalize_latest_measurements_ignores_invalid_data() -> None:
         [
             make_latest("1", 8.5),
             make_latest("unknown", 12.1),
+            make_latest(999, 44.1),
             make_latest(2, True),
             make_latest(3, 33.2),
         ],

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -5,7 +5,6 @@ from types import MappingProxyType, SimpleNamespace
 from homeassistant.components.openaq.coordinator import (
     OpenAQMeasurement,
     create_openaq_client,
-    format_openaq_url,
     get_openaq_value,
     normalize_latest_measurements,
 )
@@ -36,22 +35,6 @@ def test_get_openaq_value_dict() -> None:
 
     assert get_openaq_value(data, "id") == 123
     assert get_openaq_value(data, "missing") is None
-
-
-def test_format_openaq_url() -> None:
-    """Test formatting OpenAQ API URLs for debug logging."""
-    assert format_openaq_url(
-        "/locations",
-        {
-            "page": 1,
-            "limit": 10,
-            "radius": 5000,
-            "coordinates": (35.1, -106.6),
-        },
-    ) == (
-        "https://api.openaq.org/v3/locations"
-        "?page=1&limit=10&radius=5000&coordinates=35.1%2C-106.6"
-    )
 
 
 def test_normalize_latest_measurements_ignores_invalid_data() -> None:

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -4,6 +4,8 @@ from types import MappingProxyType, SimpleNamespace
 
 from homeassistant.components.openaq.coordinator import (
     OpenAQMeasurement,
+    create_openaq_client,
+    format_openaq_url,
     get_openaq_value,
     normalize_latest_measurements,
 )
@@ -15,12 +17,41 @@ from homeassistant.const import (
 from .conftest import make_latest, make_sensor
 
 
+async def test_create_openaq_client_uses_fresh_transport() -> None:
+    """Test OpenAQ clients do not share a closable transport."""
+    client = create_openaq_client("api-key")
+    other_client = create_openaq_client("api-key")
+
+    try:
+        assert client.transport is not other_client.transport
+        await client.close()
+        assert not other_client.transport.client.is_closed
+    finally:
+        await other_client.close()
+
+
 def test_get_openaq_value_dict() -> None:
     """Test getting OpenAQ values from dict data."""
     data = {"id": 123}
 
     assert get_openaq_value(data, "id") == 123
     assert get_openaq_value(data, "missing") is None
+
+
+def test_format_openaq_url() -> None:
+    """Test formatting OpenAQ API URLs for debug logging."""
+    assert format_openaq_url(
+        "/locations",
+        {
+            "page": 1,
+            "limit": 10,
+            "radius": 5000,
+            "coordinates": (35.1, -106.6),
+        },
+    ) == (
+        "https://api.openaq.org/v3/locations"
+        "?page=1&limit=10&radius=5000&coordinates=35.1%2C-106.6"
+    )
 
 
 def test_normalize_latest_measurements_ignores_invalid_data() -> None:

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -1,0 +1,74 @@
+"""Test OpenAQ data coordinator helpers."""
+
+from types import MappingProxyType, SimpleNamespace
+
+from homeassistant.components.openaq.coordinator import (
+    OpenAQMeasurement,
+    get_openaq_value,
+    normalize_latest_measurements,
+)
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+)
+
+from .conftest import make_latest, make_sensor
+
+
+def test_get_openaq_value_dict() -> None:
+    """Test getting OpenAQ values from dict data."""
+    data = {"id": 123}
+
+    assert get_openaq_value(data, "id") == 123
+    assert get_openaq_value(data, "missing") is None
+
+
+def test_normalize_latest_measurements_ignores_invalid_data() -> None:
+    """Test normalizing latest measurements ignores invalid API data."""
+    measurements = normalize_latest_measurements(
+        [
+            make_latest("1", 8.5),
+            make_latest("unknown", 12.1),
+            make_latest(2, True),
+            make_latest(3, 33.2),
+        ],
+        [
+            make_sensor("1", "pm2.5", "µg/m3"),
+            make_sensor(2, "pm10"),
+            make_sensor(3, "no_units", 123),
+            SimpleNamespace(id=4, parameter=SimpleNamespace()),
+        ],
+    )
+
+    assert measurements == MappingProxyType(
+        {
+            "pm25": OpenAQMeasurement(
+                parameter="pm25",
+                value=8.5,
+                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            ),
+            "nounits": OpenAQMeasurement(
+                parameter="nounits",
+                value=33.2,
+                unit=None,
+            ),
+        }
+    )
+
+
+def test_normalize_latest_measurements_uses_sensor_latest() -> None:
+    """Test normalizing measurements from sensor latest data."""
+    measurements = normalize_latest_measurements(
+        [],
+        [make_sensor(1, "pm10", "mg/m3", value=12.1)],
+    )
+
+    assert measurements == MappingProxyType(
+        {
+            "pm10": OpenAQMeasurement(
+                parameter="pm10",
+                value=12.1,
+                unit=CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+            )
+        }
+    )

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -7,12 +7,8 @@ from unittest.mock import MagicMock, patch
 from openaq import NotAuthorizedError, OpenAQ, ServerError
 import pytest
 
-from homeassistant.components.openaq.const import (
-    CONF_LOCATION_ID,
-    DOMAIN,
-    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-    OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
-)
+from homeassistant import const as ha_const
+from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import (
     OpenAQDataUpdateCoordinator,
     OpenAQMeasurement,
@@ -193,7 +189,7 @@ def test_normalize_latest_measurements() -> None:
             "pm25": OpenAQMeasurement(
                 parameter="pm25",
                 value=8.5,
-                unit=OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+                unit=ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             ),
         }
     )
@@ -212,11 +208,11 @@ def test_normalize_sensor_metadata() -> None:
         {
             "pm25": OpenAQSensorMetadata(
                 parameter="pm25",
-                unit=OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+                unit=ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             ),
             "pm10": OpenAQSensorMetadata(
                 parameter="pm10",
-                unit=OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+                unit=ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             ),
         }
     )
@@ -225,9 +221,9 @@ def test_normalize_sensor_metadata() -> None:
 @pytest.mark.parametrize(
     ("unit", "expected_unit"),
     [
-        ("μg/m³", OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER),
-        ("mg/m³", OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER),
-        ("mg/m3", OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER),
+        ("μg/m³", ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER),
+        ("mg/m³", ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
+        ("mg/m3", ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
     ],
 )
 def test_normalize_latest_measurements_normalizes_unit_aliases(

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -268,12 +268,12 @@ def test_normalize_latest_measurements_allows_missing_units() -> None:
     )
 
 
-async def test_update_data_auth_error_is_translated(
+async def test_update_data_auth_error_raises_config_entry_auth_failed(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test refresh auth errors raise a translated UpdateFailed."""
+    """Test refresh auth errors raise ConfigEntryAuthFailed."""
     coordinator = OpenAQDataUpdateCoordinator(
         hass,
         mock_config_entry,
@@ -285,7 +285,7 @@ async def test_update_data_auth_error_is_translated(
         "Invalid API key"
     )
 
-    with pytest.raises(UpdateFailed) as err:
+    with pytest.raises(ConfigEntryAuthFailed) as err:
         await coordinator._async_update_data()
 
     assert err.value.translation_domain == DOMAIN

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -4,21 +4,30 @@ from types import MappingProxyType
 from unittest.mock import AsyncMock, patch
 
 import httpx
+from openaq import NotAuthorizedError, ServerError
+import pytest
 
+from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import (
     HomeAssistantOpenAQTransport,
+    OpenAQDataUpdateCoordinator,
     OpenAQMeasurement,
     async_create_openaq_client,
     create_openaq_client,
     normalize_latest_measurements,
 )
+from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    CONF_API_KEY,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .conftest import make_latest, make_sensor
+from .conftest import API_KEY, LOCATION_ID, make_latest, make_sensor
+
+from tests.common import MockConfigEntry
 
 
 async def test_transport_sends_request_with_shared_httpx_client() -> None:
@@ -80,6 +89,60 @@ async def test_async_create_openaq_client_uses_shared_httpx_client(
         await client.close()
     finally:
         await httpx_client.aclose()
+
+
+@pytest.mark.parametrize(
+    ("first_exception", "expected_cause_type"),
+    [
+        (
+            NotAuthorizedError("Invalid API key"),
+            NotAuthorizedError,
+        ),
+        (
+            ServerError("API error"),
+            ServerError,
+        ),
+        (
+            RuntimeError("Unexpected error"),
+            RuntimeError,
+        ),
+    ],
+)
+async def test_initial_refresh_exception_group_maps_first_exception(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    first_exception: Exception,
+    expected_cause_type: type[Exception],
+) -> None:
+    """Test initial refresh TaskGroup errors raise UpdateFailed."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: API_KEY},
+        unique_id=DOMAIN,
+        subentries_data=[
+            ConfigSubentryData(
+                data={CONF_LOCATION_ID: LOCATION_ID},
+                subentry_id="ABCDEF",
+                subentry_type="location",
+                title="Del Norte",
+                unique_id=str(LOCATION_ID),
+            )
+        ],
+    )
+    coordinator = OpenAQDataUpdateCoordinator(
+        hass,
+        config_entry,
+        next(iter(config_entry.subentries.values())),
+        mock_openaq_client,
+    )
+    mock_openaq_client.locations.get.side_effect = first_exception
+    mock_openaq_client.locations.latest.side_effect = RuntimeError("Unexpected error")
+
+    with pytest.raises(UpdateFailed) as err:
+        await coordinator._async_update_data()
+
+    assert isinstance(err.value.__cause__, expected_cause_type)
 
 
 def test_normalize_latest_measurements() -> None:

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, patch
 from openaq import NotAuthorizedError, OpenAQ, ServerError
 import pytest
 
-from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
+from homeassistant.components.openaq.const import (
+    CONF_LOCATION_ID,
+    DOMAIN,
+    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
+    OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER,
+)
 from homeassistant.components.openaq.coordinator import (
     OpenAQDataUpdateCoordinator,
     OpenAQMeasurement,
@@ -18,12 +23,9 @@ from homeassistant.components.openaq.coordinator import (
     normalize_sensor_metadata,
 )
 from homeassistant.config_entries import ConfigSubentryDataWithId
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    CONF_API_KEY,
-)
+from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .conftest import API_KEY, LOCATION_ID, make_latest, make_sensor
@@ -61,10 +63,6 @@ async def test_async_create_openaq_client_uses_executor(
 @pytest.mark.parametrize(
     ("first_exception", "expected_translation_key"),
     [
-        (
-            NotAuthorizedError("Invalid API key"),
-            "authentication_failed",
-        ),
         (
             ServerError("API error"),
             "unable_to_fetch",
@@ -114,6 +112,43 @@ async def test_initial_refresh_exception_group_maps_error(
     assert err.value.translation_key == expected_translation_key
 
 
+async def test_initial_refresh_auth_error_raises_config_entry_auth_failed(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+) -> None:
+    """Test initial refresh auth errors raise ConfigEntryAuthFailed."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: API_KEY},
+        unique_id=DOMAIN,
+        subentries_data=[
+            ConfigSubentryDataWithId(
+                data={CONF_LOCATION_ID: LOCATION_ID},
+                subentry_id="ABCDEF",
+                subentry_type="location",
+                title="Del Norte",
+                unique_id=str(LOCATION_ID),
+            )
+        ],
+    )
+    coordinator = OpenAQDataUpdateCoordinator(
+        hass,
+        config_entry,
+        next(iter(config_entry.subentries.values())),
+        mock_openaq_client,
+    )
+    auth_error = NotAuthorizedError("Invalid API key")
+    mock_openaq_client.locations.get.side_effect = auth_error
+
+    with pytest.raises(ConfigEntryAuthFailed) as err:
+        await coordinator._async_update_data()
+
+    assert err.value.__cause__ is auth_error
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "authentication_failed"
+
+
 async def test_initial_refresh_runs_sdk_calls_in_executor(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
@@ -158,7 +193,7 @@ def test_normalize_latest_measurements() -> None:
             "pm25": OpenAQMeasurement(
                 parameter="pm25",
                 value=8.5,
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
             ),
         }
     )
@@ -177,11 +212,11 @@ def test_normalize_sensor_metadata() -> None:
         {
             "pm25": OpenAQSensorMetadata(
                 parameter="pm25",
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
             ),
             "pm10": OpenAQSensorMetadata(
                 parameter="pm10",
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
             ),
         }
     )
@@ -190,9 +225,9 @@ def test_normalize_sensor_metadata() -> None:
 @pytest.mark.parametrize(
     ("unit", "expected_unit"),
     [
-        ("μg/m³", CONCENTRATION_MICROGRAMS_PER_CUBIC_METER),
-        ("mg/m³", CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
-        ("mg/m3", CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
+        ("μg/m³", OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER),
+        ("mg/m³", OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER),
+        ("mg/m3", OPENAQ_UNIT_MILLIGRAMS_PER_CUBIC_METER),
     ],
 )
 def test_normalize_latest_measurements_normalizes_unit_aliases(

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -2,22 +2,22 @@
 
 from types import MappingProxyType
 from typing import cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
-import httpx
-from openaq import NotAuthorizedError, ServerError
+from openaq import NotAuthorizedError, OpenAQ, ServerError
 import pytest
 
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import (
-    HomeAssistantOpenAQTransport,
     OpenAQDataUpdateCoordinator,
     OpenAQMeasurement,
+    OpenAQSensorMetadata,
     async_create_openaq_client,
     create_openaq_client,
     normalize_latest_measurements,
+    normalize_sensor_metadata,
 )
-from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.config_entries import ConfigSubentryDataWithId
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
@@ -26,114 +26,69 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .conftest import (
-    API_KEY,
-    LOCATION_ID,
-    make_latest,
-    make_location,
-    make_response,
-    make_sensor,
-)
+from .conftest import API_KEY, LOCATION_ID, make_latest, make_sensor
 
 from tests.common import MockConfigEntry
 
 
-async def test_transport_sends_request_with_shared_httpx_client() -> None:
-    """Test the transport sends requests with the shared httpx client."""
-    response = httpx.Response(
-        200,
-        json={"results": []},
-        request=httpx.Request("GET", "https://api.openaq.org/v3/locations"),
-    )
-    httpx_client = AsyncMock(spec=httpx.AsyncClient)
-    httpx_client.request.return_value = response
-
-    transport = HomeAssistantOpenAQTransport(httpx_client)
-
-    assert (
-        await transport.send_request(
-            "GET",
-            "https://api.openaq.org/v3/locations",
-            params={"limit": 1},
-            headers={"X-API-Key": "api-key"},
-        )
-        is response
-    )
-    httpx_client.request.assert_awaited_once_with(
-        method="GET",
-        url="https://api.openaq.org/v3/locations",
-        params={"limit": 1},
-        headers={"X-API-Key": "api-key"},
-    )
-
-
-async def test_create_openaq_client_keeps_shared_httpx_client_open() -> None:
-    """Test closing the OpenAQ client does not close the shared httpx client."""
-    httpx_client = httpx.AsyncClient()
-    client = create_openaq_client("api-key", httpx_client)
+def test_create_openaq_client_uses_sync_openaq_client() -> None:
+    """Test creating an OpenAQ client uses the sync SDK client."""
+    client = create_openaq_client("api-key")
 
     try:
-        assert client.transport.client is httpx_client
-        await client.close()
-        assert not httpx_client.is_closed
+        assert isinstance(client, OpenAQ)
+        assert client.api_key == "api-key"
     finally:
-        await httpx_client.aclose()
+        client.close()
 
 
-async def test_async_create_openaq_client_uses_shared_httpx_client(
+async def test_async_create_openaq_client_uses_executor(
     hass: HomeAssistant,
 ) -> None:
-    """Test creating an OpenAQ client from Home Assistant."""
-    httpx_client = httpx.AsyncClient()
+    """Test creating an OpenAQ client through Home Assistant."""
+    mock_client = MagicMock()
 
-    try:
-        with patch(
-            "homeassistant.components.openaq.coordinator.get_async_client",
-            return_value=httpx_client,
-        ):
-            client = await async_create_openaq_client(hass, "api-key")
+    with patch(
+        "homeassistant.components.openaq.coordinator.create_openaq_client",
+        return_value=mock_client,
+    ) as mock_create:
+        client = await async_create_openaq_client(hass, "api-key")
 
-        assert client.transport.client is httpx_client
-        await client.close()
-    finally:
-        await httpx_client.aclose()
+    assert client is mock_client
+    mock_create.assert_called_once_with("api-key")
 
 
 @pytest.mark.parametrize(
-    ("first_exception", "expected_cause_type", "expected_translation_key"),
+    ("first_exception", "expected_translation_key"),
     [
         (
             NotAuthorizedError("Invalid API key"),
-            NotAuthorizedError,
             "authentication_failed",
         ),
         (
             ServerError("API error"),
-            ServerError,
             "unable_to_fetch",
         ),
         (
             RuntimeError("Unexpected error"),
-            RuntimeError,
             "unable_to_fetch",
         ),
     ],
 )
-async def test_initial_refresh_exception_group_maps_first_exception(
+async def test_initial_refresh_exception_group_maps_error(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     first_exception: Exception,
-    expected_cause_type: type[Exception],
     expected_translation_key: str,
 ) -> None:
-    """Test initial refresh TaskGroup errors raise UpdateFailed."""
+    """Test initial refresh errors raise UpdateFailed."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="OpenAQ",
         data={CONF_API_KEY: API_KEY},
         unique_id=DOMAIN,
         subentries_data=[
-            ConfigSubentryData(
+            ConfigSubentryDataWithId(
                 data={CONF_LOCATION_ID: LOCATION_ID},
                 subentry_id="ABCDEF",
                 subentry_type="location",
@@ -154,9 +109,34 @@ async def test_initial_refresh_exception_group_maps_first_exception(
     with pytest.raises(UpdateFailed) as err:
         await coordinator._async_update_data()
 
-    assert isinstance(err.value.__cause__, expected_cause_type)
+    assert err.value.__cause__ is first_exception
     assert err.value.translation_domain == DOMAIN
     assert err.value.translation_key == expected_translation_key
+
+
+async def test_initial_refresh_runs_sdk_calls_in_executor(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test blocking SDK calls run in the executor."""
+    coordinator = OpenAQDataUpdateCoordinator(
+        hass,
+        mock_config_entry,
+        next(iter(mock_config_entry.subentries.values())),
+        mock_openaq_client,
+    )
+
+    with patch.object(
+        hass, "async_add_executor_job", wraps=hass.async_add_executor_job
+    ) as mock_executor:
+        await coordinator._async_update_data()
+
+    assert [call.args[0] for call in mock_executor.call_args_list] == [
+        mock_openaq_client.locations.get,
+        mock_openaq_client.locations.latest,
+        mock_openaq_client.locations.sensors,
+    ]
 
 
 def test_normalize_latest_measurements() -> None:
@@ -178,6 +158,29 @@ def test_normalize_latest_measurements() -> None:
             "pm25": OpenAQMeasurement(
                 parameter="pm25",
                 value=8.5,
+                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            ),
+        }
+    )
+
+
+def test_normalize_sensor_metadata() -> None:
+    """Test normalizing sensor metadata by parameter."""
+    metadata = normalize_sensor_metadata(
+        [
+            make_sensor(1, "pm2.5", "µg/m3"),
+            make_sensor(2, "pm10"),
+        ]
+    )
+
+    assert metadata == MappingProxyType(
+        {
+            "pm25": OpenAQSensorMetadata(
+                parameter="pm25",
+                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            ),
+            "pm10": OpenAQSensorMetadata(
+                parameter="pm10",
                 unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             ),
         }
@@ -230,44 +233,9 @@ def test_normalize_latest_measurements_allows_missing_units() -> None:
     )
 
 
-async def test_update_data_allows_missing_location_coordinates(
-    hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
-) -> None:
-    """Test location data with missing coordinates has no home distance."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="OpenAQ",
-        data={CONF_API_KEY: API_KEY},
-        unique_id=DOMAIN,
-        subentries_data=[
-            ConfigSubentryData(
-                data={CONF_LOCATION_ID: LOCATION_ID},
-                subentry_id="ABCDEF",
-                subentry_type="location",
-                title="Del Norte",
-                unique_id=str(LOCATION_ID),
-            )
-        ],
-    )
-    coordinator = OpenAQDataUpdateCoordinator(
-        hass,
-        config_entry,
-        next(iter(config_entry.subentries.values())),
-        mock_openaq_client,
-    )
-    mock_openaq_client.locations.get.return_value = make_response(
-        [make_location(coordinates=(cast(float, None), -106.6))]
-    )
-
-    data = await coordinator._async_update_data()
-
-    assert data.distance_to_home is None
-
-
 async def test_update_data_auth_error_is_translated(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test refresh auth errors raise a translated UpdateFailed."""

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 from openaq import NotAuthorizedError, OpenAQ, ServerError
 import pytest
 
-from homeassistant import const as ha_const
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import (
     OpenAQDataUpdateCoordinator,
@@ -19,7 +18,7 @@ from homeassistant.components.openaq.coordinator import (
     normalize_sensor_metadata,
 )
 from homeassistant.config_entries import ConfigSubentryDataWithId
-from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONF_API_KEY, UnitOfDensity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -189,7 +188,7 @@ def test_normalize_latest_measurements() -> None:
             "pm25": OpenAQMeasurement(
                 parameter="pm25",
                 value=8.5,
-                unit=ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
             ),
         }
     )
@@ -208,11 +207,11 @@ def test_normalize_sensor_metadata() -> None:
         {
             "pm25": OpenAQSensorMetadata(
                 parameter="pm25",
-                unit=ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
             ),
             "pm10": OpenAQSensorMetadata(
                 parameter="pm10",
-                unit=ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
             ),
         }
     )
@@ -221,9 +220,9 @@ def test_normalize_sensor_metadata() -> None:
 @pytest.mark.parametrize(
     ("unit", "expected_unit"),
     [
-        ("μg/m³", ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER),
-        ("mg/m³", ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
-        ("mg/m3", ha_const.CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
+        ("μg/m³", UnitOfDensity.MICROGRAMS_PER_CUBIC_METER),
+        ("mg/m³", UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER),
+        ("mg/m3", UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER),
     ],
 )
 def test_normalize_latest_measurements_normalizes_unit_aliases(

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -100,19 +100,22 @@ async def test_async_create_openaq_client_uses_shared_httpx_client(
 
 
 @pytest.mark.parametrize(
-    ("first_exception", "expected_cause_type"),
+    ("first_exception", "expected_cause_type", "expected_translation_key"),
     [
         (
             NotAuthorizedError("Invalid API key"),
             NotAuthorizedError,
+            "authentication_failed",
         ),
         (
             ServerError("API error"),
             ServerError,
+            "unable_to_fetch",
         ),
         (
             RuntimeError("Unexpected error"),
             RuntimeError,
+            "unable_to_fetch",
         ),
     ],
 )
@@ -121,6 +124,7 @@ async def test_initial_refresh_exception_group_maps_first_exception(
     mock_openaq_client: AsyncMock,
     first_exception: Exception,
     expected_cause_type: type[Exception],
+    expected_translation_key: str,
 ) -> None:
     """Test initial refresh TaskGroup errors raise UpdateFailed."""
     config_entry = MockConfigEntry(
@@ -151,6 +155,8 @@ async def test_initial_refresh_exception_group_maps_first_exception(
         await coordinator._async_update_data()
 
     assert isinstance(err.value.__cause__, expected_cause_type)
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == expected_translation_key
 
 
 def test_normalize_latest_measurements() -> None:
@@ -178,11 +184,21 @@ def test_normalize_latest_measurements() -> None:
     )
 
 
-def test_normalize_latest_measurements_normalizes_unit_aliases() -> None:
+@pytest.mark.parametrize(
+    ("unit", "expected_unit"),
+    [
+        ("μg/m³", CONCENTRATION_MICROGRAMS_PER_CUBIC_METER),
+        ("mg/m³", CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
+        ("mg/m3", CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER),
+    ],
+)
+def test_normalize_latest_measurements_normalizes_unit_aliases(
+    unit: str, expected_unit: str
+) -> None:
     """Test normalizing measurement unit aliases."""
     measurements = normalize_latest_measurements(
         [make_latest(1, 12.1)],
-        [make_sensor(1, "pm10", "mg/m3")],
+        [make_sensor(1, "pm10", unit)],
     )
 
     assert measurements == MappingProxyType(
@@ -190,7 +206,7 @@ def test_normalize_latest_measurements_normalizes_unit_aliases() -> None:
             "pm10": OpenAQMeasurement(
                 parameter="pm10",
                 value=12.1,
-                unit=CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+                unit=expected_unit,
             )
         }
     )
@@ -247,3 +263,27 @@ async def test_update_data_allows_missing_location_coordinates(
     data = await coordinator._async_update_data()
 
     assert data.distance_to_home is None
+
+
+async def test_update_data_auth_error_is_translated(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test refresh auth errors raise a translated UpdateFailed."""
+    coordinator = OpenAQDataUpdateCoordinator(
+        hass,
+        mock_config_entry,
+        next(iter(mock_config_entry.subentries.values())),
+        mock_openaq_client,
+    )
+    await coordinator._async_update_data()
+    mock_openaq_client.locations.latest.side_effect = NotAuthorizedError(
+        "Invalid API key"
+    )
+
+    with pytest.raises(UpdateFailed) as err:
+        await coordinator._async_update_data()
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "authentication_failed"

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -1,6 +1,7 @@
 """Test OpenAQ data coordinator helpers."""
 
 from types import MappingProxyType
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -25,7 +26,14 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .conftest import API_KEY, LOCATION_ID, make_latest, make_sensor
+from .conftest import (
+    API_KEY,
+    LOCATION_ID,
+    make_latest,
+    make_location,
+    make_response,
+    make_sensor,
+)
 
 from tests.common import MockConfigEntry
 
@@ -186,3 +194,56 @@ def test_normalize_latest_measurements_normalizes_unit_aliases() -> None:
             )
         }
     )
+
+
+def test_normalize_latest_measurements_allows_missing_units() -> None:
+    """Test normalizing a measurement without a reported unit."""
+    measurements = normalize_latest_measurements(
+        [make_latest(1, 12.1)],
+        [make_sensor(1, "pm10", cast(str, None))],
+    )
+
+    assert measurements == MappingProxyType(
+        {
+            "pm10": OpenAQMeasurement(
+                parameter="pm10",
+                value=12.1,
+                unit=None,
+            )
+        }
+    )
+
+
+async def test_update_data_allows_missing_location_coordinates(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+) -> None:
+    """Test location data with missing coordinates has no home distance."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: API_KEY},
+        unique_id=DOMAIN,
+        subentries_data=[
+            ConfigSubentryData(
+                data={CONF_LOCATION_ID: LOCATION_ID},
+                subentry_id="ABCDEF",
+                subentry_type="location",
+                title="Del Norte",
+                unique_id=str(LOCATION_ID),
+            )
+        ],
+    )
+    coordinator = OpenAQDataUpdateCoordinator(
+        hass,
+        config_entry,
+        next(iter(config_entry.subentries.values())),
+        mock_openaq_client,
+    )
+    mock_openaq_client.locations.get.return_value = make_response(
+        [make_location(coordinates=(cast(float, None), -106.6))]
+    )
+
+    data = await coordinator._async_update_data()
+
+    assert data.distance_to_home is None

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -30,11 +30,12 @@ from tests.common import MockConfigEntry
 
 def test_create_openaq_client_uses_sync_openaq_client() -> None:
     """Test creating an OpenAQ client uses the sync SDK client."""
-    client = create_openaq_client("api-key")
+    api_key = "a" * 64
+    client = create_openaq_client(api_key)
 
     try:
         assert isinstance(client, OpenAQ)
-        assert client.api_key == "api-key"
+        assert client.api_key == api_key
     finally:
         client.close()
 

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -1,7 +1,7 @@
 """Test OpenAQ data coordinator helpers."""
 
+import asyncio
 from types import MappingProxyType
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 from openaq import NotAuthorizedError, OpenAQ, ServerError
@@ -11,7 +11,6 @@ from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import (
     OpenAQDataUpdateCoordinator,
     _build_sensor_metadata,
-    async_create_openaq_client,
     create_openaq_client,
     normalize_latest_measurements,
 )
@@ -37,20 +36,15 @@ def test_create_openaq_client_uses_sync_openaq_client() -> None:
         client.close()
 
 
-async def test_async_create_openaq_client_uses_executor(
-    hass: HomeAssistant,
-) -> None:
-    """Test creating an OpenAQ client through Home Assistant."""
-    mock_client = MagicMock()
+def test_create_openaq_client_sets_auto_wait_false() -> None:
+    """Test OpenAQ client is created with auto_wait=False."""
+    api_key = "a" * 64
+    client = create_openaq_client(api_key)
 
-    with patch(
-        "homeassistant.components.openaq.coordinator.create_openaq_client",
-        return_value=mock_client,
-    ) as mock_create:
-        client = await async_create_openaq_client(hass, "api-key")
-
-    assert client is mock_client
-    mock_create.assert_called_once_with("api-key")
+    try:
+        assert client._auto_wait is False
+    finally:
+        client.close()
 
 
 async def test_initial_refresh_sdk_error_raises_update_failed(
@@ -78,6 +72,7 @@ async def test_initial_refresh_sdk_error_raises_update_failed(
         config_entry,
         next(iter(config_entry.subentries.values())),
         mock_openaq_client,
+        asyncio.Lock(),
     )
     api_error = ServerError("API error")
     mock_openaq_client.locations.get.side_effect = api_error
@@ -115,6 +110,7 @@ async def test_initial_refresh_auth_error_raises_update_failed(
         config_entry,
         next(iter(config_entry.subentries.values())),
         mock_openaq_client,
+        asyncio.Lock(),
     )
     auth_error = NotAuthorizedError("Invalid API key")
     mock_openaq_client.locations.get.side_effect = auth_error
@@ -138,6 +134,7 @@ async def test_initial_refresh_runs_sdk_calls_in_executor(
         mock_config_entry,
         next(iter(mock_config_entry.subentries.values())),
         mock_openaq_client,
+        asyncio.Lock(),
     )
 
     with patch.object(
@@ -160,7 +157,6 @@ def test_normalize_latest_measurements() -> None:
         [
             make_latest(1, 8.5),
             make_latest(999, 44.1),
-            make_latest(2, None),
         ],
         by_id,
     )
@@ -186,39 +182,43 @@ def test_build_sensor_metadata() -> None:
 
 
 @pytest.mark.parametrize(
-    ("unit", "expected_unit"),
+    ("parameter", "unit", "expected_unit"),
     [
-        ("μg/m³", UnitOfDensity.MICROGRAMS_PER_CUBIC_METER),
-        ("mg/m³", UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER),
-        ("mg/m3", UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER),
+        ("pm10", "μg/m³", UnitOfDensity.MICROGRAMS_PER_CUBIC_METER),
+        ("co", "mg/m³", UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER),
+        ("co", "mg/m3", UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER),
     ],
+    ids=["pm10-ug-m3", "co-mg-m3-unicode", "co-mg-m3-ascii"],
 )
 def test_normalize_latest_measurements_normalizes_unit_aliases(
-    unit: str, expected_unit: str
+    parameter: str, unit: str, expected_unit: str
 ) -> None:
     """Test normalizing measurement unit aliases."""
-    by_id, units = _build_sensor_metadata([make_sensor(1, "pm10", unit)])
+    by_id, units = _build_sensor_metadata([make_sensor(1, parameter, unit)])
     measurements = normalize_latest_measurements(
         [make_latest(1, 12.1)],
         by_id,
     )
 
-    assert measurements == MappingProxyType({"pm10": 12.1})
-    assert units == MappingProxyType({"pm10": expected_unit})
+    assert measurements == MappingProxyType({parameter: 12.1})
+    assert units == MappingProxyType({parameter: expected_unit})
 
 
-def test_normalize_latest_measurements_allows_missing_units() -> None:
-    """Test normalizing a measurement without a reported unit."""
-    by_id, units = _build_sensor_metadata(
-        [make_sensor(1, "pm10", cast(str, None))],
-    )
-    measurements = normalize_latest_measurements(
-        [make_latest(1, 12.1)],
-        by_id,
-    )
+def test_build_sensor_metadata_skips_invalid_unit_for_device_class() -> None:
+    """Test that sensors with units invalid for their device class are skipped."""
+    # PM10 only accepts μg/m³; mg/m³ is invalid
+    by_id, units = _build_sensor_metadata([make_sensor(1, "pm10", "mg/m³")])
 
-    assert measurements == MappingProxyType({"pm10": 12.1})
-    assert units == MappingProxyType({"pm10": None})
+    assert by_id == {}
+    assert units == MappingProxyType({})
+
+
+def test_build_sensor_metadata_skips_unsupported_parameters() -> None:
+    """Test that sensors for unsupported parameters are skipped."""
+    by_id, units = _build_sensor_metadata([make_sensor(1, "unsupported")])
+
+    assert by_id == {}
+    assert units == MappingProxyType({})
 
 
 async def test_update_data_auth_error_raises_update_failed(
@@ -232,6 +232,7 @@ async def test_update_data_auth_error_raises_update_failed(
         mock_config_entry,
         next(iter(mock_config_entry.subentries.values())),
         mock_openaq_client,
+        asyncio.Lock(),
     )
     await coordinator._async_update_data()
     mock_openaq_client.locations.latest.side_effect = NotAuthorizedError(

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -20,7 +20,6 @@ from homeassistant.components.openaq.coordinator import (
 from homeassistant.config_entries import ConfigSubentryDataWithId
 from homeassistant.const import CONF_API_KEY, UnitOfDensity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .conftest import API_KEY, LOCATION_ID, make_latest, make_sensor
@@ -108,11 +107,11 @@ async def test_initial_refresh_exception_group_maps_error(
     assert err.value.translation_key == expected_translation_key
 
 
-async def test_initial_refresh_auth_error_raises_config_entry_auth_failed(
+async def test_initial_refresh_auth_error_raises_update_failed(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
 ) -> None:
-    """Test initial refresh auth errors raise ConfigEntryAuthFailed."""
+    """Test initial refresh auth errors raise UpdateFailed."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="OpenAQ",
@@ -137,12 +136,12 @@ async def test_initial_refresh_auth_error_raises_config_entry_auth_failed(
     auth_error = NotAuthorizedError("Invalid API key")
     mock_openaq_client.locations.get.side_effect = auth_error
 
-    with pytest.raises(ConfigEntryAuthFailed) as err:
+    with pytest.raises(UpdateFailed) as err:
         await coordinator._async_update_data()
 
     assert err.value.__cause__ is auth_error
     assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == "authentication_failed"
+    assert err.value.translation_key == "unable_to_fetch"
 
 
 async def test_initial_refresh_runs_sdk_calls_in_executor(
@@ -163,11 +162,7 @@ async def test_initial_refresh_runs_sdk_calls_in_executor(
     ) as mock_executor:
         await coordinator._async_update_data()
 
-    assert [call.args[0] for call in mock_executor.call_args_list] == [
-        mock_openaq_client.locations.get,
-        mock_openaq_client.locations.latest,
-        mock_openaq_client.locations.sensors,
-    ]
+    assert mock_executor.call_count == 1
 
 
 def test_normalize_latest_measurements() -> None:
@@ -264,12 +259,12 @@ def test_normalize_latest_measurements_allows_missing_units() -> None:
     )
 
 
-async def test_update_data_auth_error_raises_config_entry_auth_failed(
+async def test_update_data_auth_error_raises_update_failed(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test refresh auth errors raise ConfigEntryAuthFailed."""
+    """Test refresh auth errors raise UpdateFailed."""
     coordinator = OpenAQDataUpdateCoordinator(
         hass,
         mock_config_entry,
@@ -281,8 +276,8 @@ async def test_update_data_auth_error_raises_config_entry_auth_failed(
         "Invalid API key"
     )
 
-    with pytest.raises(ConfigEntryAuthFailed) as err:
+    with pytest.raises(UpdateFailed) as err:
         await coordinator._async_update_data()
 
     assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == "authentication_failed"
+    assert err.value.translation_key == "unable_to_fetch"

--- a/tests/components/openaq/test_coordinator.py
+++ b/tests/components/openaq/test_coordinator.py
@@ -10,12 +10,10 @@ import pytest
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import (
     OpenAQDataUpdateCoordinator,
-    OpenAQMeasurement,
-    OpenAQSensorMetadata,
+    _build_sensor_metadata,
     async_create_openaq_client,
     create_openaq_client,
     normalize_latest_measurements,
-    normalize_sensor_metadata,
 )
 from homeassistant.config_entries import ConfigSubentryDataWithId
 from homeassistant.const import CONF_API_KEY, UnitOfDensity
@@ -55,26 +53,11 @@ async def test_async_create_openaq_client_uses_executor(
     mock_create.assert_called_once_with("api-key")
 
 
-@pytest.mark.parametrize(
-    ("first_exception", "expected_translation_key"),
-    [
-        (
-            ServerError("API error"),
-            "unable_to_fetch",
-        ),
-        (
-            RuntimeError("Unexpected error"),
-            "unable_to_fetch",
-        ),
-    ],
-)
-async def test_initial_refresh_exception_group_maps_error(
+async def test_initial_refresh_sdk_error_raises_update_failed(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
-    first_exception: Exception,
-    expected_translation_key: str,
 ) -> None:
-    """Test initial refresh errors raise UpdateFailed."""
+    """Test initial refresh SDK errors raise UpdateFailed."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="OpenAQ",
@@ -96,15 +79,15 @@ async def test_initial_refresh_exception_group_maps_error(
         next(iter(config_entry.subentries.values())),
         mock_openaq_client,
     )
-    mock_openaq_client.locations.get.side_effect = first_exception
-    mock_openaq_client.locations.latest.side_effect = RuntimeError("Unexpected error")
+    api_error = ServerError("API error")
+    mock_openaq_client.locations.get.side_effect = api_error
 
     with pytest.raises(UpdateFailed) as err:
         await coordinator._async_update_data()
 
-    assert err.value.__cause__ is first_exception
+    assert err.value.__cause__ is api_error
     assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == expected_translation_key
+    assert err.value.translation_key == "unable_to_fetch"
 
 
 async def test_initial_refresh_auth_error_raises_update_failed(
@@ -167,48 +150,37 @@ async def test_initial_refresh_runs_sdk_calls_in_executor(
 
 def test_normalize_latest_measurements() -> None:
     """Test normalizing latest measurements by sensor metadata."""
+    by_id, _ = _build_sensor_metadata(
+        [
+            make_sensor(1, "pm2.5", "µg/m3"),
+            make_sensor(2, "pm10"),
+        ],
+    )
     measurements = normalize_latest_measurements(
         [
             make_latest(1, 8.5),
             make_latest(999, 44.1),
             make_latest(2, None),
         ],
-        [
-            make_sensor(1, "pm2.5", "µg/m3"),
-            make_sensor(2, "pm10"),
-        ],
+        by_id,
     )
 
-    assert measurements == MappingProxyType(
-        {
-            "pm25": OpenAQMeasurement(
-                parameter="pm25",
-                value=8.5,
-                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
-            ),
-        }
-    )
+    assert measurements == MappingProxyType({"pm25": 8.5})
 
 
-def test_normalize_sensor_metadata() -> None:
+def test_build_sensor_metadata() -> None:
     """Test normalizing sensor metadata by parameter."""
-    metadata = normalize_sensor_metadata(
+    _, units = _build_sensor_metadata(
         [
             make_sensor(1, "pm2.5", "µg/m3"),
             make_sensor(2, "pm10"),
         ]
     )
 
-    assert metadata == MappingProxyType(
+    assert units == MappingProxyType(
         {
-            "pm25": OpenAQSensorMetadata(
-                parameter="pm25",
-                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
-            ),
-            "pm10": OpenAQSensorMetadata(
-                parameter="pm10",
-                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
-            ),
+            "pm25": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+            "pm10": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         }
     )
 
@@ -225,38 +197,28 @@ def test_normalize_latest_measurements_normalizes_unit_aliases(
     unit: str, expected_unit: str
 ) -> None:
     """Test normalizing measurement unit aliases."""
+    by_id, units = _build_sensor_metadata([make_sensor(1, "pm10", unit)])
     measurements = normalize_latest_measurements(
         [make_latest(1, 12.1)],
-        [make_sensor(1, "pm10", unit)],
+        by_id,
     )
 
-    assert measurements == MappingProxyType(
-        {
-            "pm10": OpenAQMeasurement(
-                parameter="pm10",
-                value=12.1,
-                unit=expected_unit,
-            )
-        }
-    )
+    assert measurements == MappingProxyType({"pm10": 12.1})
+    assert units == MappingProxyType({"pm10": expected_unit})
 
 
 def test_normalize_latest_measurements_allows_missing_units() -> None:
     """Test normalizing a measurement without a reported unit."""
-    measurements = normalize_latest_measurements(
-        [make_latest(1, 12.1)],
+    by_id, units = _build_sensor_metadata(
         [make_sensor(1, "pm10", cast(str, None))],
     )
-
-    assert measurements == MappingProxyType(
-        {
-            "pm10": OpenAQMeasurement(
-                parameter="pm10",
-                value=12.1,
-                unit=None,
-            )
-        }
+    measurements = normalize_latest_measurements(
+        [make_latest(1, 12.1)],
+        by_id,
     )
+
+    assert measurements == MappingProxyType({"pm10": 12.1})
+    assert units == MappingProxyType({"pm10": None})
 
 
 async def test_update_data_auth_error_raises_update_failed(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
-from .conftest import API_KEY
+from .conftest import API_KEY, make_response
 
 from tests.common import MockConfigEntry
 
@@ -35,6 +35,20 @@ async def test_setup_retry_on_first_refresh_failure(
 ) -> None:
     """Test setup retry when first coordinator refresh fails."""
     mock_openaq_client.locations.latest.side_effect = ServerError("API error")
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    mock_openaq_client.close.assert_awaited_once()
+
+
+async def test_setup_retry_on_empty_location_response(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup retry when OpenAQ returns no location."""
+    mock_openaq_client.locations.get.return_value = make_response([])
 
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -1,5 +1,6 @@
 """Test OpenAQ initialization."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 from openaq import ServerError
@@ -10,7 +11,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
-from .conftest import API_KEY, make_response
+from .conftest import API_KEY, make_latest, make_location, make_response, make_sensor
 
 from tests.common import MockConfigEntry
 
@@ -54,6 +55,64 @@ async def test_setup_retry_on_empty_location_response(
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     mock_openaq_client.close.assert_awaited_once()
+
+
+async def test_setup_fetches_location_data_concurrently(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test coordinator fetches independent OpenAQ location data concurrently."""
+    started: set[str] = set()
+    location_started = asyncio.Event()
+    latest_started = asyncio.Event()
+    sensors_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def wait_for_release(
+        name: str, started_event: asyncio.Event, response: object
+    ) -> object:
+        """Return a response after all location data requests have started."""
+        started.add(name)
+        started_event.set()
+        await release
+        return response
+
+    async def get_location(_location_id: int) -> object:
+        """Return the location response."""
+        return await wait_for_release(
+            "location", location_started, make_response([make_location()])
+        )
+
+    async def get_latest(_location_id: int) -> object:
+        """Return the latest measurements response."""
+        return await wait_for_release(
+            "latest", latest_started, make_response([make_latest(1, 8.5)])
+        )
+
+    async def get_sensors(_location_id: int) -> object:
+        """Return the sensors response."""
+        return await wait_for_release(
+            "sensors", sensors_started, make_response([make_sensor(1, "pm25")])
+        )
+
+    mock_openaq_client.locations.get.side_effect = get_location
+    mock_openaq_client.locations.latest.side_effect = get_latest
+    mock_openaq_client.locations.sensors.side_effect = get_sensors
+
+    setup_task = asyncio.create_task(setup_integration(hass, mock_config_entry))
+    await asyncio.wait_for(
+        asyncio.gather(
+            location_started.wait(),
+            latest_started.wait(),
+            sensors_started.wait(),
+        ),
+        timeout=1,
+    )
+    assert started == {"location", "latest", "sensors"}
+    release.set()
+
+    await asyncio.wait_for(setup_task, timeout=1)
 
 
 async def test_unload_closes_client(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -39,6 +39,7 @@ async def test_setup_retry_on_first_refresh_failure(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    mock_openaq_client.close.assert_awaited_once()
 
 
 async def test_unload_closes_client(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -1,0 +1,89 @@
+"""Test OpenAQ initialization."""
+
+from unittest.mock import AsyncMock, patch
+
+from openaq import ServerError
+
+from homeassistant.components.openaq.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+from .conftest import API_KEY
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_success(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test successful setup."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.runtime_data.client is mock_openaq_client
+    assert len(mock_config_entry.runtime_data.coordinators) == 1
+
+
+async def test_setup_retry_on_first_refresh_failure(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup retry when first coordinator refresh fails."""
+    mock_openaq_client.locations.latest.side_effect = ServerError("API error")
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_unload_closes_client(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test unloading OpenAQ closes the client."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_openaq_client.close.assert_awaited_once()
+
+
+async def test_update_listener_reloads_entry(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test config entry updates reload the entry."""
+    await setup_integration(hass, mock_config_entry)
+
+    with patch.object(hass.config_entries, "async_reload") as mock_reload:
+        hass.config_entries.async_update_entry(
+            mock_config_entry,
+            data={CONF_API_KEY: "new-api-key"},
+        )
+        await hass.async_block_till_done()
+
+    mock_reload.assert_awaited_once_with(mock_config_entry.entry_id)
+
+
+async def test_setup_without_locations(
+    hass: HomeAssistant, mock_openaq_client: AsyncMock
+) -> None:
+    """Test setup before any location subentries are configured."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: API_KEY},
+    )
+
+    await setup_integration(hass, config_entry)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.runtime_data.coordinators == {}

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -11,7 +11,14 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
-from .conftest import API_KEY, make_latest, make_location, make_response, make_sensor
+from .conftest import (
+    API_KEY,
+    LOCATION_ID,
+    make_latest,
+    make_location,
+    make_response,
+    make_sensor,
+)
 
 from tests.common import MockConfigEntry
 
@@ -113,6 +120,29 @@ async def test_setup_fetches_location_data_concurrently(
     release.set()
 
     await asyncio.wait_for(setup_task, timeout=1)
+
+
+async def test_refresh_uses_cached_location_metadata(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test refresh polls latest measurements without refetching metadata."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    mock_openaq_client.locations.get.reset_mock()
+    mock_openaq_client.locations.latest.reset_mock()
+    mock_openaq_client.locations.sensors.reset_mock()
+    mock_openaq_client.locations.latest.return_value = make_response(
+        [make_latest(2, 21.2)]
+    )
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    mock_openaq_client.locations.get.assert_not_called()
+    mock_openaq_client.locations.sensors.assert_not_called()
+    mock_openaq_client.locations.latest.assert_awaited_once_with(LOCATION_ID)
 
 
 async def test_unload_closes_client(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -5,10 +5,12 @@ from unittest.mock import AsyncMock, patch
 
 from openaq import ServerError
 
-from homeassistant.components.openaq.const import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
+from homeassistant.components.openaq.coordinator import OpenAQDataUpdateCoordinator
+from homeassistant.config_entries import ConfigEntryState, ConfigSubentryData
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from . import setup_integration
 from .conftest import (
@@ -61,6 +63,70 @@ async def test_setup_retry_on_empty_location_response(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    mock_openaq_client.close.assert_awaited_once()
+
+
+async def test_setup_closes_client_after_sibling_refresh_finalizes(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+) -> None:
+    """Test setup closes the client after sibling refresh tasks finish."""
+    running_refresh_started = asyncio.Event()
+    running_refresh_finalized = asyncio.Event()
+    failing_refresh_started = asyncio.Event()
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: API_KEY},
+        unique_id=DOMAIN,
+        subentries_data=[
+            ConfigSubentryData(
+                data={CONF_LOCATION_ID: LOCATION_ID},
+                subentry_id="ABCDEF",
+                subentry_type="location",
+                title="Del Norte",
+                unique_id=str(LOCATION_ID),
+            ),
+            ConfigSubentryData(
+                data={CONF_LOCATION_ID: 9999},
+                subentry_id="GHIJKL",
+                subentry_type="location",
+                title="South Valley",
+                unique_id="9999",
+            ),
+        ],
+    )
+
+    async def first_refresh(coordinator: OpenAQDataUpdateCoordinator) -> None:
+        """Refresh one coordinator while another fails."""
+        if coordinator.location_id == LOCATION_ID:
+            running_refresh_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                running_refresh_finalized.set()
+            return
+
+        await running_refresh_started.wait()
+        failing_refresh_started.set()
+        raise ConfigEntryNotReady("API error")
+
+    async def close_client() -> None:
+        """Assert the sibling refresh finalized before closing the client."""
+        assert running_refresh_finalized.is_set()
+
+    mock_openaq_client.close.side_effect = close_client
+
+    with patch(
+        "homeassistant.components.openaq.OpenAQDataUpdateCoordinator.async_config_entry_first_refresh",
+        first_refresh,
+    ):
+        await setup_integration(hass, config_entry)
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert failing_refresh_started.is_set()
+    assert running_refresh_finalized.is_set()
     mock_openaq_client.close.assert_awaited_once()
 
 

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -82,7 +82,7 @@ async def test_setup_fetches_location_data_concurrently(
         """Return a response after all location data requests have started."""
         started.add(name)
         started_event.set()
-        await release
+        await release.wait()
         return response
 
     async def get_location(_location_id: int) -> object:

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -3,7 +3,7 @@
 import asyncio
 from unittest.mock import MagicMock, patch
 
-from openaq import ServerError
+from openaq import NotAuthorizedError, ServerError
 
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import OpenAQDataUpdateCoordinator
@@ -42,6 +42,22 @@ async def test_setup_retry_on_first_refresh_failure(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    mock_openaq_client.close.assert_called_once()
+
+
+async def test_setup_fails_auth_on_first_refresh_auth_failure(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup fails auth when first coordinator refresh has an auth error."""
+    mock_openaq_client.locations.latest.side_effect = NotAuthorizedError(
+        "Invalid API key"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     mock_openaq_client.close.assert_called_once()
 
 

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -1,33 +1,26 @@
 """Test OpenAQ initialization."""
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 from openaq import ServerError
 
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import OpenAQDataUpdateCoordinator
-from homeassistant.config_entries import ConfigEntryState, ConfigSubentryData
+from homeassistant.config_entries import ConfigEntryState, ConfigSubentryDataWithId
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from . import setup_integration
-from .conftest import (
-    API_KEY,
-    LOCATION_ID,
-    make_latest,
-    make_location,
-    make_response,
-    make_sensor,
-)
+from .conftest import API_KEY, LOCATION_ID, make_latest, make_response
 
 from tests.common import MockConfigEntry
 
 
 async def test_setup_success(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test successful setup."""
@@ -40,7 +33,7 @@ async def test_setup_success(
 
 async def test_setup_retry_on_first_refresh_failure(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test setup retry when first coordinator refresh fails."""
@@ -49,12 +42,12 @@ async def test_setup_retry_on_first_refresh_failure(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-    mock_openaq_client.close.assert_awaited_once()
+    mock_openaq_client.close.assert_called_once()
 
 
 async def test_setup_retry_on_empty_location_response(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test setup retry when OpenAQ returns no location."""
@@ -63,12 +56,12 @@ async def test_setup_retry_on_empty_location_response(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-    mock_openaq_client.close.assert_awaited_once()
+    mock_openaq_client.close.assert_called_once()
 
 
 async def test_setup_closes_client_after_sibling_refresh_finalizes(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
 ) -> None:
     """Test setup closes the client after sibling refresh tasks finish."""
     running_refresh_started = asyncio.Event()
@@ -81,14 +74,14 @@ async def test_setup_closes_client_after_sibling_refresh_finalizes(
         data={CONF_API_KEY: API_KEY},
         unique_id=DOMAIN,
         subentries_data=[
-            ConfigSubentryData(
+            ConfigSubentryDataWithId(
                 data={CONF_LOCATION_ID: LOCATION_ID},
                 subentry_id="ABCDEF",
                 subentry_type="location",
                 title="Del Norte",
                 unique_id=str(LOCATION_ID),
             ),
-            ConfigSubentryData(
+            ConfigSubentryDataWithId(
                 data={CONF_LOCATION_ID: 9999},
                 subentry_id="GHIJKL",
                 subentry_type="location",
@@ -112,7 +105,7 @@ async def test_setup_closes_client_after_sibling_refresh_finalizes(
         failing_refresh_started.set()
         raise ConfigEntryNotReady("API error")
 
-    async def close_client() -> None:
+    def close_client() -> None:
         """Assert the sibling refresh finalized before closing the client."""
         assert running_refresh_finalized.is_set()
 
@@ -127,70 +120,25 @@ async def test_setup_closes_client_after_sibling_refresh_finalizes(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
     assert failing_refresh_started.is_set()
     assert running_refresh_finalized.is_set()
-    mock_openaq_client.close.assert_awaited_once()
+    mock_openaq_client.close.assert_called_once()
 
 
-async def test_setup_fetches_location_data_concurrently(
+async def test_setup_fetches_location_data(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test coordinator fetches independent OpenAQ location data concurrently."""
-    started: set[str] = set()
-    location_started = asyncio.Event()
-    latest_started = asyncio.Event()
-    sensors_started = asyncio.Event()
-    release = asyncio.Event()
+    """Test coordinator fetches OpenAQ location data."""
+    await setup_integration(hass, mock_config_entry)
 
-    async def wait_for_release(
-        name: str, started_event: asyncio.Event, response: object
-    ) -> object:
-        """Return a response after all location data requests have started."""
-        started.add(name)
-        started_event.set()
-        await release.wait()
-        return response
-
-    async def get_location(_location_id: int) -> object:
-        """Return the location response."""
-        return await wait_for_release(
-            "location", location_started, make_response([make_location()])
-        )
-
-    async def get_latest(_location_id: int) -> object:
-        """Return the latest measurements response."""
-        return await wait_for_release(
-            "latest", latest_started, make_response([make_latest(1, 8.5)])
-        )
-
-    async def get_sensors(_location_id: int) -> object:
-        """Return the sensors response."""
-        return await wait_for_release(
-            "sensors", sensors_started, make_response([make_sensor(1, "pm25")])
-        )
-
-    mock_openaq_client.locations.get.side_effect = get_location
-    mock_openaq_client.locations.latest.side_effect = get_latest
-    mock_openaq_client.locations.sensors.side_effect = get_sensors
-
-    setup_task = asyncio.create_task(setup_integration(hass, mock_config_entry))
-    await asyncio.wait_for(
-        asyncio.gather(
-            location_started.wait(),
-            latest_started.wait(),
-            sensors_started.wait(),
-        ),
-        timeout=1,
-    )
-    assert started == {"location", "latest", "sensors"}
-    release.set()
-
-    await asyncio.wait_for(setup_task, timeout=1)
+    mock_openaq_client.locations.get.assert_called_once_with(LOCATION_ID)
+    mock_openaq_client.locations.latest.assert_called_once_with(LOCATION_ID)
+    mock_openaq_client.locations.sensors.assert_called_once_with(LOCATION_ID)
 
 
 async def test_refresh_uses_cached_location_metadata(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test refresh polls latest measurements without refetching metadata."""
@@ -208,12 +156,12 @@ async def test_refresh_uses_cached_location_metadata(
 
     mock_openaq_client.locations.get.assert_not_called()
     mock_openaq_client.locations.sensors.assert_not_called()
-    mock_openaq_client.locations.latest.assert_awaited_once_with(LOCATION_ID)
+    mock_openaq_client.locations.latest.assert_called_once_with(LOCATION_ID)
 
 
 async def test_unload_closes_client(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test unloading OpenAQ closes the client."""
@@ -222,12 +170,12 @@ async def test_unload_closes_client(
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mock_openaq_client.close.assert_awaited_once()
+    mock_openaq_client.close.assert_called_once()
 
 
 async def test_update_listener_reloads_entry(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test config entry updates reload the entry."""
@@ -244,7 +192,7 @@ async def test_update_listener_reloads_entry(
 
 
 async def test_setup_without_locations(
-    hass: HomeAssistant, mock_openaq_client: AsyncMock
+    hass: HomeAssistant, mock_openaq_client: MagicMock
 ) -> None:
     """Test setup before any location subentries are configured."""
     config_entry = MockConfigEntry(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -126,6 +126,39 @@ async def test_setup_stops_after_a_failed_location_refresh(
     mock_openaq_client.close.assert_called_once()
 
 
+async def test_coordinators_share_client_lock(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+) -> None:
+    """Test coordinators share the lock for the shared client."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OpenAQ",
+        data={CONF_API_KEY: API_KEY},
+        unique_id=DOMAIN,
+        subentries_data=[
+            ConfigSubentryDataWithId(
+                data={CONF_LOCATION_ID: LOCATION_ID},
+                subentry_id="ABCDEF",
+                subentry_type="location",
+                title="Del Norte",
+                unique_id=str(LOCATION_ID),
+            ),
+            ConfigSubentryDataWithId(
+                data={CONF_LOCATION_ID: 9999},
+                subentry_id="GHIJKL",
+                subentry_type="location",
+                title="South Valley",
+                unique_id="9999",
+            ),
+        ],
+    )
+    await setup_integration(hass, config_entry)
+    coordinators = list(config_entry.runtime_data.coordinators.values())
+
+    assert coordinators[0]._client_lock is coordinators[1]._client_lock
+
+
 async def test_setup_fetches_location_data(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 from openaq import NotAuthorizedError, ServerError
 
-from homeassistant.components.openaq import async_unload_entry
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import OpenAQDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState, ConfigSubentryDataWithId
@@ -241,7 +240,7 @@ async def test_failed_unload_does_not_close_client(
     with patch.object(
         hass.config_entries, "async_unload_platforms", return_value=False
     ):
-        assert not await async_unload_entry(hass, mock_config_entry)
+        assert not await hass.config_entries.async_unload(mock_config_entry.entry_id)
 
     mock_openaq_client.close.assert_not_called()
 

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from openaq import NotAuthorizedError, ServerError
 
+from homeassistant.components.openaq import async_unload_entry
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
 from homeassistant.components.openaq.coordinator import OpenAQDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState, ConfigSubentryDataWithId
@@ -207,6 +208,22 @@ async def test_unload_closes_client(
     await hass.async_block_till_done()
 
     mock_openaq_client.close.assert_called_once()
+
+
+async def test_failed_unload_does_not_close_client(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a failed unload does not close the client."""
+    await setup_integration(hass, mock_config_entry)
+
+    with patch.object(
+        hass.config_entries, "async_unload_platforms", return_value=False
+    ):
+        assert not await async_unload_entry(hass, mock_config_entry)
+
+    mock_openaq_client.close.assert_not_called()
 
 
 async def test_update_listener_reloads_entry(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -1,6 +1,7 @@
 """Test OpenAQ initialization."""
 
 import asyncio
+from collections.abc import Callable
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -221,6 +222,57 @@ async def test_unload_closes_client(
     await hass.async_block_till_done()
 
     mock_openaq_client.close.assert_called_once()
+
+
+async def test_unload_does_not_close_during_client_call(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test unloading does not close the client during a client call."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    loop = asyncio.get_running_loop()
+    call_started = asyncio.Event()
+    close_started = asyncio.Event()
+    release_call = threading.Event()
+
+    async def run_in_thread(target: Callable[..., object], *args: object) -> object:
+        """Run executor jobs in separate threads for this race test."""
+        return await asyncio.to_thread(target, *args)
+
+    def latest(location_id: int) -> object:
+        """Block an SDK call until the test allows it to complete."""
+        loop.call_soon_threadsafe(call_started.set)
+        release_call.wait()
+        return make_response([])
+
+    def close_client() -> None:
+        """Record when the client close starts."""
+        loop.call_soon_threadsafe(close_started.set)
+
+    mock_openaq_client.locations.latest.side_effect = latest
+    mock_openaq_client.close.side_effect = close_client
+    with patch.object(hass, "async_add_executor_job", side_effect=run_in_thread):
+        refresh_task = asyncio.create_task(coordinator.async_refresh())
+        await asyncio.wait_for(call_started.wait(), timeout=1)
+        unload_task = asyncio.create_task(
+            hass.config_entries.async_unload(mock_config_entry.entry_id)
+        )
+        try:
+            await asyncio.wait_for(close_started.wait(), timeout=0.1)
+        except TimeoutError:
+            closed_during_call = False
+        else:
+            closed_during_call = True
+        finally:
+            release_call.set()
+
+        assert await asyncio.wait_for(unload_task, timeout=1)
+        await asyncio.wait_for(refresh_task, timeout=1)
+
+    assert not closed_during_call
+    assert close_started.is_set()
 
 
 async def test_failed_unload_does_not_close_client(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -8,11 +8,9 @@ from unittest.mock import MagicMock, patch
 from openaq import NotAuthorizedError, ServerError
 
 from homeassistant.components.openaq.const import CONF_LOCATION_ID, DOMAIN
-from homeassistant.components.openaq.coordinator import OpenAQDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState, ConfigSubentryDataWithId
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 
 from . import setup_integration
 from .conftest import API_KEY, LOCATION_ID, make_latest, make_response
@@ -107,22 +105,18 @@ async def test_setup_stops_after_a_failed_location_refresh(
         ],
     )
 
-    async def first_refresh(coordinator: OpenAQDataUpdateCoordinator) -> None:
+    def get_location(location_id: int) -> object:
         """Fail the first configured location refresh."""
-        refreshed_locations.append(coordinator.location_id)
-        raise ConfigEntryNotReady("API error")
+        refreshed_locations.append(location_id)
+        raise ServerError("API error")
 
     def close_client() -> None:
         """Assert the failing refresh finished before closing the client."""
         assert refreshed_locations == [LOCATION_ID]
 
+    mock_openaq_client.locations.get.side_effect = get_location
     mock_openaq_client.close.side_effect = close_client
-
-    with patch(
-        "homeassistant.components.openaq.OpenAQDataUpdateCoordinator.async_config_entry_first_refresh",
-        first_refresh,
-    ):
-        await setup_integration(hass, config_entry)
+    await setup_integration(hass, config_entry)
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
     assert refreshed_locations == [LOCATION_ID]

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -1,5 +1,8 @@
 """Test OpenAQ initialization."""
 
+import asyncio
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 from openaq import NotAuthorizedError, ServerError
@@ -127,11 +130,11 @@ async def test_setup_stops_after_a_failed_location_refresh(
     mock_openaq_client.close.assert_called_once()
 
 
-async def test_coordinators_share_client_lock(
+async def test_refreshes_serialize_shared_client_calls(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
 ) -> None:
-    """Test coordinators share the lock for the shared client."""
+    """Test coordinators serialize calls to the shared client."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="OpenAQ",
@@ -156,8 +159,25 @@ async def test_coordinators_share_client_lock(
     )
     await setup_integration(hass, config_entry)
     coordinators = list(config_entry.runtime_data.coordinators.values())
+    active_lock = threading.Lock()
+    active_calls = 0
+    max_active_calls = 0
 
-    assert coordinators[0]._client_lock is coordinators[1]._client_lock
+    def latest(location_id: int) -> object:
+        """Track overlapping calls to the synchronous SDK client."""
+        nonlocal active_calls, max_active_calls
+        with active_lock:
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+        time.sleep(0.1)
+        with active_lock:
+            active_calls -= 1
+        return make_response([])
+
+    mock_openaq_client.locations.latest.side_effect = latest
+    await asyncio.gather(*(coordinator.async_refresh() for coordinator in coordinators))
+
+    assert max_active_calls == 1
 
 
 async def test_setup_fetches_location_data(

--- a/tests/components/openaq/test_init.py
+++ b/tests/components/openaq/test_init.py
@@ -1,6 +1,5 @@
 """Test OpenAQ initialization."""
 
-import asyncio
 from unittest.mock import MagicMock, patch
 
 from openaq import NotAuthorizedError, ServerError
@@ -45,19 +44,19 @@ async def test_setup_retry_on_first_refresh_failure(
     mock_openaq_client.close.assert_called_once()
 
 
-async def test_setup_fails_auth_on_first_refresh_auth_failure(
+async def test_setup_retries_on_first_refresh_auth_failure(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test setup fails auth when first coordinator refresh has an auth error."""
+    """Test setup retries when first coordinator refresh has an auth error."""
     mock_openaq_client.locations.latest.side_effect = NotAuthorizedError(
         "Invalid API key"
     )
 
     await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     mock_openaq_client.close.assert_called_once()
 
 
@@ -75,14 +74,12 @@ async def test_setup_retry_on_empty_location_response(
     mock_openaq_client.close.assert_called_once()
 
 
-async def test_setup_closes_client_after_sibling_refresh_finalizes(
+async def test_setup_stops_after_a_failed_location_refresh(
     hass: HomeAssistant,
     mock_openaq_client: MagicMock,
 ) -> None:
-    """Test setup closes the client after sibling refresh tasks finish."""
-    running_refresh_started = asyncio.Event()
-    running_refresh_finalized = asyncio.Event()
-    failing_refresh_started = asyncio.Event()
+    """Test setup closes after the failed refresh and skips later locations."""
+    refreshed_locations: list[int] = []
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -108,22 +105,13 @@ async def test_setup_closes_client_after_sibling_refresh_finalizes(
     )
 
     async def first_refresh(coordinator: OpenAQDataUpdateCoordinator) -> None:
-        """Refresh one coordinator while another fails."""
-        if coordinator.location_id == LOCATION_ID:
-            running_refresh_started.set()
-            try:
-                await asyncio.Event().wait()
-            finally:
-                running_refresh_finalized.set()
-            return
-
-        await running_refresh_started.wait()
-        failing_refresh_started.set()
+        """Fail the first configured location refresh."""
+        refreshed_locations.append(coordinator.location_id)
         raise ConfigEntryNotReady("API error")
 
     def close_client() -> None:
-        """Assert the sibling refresh finalized before closing the client."""
-        assert running_refresh_finalized.is_set()
+        """Assert the failing refresh finished before closing the client."""
+        assert refreshed_locations == [LOCATION_ID]
 
     mock_openaq_client.close.side_effect = close_client
 
@@ -134,8 +122,7 @@ async def test_setup_closes_client_after_sibling_refresh_finalizes(
         await setup_integration(hass, config_entry)
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
-    assert failing_refresh_started.is_set()
-    assert running_refresh_finalized.is_set()
+    assert refreshed_locations == [LOCATION_ID]
     mock_openaq_client.close.assert_called_once()
 
 

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -20,7 +20,13 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import setup_integration
-from .conftest import LOCATION_ID, make_latest, make_response, make_sensor
+from .conftest import (
+    LOCATION_ID,
+    make_latest,
+    make_location,
+    make_response,
+    make_sensor,
+)
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -159,6 +165,30 @@ async def test_distance_from_home_sensor_uses_configured_unit_system(
     assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
     assert state.state == "0.0"
     assert state.attributes["unit_of_measurement"] == UnitOfLength.MILES
+
+
+async def test_distance_from_home_sensor_unknown_without_coordinates(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test distance from Home Assistant sensor without valid coordinates."""
+    mock_openaq_client.locations.get.return_value = make_response(
+        [make_location(coordinates=(True, -106.6))]
+    )
+    entity_registry.async_get_or_create(
+        "sensor",
+        "openaq",
+        f"{LOCATION_ID}_distance_from_home",
+        suggested_object_id="del_norte_distance_from_home_assistant",
+        disabled_by=None,
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_missing_latest_values_are_not_created(

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -17,16 +17,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import setup_integration
-from .conftest import (
-    LOCATION_ID,
-    make_latest,
-    make_location,
-    make_response,
-    make_sensor,
-)
+from .conftest import LOCATION_ID, make_latest, make_response, make_sensor
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -93,7 +86,7 @@ async def test_sensor_entities(
         "sensor.del_norte_distance_from_home_assistant"
     )
     assert distance is not None
-    assert distance.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert distance.capabilities is None
     assert distance.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     assert distance.entity_category is EntityCategory.DIAGNOSTIC
     assert distance.original_device_class is SensorDeviceClass.DISTANCE
@@ -135,60 +128,6 @@ async def test_distance_from_home_sensor(
     assert state.state == "0.0"
     assert state.attributes["device_class"] == SensorDeviceClass.DISTANCE
     assert state.attributes["unit_of_measurement"] == UnitOfLength.KILOMETERS
-
-
-async def test_distance_from_home_sensor_uses_configured_unit_system(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test distance from Home Assistant sensor uses the configured unit system."""
-    hass.config.latitude = 35.1
-    hass.config.longitude = -106.6
-    hass.config.units = US_CUSTOMARY_SYSTEM
-    entity_registry.async_get_or_create(
-        "sensor",
-        "openaq",
-        f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance_from_home_assistant",
-        disabled_by=None,
-    )
-
-    await setup_integration(hass, mock_config_entry)
-
-    distance = entity_registry.async_get(
-        "sensor.del_norte_distance_from_home_assistant"
-    )
-    assert distance is not None
-    assert distance.unit_of_measurement == UnitOfLength.MILES
-    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
-    assert state.state == "0.0"
-    assert state.attributes["unit_of_measurement"] == UnitOfLength.MILES
-
-
-async def test_distance_from_home_sensor_unknown_without_coordinates(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test distance from Home Assistant sensor without valid coordinates."""
-    mock_openaq_client.locations.get.return_value = make_response(
-        [make_location(coordinates=(True, -106.6))]
-    )
-    entity_registry.async_get_or_create(
-        "sensor",
-        "openaq",
-        f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance_from_home_assistant",
-        disabled_by=None,
-    )
-
-    await setup_integration(hass, mock_config_entry)
-
-    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
-    assert state.state == STATE_UNKNOWN
 
 
 async def test_missing_latest_values_are_not_created(

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -1,0 +1,112 @@
+"""Test OpenAQ sensors."""
+
+from unittest.mock import AsyncMock
+
+from openaq import TimeoutError as OpenAQTimeoutError
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_PARTS_PER_BILLION,
+    CONCENTRATION_PARTS_PER_MILLION,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import setup_integration
+from .conftest import LOCATION_ID, make_latest, make_response, make_sensor
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_sensor_snapshot(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test OpenAQ sensor snapshots."""
+    await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_sensor_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test OpenAQ sensor entities."""
+    await setup_integration(hass, mock_config_entry)
+
+    pm25 = entity_registry.async_get("sensor.del_norte_pm2_5")
+    assert pm25 is not None
+    assert pm25.unique_id == f"{LOCATION_ID}_pm25"
+    assert pm25.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
+    assert state.state == "12.1"
+    assert state.attributes["device_class"] == SensorDeviceClass.PM25
+    assert state.attributes["unit_of_measurement"] == (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    )
+
+    co = entity_registry.async_get("sensor.del_norte_carbon_monoxide")
+    assert co is not None
+    assert (state := hass.states.get("sensor.del_norte_carbon_monoxide")) is not None
+    assert state.attributes["device_class"] == SensorDeviceClass.CO
+    assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_MILLION
+
+    no2 = entity_registry.async_get("sensor.del_norte_nitrogen_dioxide")
+    assert no2 is not None
+    assert (state := hass.states.get("sensor.del_norte_nitrogen_dioxide")) is not None
+    assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_BILLION
+
+    assert entity_registry.async_get("sensor.del_norte_unsupported") is None
+
+    device = device_registry.async_get_device(
+        identifiers={("openaq", str(LOCATION_ID))}
+    )
+    assert device is not None
+    assert device.name == "Del Norte"
+
+
+async def test_missing_latest_values_are_not_created(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors without latest values are not created."""
+    mock_openaq_client.locations.latest.return_value = make_response(
+        [make_latest(1, 8.5), make_latest(2, None)]
+    )
+    mock_openaq_client.locations.sensors.return_value = make_response(
+        [make_sensor(1, "pm1"), make_sensor(2, "pm25")]
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert entity_registry.async_get("sensor.del_norte_pm1") is not None
+    assert entity_registry.async_get("sensor.del_norte_pm2_5") is None
+
+
+async def test_entity_unavailable_on_update_failure(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors become unavailable when refresh fails."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    mock_openaq_client.locations.latest.side_effect = OpenAQTimeoutError("Timeout")
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -12,9 +12,12 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityCategory,
+    UnitOfLength,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import setup_integration
 from .conftest import LOCATION_ID, make_latest, make_response, make_sensor
@@ -30,6 +33,13 @@ async def test_sensor_snapshot(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test OpenAQ sensor snapshots."""
+    entity_registry.async_get_or_create(
+        "sensor",
+        "openaq",
+        f"{LOCATION_ID}_distance_from_home",
+        suggested_object_id="del_norte_distance_from_home_assistant",
+        disabled_by=None,
+    )
     await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
@@ -49,6 +59,7 @@ async def test_sensor_entities(
     assert pm25 is not None
     assert pm25.unique_id == f"{LOCATION_ID}_pm25"
     assert pm25.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert pm25.options == {"sensor": {"suggested_display_precision": 1}}
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == "12.1"
     assert state.attributes["device_class"] == SensorDeviceClass.PM25
@@ -58,22 +69,96 @@ async def test_sensor_entities(
 
     co = entity_registry.async_get("sensor.del_norte_carbon_monoxide")
     assert co is not None
+    assert co.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert co.options == {"sensor": {"suggested_display_precision": 2}}
     assert (state := hass.states.get("sensor.del_norte_carbon_monoxide")) is not None
     assert state.attributes["device_class"] == SensorDeviceClass.CO
     assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_MILLION
 
     no2 = entity_registry.async_get("sensor.del_norte_nitrogen_dioxide")
     assert no2 is not None
+    assert no2.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert no2.options == {"sensor": {"suggested_display_precision": 1}}
     assert (state := hass.states.get("sensor.del_norte_nitrogen_dioxide")) is not None
     assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_BILLION
 
     assert entity_registry.async_get("sensor.del_norte_unsupported") is None
+    distance = entity_registry.async_get(
+        "sensor.del_norte_distance_from_home_assistant"
+    )
+    assert distance is not None
+    assert distance.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert distance.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert distance.entity_category is EntityCategory.DIAGNOSTIC
+    assert distance.original_device_class is SensorDeviceClass.DISTANCE
+    assert distance.unit_of_measurement == UnitOfLength.KILOMETERS
 
     device = device_registry.async_get_device(
         identifiers={("openaq", str(LOCATION_ID))}
     )
     assert device is not None
     assert device.name == "Del Norte"
+
+
+async def test_distance_from_home_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test distance from Home Assistant sensor."""
+    hass.config.latitude = 35.1
+    hass.config.longitude = -106.6
+    entity_registry.async_get_or_create(
+        "sensor",
+        "openaq",
+        f"{LOCATION_ID}_distance_from_home",
+        suggested_object_id="del_norte_distance_from_home_assistant",
+        disabled_by=None,
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    distance = entity_registry.async_get(
+        "sensor.del_norte_distance_from_home_assistant"
+    )
+    assert distance is not None
+    assert distance.disabled_by is None
+    assert distance.options == {"sensor": {"suggested_display_precision": 1}}
+    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
+    assert state.state == "0.0"
+    assert state.attributes["device_class"] == SensorDeviceClass.DISTANCE
+    assert state.attributes["unit_of_measurement"] == UnitOfLength.KILOMETERS
+
+
+async def test_distance_from_home_sensor_uses_configured_unit_system(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test distance from Home Assistant sensor uses the configured unit system."""
+    hass.config.latitude = 35.1
+    hass.config.longitude = -106.6
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    entity_registry.async_get_or_create(
+        "sensor",
+        "openaq",
+        f"{LOCATION_ID}_distance_from_home",
+        suggested_object_id="del_norte_distance_from_home_assistant",
+        disabled_by=None,
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    distance = entity_registry.async_get(
+        "sensor.del_norte_distance_from_home_assistant"
+    )
+    assert distance is not None
+    assert distance.unit_of_measurement == UnitOfLength.MILES
+    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
+    assert state.state == "0.0"
+    assert state.attributes["unit_of_measurement"] == UnitOfLength.MILES
 
 
 async def test_missing_latest_values_are_not_created(

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -110,3 +111,22 @@ async def test_entity_unavailable_on_update_failure(
 
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_entity_unknown_when_measurement_disappears(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors handle measurements disappearing after setup."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    mock_openaq_client.locations.latest.return_value = make_response(
+        [make_latest(1, 8.5)]
+    )
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.openaq.const import (
@@ -10,11 +11,11 @@ from homeassistant.components.openaq.const import (
     OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
 )
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.translation import async_get_translations
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from . import setup_integration
 from .conftest import LOCATION_ID, make_latest, make_response, make_sensor
@@ -27,11 +28,11 @@ async def async_load_entity_translations(hass: HomeAssistant) -> None:
     await async_get_translations(hass, "en", "entity", [DOMAIN])
 
 
+@pytest.mark.usefixtures("mock_openaq_client")
 async def test_sensor_snapshot(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
-    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test OpenAQ sensor snapshots."""
@@ -41,11 +42,11 @@ async def test_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.usefixtures("mock_openaq_client")
 async def test_sensor_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test OpenAQ sensor entities."""
@@ -143,7 +144,11 @@ async def test_entity_unavailable_on_auth_failure(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert any(
+        flow["handler"] == DOMAIN and flow["context"]["source"] == "reauth"
+        for flow in hass.config_entries.flow.async_progress()
+    )
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == STATE_UNAVAILABLE
 

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -1,6 +1,6 @@
 """Test OpenAQ sensors."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
 from syrupy.assertion import SnapshotAssertion
@@ -13,8 +13,6 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
-    EntityCategory,
-    UnitOfLength,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -36,18 +34,11 @@ async def test_sensor_snapshot(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test OpenAQ sensor snapshots."""
     await async_load_entity_translations(hass)
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance_from_home_assistant",
-        disabled_by=None,
-    )
     await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
@@ -57,7 +48,7 @@ async def test_sensor_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test OpenAQ sensor entities."""
@@ -92,17 +83,6 @@ async def test_sensor_entities(
     assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_BILLION
 
     assert entity_registry.async_get("sensor.del_norte_unsupported") is None
-    distance_entity_id = entity_registry.async_get_entity_id(
-        "sensor", DOMAIN, f"{LOCATION_ID}_distance_from_home"
-    )
-    assert distance_entity_id is not None
-    distance = entity_registry.async_get(distance_entity_id)
-    assert distance is not None
-    assert distance.capabilities is None
-    assert distance.disabled_by is er.RegistryEntryDisabler.INTEGRATION
-    assert distance.entity_category is EntityCategory.DIAGNOSTIC
-    assert distance.original_device_class is SensorDeviceClass.DISTANCE
-    assert distance.unit_of_measurement == UnitOfLength.KILOMETERS
 
     device = device_registry.async_get_device(
         identifiers={("openaq", str(LOCATION_ID))}
@@ -111,73 +91,13 @@ async def test_sensor_entities(
     assert device.name == "Del Norte"
 
 
-async def test_distance_from_home_sensor(
+async def test_missing_latest_values_create_unknown_entity(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test distance from Home Assistant sensor."""
-    hass.config.latitude = 35.1
-    hass.config.longitude = -106.6
-    await async_load_entity_translations(hass)
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance_from_home_assistant",
-        disabled_by=None,
-    )
-
-    await setup_integration(hass, mock_config_entry)
-
-    distance = entity_registry.async_get(
-        "sensor.del_norte_distance_from_home_assistant"
-    )
-    assert distance is not None
-    assert distance.disabled_by is None
-    assert distance.options == {"sensor": {"suggested_display_precision": 1}}
-    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
-    assert state.state == "0.0"
-    assert state.attributes["device_class"] == SensorDeviceClass.DISTANCE
-    assert state.attributes["unit_of_measurement"] == UnitOfLength.KILOMETERS
-
-
-async def test_distance_from_home_sensor_updates(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test distance from Home Assistant sensor updates with coordinator data."""
-    hass.config.latitude = 35.1
-    hass.config.longitude = -106.6
-    await async_load_entity_translations(hass)
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance_from_home_assistant",
-        disabled_by=None,
-    )
-    await setup_integration(hass, mock_config_entry)
-    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
-    hass.config.latitude = 35.2
-
-    await coordinator.async_refresh()
-    await hass.async_block_till_done()
-
-    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
-    assert float(state.state) > 0
-
-
-async def test_missing_latest_values_are_not_created(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_openaq_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test sensors without latest values are not created."""
+    """Test sensors without latest values are created with unknown state."""
     mock_openaq_client.locations.latest.return_value = make_response(
         [make_latest(1, 8.5), make_latest(2, None)]
     )
@@ -188,12 +108,14 @@ async def test_missing_latest_values_are_not_created(
     await setup_integration(hass, mock_config_entry)
 
     assert entity_registry.async_get("sensor.del_norte_pm1") is not None
-    assert entity_registry.async_get("sensor.del_norte_pm2_5") is None
+    assert entity_registry.async_get("sensor.del_norte_pm2_5") is not None
+    assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_entity_unavailable_on_update_failure(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test sensors become unavailable when refresh fails."""
@@ -210,7 +132,7 @@ async def test_entity_unavailable_on_update_failure(
 
 async def test_entity_unavailable_on_auth_failure(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test sensors become unavailable when runtime authentication fails."""
@@ -230,7 +152,7 @@ async def test_entity_unavailable_on_auth_failure(
 
 async def test_entity_unknown_when_measurement_disappears(
     hass: HomeAssistant,
-    mock_openaq_client: AsyncMock,
+    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test sensors handle measurements disappearing after setup."""

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -10,7 +10,11 @@ from homeassistant.components.openaq.const import (
     DOMAIN,
     OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
 )
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -56,7 +60,7 @@ async def test_sensor_entities(
     pm25 = entity_registry.async_get("sensor.del_norte_pm2_5")
     assert pm25 is not None
     assert pm25.unique_id == f"{LOCATION_ID}_pm25"
-    assert pm25.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert pm25.capabilities == {ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT}
     assert pm25.options == {"sensor": {"suggested_display_precision": 1}}
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == "12.1"
@@ -68,7 +72,7 @@ async def test_sensor_entities(
 
     co = entity_registry.async_get("sensor.del_norte_carbon_monoxide")
     assert co is not None
-    assert co.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert co.capabilities == {ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT}
     assert co.options == {"sensor": {"suggested_display_precision": 2}}
     assert (state := hass.states.get("sensor.del_norte_carbon_monoxide")) is not None
     assert state.attributes["device_class"] == SensorDeviceClass.CO
@@ -76,7 +80,7 @@ async def test_sensor_entities(
 
     no2 = entity_registry.async_get("sensor.del_norte_nitrogen_dioxide")
     assert no2 is not None
-    assert no2.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
+    assert no2.capabilities == {ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT}
     assert no2.options == {"sensor": {"suggested_display_precision": 1}}
     assert (state := hass.states.get("sensor.del_norte_nitrogen_dioxide")) is not None
     assert state.attributes["unit_of_measurement"] == "ppb"

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from openaq import TimeoutError as OpenAQTimeoutError
+from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
@@ -16,6 +16,7 @@ from homeassistant.const import (
     UnitOfLength,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
@@ -36,7 +37,7 @@ async def test_sensor_snapshot(
         "sensor",
         "openaq",
         f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance_from_home_assistant",
+        suggested_object_id="del_norte_distance",
         disabled_by=None,
     )
     await setup_integration(hass, mock_config_entry)
@@ -82,9 +83,7 @@ async def test_sensor_entities(
     assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_BILLION
 
     assert entity_registry.async_get("sensor.del_norte_unsupported") is None
-    distance = entity_registry.async_get(
-        "sensor.del_norte_distance_from_home_assistant"
-    )
+    distance = entity_registry.async_get("sensor.del_norte_distance")
     assert distance is not None
     assert distance.capabilities is None
     assert distance.disabled_by is er.RegistryEntryDisabler.INTEGRATION
@@ -112,22 +111,47 @@ async def test_distance_from_home_sensor(
         "sensor",
         "openaq",
         f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance_from_home_assistant",
+        suggested_object_id="del_norte_distance",
         disabled_by=None,
     )
 
     await setup_integration(hass, mock_config_entry)
 
-    distance = entity_registry.async_get(
-        "sensor.del_norte_distance_from_home_assistant"
-    )
+    distance = entity_registry.async_get("sensor.del_norte_distance")
     assert distance is not None
     assert distance.disabled_by is None
     assert distance.options == {"sensor": {"suggested_display_precision": 1}}
-    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
+    assert (state := hass.states.get("sensor.del_norte_distance"))
     assert state.state == "0.0"
     assert state.attributes["device_class"] == SensorDeviceClass.DISTANCE
     assert state.attributes["unit_of_measurement"] == UnitOfLength.KILOMETERS
+
+
+async def test_distance_from_home_sensor_updates(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test distance from Home Assistant sensor updates with coordinator data."""
+    hass.config.latitude = 35.1
+    hass.config.longitude = -106.6
+    entity_registry.async_get_or_create(
+        "sensor",
+        "openaq",
+        f"{LOCATION_ID}_distance_from_home",
+        suggested_object_id="del_norte_distance",
+        disabled_by=None,
+    )
+    await setup_integration(hass, mock_config_entry)
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    hass.config.latitude = 35.2
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.del_norte_distance"))
+    assert float(state.state) > 0
 
 
 async def test_missing_latest_values_are_not_created(
@@ -163,6 +187,26 @@ async def test_entity_unavailable_on_update_failure(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
+    assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_entity_unavailable_on_auth_failure(
+    hass: HomeAssistant,
+    mock_openaq_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors become unavailable when runtime authentication fails."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    mock_openaq_client.locations.latest.side_effect = NotAuthorizedError(
+        "Invalid API key"
+    )
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert isinstance(coordinator.last_exception, HomeAssistantError)
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == STATE_UNAVAILABLE
 

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -6,7 +6,6 @@ from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant import const as ha_const
 from homeassistant.components.openaq.const import DOMAIN
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
@@ -14,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfDensity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.translation import async_get_translations
@@ -65,7 +64,7 @@ async def test_sensor_entities(
     assert state.attributes["device_class"] == SensorDeviceClass.PM25
     assert (
         state.attributes["unit_of_measurement"]
-        == ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+        == UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
     )
 
     co = entity_registry.async_get("sensor.del_norte_carbon_monoxide")

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -6,10 +6,8 @@ from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.openaq.const import (
-    DOMAIN,
-    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
-)
+from homeassistant import const as ha_const
+from homeassistant.components.openaq.const import DOMAIN
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -67,7 +65,7 @@ async def test_sensor_entities(
     assert state.attributes["device_class"] == SensorDeviceClass.PM25
     assert (
         state.attributes["unit_of_measurement"]
-        == OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER
+        == ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
     co = entity_registry.async_get("sensor.del_norte_carbon_monoxide")

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.openaq.const import DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -18,11 +19,17 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.translation import async_get_translations
 
 from . import setup_integration
 from .conftest import LOCATION_ID, make_latest, make_response, make_sensor
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def async_load_entity_translations(hass: HomeAssistant) -> None:
+    """Load OpenAQ entity translations."""
+    await async_get_translations(hass, "en", "entity", [DOMAIN])
 
 
 async def test_sensor_snapshot(
@@ -33,11 +40,12 @@ async def test_sensor_snapshot(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test OpenAQ sensor snapshots."""
+    await async_load_entity_translations(hass)
     entity_registry.async_get_or_create(
         "sensor",
-        "openaq",
+        DOMAIN,
         f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance",
+        suggested_object_id="del_norte_distance_from_home_assistant",
         disabled_by=None,
     )
     await setup_integration(hass, mock_config_entry)
@@ -53,6 +61,7 @@ async def test_sensor_entities(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test OpenAQ sensor entities."""
+    await async_load_entity_translations(hass)
     await setup_integration(hass, mock_config_entry)
 
     pm25 = entity_registry.async_get("sensor.del_norte_pm2_5")
@@ -83,7 +92,11 @@ async def test_sensor_entities(
     assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_BILLION
 
     assert entity_registry.async_get("sensor.del_norte_unsupported") is None
-    distance = entity_registry.async_get("sensor.del_norte_distance")
+    distance_entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{LOCATION_ID}_distance_from_home"
+    )
+    assert distance_entity_id is not None
+    distance = entity_registry.async_get(distance_entity_id)
     assert distance is not None
     assert distance.capabilities is None
     assert distance.disabled_by is er.RegistryEntryDisabler.INTEGRATION
@@ -107,21 +120,24 @@ async def test_distance_from_home_sensor(
     """Test distance from Home Assistant sensor."""
     hass.config.latitude = 35.1
     hass.config.longitude = -106.6
+    await async_load_entity_translations(hass)
     entity_registry.async_get_or_create(
         "sensor",
-        "openaq",
+        DOMAIN,
         f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance",
+        suggested_object_id="del_norte_distance_from_home_assistant",
         disabled_by=None,
     )
 
     await setup_integration(hass, mock_config_entry)
 
-    distance = entity_registry.async_get("sensor.del_norte_distance")
+    distance = entity_registry.async_get(
+        "sensor.del_norte_distance_from_home_assistant"
+    )
     assert distance is not None
     assert distance.disabled_by is None
     assert distance.options == {"sensor": {"suggested_display_precision": 1}}
-    assert (state := hass.states.get("sensor.del_norte_distance"))
+    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
     assert state.state == "0.0"
     assert state.attributes["device_class"] == SensorDeviceClass.DISTANCE
     assert state.attributes["unit_of_measurement"] == UnitOfLength.KILOMETERS
@@ -136,11 +152,12 @@ async def test_distance_from_home_sensor_updates(
     """Test distance from Home Assistant sensor updates with coordinator data."""
     hass.config.latitude = 35.1
     hass.config.longitude = -106.6
+    await async_load_entity_translations(hass)
     entity_registry.async_get_or_create(
         "sensor",
-        "openaq",
+        DOMAIN,
         f"{LOCATION_ID}_distance_from_home",
-        suggested_object_id="del_norte_distance",
+        suggested_object_id="del_norte_distance_from_home_assistant",
         disabled_by=None,
     )
     await setup_integration(hass, mock_config_entry)
@@ -150,7 +167,7 @@ async def test_distance_from_home_sensor_updates(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert (state := hass.states.get("sensor.del_norte_distance"))
+    assert (state := hass.states.get("sensor.del_norte_distance_from_home_assistant"))
     assert float(state.state) > 0
 
 

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -17,9 +17,9 @@ from homeassistant.const import (
     UnitOfLength,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.translation import async_get_translations
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from . import setup_integration
 from .conftest import LOCATION_ID, make_latest, make_response, make_sensor
@@ -223,7 +223,7 @@ async def test_entity_unavailable_on_auth_failure(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert isinstance(coordinator.last_exception, HomeAssistantError)
+    assert isinstance(coordinator.last_exception, UpdateFailed)
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == STATE_UNAVAILABLE
 

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -5,15 +5,12 @@ from unittest.mock import MagicMock
 from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.openaq.const import DOMAIN
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_BILLION,
-    CONCENTRATION_PARTS_PER_MILLION,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
+from homeassistant.components.openaq.const import (
+    DOMAIN,
+    OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER,
 )
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.translation import async_get_translations
@@ -63,8 +60,9 @@ async def test_sensor_entities(
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == "12.1"
     assert state.attributes["device_class"] == SensorDeviceClass.PM25
-    assert state.attributes["unit_of_measurement"] == (
-        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    assert (
+        state.attributes["unit_of_measurement"]
+        == OPENAQ_UNIT_MICROGRAMS_PER_CUBIC_METER
     )
 
     co = entity_registry.async_get("sensor.del_norte_carbon_monoxide")
@@ -73,14 +71,14 @@ async def test_sensor_entities(
     assert co.options == {"sensor": {"suggested_display_precision": 2}}
     assert (state := hass.states.get("sensor.del_norte_carbon_monoxide")) is not None
     assert state.attributes["device_class"] == SensorDeviceClass.CO
-    assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_MILLION
+    assert state.attributes["unit_of_measurement"] == "ppm"
 
     no2 = entity_registry.async_get("sensor.del_norte_nitrogen_dioxide")
     assert no2 is not None
     assert no2.capabilities == {"state_class": SensorStateClass.MEASUREMENT}
     assert no2.options == {"sensor": {"suggested_display_precision": 1}}
     assert (state := hass.states.get("sensor.del_norte_nitrogen_dioxide")) is not None
-    assert state.attributes["unit_of_measurement"] == CONCENTRATION_PARTS_PER_BILLION
+    assert state.attributes["unit_of_measurement"] == "ppb"
 
     assert entity_registry.async_get("sensor.del_norte_unsupported") is None
 

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -1,7 +1,5 @@
 """Test OpenAQ sensors."""
 
-from dataclasses import replace
-from types import MappingProxyType
 from unittest.mock import MagicMock
 
 from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
@@ -112,24 +110,6 @@ async def test_missing_latest_values_create_unknown_entity(
     assert entity_registry.async_get("sensor.del_norte_pm2_5") is not None
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == STATE_UNKNOWN
-
-
-@pytest.mark.usefixtures("mock_openaq_client")
-async def test_sensor_without_metadata_has_no_unit(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test a sensor without metadata has no native unit."""
-    await setup_integration(hass, mock_config_entry)
-    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
-    coordinator.async_set_updated_data(
-        replace(coordinator.data, sensor_metadata=MappingProxyType({}))
-    )
-
-    await hass.async_block_till_done()
-
-    assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
-    assert "unit_of_measurement" not in state.attributes
 
 
 async def test_entity_unavailable_on_update_failure(

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -114,9 +114,9 @@ async def test_missing_latest_values_create_unknown_entity(
     assert state.state == STATE_UNKNOWN
 
 
+@pytest.mark.usefixtures("mock_openaq_client")
 async def test_sensor_without_metadata_has_no_unit(
     hass: HomeAssistant,
-    mock_openaq_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test a sensor without metadata has no native unit."""

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfDensity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -145,11 +144,7 @@ async def test_entity_unavailable_on_auth_failure(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert any(
-        flow["handler"] == DOMAIN and flow["context"]["source"] == "reauth"
-        for flow in hass.config_entries.flow.async_progress()
-    )
+    assert hass.config_entries.flow.async_progress() == []
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == STATE_UNAVAILABLE
 

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -1,5 +1,7 @@
 """Test OpenAQ sensors."""
 
+from dataclasses import replace
+from types import MappingProxyType
 from unittest.mock import MagicMock
 
 from openaq import NotAuthorizedError, TimeoutError as OpenAQTimeoutError
@@ -110,6 +112,24 @@ async def test_missing_latest_values_create_unknown_entity(
     assert entity_registry.async_get("sensor.del_norte_pm2_5") is not None
     assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
     assert state.state == STATE_UNKNOWN
+
+
+async def test_sensor_without_metadata_has_no_unit(
+    hass: HomeAssistant,
+    mock_openaq_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a sensor without metadata has no native unit."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    coordinator.async_set_updated_data(
+        replace(coordinator.data, sensor_metadata=MappingProxyType({}))
+    )
+
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.del_norte_pm2_5")) is not None
+    assert "unit_of_measurement" not in state.attributes
 
 
 async def test_entity_unavailable_on_update_failure(

--- a/tests/components/openaq/test_sensor.py
+++ b/tests/components/openaq/test_sensor.py
@@ -83,8 +83,8 @@ async def test_sensor_entities(
 
     assert entity_registry.async_get("sensor.del_norte_unsupported") is None
 
-    device = device_registry.async_get_device(
-        identifiers={("openaq", str(LOCATION_ID))}
+    device = device_registry.async_get_device_by_identifier(
+        ("openaq", str(LOCATION_ID)), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.name == "Del Norte"
@@ -98,7 +98,7 @@ async def test_missing_latest_values_create_unknown_entity(
 ) -> None:
     """Test sensors without latest values are created with unknown state."""
     mock_openaq_client.locations.latest.return_value = make_response(
-        [make_latest(1, 8.5), make_latest(2, None)]
+        [make_latest(1, 8.5)]
     )
     mock_openaq_client.locations.sensors.return_value = make_response(
         [make_sensor(1, "pm1"), make_sensor(2, "pm25")]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the OpenAQ integration with API-key setup, map-based monitoring location subentries, and air quality sensor entities.

> OpenAQ is an environmental tech nonprofit. We aggregate and harmonize open air quality data from across the globe onto an open-source, open-access data platform so that anyone concerned about air quality has unfettered access to the data they need to analyze, communicate and advocate for clean air. By providing universal access to air quality data, OpenAQ empowers a global community of changemakers to solve air inequality-the unequal access to clean air.
Anyone can explore the data via [OpenAQ Explorer](https://explore.openaq.org/), an interactive web application. For programmatic access via the API or to create custom lists on OpenAQ Explorer, [user registration](https://explore.openaq.org/login) is required. See also our [AQI Hub](https://aqihub.info/), a unique website to navigate air quality indexes across the world.


The location flow searches outward from the selected Home Assistant map point, ranks useful stations by supported sensor coverage and distance, and lets the user add one station at a time. Sensor entities are created from supported location metadata and stay unknown until OpenAQ reports a numeric latest value.

This PR now targets the officially released OpenAQ Python SDK/API v1 line with `openaq==1.1.0`. The v1 SDK is synchronous, so blocking OpenAQ SDK calls run in Home Assistant's executor. The first PR scope remains the initial Bronze-level integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45177
- Link to brands pull request: https://github.com/home-assistant/brands/pull/10249
- Link to developer documentation pull request:
- Link to frontend pull request:

New dependency:

- `openaq==1.1.0`

Dependency links:

- Release notes: https://github.com/openaq/openaq-python/releases/tag/v1.1.0

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


