### PR TITLE
Bump aioautomower to 2.7.5

### DIFF
--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
   "quality_scale": "silver",
-  "requirements": ["aioautomower==2.7.4"]
+  "requirements": ["aioautomower==2.7.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ aioaseko==1.0.0
 aioasuswrt==1.5.4
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.7.4
+aioautomower==2.7.5
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -200,7 +200,7 @@ aioaseko==1.0.0
 aioasuswrt==1.5.4
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.7.4
+aioautomower==2.7.5
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -14,8 +14,13 @@ from aioautomower.exceptions import (
     HusqvarnaTimeoutError,
     HusqvarnaWSServerHandshakeError,
 )
-from aioautomower.model import Calendar, MowerAttributes, MowerStates, WorkArea
-from aioautomower.model.model_work_areas import Type
+from aioautomower.model import (
+    Calendar,
+    MowerAttributes,
+    MowerStates,
+    WorkArea,
+    WorkAreaType,
+)
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -464,7 +469,7 @@ async def test_add_and_remove_work_area(
                 last_time_completed=datetime(
                     2024, 10, 1, 11, 11, 0, tzinfo=dt_util.get_default_time_zone()
                 ),
-                type=Type.RANDOM,
+                type=WorkAreaType.RANDOM,
                 use_global_cutting_height=False,
             )
         }


### PR DESCRIPTION
## Proposed change

RN: https://github.com/Thomas55555/aioautomower/releases/tag/v2.7.5
diff: https://github.com/Thomas55555/aioautomower/compare/v2.7.4...v2.7.5

Adds `WorkAreaType` enum to `aioautomower.model`, required by #168567 to gate work area sensors on `WorkArea.type == SYSTEMATIC`.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #168567
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] New or updated dependencies have been added to \`requirements_all.txt\`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr