### PR TITLE
Use tcp sensor available flag to reflect connection errors

### DIFF
--- a/homeassistant/components/tcp/entity.py
+++ b/homeassistant/components/tcp/entity.py
@@ -66,8 +66,8 @@ class TcpEntity(Entity):
 
     def update(self) -> None:
         """Get the latest value for this sensor."""
+        # Keep initial failures as unknown, but mark later failures as unavailable.
         if self._state is not None:
-            # Do not set it as unavailable if still unknown.
             self.available = False
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:

--- a/homeassistant/components/tcp/entity.py
+++ b/homeassistant/components/tcp/entity.py
@@ -66,6 +66,10 @@ class TcpEntity(Entity):
 
     def update(self) -> None:
         """Get the latest value for this sensor."""
+        if self._state is not None:
+            # Do not set it as unavailable if still unknown.
+            self.available = False
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.settimeout(self._config[CONF_TIMEOUT])
             try:
@@ -113,7 +117,9 @@ class TcpEntity(Entity):
             value = sock.recv(self._config[CONF_BUFFER_SIZE]).decode()
 
         value_template = self._config[CONF_VALUE_TEMPLATE]
-        if value_template is not None:
+        if value_template is None:
+            self._state = value
+        else:
             try:
                 self._state = value_template.render(parse_result=False, value=value)
             except TemplateError:
@@ -123,6 +129,5 @@ class TcpEntity(Entity):
                     value,
                 )
                 return
-            return
 
-        self._state = value
+        self.available = True

--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -3,12 +3,13 @@
 from copy import copy
 from unittest.mock import call, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.sensor import SCAN_INTERVAL
 from homeassistant.components.tcp import common as tcp
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-import homeassistant.util.dt as dt_util
 
 from tests.common import assert_setup_component, async_fire_time_changed
 
@@ -248,7 +249,7 @@ async def test_ssl_state_verify_off(
 
 
 async def test_update_socket_error_after_success(
-    hass: HomeAssistant, mock_socket
+    hass: HomeAssistant, mock_socket, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test state is updated with socket errors during update, when there is an old state."""
     assert await async_setup_component(hass, "sensor", TEST_CONFIG)
@@ -260,10 +261,9 @@ async def test_update_socket_error_after_success(
     assert state.state == "7.123"
 
     mock_socket.connect.side_effect = OSError("Boom")
-    # FIXME: where is the default scan interval for tcp sensor?
-    from datetime import timedelta
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY)

--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -8,8 +8,9 @@ import pytest
 from homeassistant.components.tcp import common as tcp
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import assert_setup_component
+from tests.common import assert_setup_component, async_fire_time_changed
 
 TEST_CONFIG = {
     "sensor": {
@@ -244,3 +245,29 @@ async def test_ssl_state_verify_off(
     )
     assert mock_ssl_socket.recv.called
     assert mock_ssl_socket.recv.call_args == call(SENSOR_TEST_CONFIG["buffer_size"])
+
+
+async def test_update_socket_error_after_success(
+    hass: HomeAssistant, mock_socket
+) -> None:
+    """Test state is updated with socket errors during update, when there is an old state."""
+    assert await async_setup_component(hass, "sensor", TEST_CONFIG)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(TEST_ENTITY)
+
+    assert state
+    assert state.state == "7.123"
+
+    mock_socket.connect.side_effect = OSError("Boom")
+    # FIXME: where is the default scan interval for tcp sensor?
+    from datetime import timedelta
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(TEST_ENTITY)
+
+    assert state
+    # FIXME: state should remain the same, but how to assert the available flag?
+    assert state.state == "7.123"

--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components.sensor import SCAN_INTERVAL
 from homeassistant.components.tcp import common as tcp
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -269,5 +270,4 @@ async def test_update_socket_error_after_success(
     state = hass.states.get(TEST_ENTITY)
 
     assert state
-    # FIXME: state should remain the same, but how to assert the available flag?
-    assert state.state == "7.123"
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
> [!NOTE]
> Reopening https://github.com/home-assistant/core/pull/117602 because the original PR was closed and locked.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

* before: when a connection fails, there is no state change - it remains with the value from the last successful connection
* now: when a connection fails, state is updated to unavailable

This might have impact on automations / triggers as `unavailable` state was not used before, not sure if that's considered breaking change.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently when a TCP sensor fails to connect (DNS failure, port is closed, host is not reachable or connection times out), state does not reflect it.
It continues to show the last successful connection which is not accurate.

I propose to use sensor `available` flag by setting it to `False` whenever a connection exception occurs


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

