### PR TITLE
Handle librouteros login method argument rename

### DIFF
--- a/homeassistant/components/mikrotik/coordinator.py
+++ b/homeassistant/components/mikrotik/coordinator.py
@@ -319,7 +319,7 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
         if "login_methods" in inspect.signature(librouteros.connect).parameters
         else "login_method"
     )
-    login_arg = login_methods if login_key == "login_methods" else login_plain
+    login_arg = login_methods if login_key == "login_methods" else _login_method_with_fallback
     kwargs = {login_key: login_arg, "port": entry["port"], "encoding": "utf8"}
 
     if entry[CONF_VERIFY_SSL]:
@@ -348,3 +348,16 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
 
     _LOGGER.debug("Connected to %s successfully", entry[CONF_HOST])
     return api
+
+
+def _login_method_with_fallback(
+    api: librouteros.Api, username: str, password: str
+) -> None:
+    """Try plain auth first, then fall back to token auth for older routers."""
+    try:
+        login_plain(api, username, password)
+    except librouteros.exceptions.FatalError as err:
+        message = str(err).lower()
+        if "cannot log in" not in message and "invalid user name or password" not in message:
+            raise
+        login_token(api, username, password)

--- a/homeassistant/components/mikrotik/coordinator.py
+++ b/homeassistant/components/mikrotik/coordinator.py
@@ -314,15 +314,8 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
     _LOGGER.debug("Connecting to Mikrotik hub [%s]", entry[CONF_HOST])
 
     login_methods = (login_plain, login_token)
-    login_key = (
-        "login_methods"
-        if "login_methods" in inspect.signature(librouteros.connect).parameters
-        else "login_method"
-    )
-    login_arg = (
-        login_methods if login_key == "login_methods" else _login_method_with_fallback
-    )
-    kwargs = {login_key: login_arg, "port": entry["port"], "encoding": "utf8"}
+    login_key = _get_login_key()
+    kwargs = _get_login_kwargs(login_key, login_methods, entry["port"])
 
     if entry[CONF_VERIFY_SSL]:
         ssl_context = ssl.create_default_context()
@@ -332,6 +325,18 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
         kwargs["ssl_wrapper"] = _ssl_wrapper
 
     try:
+        api = librouteros.connect(
+            entry[CONF_HOST],
+            entry[CONF_USERNAME],
+            entry[CONF_PASSWORD],
+            **kwargs,
+        )
+    except TypeError as api_error:
+        if not _is_login_kwarg_error(api_error):
+            raise
+
+        login_key = "login_method" if login_key == "login_methods" else "login_methods"
+        kwargs = _get_login_kwargs(login_key, login_methods, entry["port"])
         api = librouteros.connect(
             entry[CONF_HOST],
             entry[CONF_USERNAME],
@@ -350,6 +355,37 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
 
     _LOGGER.debug("Connected to %s successfully", entry[CONF_HOST])
     return api
+
+
+def _get_login_key() -> str:
+    """Determine which login keyword the installed librouteros exposes."""
+    try:
+        parameters = inspect.signature(librouteros.connect).parameters
+    except (TypeError, ValueError):
+        return "login_methods"
+
+    return "login_methods" if "login_methods" in parameters else "login_method"
+
+
+def _get_login_kwargs(
+    login_key: str,
+    login_methods: tuple[Any, Any],
+    port: int,
+) -> dict[str, Any]:
+    """Build login kwargs for the detected librouteros API."""
+    login_arg = (
+        login_methods if login_key == "login_methods" else _login_method_with_fallback
+    )
+    return {login_key: login_arg, "port": port, "encoding": "utf8"}
+
+
+def _is_login_kwarg_error(err: TypeError) -> bool:
+    """Check whether TypeError came from a login keyword mismatch."""
+    message = str(err)
+    return (
+        "unexpected keyword argument 'login_method'" in message
+        or "unexpected keyword argument 'login_methods'" in message
+    )
 
 
 def _login_method_with_fallback(

--- a/homeassistant/components/mikrotik/coordinator.py
+++ b/homeassistant/components/mikrotik/coordinator.py
@@ -1,6 +1,7 @@
 """The Mikrotik router class."""
 
 from datetime import timedelta
+import inspect
 import logging
 import ssl
 from typing import Any
@@ -312,8 +313,14 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
     """Connect to Mikrotik hub."""
     _LOGGER.debug("Connecting to Mikrotik hub [%s]", entry[CONF_HOST])
 
-    _login_method = (login_plain, login_token)
-    kwargs = {"login_methods": _login_method, "port": entry["port"], "encoding": "utf8"}
+    login_methods = (login_plain, login_token)
+    login_key = (
+        "login_methods"
+        if "login_methods" in inspect.signature(librouteros.connect).parameters
+        else "login_method"
+    )
+    login_arg = login_methods if login_key == "login_methods" else login_plain
+    kwargs = {login_key: login_arg, "port": entry["port"], "encoding": "utf8"}
 
     if entry[CONF_VERIFY_SSL]:
         ssl_context = ssl.create_default_context()

--- a/homeassistant/components/mikrotik/coordinator.py
+++ b/homeassistant/components/mikrotik/coordinator.py
@@ -319,7 +319,9 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
         if "login_methods" in inspect.signature(librouteros.connect).parameters
         else "login_method"
     )
-    login_arg = login_methods if login_key == "login_methods" else _login_method_with_fallback
+    login_arg = (
+        login_methods if login_key == "login_methods" else _login_method_with_fallback
+    )
     kwargs = {login_key: login_arg, "port": entry["port"], "encoding": "utf8"}
 
     if entry[CONF_VERIFY_SSL]:
@@ -358,6 +360,9 @@ def _login_method_with_fallback(
         login_plain(api, username, password)
     except librouteros.exceptions.FatalError as err:
         message = str(err).lower()
-        if "cannot log in" not in message and "invalid user name or password" not in message:
+        if (
+            "cannot log in" not in message
+            and "invalid user name or password" not in message
+        ):
             raise
         login_token(api, username, password)

--- a/tests/components/mikrotik/test_init.py
+++ b/tests/components/mikrotik/test_init.py
@@ -134,3 +134,63 @@ def test_get_api_uses_login_method_kwarg_when_supported() -> None:
         mock_connect.call_args.kwargs["login_method"]
         is mikrotik.coordinator._login_method_with_fallback
     )
+
+
+def test_get_api_uses_login_methods_kwarg_when_supported() -> None:
+    """Test get_api uses login_methods for older librouteros signatures."""
+    entry = dict(MOCK_DATA)
+    mock_connect = MagicMock(return_value=MagicMock())
+    mock_connect.__signature__ = inspect.Signature(
+        parameters=[
+            inspect.Parameter("host", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("username", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("password", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter(
+                "login_methods", inspect.Parameter.KEYWORD_ONLY, default=None
+            ),
+        ]
+    )
+
+    with patch(
+        "homeassistant.components.mikrotik.coordinator.librouteros.connect",
+        mock_connect,
+    ):
+        mikrotik.coordinator.get_api(entry)
+
+    assert "login_methods" in mock_connect.call_args.kwargs
+    assert "login_method" not in mock_connect.call_args.kwargs
+    assert mock_connect.call_args.kwargs["login_methods"] == (
+        mikrotik.coordinator.login_plain,
+        mikrotik.coordinator.login_token,
+    )
+
+
+def test_get_api_retries_alternate_login_kwarg_when_signature_fails() -> None:
+    """Test get_api retries with the alternate login keyword after kwarg mismatch."""
+    entry = dict(MOCK_DATA)
+    api = MagicMock()
+    mock_connect = MagicMock(
+        side_effect=[
+            TypeError("connect() got an unexpected keyword argument 'login_methods'"),
+            api,
+        ]
+    )
+
+    with (
+        patch(
+            "homeassistant.components.mikrotik.coordinator.inspect.signature",
+            side_effect=TypeError,
+        ),
+        patch(
+            "homeassistant.components.mikrotik.coordinator.librouteros.connect",
+            mock_connect,
+        ),
+    ):
+        assert mikrotik.coordinator.get_api(entry) is api
+
+    first_call = mock_connect.call_args_list[0].kwargs
+    second_call = mock_connect.call_args_list[1].kwargs
+    assert "login_methods" in first_call
+    assert "login_method" not in first_call
+    assert "login_method" in second_call
+    assert "login_methods" not in second_call

--- a/tests/components/mikrotik/test_init.py
+++ b/tests/components/mikrotik/test_init.py
@@ -97,7 +97,9 @@ def test_login_method_with_fallback_uses_token_for_legacy_auth() -> None:
                 "cannot log in"
             ),
         ) as mock_plain,
-        patch("homeassistant.components.mikrotik.coordinator.login_token") as mock_token,
+        patch(
+            "homeassistant.components.mikrotik.coordinator.login_token"
+        ) as mock_token,
     ):
         mikrotik.coordinator._login_method_with_fallback(api, "user", "pass")
 

--- a/tests/components/mikrotik/test_init.py
+++ b/tests/components/mikrotik/test_init.py
@@ -1,5 +1,6 @@
 """Test Mikrotik setup process."""
 
+import inspect
 from unittest.mock import MagicMock, patch
 
 from librouteros.exceptions import ConnectionClosed, LibRouterosError
@@ -83,3 +84,51 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+def test_login_method_with_fallback_uses_token_for_legacy_auth() -> None:
+    """Test legacy fallback uses token auth after plain auth rejection."""
+    api = MagicMock()
+
+    with (
+        patch(
+            "homeassistant.components.mikrotik.coordinator.login_plain",
+            side_effect=mikrotik.coordinator.librouteros.exceptions.FatalError(
+                "cannot log in"
+            ),
+        ) as mock_plain,
+        patch("homeassistant.components.mikrotik.coordinator.login_token") as mock_token,
+    ):
+        mikrotik.coordinator._login_method_with_fallback(api, "user", "pass")
+
+    mock_plain.assert_called_once_with(api, "user", "pass")
+    mock_token.assert_called_once_with(api, "user", "pass")
+
+
+def test_get_api_uses_login_method_kwarg_when_supported() -> None:
+    """Test get_api uses login_method for newer librouteros signatures."""
+    entry = dict(MOCK_DATA)
+    mock_connect = MagicMock(return_value=MagicMock())
+    mock_connect.__signature__ = inspect.Signature(
+        parameters=[
+            inspect.Parameter("host", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("username", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("password", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter(
+                "login_method", inspect.Parameter.KEYWORD_ONLY, default=None
+            ),
+        ]
+    )
+
+    with patch(
+        "homeassistant.components.mikrotik.coordinator.librouteros.connect",
+        mock_connect,
+    ):
+        mikrotik.coordinator.get_api(entry)
+
+    assert "login_method" in mock_connect.call_args.kwargs
+    assert "login_methods" not in mock_connect.call_args.kwargs
+    assert (
+        mock_connect.call_args.kwargs["login_method"]
+        is mikrotik.coordinator._login_method_with_fallback
+    )


### PR DESCRIPTION
## Summary
- Detect whether the installed `librouteros.connect` supports `login_methods` or `login_method`.
- Pass the login argument using the keyword supported by the installed library.
- Preserve the current multi-method behavior for older `librouteros`, while allowing newer versions that renamed the argument to connect successfully.

## Why
The Mikrotik integration can fail to set up when another integration or environment loads a newer `librouteros` whose `connect` signature expects `login_method` instead of `login_methods`.

The error looks like:

```text
TypeError: connect() got an unexpected keyword argument 'login_methods'. Did you mean 'login_method'?
```

This change makes the integration tolerant of both signatures.

## Validation
- Reproduced on Home Assistant Core 2026.4.4 in an environment where `librouteros.connect` exposes `login_method`.
- Applied an equivalent local override and verified Mikrotik `device_tracker` entities update again.
- Verified the patched official integration no longer logs the `login_methods` TypeError after restart.
