### PR TITLE
feat(lutron): update fan entity to support 4 speeds

### DIFF
--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -37,7 +37,7 @@ class LutronFan(LutronDevice, FanEntity):
 
     _attr_name = None
     _attr_should_poll = False
-    _attr_speed_count = 3
+    _attr_speed_count = 4
     _attr_supported_features = (
         FanEntityFeature.SET_SPEED
         | FanEntityFeature.TURN_OFF
@@ -66,7 +66,7 @@ class LutronFan(LutronDevice, FanEntity):
             new_percentage = percentage
         elif not self._prev_percentage:
             # Default to medium speed
-            new_percentage = 67
+            new_percentage = 50
         else:
             new_percentage = self._prev_percentage
         self.set_percentage(new_percentage)

--- a/tests/components/lutron/snapshots/test_fan.ambr
+++ b/tests/components/lutron/snapshots/test_fan.ambr
@@ -43,7 +43,7 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Fan',
       'percentage': 0,
-      'percentage_step': 33.333333333333336,
+      'percentage_step': 25.0,
       'preset_mode': None,
       'preset_modes': None,
       'supported_features': <FanEntityFeature: 49>,

--- a/tests/components/lutron/test_fan.py
+++ b/tests/components/lutron/test_fan.py
@@ -61,14 +61,14 @@ async def test_fan_services(
 
     entity_id = "fan.test_fan"
 
-    # Turn on (defaults to medium - 67%)
+    # Turn on (defaults to medium - 50%)
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert fan.level == 67
+    assert fan.level == 50
 
     # Turn off
     await hass.services.async_call(


### PR DESCRIPTION
The Lutron fan physical switch has 4 speed dots but the integration only exposed 3 speeds. Update speed_count to 4 and default turn-on percentage to 50% (medium) to match the physical device.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Lutron fan controller has 4 physical speed dots, but the integration only exposed 3 speeds. This caused a mismatch between the physical device  and Home Assistant's fan control.

This PR updates `speed_count` from 3 to 4 and adjusts the default turn-on percentage to 50% (medium) to align with the physical device's behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
