### PR TITLE
Remove show_advanced_options in Ecovacs and always show all options

### DIFF
--- a/homeassistant/components/ecovacs/config_flow.py
+++ b/homeassistant/components/ecovacs/config_flow.py
@@ -137,10 +137,6 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-
-        if not self.show_advanced_options:
-            return await self.async_step_auth()
-
         if user_input:
             self._mode = user_input[CONF_MODE]
             return await self.async_step_auth()

--- a/tests/components/ecovacs/test_config_flow.py
+++ b/tests/components/ecovacs/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test Ecovacs config flow."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import ssl
 from typing import Any
@@ -40,26 +40,6 @@ class _TestFnUserInput:
     user: dict[str, Any] = field(default_factory=dict)
 
 
-async def _test_user_flow(
-    hass: HomeAssistant,
-    user_input: _TestFnUserInput,
-) -> dict[str, Any]:
-    """Test config flow."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "auth"
-    assert not result["errors"]
-
-    return await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=user_input.auth,
-    )
-
-
 async def _test_user_flow_show_advanced_options(
     hass: HomeAssistant,
     user_input: _TestFnUserInput,
@@ -67,7 +47,7 @@ async def _test_user_flow_show_advanced_options(
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
+        context={"source": SOURCE_USER},
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -90,37 +70,29 @@ async def _test_user_flow_show_advanced_options(
 
 
 @pytest.mark.parametrize(
-    ("test_fn", "test_fn_user_input", "entry_data"),
+    ("test_fn_user_input", "entry_data"),
     [
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
             VALID_ENTRY_DATA_CLOUD,
         ),
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
             VALID_ENTRY_DATA_SELF_HOSTED,
         ),
-        (
-            _test_user_flow,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-            VALID_ENTRY_DATA_CLOUD,
-        ),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted", "cloud"],
+    ids=["advanced_cloud", "advanced_self_hosted"],
 )
 async def test_user_flow(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_authenticator_authenticate: AsyncMock,
     mock_mqtt_client: Mock,
-    test_fn: Callable[[HomeAssistant, _TestFnUserInput], Awaitable[dict[str, Any]]],
     test_fn_user_input: _TestFnUserInput,
     entry_data: dict[str, Any],
 ) -> None:
     """Test the user config flow."""
-    result = await test_fn(hass, test_fn_user_input)
+    result = await _test_user_flow_show_advanced_options(hass, test_fn_user_input)
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == entry_data[CONF_USERNAME]
     assert result["data"] == entry_data
@@ -156,25 +128,18 @@ def _cannot_connect_error(user_input: dict[str, Any]) -> str:
     ids=["cannot_connect", "invalid_auth", "unknown"],
 )
 @pytest.mark.parametrize(
-    ("test_fn", "test_fn_user_input", "entry_data"),
+    ("test_fn_user_input", "entry_data"),
     [
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
             VALID_ENTRY_DATA_CLOUD,
         ),
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
             VALID_ENTRY_DATA_SELF_HOSTED_WITH_VALIDATE_CERT,
         ),
-        (
-            _test_user_flow,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-            VALID_ENTRY_DATA_CLOUD,
-        ),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted", "cloud"],
+    ids=["advanced_cloud", "advanced_self_hosted"],
 )
 async def test_user_flow_raise_error(
     hass: HomeAssistant,
@@ -185,7 +150,6 @@ async def test_user_flow_raise_error(
     reason_rest: str,
     side_effect_mqtt: Exception,
     errors_mqtt: Callable[[dict[str, Any]], str],
-    test_fn: Callable[[HomeAssistant, _TestFnUserInput], Awaitable[dict[str, Any]]],
     test_fn_user_input: _TestFnUserInput,
     entry_data: dict[str, Any],
 ) -> None:
@@ -194,7 +158,7 @@ async def test_user_flow_raise_error(
 
     # Authenticator raises error
     mock_authenticator_authenticate.side_effect = side_effect_rest
-    result = await test_fn(hass, test_fn_user_input)
+    result = await _test_user_flow_show_advanced_options(hass, test_fn_user_input)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["errors"] == {"base": reason_rest}
@@ -289,32 +253,21 @@ async def test_user_flow_self_hosted_error(
 
 
 @pytest.mark.parametrize(
-    ("test_fn", "test_fn_user_input"),
+    ("test_fn_user_input"),
     [
-        (
-            _test_user_flow_show_advanced_options,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-        ),
-        (
-            _test_user_flow_show_advanced_options,
-            _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
-        ),
-        (
-            _test_user_flow,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-        ),
+        _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
+        _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted", "cloud"],
+    ids=["advanced_cloud", "advanced_self_hosted"],
 )
 async def test_already_exists(
     hass: HomeAssistant,
-    test_fn: Callable[[HomeAssistant, _TestFnUserInput], Awaitable[dict[str, Any]]],
     test_fn_user_input: _TestFnUserInput,
 ) -> None:
     """Test we don't allow duplicated config entries."""
     MockConfigEntry(domain=DOMAIN, data=test_fn_user_input.auth).add_to_hass(hass)
 
-    result = await test_fn(
+    result = await _test_user_flow_show_advanced_options(
         hass,
         test_fn_user_input,
     )

--- a/tests/components/ecovacs/test_config_flow.py
+++ b/tests/components/ecovacs/test_config_flow.py
@@ -40,7 +40,7 @@ class _TestFnUserInput:
     user: dict[str, Any] = field(default_factory=dict)
 
 
-async def _test_user_flow_show_advanced_options(
+async def _test_user_flow(
     hass: HomeAssistant,
     user_input: _TestFnUserInput,
 ) -> dict[str, Any]:
@@ -81,7 +81,7 @@ async def _test_user_flow_show_advanced_options(
             VALID_ENTRY_DATA_SELF_HOSTED,
         ),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted"],
+    ids=["cloud", "self_hosted"],
 )
 async def test_user_flow(
     hass: HomeAssistant,
@@ -92,7 +92,7 @@ async def test_user_flow(
     entry_data: dict[str, Any],
 ) -> None:
     """Test the user config flow."""
-    result = await _test_user_flow_show_advanced_options(hass, test_fn_user_input)
+    result = await _test_user_flow(hass, test_fn_user_input)
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == entry_data[CONF_USERNAME]
     assert result["data"] == entry_data
@@ -139,7 +139,7 @@ def _cannot_connect_error(user_input: dict[str, Any]) -> str:
             VALID_ENTRY_DATA_SELF_HOSTED_WITH_VALIDATE_CERT,
         ),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted"],
+    ids=["cloud", "self_hosted"],
 )
 async def test_user_flow_raise_error(
     hass: HomeAssistant,
@@ -158,7 +158,7 @@ async def test_user_flow_raise_error(
 
     # Authenticator raises error
     mock_authenticator_authenticate.side_effect = side_effect_rest
-    result = await _test_user_flow_show_advanced_options(hass, test_fn_user_input)
+    result = await _test_user_flow(hass, test_fn_user_input)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["errors"] == {"base": reason_rest}
@@ -204,7 +204,7 @@ async def test_user_flow_self_hosted_error(
 ) -> None:
     """Test handling selfhosted errors and custom ssl context."""
 
-    result = await _test_user_flow_show_advanced_options(
+    result = await _test_user_flow(
         hass,
         _TestFnUserInput(
             VALID_ENTRY_DATA_SELF_HOSTED
@@ -258,7 +258,7 @@ async def test_user_flow_self_hosted_error(
         _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
         _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted"],
+    ids=["cloud", "self_hosted"],
 )
 async def test_already_exists(
     hass: HomeAssistant,
@@ -267,7 +267,7 @@ async def test_already_exists(
     """Test we don't allow duplicated config entries."""
     MockConfigEntry(domain=DOMAIN, data=test_fn_user_input.auth).add_to_hass(hass)
 
-    result = await _test_user_flow_show_advanced_options(
+    result = await _test_user_flow(
         hass,
         test_fn_user_input,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove show_advanced_options in Ecovacs and always show all options
Relates to https://github.com/home-assistant/core/issues/163890

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
