### PR TITLE
Add method _should_include to EntityTriggerBase

### DIFF
--- a/homeassistant/components/climate/trigger.py
+++ b/homeassistant/components/climate/trigger.py
@@ -8,14 +8,15 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
     ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    EntityNumericalStateChangedTriggerBase,
     EntityNumericalStateChangedTriggerWithUnitBase,
+    EntityNumericalStateCrossedThresholdTriggerBase,
     EntityNumericalStateCrossedThresholdTriggerWithUnitBase,
+    EntityNumericalStateTriggerBase,
     EntityNumericalStateTriggerWithUnitBase,
     EntityTargetStateTriggerBase,
     Trigger,
     TriggerConfig,
-    make_entity_numerical_state_changed_trigger,
-    make_entity_numerical_state_crossed_threshold_trigger,
     make_entity_target_state_trigger,
     make_entity_transition_trigger,
 )
@@ -75,6 +76,32 @@ class ClimateTargetTemperatureCrossedThresholdTrigger(
     """Trigger for climate target temperature value crossing a threshold."""
 
 
+class _ClimateTargetHumidityTriggerMixin(EntityNumericalStateTriggerBase):
+    """Mixin for climate target humidity triggers."""
+
+    _domain_specs = {DOMAIN: DomainSpec(value_source=ATTR_HUMIDITY)}
+    _valid_unit = "%"
+
+    def _should_include(self, state: State) -> bool:
+        """Skip climate entities that do not expose a target humidity."""
+        return (
+            super()._should_include(state)
+            and state.attributes.get(ATTR_HUMIDITY) is not None
+        )
+
+
+class ClimateTargetHumidityChangedTrigger(
+    _ClimateTargetHumidityTriggerMixin, EntityNumericalStateChangedTriggerBase
+):
+    """Trigger for climate target humidity value changes."""
+
+
+class ClimateTargetHumidityCrossedThresholdTrigger(
+    _ClimateTargetHumidityTriggerMixin, EntityNumericalStateCrossedThresholdTriggerBase
+):
+    """Trigger for climate target humidity value crossing a threshold."""
+
+
 TRIGGERS: dict[str, type[Trigger]] = {
     "hvac_mode_changed": HVACModeChangedTrigger,
     "started_cooling": make_entity_target_state_trigger(
@@ -83,14 +110,8 @@ TRIGGERS: dict[str, type[Trigger]] = {
     "started_drying": make_entity_target_state_trigger(
         {DOMAIN: DomainSpec(value_source=ATTR_HVAC_ACTION)}, HVACAction.DRYING
     ),
-    "target_humidity_changed": make_entity_numerical_state_changed_trigger(
-        {DOMAIN: DomainSpec(value_source=ATTR_HUMIDITY)},
-        valid_unit="%",
-    ),
-    "target_humidity_crossed_threshold": make_entity_numerical_state_crossed_threshold_trigger(
-        {DOMAIN: DomainSpec(value_source=ATTR_HUMIDITY)},
-        valid_unit="%",
-    ),
+    "target_humidity_changed": ClimateTargetHumidityChangedTrigger,
+    "target_humidity_crossed_threshold": ClimateTargetHumidityCrossedThresholdTrigger,
     "target_temperature_changed": ClimateTargetTemperatureChangedTrigger,
     "target_temperature_crossed_threshold": ClimateTargetTemperatureCrossedThresholdTrigger,
     "turned_off": make_entity_target_state_trigger(DOMAIN, HVACMode.OFF),

--- a/homeassistant/components/media_player/trigger.py
+++ b/homeassistant/components/media_player/trigger.py
@@ -33,27 +33,7 @@ class _MediaPlayerMutedStateTriggerBase(EntityTriggerBase):
         excluded from the check - otherwise an "all" check would never
         pass when there are media players without volume support.
         """
-        return state.state not in self._excluded_states and self._has_volume_attributes(
-            state
-        )
-
-    def check_all_match(self, entity_ids: set[str]) -> bool:
-        """Check if all mutable entity states match."""
-        return all(
-            self.is_valid_state(state)
-            for entity_id in entity_ids
-            if (state := self._hass.states.get(entity_id)) is not None
-            and self._should_include(state)
-        )
-
-    def count_matches(self, entity_ids: set[str]) -> int:
-        """Count matching mutable entities."""
-        return sum(
-            self.is_valid_state(state)
-            for entity_id in entity_ids
-            if (state := self._hass.states.get(entity_id)) is not None
-            and self._should_include(state)
-        )
+        return super()._should_include(state) and self._has_volume_attributes(state)
 
     def is_muted(self, state: State) -> bool:
         """Check if the media player is muted."""

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -407,23 +407,26 @@ class EntityTriggerBase(Trigger):
         """
         return state.state not in self._excluded_states
 
-    def check_all_match(self, entity_ids: set[str]) -> bool:
-        """Check if all entity states match."""
-        return all(
-            self.is_valid_state(state)
-            for entity_id in entity_ids
-            if (state := self._hass.states.get(entity_id)) is not None
-            and self._should_include(state)
-        )
+    def count_matches(self, entity_ids: set[str]) -> tuple[int, int]:
+        """Return (matches, included) for the entity set.
 
-    def count_matches(self, entity_ids: set[str]) -> int:
-        """Count the number of entity states that match."""
-        return sum(
-            self.is_valid_state(state)
-            for entity_id in entity_ids
-            if (state := self._hass.states.get(entity_id)) is not None
-            and self._should_include(state)
-        )
+        `matches` is the number of entities that pass `_should_include` AND
+        `is_valid_state`. `included` is the number that pass
+        `_should_include` (i.e. are visible to the all/count check at all).
+        Callers can use the pair to distinguish vacuous truth
+        (`included == 0`) from a genuine all-match
+        (`matches == included > 0`).
+        """
+        matches = 0
+        included = 0
+        for entity_id in entity_ids:
+            state = self._hass.states.get(entity_id)
+            if state is None or not self._should_include(state):
+                continue
+            included += 1
+            if self.is_valid_state(state):
+                matches += 1
+        return matches, included
 
     @override
     async def async_attach_runner(
@@ -455,14 +458,20 @@ class EntityTriggerBase(Trigger):
                 For behavior first/last, checks the combined state.
                 """
                 if behavior == BEHAVIOR_LAST:
-                    return self.check_all_match(
+                    matches, included = self.count_matches(
                         target_state_change_data.targeted_entity_ids
                     )
+                    # Require at least one included entity to avoid keeping
+                    # the timer alive when every targeted entity has been
+                    # filtered out since it started — a vacuous all-match
+                    # (`included == 0`) would otherwise let the action fire
+                    # after `for:` even though no entity still matches.
+                    return included > 0 and matches == included
                 if behavior == BEHAVIOR_FIRST:
-                    return (
-                        self.count_matches(target_state_change_data.targeted_entity_ids)
-                        >= 1
+                    matches, _included = self.count_matches(
+                        target_state_change_data.targeted_entity_ids
                     )
+                    return matches >= 1
                 # Behavior any: check the individual entity's state
                 if not to_state:
                     return False
@@ -480,18 +489,19 @@ class EntityTriggerBase(Trigger):
                 return
 
             if behavior == BEHAVIOR_LAST:
-                if not self.check_all_match(
+                matches, included = self.count_matches(
                     target_state_change_data.targeted_entity_ids
-                ):
+                )
+                if matches != included:
                     return
             elif behavior == BEHAVIOR_FIRST:
                 # Note: It's enough to test for exactly 1 match here because if there
                 # were previously 2 matches the transition would not be valid and we
                 # would have returned already.
-                if (
-                    self.count_matches(target_state_change_data.targeted_entity_ids)
-                    != 1
-                ):
+                matches, _ = self.count_matches(
+                    target_state_change_data.targeted_entity_ids
+                )
+                if matches != 1:
                     return
 
             @callback

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -397,13 +397,23 @@ class EntityTriggerBase(Trigger):
     def is_valid_state(self, state: State) -> bool:
         """Check if the new state matches the expected state(s)."""
 
+    def _should_include(self, state: State) -> bool:
+        """Check if an entity should participate in all/count checks.
+
+        The default implementation excludes only entities whose state.state
+        is in `_excluded_states` (unavailable / unknown). Subclasses can
+        override to also exclude entities that lack the optional capability
+        the trigger relies on (e.g. a missing volume_level attribute).
+        """
+        return state.state not in self._excluded_states
+
     def check_all_match(self, entity_ids: set[str]) -> bool:
         """Check if all entity states match."""
         return all(
             self.is_valid_state(state)
             for entity_id in entity_ids
             if (state := self._hass.states.get(entity_id)) is not None
-            and state.state not in self._excluded_states
+            and self._should_include(state)
         )
 
     def count_matches(self, entity_ids: set[str]) -> int:
@@ -412,7 +422,7 @@ class EntityTriggerBase(Trigger):
             self.is_valid_state(state)
             for entity_id in entity_ids
             if (state := self._hass.states.get(entity_id)) is not None
-            and state.state not in self._excluded_states
+            and self._should_include(state)
         )
 
     @override

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -218,7 +218,10 @@ async def test_climate_state_trigger_behavior_any(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_numerical_attribute_changed_trigger_states(
-            "climate.target_humidity_changed", HVACMode.AUTO, ATTR_HUMIDITY
+            "climate.target_humidity_changed",
+            HVACMode.AUTO,
+            ATTR_HUMIDITY,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_changed_trigger_states(
             "climate.target_temperature_changed",
@@ -227,7 +230,10 @@ async def test_climate_state_trigger_behavior_any(
             threshold_unit=UnitOfTemperature.CELSIUS,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
-            "climate.target_humidity_crossed_threshold", HVACMode.AUTO, ATTR_HUMIDITY
+            "climate.target_humidity_crossed_threshold",
+            HVACMode.AUTO,
+            ATTR_HUMIDITY,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "climate.target_temperature_crossed_threshold",
@@ -342,7 +348,10 @@ async def test_climate_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
-            "climate.target_humidity_crossed_threshold", HVACMode.AUTO, ATTR_HUMIDITY
+            "climate.target_humidity_crossed_threshold",
+            HVACMode.AUTO,
+            ATTR_HUMIDITY,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "climate.target_temperature_crossed_threshold",
@@ -457,7 +466,10 @@ async def test_climate_state_trigger_behavior_last(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
-            "climate.target_humidity_crossed_threshold", HVACMode.AUTO, ATTR_HUMIDITY
+            "climate.target_humidity_crossed_threshold",
+            HVACMode.AUTO,
+            ATTR_HUMIDITY,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "climate.target_temperature_crossed_threshold",

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -399,6 +399,7 @@ def parametrize_trigger_states(
     target_states: list[str | None | tuple[str | None, dict]],
     other_states: list[str | None | tuple[str | None, dict]],
     extra_excluded_states: list[str | None | tuple[str | None, dict]] | None = None,
+    trigger_from_excluded: bool = False,
     extra_invalid_states: list[str | None | tuple[str | None, dict]] | None = None,
     required_filter_attributes: dict | None = None,
     trigger_from_none: bool = True,
@@ -431,6 +432,18 @@ def parametrize_trigger_states(
     though the other entities never matched, because they are invisible to
     the all/count check.
 
+    Set `trigger_from_excluded` to True if the trigger is expected to fire
+    when the initial state is one of `extra_excluded_states` and transitions
+    directly to a target state. When True, the helper generates an
+    additional pattern that places the entity under test in each
+    `extra_excluded_states` value initially and verifies the trigger fires
+    on the transition to a target (count=1). Pass True only when the
+    trigger's `is_valid_transition` actually permits transitions out of the
+    extra-excluded state into a target — typically true for numerical
+    triggers (None -> numeric is a valid change/threshold cross), false for
+    state-based triggers like media_player.unmuted where moving from
+    no-attrs to muted=False is the same is_muted value.
+
     `extra_invalid_states` are *additional* states (on top of the always-
     included STATE_UNAVAILABLE and STATE_UNKNOWN) that should be treated as
     invalid by the trigger (i.e. `is_valid_transition` rejects transitions
@@ -452,6 +465,7 @@ def parametrize_trigger_states(
         STATE_UNKNOWN,
         *(extra_invalid_states or []),
     ]
+    extra_excluded_states = list(extra_excluded_states or [])
     # The excluded_states pattern iterates over every state the base
     # _should_include impl filters out (a missing state object, unavailable,
     # unknown), plus any caller-supplied additions filtered by a
@@ -460,7 +474,7 @@ def parametrize_trigger_states(
         None,
         STATE_UNAVAILABLE,
         STATE_UNKNOWN,
-        *(extra_excluded_states or []),
+        *extra_excluded_states,
     ]
     required_filter_attributes = required_filter_attributes or {}
     trigger_options = trigger_options or {}
@@ -720,6 +734,37 @@ def parametrize_trigger_states(
         )
     )
 
+    if trigger_from_excluded and extra_excluded_states:
+        # Pattern: the entity under test sits in an `extra_excluded_states`
+        # value alongside the other targeted entities, then transitions
+        # directly to a `target_state`. `is_valid_transition` is expected to
+        # accept that transition (caller opted in via
+        # `trigger_from_excluded=True`), so the trigger must fire.
+        # The other entities stay in the same extra-excluded state and are
+        # filtered out of the all/count check, so behavior=last/first/any
+        # all see exactly one matching entity and fire (count=1).
+        # Sequence per (excluded, target):
+        #   entity_id: excluded -> target   (1)
+        #   others:    excluded -> excluded (no-op, no fire)
+        tests.append(
+            (
+                trigger,
+                trigger_options,
+                list(
+                    itertools.chain.from_iterable(
+                        (
+                            state_with_attributes(excluded_state, 0),
+                            state_with_attributes(
+                                target_state, 1, others_state=excluded_state
+                            ),
+                        )
+                        for excluded_state in extra_excluded_states
+                        for target_state in target_states
+                    )
+                ),
+            )
+        )
+
     # Drop patterns whose state list is empty (e.g. when other_states is empty
     # because all "other" candidates are now in extra_excluded_states).
     return [t for t in tests if t[2]]
@@ -813,6 +858,7 @@ def parametrize_numerical_attribute_changed_trigger_states(
             ],
             other_states=other_none_states,
             extra_excluded_states=extra_excluded_states,
+            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -837,6 +883,7 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 0} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
+            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -861,6 +908,7 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
+            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -947,6 +995,7 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
+            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -972,6 +1021,7 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 60} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
+            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -995,6 +1045,7 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 0} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
+            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -1018,6 +1069,7 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
+            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
     ]

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -220,6 +220,12 @@ class TriggerStateDescription(BasicTriggerStateDescription):
     """Test state and expected service call count for both included and excluded entities."""
 
     excluded_state: StateDescription  # State for entities not meant to be targeted
+    # State for the *other* targeted entities (the ones not under direct test).
+    # Usually equal to `included_state`; differs when the test exercises a
+    # scenario where targeted-but-not-under-test entities sit in a state that
+    # the trigger's `_should_include` override filters out of the all/count
+    # checks.
+    others_state: StateDescription
 
 
 class ConditionStateDescription(TypedDict):
@@ -392,6 +398,7 @@ def parametrize_trigger_states(
     trigger_options: dict[str, Any] | None = None,
     target_states: list[str | None | tuple[str | None, dict]],
     other_states: list[str | None | tuple[str | None, dict]],
+    extra_excluded_states: list[str | None | tuple[str | None, dict]] | None = None,
     extra_invalid_states: list[str | None | tuple[str | None, dict]] | None = None,
     required_filter_attributes: dict | None = None,
     trigger_from_none: bool = True,
@@ -403,7 +410,7 @@ def parametrize_trigger_states(
     `states` is a list of TriggerStateDescription dicts describing the state
     sequence to drive the trigger through.
 
-    The target_states, other_states, and extra_invalid_states
+    The target_states, other_states, excluded_states, and extra_invalid_states
     iterables are either iterables of states or iterables of (state, attributes)
     tuples.
 
@@ -412,6 +419,17 @@ def parametrize_trigger_states(
     `other_states` are states that should NOT fire the trigger and that DO
     count toward the all/count check (i.e. an entity in such a state blocks
     behavior=last).
+
+    `extra_excluded_states` are *additional* states (on top of the always-
+    included missing/unavailable/unknown that the base `_should_include`
+    filters out) that the trigger's `_should_include` override is expected
+    to filter out of the all/count check. The helper iterates over the full
+    filtered set (`[None, STATE_UNAVAILABLE, STATE_UNKNOWN,
+    *extra_excluded_states]`) and generates an additional pattern that sets
+    the *other* targeted entities into each filtered state while the entity
+    under test transitions to a target state — the trigger should fire even
+    though the other entities never matched, because they are invisible to
+    the all/count check.
 
     `extra_invalid_states` are *additional* states (on top of the always-
     included STATE_UNAVAILABLE and STATE_UNKNOWN) that should be treated as
@@ -433,6 +451,16 @@ def parametrize_trigger_states(
         STATE_UNAVAILABLE,
         STATE_UNKNOWN,
         *(extra_invalid_states or []),
+    ]
+    # The excluded_states pattern iterates over every state the base
+    # _should_include impl filters out (a missing state object, unavailable,
+    # unknown), plus any caller-supplied additions filtered by a
+    # `_should_include` override.
+    excluded_states = [
+        None,
+        STATE_UNAVAILABLE,
+        STATE_UNKNOWN,
+        *(extra_excluded_states or []),
     ]
     required_filter_attributes = required_filter_attributes or {}
     trigger_options = trigger_options or {}
@@ -474,11 +502,19 @@ def parametrize_trigger_states(
     def state_with_attributes(
         state: str | None | tuple[str | None, dict],
         count: int,
+        *,
+        others_state: str | None | tuple[str | None, dict] | UndefinedType = UNDEFINED,
     ) -> TriggerStateDescription:
         """Return TriggerStateDescription dict."""
+        included = _included_state_desc(state)
         return {
-            "included_state": _included_state_desc(state),
+            "included_state": included,
             "excluded_state": _excluded_state_desc(state),
+            "others_state": (
+                included
+                if isinstance(others_state, UndefinedType)
+                else _included_state_desc(others_state)
+            ),
             "count": count,
         }
 
@@ -650,7 +686,43 @@ def parametrize_trigger_states(
             ),
         )
 
-    return tests
+    # Pattern: the OTHER targeted entities sit in a state filtered by the
+    # trigger's `_should_include` (default impl filters
+    # missing/unavailable/unknown; overrides may add more, supplied by the
+    # caller via `extra_excluded_states`). They are invisible to the
+    # all/count checks, so even though they never enter `target_state` the
+    # trigger should still fire when the entity under test alone transitions
+    # other -> target.
+    # Sequence per (target, other, excluded):
+    #   entity_id: other        -> target (1)
+    #   others:    other        -> excluded
+    # i.e. step 0 sets all entities to `other`; step 1 transitions the
+    # entity under test to `target` while the others go to `excluded` (via
+    # `others_state`). The all/count check filters the others out, so a
+    # single matching entity is enough to fire `behavior=last`.
+    tests.append(
+        (
+            trigger,
+            trigger_options,
+            list(
+                itertools.chain.from_iterable(
+                    (
+                        state_with_attributes(other_state, 0),
+                        state_with_attributes(
+                            target_state, 1, others_state=excluded_state
+                        ),
+                    )
+                    for target_state in target_states
+                    for other_state in other_states
+                    for excluded_state in excluded_states
+                )
+            ),
+        )
+    )
+
+    # Drop patterns whose state list is empty (e.g. when other_states is empty
+    # because all "other" candidates are now in extra_excluded_states).
+    return [t for t in tests if t[2]]
 
 
 def _add_threshold_unit(
@@ -677,6 +749,7 @@ def parametrize_numerical_attribute_changed_trigger_states(
     trigger_options: dict[str, Any] | None = None,
     required_filter_attributes: dict | None = None,
     unit_attributes: dict | None = None,
+    attribute_required: bool = False,
 ) -> list[tuple[str, dict[str, Any], list[TriggerStateDescription]]]:
     """Parametrize states and expected service call counts for numerical-changed triggers.
 
@@ -709,9 +782,17 @@ def parametrize_numerical_attribute_changed_trigger_states(
         unit_attributes: Attributes (typically `{ATTR_UNIT_OF_MEASUREMENT: ...}`)
             merged into every generated state, so the entity carries a unit
             alongside its tracked attribute.
+        attribute_required: When True, `(state, {attribute: None})` is
+            classified as an *excluded* state (filtered out of the all/count
+            check by the trigger's `_should_include` override) instead of an
+            "other" state. Set this for triggers that override
+            `_should_include` to skip entities lacking the attribute.
     """
     trigger_options = trigger_options or {}
     unit_attributes = unit_attributes or {}
+    none_state = (state, {attribute: None} | unit_attributes)
+    extra_excluded_states = [none_state] if attribute_required else None
+    other_none_states = [] if attribute_required else [none_state]
 
     return [
         *parametrize_trigger_states(
@@ -730,7 +811,8 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 50} | unit_attributes),
                 (state, {attribute: 100} | unit_attributes),
             ],
-            other_states=[(state, {attribute: None} | unit_attributes)],
+            other_states=other_none_states,
+            extra_excluded_states=extra_excluded_states,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -751,9 +833,10 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             other_states=[
-                (state, {attribute: None} | unit_attributes),
+                *other_none_states,
                 (state, {attribute: 0} | unit_attributes),
             ],
+            extra_excluded_states=extra_excluded_states,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -774,9 +857,10 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 50} | unit_attributes),
             ],
             other_states=[
-                (state, {attribute: None} | unit_attributes),
+                *other_none_states,
                 (state, {attribute: 100} | unit_attributes),
             ],
+            extra_excluded_states=extra_excluded_states,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -792,6 +876,7 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
     trigger_options: dict[str, Any] | None = None,
     required_filter_attributes: dict | None = None,
     unit_attributes: dict | None = None,
+    attribute_required: bool = False,
 ) -> list[tuple[str, dict[str, Any], list[TriggerStateDescription]]]:
     """Parametrize states and expected service call counts for numerical crossed-threshold triggers.
 
@@ -826,9 +911,17 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
         unit_attributes: Attributes (typically `{ATTR_UNIT_OF_MEASUREMENT: ...}`)
             merged into every generated state, so the entity carries a unit
             alongside its tracked attribute.
+        attribute_required: When True, `(state, {attribute: None})` is
+            classified as an *excluded* state (filtered out of the all/count
+            check by the trigger's `_should_include` override) instead of an
+            "other" state. Set this for triggers that override
+            `_should_include` to skip entities lacking the attribute.
     """
     trigger_options = trigger_options or {}
     unit_attributes = unit_attributes or {}
+    none_state = (state, {attribute: None} | unit_attributes)
+    extra_excluded_states = [none_state] if attribute_required else None
+    other_none_states = [] if attribute_required else [none_state]
 
     return [
         *parametrize_trigger_states(
@@ -849,10 +942,11 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 60} | unit_attributes),
             ],
             other_states=[
-                (state, {attribute: None} | unit_attributes),
+                *other_none_states,
                 (state, {attribute: 0} | unit_attributes),
                 (state, {attribute: 100} | unit_attributes),
             ],
+            extra_excluded_states=extra_excluded_states,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -873,10 +967,11 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             other_states=[
-                (state, {attribute: None} | unit_attributes),
+                *other_none_states,
                 (state, {attribute: 50} | unit_attributes),
                 (state, {attribute: 60} | unit_attributes),
             ],
+            extra_excluded_states=extra_excluded_states,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -896,9 +991,10 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             other_states=[
-                (state, {attribute: None} | unit_attributes),
+                *other_none_states,
                 (state, {attribute: 0} | unit_attributes),
             ],
+            extra_excluded_states=extra_excluded_states,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -918,9 +1014,10 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 50} | unit_attributes),
             ],
             other_states=[
-                (state, {attribute: None} | unit_attributes),
+                *other_none_states,
                 (state, {attribute: 100} | unit_attributes),
             ],
+            extra_excluded_states=extra_excluded_states,
             required_filter_attributes=required_filter_attributes,
         ),
     ]
@@ -1516,6 +1613,7 @@ async def assert_trigger_behavior_any(
     for state in states[1:]:
         excluded_state = state["excluded_state"]
         included_state = state["included_state"]
+        others_state = state["others_state"]
         set_or_remove_state(hass, entity_id, included_state)
         await hass.async_block_till_done()
         assert len(calls) == state["count"]
@@ -1524,12 +1622,20 @@ async def assert_trigger_behavior_any(
         calls.clear()
 
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, included_state)
+            set_or_remove_state(hass, other_entity_id, others_state)
             await hass.async_block_till_done()
         for excluded_entity_id in excluded_entity_ids:
             set_or_remove_state(hass, excluded_entity_id, excluded_state)
             await hass.async_block_till_done()
-        assert len(calls) == (entities_in_target - 1) * state["count"]
+        # When others_state differs from included_state, the post-others count
+        # is 0: others are placed in a state filtered or rejected by the
+        # trigger, so they don't fire individually.
+        expected_others_count = (
+            (entities_in_target - 1) * state["count"]
+            if others_state == included_state
+            else 0
+        )
+        assert len(calls) == expected_others_count
         calls.clear()
 
 
@@ -1567,6 +1673,7 @@ async def assert_trigger_behavior_first(
     for state in states[1:]:
         excluded_state = state["excluded_state"]
         included_state = state["included_state"]
+        others_state = state["others_state"]
         set_or_remove_state(hass, entity_id, included_state)
         await hass.async_block_till_done()
         assert len(calls) == state["count"]
@@ -1575,7 +1682,7 @@ async def assert_trigger_behavior_first(
         calls.clear()
 
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, included_state)
+            set_or_remove_state(hass, other_entity_id, others_state)
             await hass.async_block_till_done()
         for excluded_entity_id in excluded_entity_ids:
             set_or_remove_state(hass, excluded_entity_id, excluded_state)
@@ -1617,8 +1724,9 @@ async def assert_trigger_behavior_last(
     for state in states[1:]:
         excluded_state = state["excluded_state"]
         included_state = state["included_state"]
+        others_state = state["others_state"]
         for other_entity_id in other_entity_ids:
-            set_or_remove_state(hass, other_entity_id, included_state)
+            set_or_remove_state(hass, other_entity_id, others_state)
             await hass.async_block_till_done()
         assert len(calls) == 0
 

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -399,7 +399,6 @@ def parametrize_trigger_states(
     target_states: list[str | None | tuple[str | None, dict]],
     other_states: list[str | None | tuple[str | None, dict]],
     extra_excluded_states: list[str | None | tuple[str | None, dict]] | None = None,
-    trigger_from_excluded: bool = False,
     extra_invalid_states: list[str | None | tuple[str | None, dict]] | None = None,
     required_filter_attributes: dict | None = None,
     trigger_from_none: bool = True,
@@ -431,18 +430,6 @@ def parametrize_trigger_states(
     under test transitions to a target state — the trigger should fire even
     though the other entities never matched, because they are invisible to
     the all/count check.
-
-    Set `trigger_from_excluded` to True if the trigger is expected to fire
-    when the initial state is one of `extra_excluded_states` and transitions
-    directly to a target state. When True, the helper generates an
-    additional pattern that places the entity under test in each
-    `extra_excluded_states` value initially and verifies the trigger fires
-    on the transition to a target (count=1). Pass True only when the
-    trigger's `is_valid_transition` actually permits transitions out of the
-    extra-excluded state into a target — typically true for numerical
-    triggers (None -> numeric is a valid change/threshold cross), false for
-    state-based triggers like media_player.unmuted where moving from
-    no-attrs to muted=False is the same is_muted value.
 
     `extra_invalid_states` are *additional* states (on top of the always-
     included STATE_UNAVAILABLE and STATE_UNKNOWN) that should be treated as
@@ -734,40 +721,7 @@ def parametrize_trigger_states(
         )
     )
 
-    if trigger_from_excluded and extra_excluded_states:
-        # Pattern: the entity under test sits in an `extra_excluded_states`
-        # value alongside the other targeted entities, then transitions
-        # directly to a `target_state`. `is_valid_transition` is expected to
-        # accept that transition (caller opted in via
-        # `trigger_from_excluded=True`), so the trigger must fire.
-        # The other entities stay in the same extra-excluded state and are
-        # filtered out of the all/count check, so behavior=last/first/any
-        # all see exactly one matching entity and fire (count=1).
-        # Sequence per (excluded, target):
-        #   entity_id: excluded -> target   (1)
-        #   others:    excluded -> excluded (no-op, no fire)
-        tests.append(
-            (
-                trigger,
-                trigger_options,
-                list(
-                    itertools.chain.from_iterable(
-                        (
-                            state_with_attributes(excluded_state, 0),
-                            state_with_attributes(
-                                target_state, 1, others_state=excluded_state
-                            ),
-                        )
-                        for excluded_state in extra_excluded_states
-                        for target_state in target_states
-                    )
-                ),
-            )
-        )
-
-    # Drop patterns whose state list is empty (e.g. when other_states is empty
-    # because all "other" candidates are now in extra_excluded_states).
-    return [t for t in tests if t[2]]
+    return tests
 
 
 def _add_threshold_unit(
@@ -835,9 +789,20 @@ def parametrize_numerical_attribute_changed_trigger_states(
     """
     trigger_options = trigger_options or {}
     unit_attributes = unit_attributes or {}
-    none_state = (state, {attribute: None} | unit_attributes)
-    extra_excluded_states = [none_state] if attribute_required else None
-    other_none_states = [] if attribute_required else [none_state]
+    # When `attribute_required=True`, `(attr=None)` is filtered by the
+    # trigger's `_should_include` override, so it can no longer play the
+    # role of a "non-firing but counted" other state. Substitute a
+    # non-numeric string value: it fails `float(...)` (so is_valid_state is
+    # False) but is still `is not None` (so the override includes it in
+    # the all/count check), giving us a proper "other" state. Mirrors how
+    # `parametrize_numerical_state_value_changed_trigger_states` uses the
+    # literal string "none" as a non-numeric state value.
+    if attribute_required:
+        extra_excluded_states = [(state, {attribute: None} | unit_attributes)]
+        other_invalid_attr = (state, {attribute: "none"} | unit_attributes)
+    else:
+        extra_excluded_states = None
+        other_invalid_attr = (state, {attribute: None} | unit_attributes)
 
     return [
         *parametrize_trigger_states(
@@ -856,9 +821,8 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 50} | unit_attributes),
                 (state, {attribute: 100} | unit_attributes),
             ],
-            other_states=other_none_states,
+            other_states=[other_invalid_attr],
             extra_excluded_states=extra_excluded_states,
-            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -879,11 +843,10 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             other_states=[
-                *other_none_states,
+                other_invalid_attr,
                 (state, {attribute: 0} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
-            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -904,11 +867,10 @@ def parametrize_numerical_attribute_changed_trigger_states(
                 (state, {attribute: 50} | unit_attributes),
             ],
             other_states=[
-                *other_none_states,
+                other_invalid_attr,
                 (state, {attribute: 100} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
-            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
             retrigger_on_target_state=True,
         ),
@@ -967,9 +929,17 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
     """
     trigger_options = trigger_options or {}
     unit_attributes = unit_attributes or {}
-    none_state = (state, {attribute: None} | unit_attributes)
-    extra_excluded_states = [none_state] if attribute_required else None
-    other_none_states = [] if attribute_required else [none_state]
+    # See `parametrize_numerical_attribute_changed_trigger_states` for the
+    # rationale of substituting a non-numeric string-attr for `(attr=None)`
+    # when `attribute_required=True`: the override would filter `None`
+    # out of the all/count check, so we use a value that fails
+    # `is_valid_state` but is still included.
+    if attribute_required:
+        extra_excluded_states = [(state, {attribute: None} | unit_attributes)]
+        other_invalid_attr = (state, {attribute: "none"} | unit_attributes)
+    else:
+        extra_excluded_states = None
+        other_invalid_attr = (state, {attribute: None} | unit_attributes)
 
     return [
         *parametrize_trigger_states(
@@ -990,12 +960,11 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 60} | unit_attributes),
             ],
             other_states=[
-                *other_none_states,
+                other_invalid_attr,
                 (state, {attribute: 0} | unit_attributes),
                 (state, {attribute: 100} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
-            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -1016,12 +985,11 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             other_states=[
-                *other_none_states,
+                other_invalid_attr,
                 (state, {attribute: 50} | unit_attributes),
                 (state, {attribute: 60} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
-            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -1041,11 +1009,10 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 100} | unit_attributes),
             ],
             other_states=[
-                *other_none_states,
+                other_invalid_attr,
                 (state, {attribute: 0} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
-            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
         *parametrize_trigger_states(
@@ -1065,11 +1032,10 @@ def parametrize_numerical_attribute_crossed_threshold_trigger_states(
                 (state, {attribute: 50} | unit_attributes),
             ],
             other_states=[
-                *other_none_states,
+                other_invalid_attr,
                 (state, {attribute: 100} | unit_attributes),
             ],
             extra_excluded_states=extra_excluded_states,
-            trigger_from_excluded=attribute_required,
             required_filter_attributes=required_filter_attributes,
         ),
     ]

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -223,7 +223,7 @@ class TriggerStateDescription(BasicTriggerStateDescription):
     # State for the *other* targeted entities (the ones not under direct test).
     # Usually equal to `included_state`; differs when the test exercises a
     # scenario where targeted-but-not-under-test entities sit in a state that
-    # the trigger's `_should_include` override filters out of the all/count
+    # the trigger's `_should_include` method filters out of the all/count
     # checks.
     others_state: StateDescription
 

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -82,7 +82,7 @@ _IS_NOT_MUTED_STATES = [
 
 def parametrize_muted_trigger_states(
     trigger: str, target_muted: bool
-) -> list[tuple[str, list[TriggerStateDescription]]]:
+) -> list[tuple[str, dict[str, Any], list[TriggerStateDescription]]]:
     """Parametrize states and expected service call counts for muted/unmuted.
 
     `target_muted` selects which side fires: True for `media_player.muted`,
@@ -92,10 +92,7 @@ def parametrize_muted_trigger_states(
     States without any volume attributes are passed as
     `extra_excluded_states` because
     `_MediaPlayerMutedStateTriggerBase._should_include` filters them out of
-    the all/count checks. Transitioning from a no-attrs state into a target
-    state fires only for the muted trigger (no-attrs has is_muted=False, so
-    the transition into muted=True flips is_muted, but a transition into
-    muted=False does not).
+    the all/count checks.
 
     Returns a list of tuples with (trigger, trigger_options, list of states).
     """
@@ -107,7 +104,6 @@ def parametrize_muted_trigger_states(
             # State without any volume attributes — filtered by _should_include
             MediaPlayerState.PLAYING,
         ],
-        trigger_from_excluded=target_muted,
     )
 
 
@@ -398,5 +394,43 @@ async def test_muted_trigger_does_not_fire_on_losing_volume_attributes(
     # Lose volume attributes — should not fire (transition to no-attributes
     # is not a valid transition because to_state has no volume attributes)
     hass.states.async_set(entity_id, MediaPlayerState.PLAYING, {})
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+async def test_unmuted_trigger_does_not_fire_when_entity_gains_volume_attributes(
+    hass: HomeAssistant,
+) -> None:
+    """Test that media_player.unmuted does not fire when an entity gains volume attributes already-unmuted.
+
+    `is_muted` defaults to False for a state without volume attributes, so a
+    transition `(PLAYING, {})` -> `(PLAYING, {muted=False})` keeps `is_muted`
+    at False — `is_valid_transition` rejects it and the unmuted trigger
+    must stay silent. The shared muted/unmuted helper iterates entity_id
+    through the firing transitions for both sides via `_IS_MUTED_STATES`
+    and `_IS_NOT_MUTED_STATES`; this dedicated test covers the inverse
+    no-attrs-as-initial case for unmuted, which the helper does not
+    exercise on its own.
+    """
+    entity_id = "media_player.gains_volume"
+    calls: list[str] = []
+
+    # Start without volume attributes
+    hass.states.async_set(entity_id, MediaPlayerState.PLAYING, {})
+    await hass.async_block_till_done()
+
+    await arm_trigger(
+        hass,
+        "media_player.unmuted",
+        None,
+        {CONF_ENTITY_ID: [entity_id]},
+        calls,
+    )
+
+    # Gain volume attributes already-unmuted — must not fire
+    hass.states.async_set(
+        entity_id, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: False}
+    )
     await hass.async_block_till_done()
     assert len(calls) == 0

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -56,9 +56,9 @@ def parametrize_muted_trigger_states() -> list[
 ]:
     """Parametrize states and expected service call counts.
 
-    Only states with volume attributes are used as other_states, because
-    entities without volume attributes are excluded from all/last checks
-    and would cause those tests to fire prematurely.
+    States without volume attributes are passed as `extra_excluded_states`
+    because `_MediaPlayerMutedStateTriggerBase._should_include` filters them
+    out of the all/count checks.
 
     Returns a list of tuples with (trigger, list of states),
     where states is a list of TriggerStateDescription dicts.
@@ -95,6 +95,10 @@ def parametrize_muted_trigger_states() -> list[
                 MediaPlayerState.PLAYING,
                 {ATTR_MEDIA_VOLUME_LEVEL: 1, ATTR_MEDIA_VOLUME_MUTED: False},
             ),
+        ],
+        extra_excluded_states=[
+            # State without any volume attributes — filtered by _should_include
+            MediaPlayerState.PLAYING,
         ],
     )
 

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -391,62 +391,6 @@ async def test_muted_trigger_fires_when_entity_gains_volume_attributes(
 
 
 @pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    ("trigger", "initial_muted", "target_muted"),
-    [
-        ("media_player.muted", False, True),
-        ("media_player.unmuted", True, False),
-    ],
-)
-async def test_muted_trigger_last_skips_entities_without_volume_attributes(
-    hass: HomeAssistant,
-    trigger: str,
-    initial_muted: bool,
-    target_muted: bool,
-) -> None:
-    """Test that 'last' behavior skips entities without volume attributes.
-
-    With entities a (has volume), b (has volume), c (no volume):
-    The trigger should fire when both a and b transition, regardless of c.
-    """
-    entity_a = "media_player.with_volume_a"
-    entity_b = "media_player.with_volume_b"
-    entity_c = "media_player.no_volume"
-    calls: list[str] = []
-
-    hass.states.async_set(
-        entity_a, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: initial_muted}
-    )
-    hass.states.async_set(
-        entity_b, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: initial_muted}
-    )
-    hass.states.async_set(entity_c, MediaPlayerState.PLAYING, {})
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        trigger,
-        {"behavior": "last"},
-        {CONF_ENTITY_ID: [entity_a, entity_b, entity_c]},
-        calls,
-    )
-
-    # Transition entity a — not all mutable entities transitioned yet
-    hass.states.async_set(
-        entity_a, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: target_muted}
-    )
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-    # Transition entity b — now all mutable entities have transitioned, fires
-    hass.states.async_set(
-        entity_b, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: target_muted}
-    )
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
 async def test_muted_trigger_does_not_fire_on_losing_volume_attributes(
     hass: HomeAssistant,
 ) -> None:
@@ -471,59 +415,5 @@ async def test_muted_trigger_does_not_fire_on_losing_volume_attributes(
     # Lose volume attributes — should not fire (transition to no-attributes
     # is not a valid transition because to_state has no volume attributes)
     hass.states.async_set(entity_id, MediaPlayerState.PLAYING, {})
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    ("trigger", "initial_muted", "target_muted"),
-    [
-        ("media_player.muted", False, True),
-        ("media_player.unmuted", True, False),
-    ],
-)
-async def test_muted_trigger_first_skips_entities_without_volume_attributes(
-    hass: HomeAssistant,
-    trigger: str,
-    initial_muted: bool,
-    target_muted: bool,
-) -> None:
-    """Test that 'first' behavior skips entities without volume attributes."""
-    entity_a = "media_player.with_volume_a"
-    entity_b = "media_player.with_volume_b"
-    entity_c = "media_player.no_volume"
-    calls: list[str] = []
-
-    hass.states.async_set(
-        entity_a, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: initial_muted}
-    )
-    hass.states.async_set(
-        entity_b, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: initial_muted}
-    )
-    hass.states.async_set(entity_c, MediaPlayerState.PLAYING, {})
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        trigger,
-        {"behavior": "first"},
-        {CONF_ENTITY_ID: [entity_a, entity_b, entity_c]},
-        calls,
-    )
-
-    # Transition entity a — first mutable entity transitions, fires
-    hass.states.async_set(
-        entity_a, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: target_muted}
-    )
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0] == entity_a
-    calls.clear()
-
-    # Transition entity b — first behavior already armed, does not fire again
-    hass.states.async_set(
-        entity_b, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: target_muted}
-    )
     await hass.async_block_till_done()
     assert len(calls) == 0

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -51,61 +51,63 @@ async def test_media_player_triggers_gated_by_labs_flag(
     await assert_trigger_gated_by_labs_flag(hass, caplog, trigger_key)
 
 
-def parametrize_muted_trigger_states() -> list[
-    tuple[str, list[TriggerStateDescription]]
-]:
-    """Parametrize states and expected service call counts.
+# is_muted=True states (mute attr True OR volume_level == 0)
+_IS_MUTED_STATES = [
+    (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: True}),
+    (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_LEVEL: 0}),
+    (
+        MediaPlayerState.PLAYING,
+        {ATTR_MEDIA_VOLUME_LEVEL: 0, ATTR_MEDIA_VOLUME_MUTED: True},
+    ),
+    (
+        MediaPlayerState.PLAYING,
+        {ATTR_MEDIA_VOLUME_LEVEL: 0, ATTR_MEDIA_VOLUME_MUTED: False},
+    ),
+    (
+        MediaPlayerState.PLAYING,
+        {ATTR_MEDIA_VOLUME_LEVEL: 1, ATTR_MEDIA_VOLUME_MUTED: True},
+    ),
+]
 
-    States without volume attributes are passed as `extra_excluded_states`
-    because `_MediaPlayerMutedStateTriggerBase._should_include` filters them
-    out of the all/count checks.
+# is_muted=False states (mute attr False/missing AND volume_level != 0)
+_IS_NOT_MUTED_STATES = [
+    (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: False}),
+    (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_LEVEL: 1}),
+    (
+        MediaPlayerState.PLAYING,
+        {ATTR_MEDIA_VOLUME_LEVEL: 1, ATTR_MEDIA_VOLUME_MUTED: False},
+    ),
+]
 
-    Returns a list of tuples with (trigger, list of states),
-    where states is a list of TriggerStateDescription dicts.
+
+def parametrize_muted_trigger_states(
+    trigger: str, target_muted: bool
+) -> list[tuple[str, list[TriggerStateDescription]]]:
+    """Parametrize states and expected service call counts for muted/unmuted.
+
+    `target_muted` selects which side fires: True for `media_player.muted`,
+    False for `media_player.unmuted`. The helper swaps target / other state
+    sets accordingly.
+
+    States without any volume attributes are passed as
+    `extra_excluded_states` because
+    `_MediaPlayerMutedStateTriggerBase._should_include` filters them out of
+    the all/count checks. Transitioning from a no-attrs state into a target
+    state fires only for the muted trigger (no-attrs has is_muted=False, so
+    the transition into muted=True flips is_muted, but a transition into
+    muted=False does not).
+
+    Returns a list of tuples with (trigger, trigger_options, list of states).
     """
-    trigger = "media_player.muted"
     return parametrize_trigger_states(
         trigger=trigger,
-        target_states=[
-            # States with muted attribute
-            (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: True}),
-            # States with volume attribute
-            (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_LEVEL: 0}),
-            # States with muted and volume attribute
-            (
-                MediaPlayerState.PLAYING,
-                {ATTR_MEDIA_VOLUME_LEVEL: 0, ATTR_MEDIA_VOLUME_MUTED: True},
-            ),
-            (
-                MediaPlayerState.PLAYING,
-                {ATTR_MEDIA_VOLUME_LEVEL: 0, ATTR_MEDIA_VOLUME_MUTED: False},
-            ),
-            (
-                MediaPlayerState.PLAYING,
-                {ATTR_MEDIA_VOLUME_LEVEL: 1, ATTR_MEDIA_VOLUME_MUTED: True},
-            ),
-        ],
-        other_states=[
-            # States with muted attribute (not muted)
-            (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: False}),
-            # States with volume attribute (not muted)
-            (MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_LEVEL: 1}),
-            # States with muted and volume attribute (not muted)
-            (
-                MediaPlayerState.PLAYING,
-                {ATTR_MEDIA_VOLUME_LEVEL: 1, ATTR_MEDIA_VOLUME_MUTED: False},
-            ),
-        ],
+        target_states=_IS_MUTED_STATES if target_muted else _IS_NOT_MUTED_STATES,
+        other_states=_IS_NOT_MUTED_STATES if target_muted else _IS_MUTED_STATES,
         extra_excluded_states=[
             # State without any volume attributes — filtered by _should_include
             MediaPlayerState.PLAYING,
         ],
-        # Transitioning from a no-volume-attrs state to muted=True is a valid
-        # transition (is_muted goes False -> True) and should fire. Only set
-        # for "muted"; "unmuted" is not routed through this helper and would
-        # not satisfy the recovery contract (no-attrs -> muted=False keeps
-        # is_muted at False).
-        trigger_from_excluded=True,
+        trigger_from_excluded=target_muted,
     )
 
 
@@ -147,7 +149,8 @@ async def test_media_player_trigger_options_validation(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
     [
-        *parametrize_muted_trigger_states(),
+        *parametrize_muted_trigger_states("media_player.muted", target_muted=True),
+        *parametrize_muted_trigger_states("media_player.unmuted", target_muted=False),
         *parametrize_trigger_states(
             trigger="media_player.paused_playing",
             target_states=[
@@ -243,7 +246,8 @@ async def test_media_player_state_trigger_behavior_any(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
     [
-        *parametrize_muted_trigger_states(),
+        *parametrize_muted_trigger_states("media_player.muted", target_muted=True),
+        *parametrize_muted_trigger_states("media_player.unmuted", target_muted=False),
         *parametrize_trigger_states(
             trigger="media_player.stopped_playing",
             target_states=[
@@ -290,7 +294,8 @@ async def test_media_player_state_trigger_behavior_first(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
     [
-        *parametrize_muted_trigger_states(),
+        *parametrize_muted_trigger_states("media_player.muted", target_muted=True),
+        *parametrize_muted_trigger_states("media_player.unmuted", target_muted=False),
         *parametrize_trigger_states(
             trigger="media_player.stopped_playing",
             target_states=[

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -100,6 +100,12 @@ def parametrize_muted_trigger_states() -> list[
             # State without any volume attributes — filtered by _should_include
             MediaPlayerState.PLAYING,
         ],
+        # Transitioning from a no-volume-attrs state to muted=True is a valid
+        # transition (is_muted goes False -> True) and should fire. Only set
+        # for "muted"; "unmuted" is not routed through this helper and would
+        # not satisfy the recovery contract (no-attrs -> muted=False keeps
+        # is_muted at False).
+        trigger_from_excluded=True,
     )
 
 
@@ -355,34 +361,6 @@ async def test_muted_trigger_ignores_entities_without_volume_attributes(
     assert len(calls) == 0
 
     # Transition to muted — should fire
-    hass.states.async_set(
-        entity_id, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: True}
-    )
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-async def test_muted_trigger_fires_when_entity_gains_volume_attributes(
-    hass: HomeAssistant,
-) -> None:
-    """Test that the trigger fires when an entity gains volume attributes and becomes muted."""
-    entity_id = "media_player.gains_volume"
-    calls: list[str] = []
-
-    # Start without volume attributes
-    hass.states.async_set(entity_id, MediaPlayerState.PLAYING, {})
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        "media_player.muted",
-        None,
-        {CONF_ENTITY_ID: [entity_id]},
-        calls,
-    )
-
-    # Gain volume attributes and become muted in one transition
     hass.states.async_set(
         entity_id, MediaPlayerState.PLAYING, {ATTR_MEDIA_VOLUME_MUTED: True}
     )

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -3301,7 +3301,7 @@ async def test_entity_trigger_first_requires_exactly_one(
 async def test_entity_trigger_last_ignores_unavailable_and_unknown_entity(
     hass: HomeAssistant, invalid_state: str
 ) -> None:
-    """Test behavior last: unavailable/unknown entities are excluded from check_all_match.
+    """Test behavior last: unavailable/unknown entities are excluded from the all-match check.
 
     With three entities (A=off, B=unavailable, C=off), turning A on should
     not fire because C is still off, so the available entities do not all
@@ -3565,6 +3565,51 @@ async def test_entity_trigger_duration_last_requires_all(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert len(calls) == 1
+
+    unsub()
+
+
+async def test_entity_trigger_duration_last_cancelled_when_all_entities_filtered(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test behavior last with for: timer is cancelled when every targeted entity is filtered out.
+
+    With behavior=last + `for:`, an "all match" check that becomes vacuously
+    True (every targeted entity filtered by `_should_include` — here all
+    entities go unavailable) must not keep the timer alive; otherwise the
+    action would fire after the duration even though no entity still
+    matches.
+    """
+    entity_a = "test.entity_a"
+    entity_b = "test.entity_b"
+    hass.states.async_set(entity_a, STATE_OFF)
+    hass.states.async_set(entity_b, STATE_OFF)
+    await hass.async_block_till_done()
+
+    calls: list[dict[str, Any]] = []
+    unsub = await _arm_off_to_on_trigger(
+        hass, [entity_a, entity_b], BEHAVIOR_LAST, calls, duration={"seconds": 5}
+    )
+
+    # Turn both on — combined state "all on", timer starts
+    hass.states.async_set(entity_a, STATE_ON)
+    hass.states.async_set(entity_b, STATE_ON)
+    await hass.async_block_till_done()
+
+    # After 2 seconds, every targeted entity goes unavailable. Both are
+    # filtered out of the all-check by `_should_include`, leaving the
+    # check vacuously True. The timer must still be cancelled.
+    freezer.tick(datetime.timedelta(seconds=2))
+    async_fire_time_changed(hass)
+    hass.states.async_set(entity_a, STATE_UNAVAILABLE)
+    hass.states.async_set(entity_b, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    # Advance past the original duration — should NOT fire
+    freezer.tick(datetime.timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
 
     unsub()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add method `_should_include` to `EntityTriggerBase` replacing the hardcoded list of excluded states (`unavailable`, `unknown`) which is checked when trigger behavior is `first` or `last`

This allows triggers to ignore additional states when checking if all states meet a certain criteria.

The method was introduced for the `media_player` mute triggers, and after some discussion we concluded we want to expand it to other triggers which consume optional state attributes.

In this PR, the media player triggers `media_player.muted` and `media_plaer.unmuted`, which introduced the method, as well as `climate.target_humidity_crossed_threshold`, and `climate.target_humidity_crossed_threshold` are migrated.

Also, test helpers are improved so the new functionality can be tested without having to write custom tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
