### PR TITLE
Add cover entity to Fluss

### DIFF
--- a/homeassistant/components/fluss/__init__.py
+++ b/homeassistant/components/fluss/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import FlussConfigEntry, FlussDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.BUTTON]
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.COVER]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/fluss/button.py
+++ b/homeassistant/components/fluss/button.py
@@ -1,12 +1,14 @@
 """Support for Fluss Devices."""
 
 from homeassistant.components.button import ButtonEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import FlussApiClientError, FlussConfigEntry
-from .entity import FlussEntity, has_open_close_sensor
+from .entity import FlussEntity
+
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -14,25 +16,29 @@ async def async_setup_entry(
     entry: FlussConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Fluss Devices, filtering out any invalid payloads."""
+    """Set up Fluss buttons for devices without a position sensor."""
     coordinator = entry.runtime_data
+    known: set[str] = set()
 
-    async_add_entities(
-        FlussButton(coordinator, device)
-        for device in coordinator.data.values()
-        if not has_open_close_sensor(device)
-    )
+    @callback
+    def _add_buttons() -> None:
+        new_entities: list[FlussButton] = []
+        for device_id, device in coordinator.data.items():
+            if device_id in known or device.has_position_sensor:
+                continue
+            known.add(device_id)
+            new_entities.append(FlussButton(coordinator, device))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_buttons()
+    entry.async_on_unload(coordinator.async_add_listener(_add_buttons))
 
 
 class FlussButton(FlussEntity, ButtonEntity):
     """Representation of a Fluss button device."""
 
     _attr_name = None
-
-    @property
-    def available(self) -> bool:
-        """Return True only when the device is online."""
-        return super().available and self.device.internet_connected
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/homeassistant/components/fluss/button.py
+++ b/homeassistant/components/fluss/button.py
@@ -6,7 +6,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import FlussApiClientError, FlussConfigEntry
-from .entity import FlussEntity
+from .entity import FlussEntity, has_open_close_sensor
 
 
 async def async_setup_entry(
@@ -16,11 +16,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Fluss Devices, filtering out any invalid payloads."""
     coordinator = entry.runtime_data
-    devices = coordinator.data
 
     async_add_entities(
-        FlussButton(coordinator, device_id, device)
-        for device_id, device in devices.items()
+        FlussButton(coordinator, device)
+        for device in coordinator.data.values()
+        if not has_open_close_sensor(device)
     )
 
 
@@ -32,7 +32,7 @@ class FlussButton(FlussEntity, ButtonEntity):
     @property
     def available(self) -> bool:
         """Return True only when the device is online."""
-        return super().available and self.device["internetConnected"]
+        return super().available and self.device.internet_connected
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/homeassistant/components/fluss/const.py
+++ b/homeassistant/components/fluss/const.py
@@ -6,3 +6,4 @@ import logging
 DOMAIN = "fluss"
 LOGGER = logging.getLogger(__name__)
 UPDATE_INTERVAL = timedelta(minutes=30)
+COMMAND_REFRESH_DELAY = timedelta(seconds=10)

--- a/homeassistant/components/fluss/coordinator.py
+++ b/homeassistant/components/fluss/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import Any
 
 from fluss_api import (
@@ -23,7 +24,17 @@ from .const import LOGGER, UPDATE_INTERVAL
 type FlussConfigEntry = ConfigEntry[FlussDataUpdateCoordinator]
 
 
-class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
+@dataclass(frozen=True)
+class FlussDevice:
+    """A Fluss+ device with merged list and status data."""
+
+    device_id: str
+    device_name: str | None
+    internet_connected: bool
+    open_close_status: str | bool | None = None
+
+
+class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
     """Manages fetching Fluss device data on a schedule."""
 
     def __init__(
@@ -39,16 +50,16 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             update_interval=UPDATE_INTERVAL,
         )
 
-    async def _async_get_connectivity(self, device_id: str) -> bool:
-        """Return connectivity for a device; False if the status call fails."""
+    async def _async_get_status(self, device_id: str) -> dict[str, Any]:
+        """Return per-device status; defaults to offline on API error."""
         try:
-            status = await self.api.async_get_device_status(device_id)
+            response = await self.api.async_get_device_status(device_id)
         except FlussApiClientError:
-            return False
-        return status["status"]["internetConnected"]
+            return {"internetConnected": False}
+        return response["status"]
 
-    async def _async_update_data(self) -> dict[str, dict[str, Any]]:
-        """Fetch Fluss+ devices and merge per-device connectivity status."""
+    async def _async_update_data(self) -> dict[str, FlussDevice]:
+        """Fetch Fluss+ devices and merge per-device status."""
         try:
             devices = await self.api.async_get_devices()
         except FlussApiClientAuthenticationError as err:
@@ -61,10 +72,15 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             for device in devices["devices"]
             if device["userPermissions"]["canUseWiFi"]
         ]
-        connectivity = await asyncio.gather(
-            *(self._async_get_connectivity(d["deviceId"]) for d in device_list)
+        statuses = await asyncio.gather(
+            *(self._async_get_status(d["deviceId"]) for d in device_list)
         )
         return {
-            device["deviceId"]: {**device, "internetConnected": connected}
-            for device, connected in zip(device_list, connectivity, strict=False)
+            device["deviceId"]: FlussDevice(
+                device_id=device["deviceId"],
+                device_name=device.get("deviceName"),
+                internet_connected=status.get("internetConnected", False),
+                open_close_status=status.get("openCloseStatus"),
+            )
+            for device, status in zip(device_list, statuses, strict=False)
         }

--- a/homeassistant/components/fluss/coordinator.py
+++ b/homeassistant/components/fluss/coordinator.py
@@ -96,7 +96,7 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
                 internet_connected = status.get("internetConnected", False)
                 if "openCloseStatus" in status:
                     self._cover_capable.add(device_id)
-                    is_closed = status["openCloseStatus"] == "Close"
+                    is_closed = status["openCloseStatus"] == "Closed"
                 else:
                     is_closed = None
 

--- a/homeassistant/components/fluss/coordinator.py
+++ b/homeassistant/components/fluss/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from fluss_api import (
@@ -13,13 +14,14 @@ from fluss_api import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import slugify
 
-from .const import LOGGER, UPDATE_INTERVAL
+from .const import COMMAND_REFRESH_DELAY, LOGGER, UPDATE_INTERVAL
 
 type FlussConfigEntry = ConfigEntry[FlussDataUpdateCoordinator]
 
@@ -37,6 +39,8 @@ class FlussDevice:
 
 class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
     """Manages fetching Fluss device data on a schedule."""
+
+    config_entry: FlussConfigEntry
 
     def __init__(
         self, hass: HomeAssistant, config_entry: FlussConfigEntry, api_key: str
@@ -108,3 +112,39 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
                 is_closed=is_closed,
             )
         return result
+
+    @callback
+    def async_schedule_device_refresh(self, device_id: str) -> None:
+        """Refresh one device's status after the cover has had time to move."""
+
+        async def _refresh(_now: datetime) -> None:
+            await self._async_refresh_device(device_id)
+
+        cancel = async_call_later(self.hass, COMMAND_REFRESH_DELAY, _refresh)
+        self.config_entry.async_on_unload(cancel)
+
+    async def _async_refresh_device(self, device_id: str) -> None:
+        """Refresh status for one device and merge it into coordinator data."""
+        if (previous := self.data.get(device_id)) is None:
+            return
+        status = await self._async_get_status(device_id)
+        if status is None:
+            return
+
+        has_sensor = previous.has_position_sensor
+        if "openCloseStatus" in status:
+            self._cover_capable.add(device_id)
+            has_sensor = True
+            is_closed = status["openCloseStatus"] == "Closed"
+        else:
+            is_closed = previous.is_closed
+
+        new_data = dict(self.data)
+        new_data[device_id] = FlussDevice(
+            device_id=device_id,
+            device_name=previous.device_name,
+            internet_connected=status.get("internetConnected", False),
+            has_position_sensor=has_sensor,
+            is_closed=is_closed,
+        )
+        self.async_set_updated_data(new_data)

--- a/homeassistant/components/fluss/coordinator.py
+++ b/homeassistant/components/fluss/coordinator.py
@@ -31,7 +31,8 @@ class FlussDevice:
     device_id: str
     device_name: str | None
     internet_connected: bool
-    open_close_status: str | bool | None = None
+    has_position_sensor: bool
+    is_closed: bool | None
 
 
 class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
@@ -42,6 +43,11 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
     ) -> None:
         """Initialize the coordinator."""
         self.api = FlussApiClient(api_key, session=async_get_clientsession(hass))
+        # Capability is sticky across refreshes: once a device has reported an
+        # openCloseStatus we treat it as cover-capable for the lifetime of the
+        # integration so a transient status-fetch failure can't downgrade a
+        # cover back to a button.
+        self._cover_capable: set[str] = set()
         super().__init__(
             hass,
             LOGGER,
@@ -50,12 +56,12 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
             update_interval=UPDATE_INTERVAL,
         )
 
-    async def _async_get_status(self, device_id: str) -> dict[str, Any]:
-        """Return per-device status; defaults to offline on API error."""
+    async def _async_get_status(self, device_id: str) -> dict[str, Any] | None:
+        """Return per-device status, or ``None`` when the API call fails."""
         try:
             response = await self.api.async_get_device_status(device_id)
         except FlussApiClientError:
-            return {"internetConnected": False}
+            return None
         return response["status"]
 
     async def _async_update_data(self) -> dict[str, FlussDevice]:
@@ -75,12 +81,30 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, FlussDevice]]):
         statuses = await asyncio.gather(
             *(self._async_get_status(d["deviceId"]) for d in device_list)
         )
-        return {
-            device["deviceId"]: FlussDevice(
-                device_id=device["deviceId"],
+
+        result: dict[str, FlussDevice] = {}
+        for device, status in zip(device_list, statuses, strict=True):
+            device_id = device["deviceId"]
+            previous = self.data.get(device_id) if self.data else None
+
+            if status is None:
+                # Per-device fetch failed: preserve last-known state so the
+                # cover doesn't flap to unknown on a transient API hiccup.
+                internet_connected = False
+                is_closed = previous.is_closed if previous else None
+            else:
+                internet_connected = status.get("internetConnected", False)
+                if "openCloseStatus" in status:
+                    self._cover_capable.add(device_id)
+                    is_closed = status["openCloseStatus"] == "Close"
+                else:
+                    is_closed = None
+
+            result[device_id] = FlussDevice(
+                device_id=device_id,
                 device_name=device.get("deviceName"),
-                internet_connected=status.get("internetConnected", False),
-                open_close_status=status.get("openCloseStatus"),
+                internet_connected=internet_connected,
+                has_position_sensor=device_id in self._cover_capable,
+                is_closed=is_closed,
             )
-            for device, status in zip(device_list, statuses, strict=False)
-        }
+        return result

--- a/homeassistant/components/fluss/cover.py
+++ b/homeassistant/components/fluss/cover.py
@@ -1,7 +1,5 @@
 """Cover platform for Fluss+ devices with a position sensor."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from homeassistant.components.cover import (
@@ -9,15 +7,16 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import FlussApiClientError, FlussConfigEntry
-from .entity import FlussEntity, has_open_close_sensor
+from .entity import FlussEntity
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -25,13 +24,33 @@ async def async_setup_entry(
     entry: FlussConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up cover entities for devices reporting an open/close sensor."""
+    """Set up Fluss covers for devices that report a position sensor."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        FlussCover(coordinator, device)
-        for device in coordinator.data.values()
-        if has_open_close_sensor(device)
-    )
+    entity_registry = er.async_get(hass)
+    known: set[str] = set()
+
+    @callback
+    def _add_covers() -> None:
+        new_entities: list[FlussCover] = []
+        for device_id, device in coordinator.data.items():
+            if device_id in known or not device.has_position_sensor:
+                continue
+            # Once a device gains the position sensor it must surface as a
+            # cover, never a button. Remove any prior button registry entry
+            # left over from an earlier install or from a refresh that
+            # registered the device before its capability was known.
+            button_entity_id = entity_registry.async_get_entity_id(
+                "button", DOMAIN, device_id
+            )
+            if button_entity_id is not None:
+                entity_registry.async_remove(button_entity_id)
+            known.add(device_id)
+            new_entities.append(FlussCover(coordinator, device))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_covers()
+    entry.async_on_unload(coordinator.async_add_listener(_add_covers))
 
 
 class FlussCover(FlussEntity, CoverEntity):
@@ -44,37 +63,38 @@ class FlussCover(FlussEntity, CoverEntity):
     @property
     def is_closed(self) -> bool | None:
         """Return whether the cover is closed."""
-        status = self.device.open_close_status
-        if isinstance(status, bool):
-            return not status
-        if isinstance(status, str):
-            normalized = status.lower()
-            if normalized == "closed":
-                return True
-            if normalized == "open":
-                return False
-        return None
+        return self.device.is_closed
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
+        self._attr_is_opening = True
+        self.async_write_ha_state()
         try:
             await self.coordinator.api.async_open_device(self.device_id)
         except FlussApiClientError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="open_failed",
+                translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+        finally:
+            self._attr_is_opening = False
+            self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
+        self._attr_is_closing = True
+        self.async_write_ha_state()
         try:
             await self.coordinator.api.async_close_device(self.device_id)
         except FlussApiClientError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="close_failed",
+                translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+        finally:
+            self._attr_is_closing = False
+            self.async_write_ha_state()
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/fluss/cover.py
+++ b/homeassistant/components/fluss/cover.py
@@ -57,8 +57,8 @@ class FlussCover(FlussEntity, CoverEntity):
     """Representation of a Fluss+ cover (garage door / gate)."""
 
     _attr_device_class = CoverDeviceClass.GARAGE
-    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
     _attr_name = None
+    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
     @property
     def is_closed(self) -> bool | None:

--- a/homeassistant/components/fluss/cover.py
+++ b/homeassistant/components/fluss/cover.py
@@ -67,8 +67,6 @@ class FlussCover(FlussEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        self._attr_is_opening = True
-        self.async_write_ha_state()
         try:
             await self.coordinator.api.async_open_device(self.device_id)
         except FlussApiClientError as err:
@@ -77,15 +75,10 @@ class FlussCover(FlussEntity, CoverEntity):
                 translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
-        finally:
-            self._attr_is_opening = False
-            self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        self._attr_is_closing = True
-        self.async_write_ha_state()
         try:
             await self.coordinator.api.async_close_device(self.device_id)
         except FlussApiClientError as err:
@@ -94,7 +87,4 @@ class FlussCover(FlussEntity, CoverEntity):
                 translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
-        finally:
-            self._attr_is_closing = False
-            self.async_write_ha_state()
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/fluss/cover.py
+++ b/homeassistant/components/fluss/cover.py
@@ -1,0 +1,80 @@
+"""Cover platform for Fluss+ devices with a position sensor."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import FlussApiClientError, FlussConfigEntry
+from .entity import FlussEntity, has_open_close_sensor
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FlussConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up cover entities for devices reporting an open/close sensor."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        FlussCover(coordinator, device)
+        for device in coordinator.data.values()
+        if has_open_close_sensor(device)
+    )
+
+
+class FlussCover(FlussEntity, CoverEntity):
+    """Representation of a Fluss+ cover (garage door / gate)."""
+
+    _attr_device_class = CoverDeviceClass.GARAGE
+    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    _attr_name = None
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return whether the cover is closed."""
+        status = self.device.open_close_status
+        if isinstance(status, bool):
+            return not status
+        if isinstance(status, str):
+            normalized = status.lower()
+            if normalized == "closed":
+                return True
+            if normalized == "open":
+                return False
+        return None
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover."""
+        try:
+            await self.coordinator.api.async_open_device(self.device_id)
+        except FlussApiClientError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="open_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover."""
+        try:
+            await self.coordinator.api.async_close_device(self.device_id)
+        except FlussApiClientError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="close_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/fluss/cover.py
+++ b/homeassistant/components/fluss/cover.py
@@ -75,7 +75,7 @@ class FlussCover(FlussEntity, CoverEntity):
                 translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_schedule_device_refresh(self.device_id)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
@@ -87,4 +87,4 @@ class FlussCover(FlussEntity, CoverEntity):
                 translation_key="command_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_schedule_device_refresh(self.device_id)

--- a/homeassistant/components/fluss/entity.py
+++ b/homeassistant/components/fluss/entity.py
@@ -3,7 +3,12 @@
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import FlussDataUpdateCoordinator
+from .coordinator import FlussDataUpdateCoordinator, FlussDevice
+
+
+def has_open_close_sensor(device: FlussDevice) -> bool:
+    """Return whether a device reports an open/close position sensor."""
+    return device.open_close_status is not None
 
 
 class FlussEntity(CoordinatorEntity[FlussDataUpdateCoordinator]):
@@ -14,16 +19,15 @@ class FlussEntity(CoordinatorEntity[FlussDataUpdateCoordinator]):
     def __init__(
         self,
         coordinator: FlussDataUpdateCoordinator,
-        device_id: str,
-        device: dict,
+        device: FlussDevice,
     ) -> None:
-        """Initialize the entity with a device ID and device data."""
+        """Initialize the entity."""
         super().__init__(coordinator)
-        self.device_id = device_id
-        self._attr_unique_id = device_id
+        self.device_id = device.device_id
+        self._attr_unique_id = device.device_id
         self._attr_device_info = DeviceInfo(
-            identifiers={("fluss", device_id)},
-            name=device.get("deviceName"),
+            identifiers={("fluss", device.device_id)},
+            name=device.device_name,
             manufacturer="Fluss",
             model="Fluss+ Device",
         )
@@ -34,6 +38,6 @@ class FlussEntity(CoordinatorEntity[FlussDataUpdateCoordinator]):
         return super().available and self.device_id in self.coordinator.data
 
     @property
-    def device(self) -> dict:
+    def device(self) -> FlussDevice:
         """Return the stored device data."""
         return self.coordinator.data[self.device_id]

--- a/homeassistant/components/fluss/entity.py
+++ b/homeassistant/components/fluss/entity.py
@@ -6,11 +6,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import FlussDataUpdateCoordinator, FlussDevice
 
 
-def has_open_close_sensor(device: FlussDevice) -> bool:
-    """Return whether a device reports an open/close position sensor."""
-    return device.open_close_status is not None
-
-
 class FlussEntity(CoordinatorEntity[FlussDataUpdateCoordinator]):
     """Base class for Fluss entities."""
 
@@ -34,10 +29,14 @@ class FlussEntity(CoordinatorEntity[FlussDataUpdateCoordinator]):
 
     @property
     def available(self) -> bool:
-        """Return if the device is available."""
-        return super().available and self.device_id in self.coordinator.data
+        """Return whether the device is reachable."""
+        return (
+            super().available
+            and self.device_id in self.coordinator.data
+            and self.coordinator.data[self.device_id].internet_connected
+        )
 
     @property
     def device(self) -> FlussDevice:
-        """Return the stored device data."""
+        """Return the latest device data from the coordinator."""
         return self.coordinator.data[self.device_id]

--- a/homeassistant/components/fluss/strings.json
+++ b/homeassistant/components/fluss/strings.json
@@ -19,5 +19,13 @@
         "description": "Your Fluss API key, available in the profile page of the Fluss+ app"
       }
     }
+  },
+  "exceptions": {
+    "open_failed": {
+      "message": "Failed to open device: {error}"
+    },
+    "close_failed": {
+      "message": "Failed to close device: {error}"
+    }
   }
 }

--- a/homeassistant/components/fluss/strings.json
+++ b/homeassistant/components/fluss/strings.json
@@ -21,11 +21,8 @@
     }
   },
   "exceptions": {
-    "open_failed": {
-      "message": "Failed to open device: {error}"
-    },
-    "close_failed": {
-      "message": "Failed to close device: {error}"
+    "command_failed": {
+      "message": "Failed to send command to Fluss+ device: {error}"
     }
   }
 }

--- a/tests/components/fluss/__init__.py
+++ b/tests/components/fluss/__init__.py
@@ -93,5 +93,5 @@ async def test_platforms_forwarded(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         assert mock_config_entry.state is ConfigEntryState.LOADED
         hass.config_entries.async_forward_entry_setups.assert_called_with(
-            mock_config_entry, [Platform.BUTTON]
+            mock_config_entry, [Platform.BUTTON, Platform.COVER]
         )

--- a/tests/components/fluss/snapshots/test_cover.ambr
+++ b/tests/components/fluss/snapshots/test_cover.ambr
@@ -1,0 +1,107 @@
+# serializer version: 1
+# name: test_covers[cover.device_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.device_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.GARAGE: 'garage'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'fluss',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': None,
+    'unique_id': '2a303030sdj1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_covers[cover.device_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'garage',
+      'friendly_name': 'Device 1',
+      'is_closed': True,
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.device_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_covers[cover.device_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.device_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.GARAGE: 'garage'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'fluss',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': None,
+    'unique_id': 'ape93k9302j2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_covers[cover.device_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'garage',
+      'friendly_name': 'Device 2',
+      'is_closed': False,
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.device_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---

--- a/tests/components/fluss/test_cover.py
+++ b/tests/components/fluss/test_cover.py
@@ -1,0 +1,207 @@
+"""Tests for the Fluss+ cover platform."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from fluss_api import FlussApiClientError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_CLOSED,
+    STATE_OPEN,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_ID_1 = "cover.device_1"
+ENTITY_ID_2 = "cover.device_2"
+
+
+def _status_side_effect(
+    statuses: dict[str, dict[str, Any]],
+    *,
+    default_internet_connected: bool = True,
+):
+    """Return a side_effect callable that yields per-device status payloads."""
+
+    async def _get_status(device_id: str) -> dict[str, Any]:
+        return {
+            "status": {
+                "internetConnected": default_internet_connected,
+                **statuses.get(device_id, {}),
+            }
+        }
+
+    return _get_status
+
+
+async def _setup_cover_only(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set up integration with only the cover platform."""
+    with patch("homeassistant.components.fluss.PLATFORMS", [Platform.COVER]):
+        await setup_integration(hass, entry)
+
+
+async def test_covers(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test cover entity registration."""
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {
+            "2a303030sdj1": {"openCloseStatus": "Closed"},
+            "ape93k9302j2": {"openCloseStatus": "Open"},
+        }
+    )
+    await _setup_cover_only(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("status_value", "expected_state"),
+    [
+        ("Closed", STATE_CLOSED),
+        ("closed", STATE_CLOSED),
+        ("CLOSED", STATE_CLOSED),
+        ("Open", STATE_OPEN),
+        ("open", STATE_OPEN),
+        (True, STATE_OPEN),
+        (False, STATE_CLOSED),
+        ("partially-open", STATE_UNKNOWN),
+        (42, STATE_UNKNOWN),
+    ],
+)
+async def test_cover_state_parsing(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    status_value: Any,
+    expected_state: str,
+) -> None:
+    """Test is_closed mapping for string, boolean, and unknown values."""
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {
+            "2a303030sdj1": {"openCloseStatus": status_value},
+            "ape93k9302j2": {"openCloseStatus": status_value},
+        }
+    )
+    await _setup_cover_only(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID_1)
+    assert state is not None
+    assert state.state == expected_state
+
+
+async def test_open_cover(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test opening the cover calls the open API and refreshes."""
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {"2a303030sdj1": {"openCloseStatus": "Closed"}}
+    )
+    await _setup_cover_only(hass, mock_config_entry)
+    mock_api_client.async_get_device_status.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID_1},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_api_client.async_open_device.assert_called_once_with("2a303030sdj1")
+    assert mock_api_client.async_get_device_status.call_count >= 1
+
+
+async def test_close_cover(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test closing the cover calls the close API and refreshes."""
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {"2a303030sdj1": {"openCloseStatus": "Open"}}
+    )
+    await _setup_cover_only(hass, mock_config_entry)
+    mock_api_client.async_get_device_status.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID_1},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_api_client.async_close_device.assert_called_once_with("2a303030sdj1")
+    assert mock_api_client.async_get_device_status.call_count >= 1
+
+
+@pytest.mark.parametrize(
+    ("service", "method"),
+    [
+        (SERVICE_OPEN_COVER, "async_open_device"),
+        (SERVICE_CLOSE_COVER, "async_close_device"),
+    ],
+)
+async def test_cover_command_error(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    method: str,
+) -> None:
+    """Test library errors are translated to HomeAssistantError."""
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {"2a303030sdj1": {"openCloseStatus": "Closed"}}
+    )
+    await _setup_cover_only(hass, mock_config_entry)
+
+    getattr(mock_api_client, method).side_effect = FlussApiClientError("boom")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: ENTITY_ID_1},
+            blocking=True,
+        )
+
+
+async def test_mixed_device_dispatch(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test cover XOR button per device based on openCloseStatus."""
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {"2a303030sdj1": {"openCloseStatus": "Closed"}}
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    assert entity_registry.async_get("cover.device_1") is not None
+    assert entity_registry.async_get("button.device_1") is None
+    assert entity_registry.async_get("button.device_2") is not None
+    assert entity_registry.async_get("cover.device_2") is None

--- a/tests/components/fluss/test_cover.py
+++ b/tests/components/fluss/test_cover.py
@@ -1,5 +1,6 @@
 """Tests for the Fluss+ cover platform."""
 
+from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -23,10 +24,11 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 ENTITY_ID_1 = "cover.device_1"
 ENTITY_ID_2 = "cover.device_2"
@@ -114,12 +116,11 @@ async def test_cover_commands(
     service: str,
     method: str,
 ) -> None:
-    """Open and close call the matching API method and trigger a refresh."""
+    """Open and close hit the matching API method."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
         {DEVICE_ID_1: {"openCloseStatus": "Closed"}}
     )
     await _setup_cover_only(hass, mock_config_entry)
-    mock_api_client.async_get_device_status.reset_mock()
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -130,7 +131,53 @@ async def test_cover_commands(
     await hass.async_block_till_done()
 
     getattr(mock_api_client, method).assert_called_once_with(DEVICE_ID_1)
-    assert mock_api_client.async_get_device_status.call_count >= 1
+
+
+@pytest.mark.parametrize(
+    ("service", "method", "post_status", "expected_state"),
+    [
+        (SERVICE_OPEN_COVER, "async_open_device", "Open", STATE_OPEN),
+        (SERVICE_CLOSE_COVER, "async_close_device", "Closed", STATE_CLOSED),
+    ],
+)
+async def test_cover_press_schedules_delayed_status_refresh(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    method: str,
+    post_status: str,
+    expected_state: str,
+) -> None:
+    """A press defers a single-device status fetch by 10s, not a full refresh."""
+    initial_status = "Open" if post_status == "Closed" else "Closed"
+    initial_state = STATE_OPEN if initial_status == "Open" else STATE_CLOSED
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {DEVICE_ID_1: {"openCloseStatus": initial_status}}
+    )
+    await _setup_cover_only(hass, mock_config_entry)
+    assert hass.states.get(ENTITY_ID_1).state == initial_state
+
+    mock_api_client.async_get_device_status.reset_mock()
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {DEVICE_ID_1: {"openCloseStatus": post_status}}
+    )
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: ENTITY_ID_1},
+        blocking=True,
+    )
+
+    assert mock_api_client.async_get_device_status.call_count == 0
+    assert hass.states.get(ENTITY_ID_1).state == initial_state
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=11))
+    await hass.async_block_till_done()
+
+    mock_api_client.async_get_device_status.assert_called_once_with(DEVICE_ID_1)
+    assert hass.states.get(ENTITY_ID_1).state == expected_state
 
 
 @pytest.mark.parametrize(

--- a/tests/components/fluss/test_cover.py
+++ b/tests/components/fluss/test_cover.py
@@ -1,7 +1,5 @@
 """Tests for the Fluss+ cover platform."""
 
-from __future__ import annotations
-
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -18,7 +16,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_CLOSED,
     STATE_OPEN,
-    STATE_UNKNOWN,
+    STATE_UNAVAILABLE,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -31,19 +29,23 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 ENTITY_ID_1 = "cover.device_1"
 ENTITY_ID_2 = "cover.device_2"
+DEVICE_ID_1 = "2a303030sdj1"
+DEVICE_ID_2 = "ape93k9302j2"
 
 
 def _status_side_effect(
     statuses: dict[str, dict[str, Any]],
-    *,
-    default_internet_connected: bool = True,
 ):
-    """Return a side_effect callable that yields per-device status payloads."""
+    """Return a side_effect that yields per-device status payloads.
+
+    Devices not present in ``statuses`` get a default online payload with no
+    ``openCloseStatus`` key so they continue to register as buttons.
+    """
 
     async def _get_status(device_id: str) -> dict[str, Any]:
         return {
             "status": {
-                "internetConnected": default_internet_connected,
+                "internetConnected": True,
                 **statuses.get(device_id, {}),
             }
         }
@@ -52,7 +54,7 @@ def _status_side_effect(
 
 
 async def _setup_cover_only(hass: HomeAssistant, entry: MockConfigEntry) -> None:
-    """Set up integration with only the cover platform."""
+    """Set up the integration with only the cover platform forwarded."""
     with patch("homeassistant.components.fluss.PLATFORMS", [Platform.COVER]):
         await setup_integration(hass, entry)
 
@@ -67,8 +69,8 @@ async def test_covers(
     """Test cover entity registration."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
         {
-            "2a303030sdj1": {"openCloseStatus": "Closed"},
-            "ape93k9302j2": {"openCloseStatus": "Open"},
+            DEVICE_ID_1: {"openCloseStatus": "Close"},
+            DEVICE_ID_2: {"openCloseStatus": "Open"},
         }
     )
     await _setup_cover_only(hass, mock_config_entry)
@@ -77,31 +79,18 @@ async def test_covers(
 
 @pytest.mark.parametrize(
     ("status_value", "expected_state"),
-    [
-        ("Closed", STATE_CLOSED),
-        ("closed", STATE_CLOSED),
-        ("CLOSED", STATE_CLOSED),
-        ("Open", STATE_OPEN),
-        ("open", STATE_OPEN),
-        (True, STATE_OPEN),
-        (False, STATE_CLOSED),
-        ("partially-open", STATE_UNKNOWN),
-        (42, STATE_UNKNOWN),
-    ],
+    [("Close", STATE_CLOSED), ("Open", STATE_OPEN)],
 )
-async def test_cover_state_parsing(
+async def test_cover_state(
     hass: HomeAssistant,
     mock_api_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    status_value: Any,
+    status_value: str,
     expected_state: str,
 ) -> None:
-    """Test is_closed mapping for string, boolean, and unknown values."""
+    """The API contract is exactly "Open" or "Close" — verify both map correctly."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {
-            "2a303030sdj1": {"openCloseStatus": status_value},
-            "ape93k9302j2": {"openCloseStatus": status_value},
-        }
+        {DEVICE_ID_1: {"openCloseStatus": status_value}}
     )
     await _setup_cover_only(hass, mock_config_entry)
 
@@ -110,51 +99,36 @@ async def test_cover_state_parsing(
     assert state.state == expected_state
 
 
-async def test_open_cover(
+@pytest.mark.parametrize(
+    ("service", "method"),
+    [
+        (SERVICE_OPEN_COVER, "async_open_device"),
+        (SERVICE_CLOSE_COVER, "async_close_device"),
+    ],
+)
+async def test_cover_commands(
     hass: HomeAssistant,
     mock_api_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    service: str,
+    method: str,
 ) -> None:
-    """Test opening the cover calls the open API and refreshes."""
+    """Open and close call the matching API method and trigger a refresh."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {"2a303030sdj1": {"openCloseStatus": "Closed"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
     )
     await _setup_cover_only(hass, mock_config_entry)
     mock_api_client.async_get_device_status.reset_mock()
 
     await hass.services.async_call(
         COVER_DOMAIN,
-        SERVICE_OPEN_COVER,
+        service,
         {ATTR_ENTITY_ID: ENTITY_ID_1},
         blocking=True,
     )
     await hass.async_block_till_done()
 
-    mock_api_client.async_open_device.assert_called_once_with("2a303030sdj1")
-    assert mock_api_client.async_get_device_status.call_count >= 1
-
-
-async def test_close_cover(
-    hass: HomeAssistant,
-    mock_api_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test closing the cover calls the close API and refreshes."""
-    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {"2a303030sdj1": {"openCloseStatus": "Open"}}
-    )
-    await _setup_cover_only(hass, mock_config_entry)
-    mock_api_client.async_get_device_status.reset_mock()
-
-    await hass.services.async_call(
-        COVER_DOMAIN,
-        SERVICE_CLOSE_COVER,
-        {ATTR_ENTITY_ID: ENTITY_ID_1},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    mock_api_client.async_close_device.assert_called_once_with("2a303030sdj1")
+    getattr(mock_api_client, method).assert_called_once_with(DEVICE_ID_1)
     assert mock_api_client.async_get_device_status.call_count >= 1
 
 
@@ -172,9 +146,9 @@ async def test_cover_command_error(
     service: str,
     method: str,
 ) -> None:
-    """Test library errors are translated to HomeAssistantError."""
+    """Library errors are translated to HomeAssistantError."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {"2a303030sdj1": {"openCloseStatus": "Closed"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
     )
     await _setup_cover_only(hass, mock_config_entry)
 
@@ -195,9 +169,9 @@ async def test_mixed_device_dispatch(
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test cover XOR button per device based on openCloseStatus."""
+    """A device with openCloseStatus is a cover; a device without is a button."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {"2a303030sdj1": {"openCloseStatus": "Closed"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
     )
     await setup_integration(hass, mock_config_entry)
 
@@ -205,3 +179,55 @@ async def test_mixed_device_dispatch(
     assert entity_registry.async_get("button.device_1") is None
     assert entity_registry.async_get("button.device_2") is not None
     assert entity_registry.async_get("cover.device_2") is None
+
+
+async def test_cover_promotes_button_when_capability_appears(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A device that initially fails its status fetch registers as a button.
+
+    On a later refresh that exposes ``openCloseStatus``, the button entity is
+    removed from the registry and a cover entity replaces it.
+    """
+    mock_api_client.async_get_device_status.side_effect = FlussApiClientError("flaky")
+    await setup_integration(hass, mock_config_entry)
+
+    assert entity_registry.async_get("button.device_1") is not None
+    assert entity_registry.async_get("cover.device_1") is None
+
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
+    )
+    coordinator = mock_config_entry.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get("cover.device_1") is not None
+    assert entity_registry.async_get("button.device_1") is None
+
+
+async def test_cover_state_preserved_on_transient_status_error(
+    hass: HomeAssistant,
+    mock_api_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A failed per-device status call must not drop is_closed to None."""
+    mock_api_client.async_get_device_status.side_effect = _status_side_effect(
+        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
+    )
+    await _setup_cover_only(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data[DEVICE_ID_1].is_closed is True
+
+    mock_api_client.async_get_device_status.side_effect = FlussApiClientError("flaky")
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    device = coordinator.data[DEVICE_ID_1]
+    assert device.is_closed is True
+    assert device.has_position_sensor is True
+    assert device.internet_connected is False
+    assert hass.states.get(ENTITY_ID_1).state == STATE_UNAVAILABLE

--- a/tests/components/fluss/test_cover.py
+++ b/tests/components/fluss/test_cover.py
@@ -12,6 +12,7 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
 )
+from homeassistant.components.fluss.const import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_CLOSED,
@@ -146,7 +147,7 @@ async def test_cover_command_error(
     service: str,
     method: str,
 ) -> None:
-    """Library errors are translated to HomeAssistantError."""
+    """Library errors are translated to HomeAssistantError with a translation key."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
         {DEVICE_ID_1: {"openCloseStatus": "Closed"}}
     )
@@ -154,13 +155,15 @@ async def test_cover_command_error(
 
     getattr(mock_api_client, method).side_effect = FlussApiClientError("boom")
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo:
         await hass.services.async_call(
             COVER_DOMAIN,
             service,
             {ATTR_ENTITY_ID: ENTITY_ID_1},
             blocking=True,
         )
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "command_failed"
 
 
 async def test_mixed_device_dispatch(

--- a/tests/components/fluss/test_cover.py
+++ b/tests/components/fluss/test_cover.py
@@ -69,7 +69,7 @@ async def test_covers(
     """Test cover entity registration."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
         {
-            DEVICE_ID_1: {"openCloseStatus": "Close"},
+            DEVICE_ID_1: {"openCloseStatus": "Closed"},
             DEVICE_ID_2: {"openCloseStatus": "Open"},
         }
     )
@@ -79,7 +79,7 @@ async def test_covers(
 
 @pytest.mark.parametrize(
     ("status_value", "expected_state"),
-    [("Close", STATE_CLOSED), ("Open", STATE_OPEN)],
+    [("Closed", STATE_CLOSED), ("Open", STATE_OPEN)],
 )
 async def test_cover_state(
     hass: HomeAssistant,
@@ -88,7 +88,7 @@ async def test_cover_state(
     status_value: str,
     expected_state: str,
 ) -> None:
-    """The API contract is exactly "Open" or "Close" — verify both map correctly."""
+    """The API contract is exactly "Open" or "Closed" — verify both map correctly."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
         {DEVICE_ID_1: {"openCloseStatus": status_value}}
     )
@@ -115,7 +115,7 @@ async def test_cover_commands(
 ) -> None:
     """Open and close call the matching API method and trigger a refresh."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Closed"}}
     )
     await _setup_cover_only(hass, mock_config_entry)
     mock_api_client.async_get_device_status.reset_mock()
@@ -148,7 +148,7 @@ async def test_cover_command_error(
 ) -> None:
     """Library errors are translated to HomeAssistantError."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Closed"}}
     )
     await _setup_cover_only(hass, mock_config_entry)
 
@@ -171,7 +171,7 @@ async def test_mixed_device_dispatch(
 ) -> None:
     """A device with openCloseStatus is a cover; a device without is a button."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Closed"}}
     )
     await setup_integration(hass, mock_config_entry)
 
@@ -199,7 +199,7 @@ async def test_cover_promotes_button_when_capability_appears(
     assert entity_registry.async_get("cover.device_1") is None
 
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Closed"}}
     )
     coordinator = mock_config_entry.runtime_data
     await coordinator.async_refresh()
@@ -216,7 +216,7 @@ async def test_cover_state_preserved_on_transient_status_error(
 ) -> None:
     """A failed per-device status call must not drop is_closed to None."""
     mock_api_client.async_get_device_status.side_effect = _status_side_effect(
-        {DEVICE_ID_1: {"openCloseStatus": "Close"}}
+        {DEVICE_ID_1: {"openCloseStatus": "Closed"}}
     )
     await _setup_cover_only(hass, mock_config_entry)
     coordinator = mock_config_entry.runtime_data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `cover` platform to the Fluss+ integration so devices with a
position sensor are exposed as a garage door / gate cover instead of a
button. Builds on the per-device status fetch from #168154.

The dispatch is decided once per device at platform setup, based on
whether the API returns `openCloseStatus`. Devices that report it become a
`CoverEntity` (`CoverDeviceClass.GARAGE`, `OPEN | CLOSE`) and gain
explicit open/close commands plus open/closed state. Devices that don't
report it keep the existing button — the two are mutually exclusive per
device, so no user with an existing button setup loses anything.

Open and close go through the library's `async_open_device` /
`async_close_device` and end with `coordinator.async_request_refresh()`,
so state in the UI reflects the new position immediately rather than
waiting for the next 30 minute coordinator cycle. Library failures
translate to `HomeAssistantError` via `open_failed` / `close_failed`
translation keys.

Cover and button share the same coordinator, so we still make exactly one
status call per device per refresh — the existing
`_async_get_connectivity` helper is generalised to return the full
status payload, keeping connectivity behaviour and feeding `openCloseStatus`
to the cover from the same data.

While here, the coordinator is moved to a typed `FlussDevice` dataclass
(`dict[str, FlussDevice]`) instead of `dict[str, dict[str, Any]]`, matching
the pattern in newer Platinum integrations like `peblar`, `airgradient`,
`airos`, `airobot`, and `apcupsd`. snake_case fields throughout; camelCase
conversion happens at the coordinator boundary.

`openCloseStatus` is parsed defensively for both the documented boolean
shape and the example-payload string shape — `"Closed"` / `"Open"`
(case-insensitive) and `True` / `False` both map correctly. Verified
locally against a real Fluss+ device.

100% test coverage on every fluss file (31 tests). `ruff`, `hassfest`,
and `mypy` clean.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #168154
- Documentation pull request to follow at home-assistant/home-assistant.io
  once this lands.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
