### PR TITLE
Matter: Add option to synchronise HA device names to Matter NodeLabel

### DIFF
--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 from functools import cache
 from typing import TYPE_CHECKING
 
+from chip.clusters import Objects as clusters
 from matter_server.client import MatterClient
 from matter_server.client.exceptions import (
     CannotConnect,
@@ -12,7 +13,9 @@ from matter_server.client.exceptions import (
     ServerVersionTooNew,
     ServerVersionTooOld,
 )
+from matter_server.client.models.node import MatterEndpoint
 from matter_server.common.errors import MatterError, NodeNotExists
+from matter_server.common.helpers.util import create_attribute_path_from_attribute
 from yarl import URL
 
 from homeassistant.components.hassio import AddonError, AddonManager, AddonState
@@ -22,6 +25,10 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import (
+    EVENT_DEVICE_REGISTRY_UPDATED,
+    EventDeviceRegistryUpdatedData,
+)
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
@@ -32,11 +39,19 @@ from homeassistant.helpers.typing import ConfigType
 from .adapter import MatterAdapter
 from .addon import get_addon_manager
 from .api import async_register_api
-from .const import CONF_INTEGRATION_CREATED_ADDON, CONF_USE_ADDON, DOMAIN, LOGGER
+from .const import (
+    CONF_INTEGRATION_CREATED_ADDON,
+    CONF_SYNC_NAMES,
+    CONF_USE_ADDON,
+    DOMAIN,
+    LOGGER,
+    NODE_LABEL_MAX_BYTES,
+)
 from .discovery import SUPPORTED_PLATFORMS
 from .helpers import (
     MatterConfigEntry,
     MatterEntryData,
+    get_endpoint_from_device_entry,
     get_matter,
     get_node_from_device_entry,
     node_from_ha_device_id,
@@ -220,6 +235,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MatterConfigEntry) -> bo
             setup_error = listen_err
 
     if setup_error is None:
+        _async_setup_name_sync(hass, entry)
         return True
 
     await hass.config_entries.async_unload_platforms(entry, SUPPORTED_PLATFORMS)
@@ -250,6 +266,119 @@ def _derive_ble_proxy_url(matter_ws_url: str) -> str | None:
     else:
         return None
     return str(parsed.with_path(new_path))
+
+
+def _truncate_node_label(name: str) -> str:
+    """Truncate a label to fit Matter's 32 UTF-8 byte NodeLabel limit."""
+    encoded = name.encode("utf-8")
+    if len(encoded) <= NODE_LABEL_MAX_BYTES:
+        return name
+    # Decode back, dropping a partial trailing multi-byte sequence if any.
+    return encoded[:NODE_LABEL_MAX_BYTES].decode("utf-8", errors="ignore")
+
+
+async def _async_write_node_label(
+    matter_client: MatterClient,
+    endpoint: MatterEndpoint,
+    label: str,
+) -> None:
+    """Push a label to the right NodeLabel attribute for an endpoint."""
+    if endpoint.is_bridged_device:
+        attribute = clusters.BridgedDeviceBasicInformation.Attributes.NodeLabel
+        target_endpoint_id = endpoint.endpoint_id
+    else:
+        # BasicInformation lives on the root endpoint of the node.
+        attribute = clusters.BasicInformation.Attributes.NodeLabel
+        target_endpoint_id = 0
+    try:
+        await matter_client.write_attribute(
+            node_id=endpoint.node.node_id,
+            attribute_path=create_attribute_path_from_attribute(
+                target_endpoint_id, attribute
+            ),
+            value=_truncate_node_label(label),
+        )
+    except MatterError as err:
+        LOGGER.debug(
+            "Failed to sync NodeLabel for node %s endpoint %s: %s",
+            endpoint.node.node_id,
+            endpoint.endpoint_id,
+            err,
+        )
+
+
+def _resolve_label(device: dr.DeviceEntry) -> str | None:
+    """Pick the label to push: user override, else inferred name."""
+    return device.name_by_user or device.name or None
+
+
+@callback
+def _async_setup_name_sync(hass: HomeAssistant, entry: MatterConfigEntry) -> None:
+    """Wire HA-device-rename → Matter NodeLabel sync (one-way)."""
+    matter_client = entry.runtime_data.adapter.matter_client
+
+    @callback
+    def _handle_device_update(
+        event: Event[EventDeviceRegistryUpdatedData],
+    ) -> None:
+        if not entry.options.get(CONF_SYNC_NAMES):
+            return
+        if event.data["action"] != "update":
+            return
+        if "name_by_user" not in event.data.get("changes", {}):
+            return
+        device = dr.async_get(hass).async_get(event.data["device_id"])
+        if device is None or entry.entry_id not in device.config_entries:
+            return
+        endpoint = get_endpoint_from_device_entry(matter_client, device)
+        if endpoint is None:
+            return
+        label = _resolve_label(device)
+        if label is None:
+            return
+        entry.async_create_background_task(
+            hass,
+            _async_write_node_label(matter_client, endpoint, label),
+            "matter_sync_node_label",
+        )
+
+    entry.async_on_unload(
+        hass.bus.async_listen(EVENT_DEVICE_REGISTRY_UPDATED, _handle_device_update)
+    )
+
+    async def _async_options_updated(
+        hass: HomeAssistant, entry: MatterConfigEntry
+    ) -> None:
+        """Backfill labels whenever options are saved with sync enabled."""
+        if not entry.options.get(CONF_SYNC_NAMES):
+            return
+        await _async_backfill_node_labels(hass, entry)
+
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+
+    if entry.options.get(CONF_SYNC_NAMES):
+        # Sync enabled across a reload: backfill from the current registry.
+        entry.async_create_background_task(
+            hass,
+            _async_backfill_node_labels(hass, entry),
+            "matter_sync_node_label_backfill",
+        )
+
+
+async def _async_backfill_node_labels(
+    hass: HomeAssistant, entry: MatterConfigEntry
+) -> None:
+    """Push current HA names to every Matter device for this entry."""
+    matter_client = entry.runtime_data.adapter.matter_client
+    devices = dr.async_entries_for_config_entry(dr.async_get(hass), entry.entry_id)
+    for device in devices:
+        endpoint = get_endpoint_from_device_entry(matter_client, device)
+        if endpoint is None:
+            continue
+        label = _resolve_label(device)
+        if label is None:
+            continue
+        await _async_write_node_label(matter_client, endpoint, label)
 
 
 async def _client_listen(

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -298,7 +298,7 @@ async def _async_write_node_label(
             ),
             value=_truncate_node_label(label),
         )
-    except MatterError as err:
+    except (NotConnected, MatterError) as err:
         LOGGER.debug(
             "Failed to sync NodeLabel for node %s endpoint %s: %s",
             endpoint.node.node_id,

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -352,7 +352,11 @@ def _async_setup_name_sync(hass: HomeAssistant, entry: MatterConfigEntry) -> Non
         """Backfill labels whenever options are saved with sync enabled."""
         if not entry.options.get(CONF_SYNC_NAMES):
             return
-        await _async_backfill_node_labels(hass, entry)
+        entry.async_create_background_task(
+            hass,
+            _async_backfill_node_labels(hass, entry),
+            "matter_sync_node_label_backfill",
+        )
 
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -14,9 +14,14 @@ from homeassistant.components.hassio import (
     AddonState,
 )
 from homeassistant.components.onboarding import async_is_onboarded
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_URL
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import aiohttp_client
@@ -28,6 +33,7 @@ from .addon import get_addon_manager
 from .const import (
     ADDON_SLUG,
     CONF_INTEGRATION_CREATED_ADDON,
+    CONF_SYNC_NAMES,
     CONF_USE_ADDON,
     DOMAIN,
     LOGGER,
@@ -61,6 +67,14 @@ class MatterConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Matter."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> MatterOptionsFlowHandler:
+        """Return the options flow."""
+        return MatterOptionsFlowHandler()
 
     def __init__(self) -> None:
         """Set up flow instance."""
@@ -343,6 +357,29 @@ class MatterConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_USE_ADDON: self.use_addon,
                 CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
             },
+        )
+
+
+class MatterOptionsFlowHandler(OptionsFlow):
+    """Handle Matter integration options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SYNC_NAMES,
+                        default=self.config_entry.options.get(CONF_SYNC_NAMES, False),
+                    ): bool,
+                }
+            ),
         )
 
 

--- a/homeassistant/components/matter/const.py
+++ b/homeassistant/components/matter/const.py
@@ -8,7 +8,11 @@ from chip.clusters import Objects as clusters
 ADDON_SLUG = "core_matter_server"
 
 CONF_INTEGRATION_CREATED_ADDON = "integration_created_addon"
+CONF_SYNC_NAMES = "sync_names"
 CONF_USE_ADDON = "use_addon"
+
+# Matter spec caps NodeLabel at 32 UTF-8 bytes.
+NODE_LABEL_MAX_BYTES = 32
 
 DOMAIN = "matter"
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -150,7 +150,7 @@ def get_endpoint_from_device_entry(
     if device_id_full is None:
         return None
 
-    device_id = device_id_full.lstrip(device_id_type_prefix)
+    device_id = device_id_full.removeprefix(device_id_type_prefix)
     server_info = matter_client.server_info
 
     if server_info is None:

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -107,7 +107,7 @@ def get_node_from_device_entry(
     if device_id_full is None:
         return None
 
-    device_id = device_id_full.lstrip(device_id_type_prefix)
+    device_id = device_id_full.removeprefix(device_id_type_prefix)
     matter_client = matter.matter_client
     server_info = matter_client.server_info
 
@@ -156,7 +156,7 @@ def get_endpoint_from_device_entry(
     if server_info is None:
         raise RuntimeError("Matter server information is not available")
 
-    return next(
+    matched = next(
         (
             endpoint
             for node in matter_client.get_nodes()
@@ -165,3 +165,8 @@ def get_endpoint_from_device_entry(
         ),
         None,
     )
+    if matched is None:
+        return None
+    if compose_parent := matched.node.get_compose_parent(matched.endpoint_id):
+        return compose_parent
+    return matched

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -13,6 +13,7 @@ from .const import DOMAIN, ID_TYPE_DEVICE_ID
 
 if TYPE_CHECKING:
     from matter_ble_proxy import MatterBleProxy
+    from matter_server.client import MatterClient
     from matter_server.client.models.node import MatterEndpoint, MatterNode
     from matter_server.common.models import ServerInfoMessage
 
@@ -116,6 +117,48 @@ def get_node_from_device_entry(
     return next(
         (
             node
+            for node in matter_client.get_nodes()
+            for endpoint in node.endpoints.values()
+            if get_device_id(server_info, endpoint) == device_id
+        ),
+        None,
+    )
+
+
+@callback
+def get_endpoint_from_device_entry(
+    matter_client: MatterClient, device: dr.DeviceEntry
+) -> MatterEndpoint | None:
+    """Return the MatterEndpoint backing a device entry.
+
+    Takes the MatterClient directly so callers can resolve endpoints during
+    setup, before the entry is registered as loaded. Resolves to the specific
+    endpoint (not just the node) so callers can target bridged endpoints
+    (e.g. for BridgedDeviceBasicInformation writes).
+    """
+    device_id_type_prefix = f"{ID_TYPE_DEVICE_ID}_"
+    device_id_full = next(
+        (
+            identifier[1]
+            for identifier in device.identifiers
+            if identifier[0] == DOMAIN
+            and identifier[1].startswith(device_id_type_prefix)
+        ),
+        None,
+    )
+
+    if device_id_full is None:
+        return None
+
+    device_id = device_id_full.lstrip(device_id_type_prefix)
+    server_info = matter_client.server_info
+
+    if server_info is None:
+        raise RuntimeError("Matter server information is not available")
+
+    return next(
+        (
+            endpoint
             for node in matter_client.get_nodes()
             for endpoint in node.endpoints.values()
             if get_device_id(server_info, endpoint) == device_id

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -154,7 +154,7 @@ def get_endpoint_from_device_entry(
     server_info = matter_client.server_info
 
     if server_info is None:
-        raise RuntimeError("Matter server information is not available")
+        return None
 
     matched = next(
         (

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -676,7 +676,7 @@
     "step": {
       "init": {
         "data": {
-          "sync_names": "Synchronise device names to Matter (one-way)"
+          "sync_names": "Synchronize device names to Matter (one-way)"
         },
         "description": "When enabled, renaming a device in Home Assistant pushes the new name to the Matter device's NodeLabel. This is **one-way**: changing the name on the Matter side will not update Home Assistant. Names are truncated to 32 bytes to comply with the Matter spec.",
         "title": "Matter options"

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -672,6 +672,17 @@
       "title": "Newer version of Matter Server needed"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "sync_names": "Synchronise device names to Matter (one-way)"
+        },
+        "description": "When enabled, renaming a device in Home Assistant pushes the new name to the Matter device's NodeLabel. This is **one-way**: changing the name on the Matter side will not update Home Assistant. Names are truncated to 32 bytes to comply with the Matter spec.",
+        "title": "Matter options"
+      }
+    }
+  },
   "services": {
     "clear_lock_credential": {
       "description": "Removes a credential from a lock.",

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -11,7 +11,7 @@ from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.matter.const import ADDON_SLUG, DOMAIN
+from homeassistant.components.matter.const import ADDON_SLUG, CONF_SYNC_NAMES, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
@@ -1649,3 +1649,36 @@ async def test_addon_not_installed_already_configured(
     assert entry.data["url"] == "ws://host1:5581/ws"
     assert entry.title == "Matter"
     assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("initial_options", "submitted"),
+    [
+        ({}, {CONF_SYNC_NAMES: True}),
+        ({CONF_SYNC_NAMES: True}, {CONF_SYNC_NAMES: False}),
+    ],
+)
+async def test_options_flow(
+    hass: HomeAssistant,
+    initial_options: dict[str, bool],
+    submitted: dict[str, bool],
+) -> None:
+    """Options flow shows the form and persists the submitted value."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"url": "ws://localhost:5580/ws"},
+        options=initial_options,
+        title="Matter",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=submitted
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == submitted
+    assert entry.options == submitted

--- a/tests/components/matter/test_name_sync.py
+++ b/tests/components/matter/test_name_sync.py
@@ -88,6 +88,30 @@ async def test_rename_truncates_long_label_to_32_bytes(
     assert sent == "a" * 32
 
 
+async def test_rename_truncates_multibyte_utf8_label_on_char_boundary(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Truncation never splits a multibyte UTF-8 character."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+
+    # "é" is 2 bytes in UTF-8; 16 × "é" = 32 bytes (fits exactly).
+    # Adding one more "é" would require 34 bytes, so it should be dropped.
+    multibyte_name = "é" * 17
+    device = _matter_devices_for_entry(hass, entry.entry_id)[0]
+    dr.async_get(hass).async_update_device(device.id, name_by_user=multibyte_name)
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count == 1
+    sent = matter_client.write_attribute.call_args.kwargs["value"]
+    assert sent == "é" * 16
+    assert len(sent.encode("utf-8")) <= 32
+
+
 async def test_rename_syncs_bridged_endpoint_node_label(
     hass: HomeAssistant,
     matter_client: MagicMock,

--- a/tests/components/matter/test_name_sync.py
+++ b/tests/components/matter/test_name_sync.py
@@ -1,0 +1,194 @@
+"""Tests for the HA → Matter name synchronisation feature."""
+
+from unittest.mock import MagicMock
+
+from chip.clusters import Objects as clusters
+from matter_server.common.helpers.util import create_attribute_path_from_attribute
+
+from homeassistant.components.matter.const import CONF_SYNC_NAMES, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .common import create_node_from_fixture, setup_integration_with_node_fixture
+
+from tests.common import MockConfigEntry
+
+BASIC_INFO_NODE_LABEL_PATH = create_attribute_path_from_attribute(
+    0, clusters.BasicInformation.Attributes.NodeLabel
+)
+
+
+def _matter_devices_for_entry(
+    hass: HomeAssistant, entry_id: str
+) -> list[dr.DeviceEntry]:
+    """Return all device entries linked to the given Matter config entry."""
+    return dr.async_entries_for_config_entry(dr.async_get(hass), entry_id)
+
+
+async def test_rename_does_not_sync_when_option_disabled(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Renaming a device must not push to Matter when sync_names is off."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    matter_client.write_attribute.reset_mock()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    device = _matter_devices_for_entry(hass, entry.entry_id)[0]
+
+    dr.async_get(hass).async_update_device(device.id, name_by_user="New Name")
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count == 0
+
+
+async def test_rename_syncs_root_node_label(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Renaming a non-bridged device writes BasicInformation.NodeLabel."""
+    node = await setup_integration_with_node_fixture(
+        hass, "device_diagnostics", matter_client
+    )
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+
+    device = _matter_devices_for_entry(hass, entry.entry_id)[0]
+    dr.async_get(hass).async_update_device(device.id, name_by_user="My Light")
+    await hass.async_block_till_done()
+
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=node.node_id,
+        attribute_path=BASIC_INFO_NODE_LABEL_PATH,
+        value="My Light",
+    )
+
+
+async def test_rename_truncates_long_label_to_32_bytes(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Names longer than the Matter NodeLabel limit are truncated to 32 bytes."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+
+    long_name = "a" * 50
+    device = _matter_devices_for_entry(hass, entry.entry_id)[0]
+    dr.async_get(hass).async_update_device(device.id, name_by_user=long_name)
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count == 1
+    sent = matter_client.write_attribute.call_args.kwargs["value"]
+    assert sent == "a" * 32
+
+
+async def test_rename_syncs_bridged_endpoint_node_label(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Renaming a bridged device writes BridgedDeviceBasicInformation.NodeLabel."""
+    node = await setup_integration_with_node_fixture(
+        hass, "atios_knx_bridge", matter_client
+    )
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+
+    bridged_endpoint_id = next(
+        ep.endpoint_id for ep in node.endpoints.values() if ep.is_bridged_device
+    )
+    bridged_device = next(
+        d
+        for d in _matter_devices_for_entry(hass, entry.entry_id)
+        if any(
+            f"-{bridged_endpoint_id}" in identifier[1] for identifier in d.identifiers
+        )
+    )
+    dr.async_get(hass).async_update_device(
+        bridged_device.id, name_by_user="Hallway Light"
+    )
+    await hass.async_block_till_done()
+
+    expected_path = create_attribute_path_from_attribute(
+        bridged_endpoint_id,
+        clusters.BridgedDeviceBasicInformation.Attributes.NodeLabel,
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=node.node_id,
+        attribute_path=expected_path,
+        value="Hallway Light",
+    )
+
+
+async def test_enabling_option_backfills_existing_devices(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Saving options with sync_names=True pushes labels for all existing devices."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    matter_client.write_attribute.reset_mock()
+
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count >= 1
+    assert (
+        matter_client.write_attribute.call_args.kwargs["attribute_path"]
+        == BASIC_INFO_NODE_LABEL_PATH
+    )
+
+
+async def test_initial_sync_runs_on_setup_when_option_enabled(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """If the option is already enabled, setup performs a one-shot backfill."""
+    node = create_node_from_fixture("device_diagnostics")
+    matter_client.get_nodes.return_value = [node]
+    matter_client.get_node.return_value = node
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"url": "ws://localhost:5580/ws"},
+        options={CONF_SYNC_NAMES: True},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert matter_client.write_attribute.call_count >= 1
+
+
+async def test_clearing_override_falls_back_to_inferred_name(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Clearing the user override pushes the inferred device name to Matter."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+
+    device_id = _matter_devices_for_entry(hass, entry.entry_id)[0].id
+    dr.async_get(hass).async_update_device(device_id, name_by_user="Override")
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+
+    dr.async_get(hass).async_update_device(device_id, name_by_user=None)
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count == 1
+    pushed = matter_client.write_attribute.call_args.kwargs["value"]
+    inferred = dr.async_get(hass).async_get(device_id).name
+    assert pushed == inferred
+    assert pushed != "Override"

--- a/tests/components/matter/test_name_sync.py
+++ b/tests/components/matter/test_name_sync.py
@@ -3,9 +3,18 @@
 from unittest.mock import MagicMock
 
 from chip.clusters import Objects as clusters
+from matter_server.client.exceptions import NotConnected
 from matter_server.common.helpers.util import create_attribute_path_from_attribute
 
-from homeassistant.components.matter.const import CONF_SYNC_NAMES, DOMAIN
+from homeassistant.components.matter.const import (
+    CONF_SYNC_NAMES,
+    DOMAIN,
+    ID_TYPE_DEVICE_ID,
+)
+from homeassistant.components.matter.helpers import (
+    get_device_id,
+    get_endpoint_from_device_entry,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -215,3 +224,163 @@ async def test_clearing_override_falls_back_to_inferred_name(
     inferred = dr.async_get(hass).async_get(device_id).name
     assert pushed == inferred
     assert pushed != "Override"
+
+
+async def test_get_endpoint_from_device_entry_edge_cases(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Endpoint resolution skips gracefully when it cannot find an endpoint."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    real_device = _matter_devices_for_entry(hass, entry.entry_id)[0]
+
+    # A real (non-bridged) device resolves to its backing endpoint.
+    assert get_endpoint_from_device_entry(matter_client, real_device) is not None
+
+    # A device without any Matter device-id identifier resolves to None.
+    no_identifier = MagicMock(identifiers=set())
+    assert get_endpoint_from_device_entry(matter_client, no_identifier) is None
+
+    # A device-id identifier that matches no endpoint resolves to None.
+    unknown = MagicMock(identifiers={(DOMAIN, f"{ID_TYPE_DEVICE_ID}_does-not-exist")})
+    assert get_endpoint_from_device_entry(matter_client, unknown) is None
+
+    # When server info is momentarily unavailable, resolution is skipped.
+    matter_client.server_info = None
+    assert get_endpoint_from_device_entry(matter_client, real_device) is None
+
+
+async def test_get_endpoint_returns_compose_parent_for_composed_device(
+    matter_client: MagicMock,
+) -> None:
+    """A composed endpoint resolves to its compose parent (e.g. bridged sub-device)."""
+    parent = MagicMock(is_bridged_device=False, endpoint_id=0)
+    child = MagicMock(endpoint_id=1)
+    child.node = MagicMock(node_id=1)
+    child.node.get_compose_parent.return_value = parent
+    matter_client.get_nodes.return_value = [MagicMock(endpoints={1: child})]
+
+    device_id = get_device_id(matter_client.server_info, child)
+    device = MagicMock(identifiers={(DOMAIN, f"{ID_TYPE_DEVICE_ID}_{device_id}")})
+
+    assert get_endpoint_from_device_entry(matter_client, device) is parent
+
+
+async def test_rename_swallows_write_failure(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """A failed NodeLabel write is logged and never escapes the listener."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+    matter_client.write_attribute.side_effect = NotConnected("server disconnected")
+
+    device = _matter_devices_for_entry(hass, entry.entry_id)[0]
+    dr.async_get(hass).async_update_device(device.id, name_by_user="Will Fail")
+    await hass.async_block_till_done()
+
+    # The write was attempted; the connection error was swallowed (no raise).
+    assert matter_client.write_attribute.call_count == 1
+
+
+async def test_options_update_with_sync_disabled_skips_backfill(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Saving options with sync disabled does not trigger a backfill."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: False})
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count == 0
+
+
+async def test_rename_skips_when_endpoint_cannot_be_resolved(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """A rename is silently skipped when no Matter endpoint can be resolved."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+    matter_client.server_info = None
+
+    device = _matter_devices_for_entry(hass, entry.entry_id)[0]
+    dr.async_get(hass).async_update_device(device.id, name_by_user="No Endpoint")
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count == 0
+
+
+async def test_listener_ignores_unrelated_registry_events(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Creates, non-name updates, and other entries' devices are all ignored."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+    matter_client.write_attribute.reset_mock()
+    device_registry = dr.async_get(hass)
+
+    # A new device in the entry fires a "create" action, not "update".
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "name-sync-extra")},
+        name="Extra",
+    )
+    await hass.async_block_till_done()
+
+    # Updating an unrelated field fires "update" without a name_by_user change.
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "name-sync-extra")},
+        manufacturer="Acme",
+    )
+    await hass.async_block_till_done()
+
+    # A renamed device belonging to a different config entry is ignored.
+    other_entry = MockConfigEntry(domain="other_domain")
+    other_entry.add_to_hass(hass)
+    other_device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other_domain", "other-device")},
+        name="Other",
+    )
+    device_registry.async_update_device(other_device.id, name_by_user="Renamed")
+    await hass.async_block_till_done()
+
+    assert matter_client.write_attribute.call_count == 0
+
+
+async def test_backfill_skips_unresolvable_device(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Backfill skips devices whose Matter endpoint cannot be resolved."""
+    await setup_integration_with_node_fixture(hass, "device_diagnostics", matter_client)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "unresolvable")},
+        name="Ghost",
+    )
+    matter_client.write_attribute.reset_mock()
+
+    hass.config_entries.async_update_entry(entry, options={CONF_SYNC_NAMES: True})
+    await hass.async_block_till_done()
+
+    # Real devices were backfilled; the unresolvable one was skipped (no crash).
+    assert matter_client.write_attribute.call_count >= 1

--- a/tests/components/matter/test_name_sync.py
+++ b/tests/components/matter/test_name_sync.py
@@ -128,12 +128,11 @@ async def test_rename_syncs_bridged_endpoint_node_label(
     bridged_endpoint_id = next(
         ep.endpoint_id for ep in node.endpoints.values() if ep.is_bridged_device
     )
+    bridged_suffix = f"-{bridged_endpoint_id}"
     bridged_device = next(
         d
         for d in _matter_devices_for_entry(hass, entry.entry_id)
-        if any(
-            f"-{bridged_endpoint_id}" in identifier[1] for identifier in d.identifiers
-        )
+        if any(identifier[1].endswith(bridged_suffix) for identifier in d.identifiers)
     )
     dr.async_get(hass).async_update_device(
         bridged_device.id, name_by_user="Hallway Light"
@@ -164,9 +163,9 @@ async def test_enabling_option_backfills_existing_devices(
     await hass.async_block_till_done()
 
     assert matter_client.write_attribute.call_count >= 1
-    assert (
-        matter_client.write_attribute.call_args.kwargs["attribute_path"]
-        == BASIC_INFO_NODE_LABEL_PATH
+    assert any(
+        call.kwargs["attribute_path"] == BASIC_INFO_NODE_LABEL_PATH
+        for call in matter_client.write_attribute.call_args_list
     )
 
 


### PR DESCRIPTION
## Proposed change

Adds a per-config-entry option (under **Configure** on the Matter integration card) that, when enabled, pushes Home Assistant device renames to the corresponding Matter device's NodeLabel attribute.

Behaviour:

- One-way: HA → Matter only. NodeLabel changes on the Matter side are not reflected back into HA.
- Bridged endpoints: writes `BridgedDeviceBasicInformation.NodeLabel` on the bridged endpoint.
- Root nodes: writes `BasicInformation.NodeLabel` on endpoint 0.
- Names are truncated to 32 UTF-8 bytes (Matter spec limit), with partial trailing multi-byte sequences dropped cleanly.
- Toggling the option on (or having it on at setup) triggers a one-shot backfill so existing HA names propagate immediately.
- Listener fires only on `name_by_user` changes; clearing an override falls back to the inferred device name so the Matter side is not left stale.

The existing `get_endpoint_from_device_entry` helper now takes the `MatterClient` directly so resolution works during the entry's setup phase, before it transitions to LOADED.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr