### PR TITLE
Add quality scale for season integration

### DIFF
--- a/homeassistant/components/season/quality_scale.yaml
+++ b/homeassistant/components/season/quality_scale.yaml
@@ -1,0 +1,78 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: todo
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: todo
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description:
+    status: exempt
+    comment: |
+      Is an internal integration, and does not interact with any external devices or services.
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: todo
+  test-before-configure:
+    status: exempt
+    comment: |
+      Integration does not connect to an external device or service.
+  test-before-setup: todo
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow:
+    status: exempt
+    comment: Integration does not authenticate with any external devices or services.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: |
+      Integration is not discoverable and has no discovery information.
+  discovery:
+    status: exempt
+    comment: |
+      Integration is not discoverable and has no discovery information.
+  docs-data-update: todo
+  docs-examples: done
+  docs-known-limitations: todo
+  docs-supported-devices:
+    status: exempt
+    comment: Integration does not connect to any external devices or services.
+  docs-supported-functions: done
+  docs-troubleshooting: todo
+  docs-use-cases: done
+  dynamic-devices: done
+  entity-category: todo
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues: done
+  stale-devices: done
+
+  # Platinum
+  async-dependency: todo
+  inject-websession:
+    status: exempt
+    comment: Integration does not make HTTP requests.
+  strict-typing: todo

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -827,7 +827,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "scrape",
     "screenlogic",
     "scsgate",
-    "season",
     "sendgrid",
     "sense",
     "sensirion_ble",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Analysed the season integration and added a quality_scale.yaml following the proper documentation, then removed season from the hassfest quality scale scale exception list. Reasoning for each check is as follows:

## Bronze
- [X] `action-setup` - done: integration has no service actions.
- [ ] `appropriate-polling` - todo: integration uses local polling but no explicit polling interval given in code. Should probably be reviewed as season only needs infrequent updates.
- [X] `brands` - done: all required icons/logos exist in brands.home-assistant.io/season/.
- [X] `common-modules` - done: integration is very small, no duplicated logic.
- [X] `config-flow-test-coverage` - done: user flow coverage in test/components/season/test_config_flow.py.
- [ ] `config-flow` - todo: config_flow.py exists but 'season' contains no data_description.
    - [ ] Uses `data_description` to give context to fields
    - [X] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [X] `dependency-transparency` - done: clear dependency on ephem 4.1.6 given in manifest.json:11
- [X] `docs-actions` - done: no service actions to document.
- [X] `docs-high-level-description` - exempt: is an internal integration, and does not interact with any external devices or services.
- [X] `docs-installation-instructions` - done: automatic and manual installation instructions provided at https://www.home-assistant.io/integrations/season#configuration
- [X] `docs-removal-instructions` - done: removal instructions provided at https://www.home-assistant.io/integrations/season#removing-the-integration
- [X] `entity-event-setup` - done: no entity events to subscribe to.
- [X] `entity-unique-id` - done: season sensor entity id setup at config_flow.py:28
- [X] `has-entity-name` - done: season sensor sets _attr_has_entity_name to True at sensor.py:101
- [ ] `runtime-data` - todo: integration does not currrently store runtime data.
- [X] `test-before-configure` - exempt: integration does not connect to device/service.
- [ ] `test-before-setup` - done: integration does not test for any failure paths during async_setup_entry.
- [X] `unique-config-entry` - done: Handling for duplicate configurations at config_flow.py:29

## Silver
- [X] `action-exceptions` - done: no service actions in integration.
- [X] `config-entry-unloading` - done: integration unloading support at __init__.py:15
- [X] `docs-configuration-parameters` - done: Configuration for season definition defined at https://www.home-assistant.io/integrations/season#supported-functionality.
- [X] `docs-installation-parameters` - done: season parameter defined at https://www.home-assistant.io/integrations/season#configuration
- [X] `entity-unavailable` - done: integration does not need to fetch any data.
- [X] `integration-owner` - done: integration owner specified at manifest.json:4.
- [X] `log-when-unavailable` - done: integration has no external dependencies it needs to log.
- [ ] `parallel-updates` - todo: number of parallel updates is not specified.
- [X] `reauthentication-flow` - exempt: integration does not authenticate with any external devices or services.
- [X] `test-coverage` - done: 100% test coverage across all modules in integration (ran pytest ./tests/components/season/ --cov=homeassistant.components.season --cov-report term-missing).

## Gold
- [X] `devices` - done: sensor properly creates device and associated info.
- [ ] `diagnostics` - todo: no diagnositics.py implemented.
- [X] `discovery-update-info` - exempt: integration is not discoverable and has no discovery information.
- [X] `discovery` - exempt: integration is not discoverable and has no discovery information.
- [ ] `docs-data-update` - todo: while the data update rate is given in documentation, it is non-specific and not reflected in the code. Kind of depends on the appropriate-polling rule.
- [X] `docs-examples` - done: examples of automations are specified at https://www.home-assistant.io/integrations/season#examples
- [ ] `docs-known-limitations` - todo: no examples of limitations provided.
- [X] `docs-supported-devices` - exempt: integration does not connect to any external devices or services.
- [X] `docs-supported-functions` - done: supported functionalities specified at https://www.home-assistant.io/integrations/season#supported-functionality
- [ ] `docs-troubleshooting` - todo: no troubleshooting information given.
- [X] `docs-use-cases` - done: use cases provided at https://www.home-assistant.io/integrations/season
- [X] `dynamic-devices` - done: no dynamic devices are created after initialisation.
- [ ] `entity-category` - todo: season sensor not given appropriate category.
- [X] `entity-device-class` - done: season sensor does not fall under any relevant device class, so ENUM with options attribute is suitable.
- [X] `entity-disabled-by-default` - done: integration does not need to handle noisy entities.
- [X] `entity-translations` - done: seasons and season types have translated names.
- [X] `exception-translations` - done: no exception messages currently implemented.
- [X] `icon-translations` - done: season translation key is state-defined depending on the season (sensor.py:104, icons.json).
- [ ] `reconfiguration-flow` - todo: no reconfiguration flow implemented.
- [X] `repair-issues` - done: no user-intevention failure cases to repair.
- [X] `stale-devices` - done: no dynamic devices to become stale.

## Platinum
- [ ] `async-dependency` - todo: asyncio not implemented.
- [X] `inject-websession` - exempt: integration does not make HTTP requests.
- [ ] `strict-typing` - todo: integration added to .strict-typing but no py.typed exists for the ephem dependency.

Tests Done:
- python3 -m script.hassfest (passed)
- ruff format homeassistant tests (passed)
- prek run --all-files (passed but gave unrelated error: 'Duplicate module named "homeassistant.util.signal_type"')

As I'm new to contributing to Home Assistant, any feedback on the PR is appreciated. I'm currently involved with a group of students who are contributing to Home Assistant for an open-source project, and we all look forward to contributing to the platform.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
