### PR TITLE
ElkM1 integration: add number entity for elk settings

### DIFF
--- a/homeassistant/brands/sensereo.json
+++ b/homeassistant/brands/sensereo.json
@@ -1,0 +1,5 @@
+{
+  "domain": "sensereo",
+  "name": "Sensereo",
+  "iot_standards": ["matter"]
+}

--- a/homeassistant/brands/zunzunbee.json
+++ b/homeassistant/brands/zunzunbee.json
@@ -1,0 +1,5 @@
+{
+  "domain": "zunzunbee",
+  "name": "Zunzunbee",
+  "iot_standards": ["zigbee"]
+}

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["hassil==3.5.0", "home-assistant-intents==2026.3.24"]
+  "requirements": ["hassil==3.5.0", "home-assistant-intents==2026.5.5"]
 }

--- a/homeassistant/components/duco/diagnostics.py
+++ b/homeassistant/components/duco/diagnostics.py
@@ -13,6 +13,9 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import DOMAIN
 from .coordinator import DucoConfigEntry
 
+# MAC addresses and serial numbers are redacted because a Duco installer or
+# manufacturer could cross-reference them against an installation registry to
+# identify the physical location of the device.
 TO_REDACT = {
     CONF_HOST,
     "mac",
@@ -31,9 +34,15 @@ async def async_get_config_entry_diagnostics(
     coordinator = entry.runtime_data
 
     board = asdict(coordinator.board_info)
+    # `time` is a Unix epoch timestamp of the last board info fetch; not useful for support triage.
     board.pop("time")
+    if board["public_api_version"] is None:
+        board.pop("public_api_version")
+    if board["software_version"] is None:
+        board.pop("software_version")
 
     try:
+        api_info_obj = await coordinator.client.async_get_api_info()
         lan_info = await coordinator.client.async_get_lan_info()
         duco_diags = await coordinator.client.async_get_diagnostics()
         write_remaining = await coordinator.client.async_get_write_req_remaining()
@@ -43,10 +52,15 @@ async def async_get_config_entry_diagnostics(
             translation_key="connection_error",
         ) from err
 
+    api_info: dict[str, Any] = {"public_api_version": api_info_obj.public_api_version}
+    if api_info_obj.reported_api_version is not None:
+        api_info["reported_api_version"] = api_info_obj.reported_api_version
+
     return async_redact_data(
         {
             "entry_data": entry.data,
             "board_info": board,
+            "api_info": api_info,
             "lan_info": asdict(lan_info),
             "nodes": {
                 str(node_id): asdict(node)

--- a/homeassistant/components/ecovacs/config_flow.py
+++ b/homeassistant/components/ecovacs/config_flow.py
@@ -137,10 +137,6 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-
-        if not self.show_advanced_options:
-            return await self.async_step_auth()
-
         if user_input:
             self._mode = user_input[CONF_MODE]
             return await self.async_step_auth()

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -72,6 +72,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.LIGHT,
+    Platform.NUMBER,
     Platform.SCENE,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/elkm1/entity.py
+++ b/homeassistant/components/elkm1/entity.py
@@ -47,6 +47,30 @@ def create_elk_entities(
     return entities
 
 
+def generate_unique_id(
+    element: Element, prefix: str, uniqueness: str | None = None
+) -> str:
+    """Generate a unique_id."""
+    # unique_id starts with elkm1_ iff there is no prefix
+    # it starts with elkm1m_{prefix} iff there is a prefix
+    # this is to avoid a conflict between
+    # prefix=foo, name=bar  (which would be elkm1_foo_bar)
+    #   - and -
+    # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
+    # we could have used elkm1__foo_bar for the latter, but that
+    # would have been a breaking change
+    if prefix != "":
+        uid_start = f"elkm1m_{prefix}"
+    else:
+        uid_start = "elkm1"
+
+    if uniqueness:
+        uniqueness = "_" + uniqueness.replace(":", "_")
+    else:
+        uniqueness = ""
+    return f"{uid_start}_{element.default_name('_')}{uniqueness}".lower()
+
+
 class ElkEntity(Entity):
     """Base class for all Elk entities."""
 
@@ -60,19 +84,7 @@ class ElkEntity(Entity):
         self._mac = elk_data.mac
         self._prefix = elk_data.prefix
         self._temperature_unit: str = elk_data.config["temperature_unit"]
-        # unique_id starts with elkm1_ iff there is no prefix
-        # it starts with elkm1m_{prefix} iff there is a prefix
-        # this is to avoid a conflict between
-        # prefix=foo, name=bar  (which would be elkm1_foo_bar)
-        #   - and -
-        # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
-        # we could have used elkm1__foo_bar for the latter, but that
-        # would have been a breaking change
-        if self._prefix != "":
-            uid_start = f"elkm1m_{self._prefix}"
-        else:
-            uid_start = "elkm1"
-        self._unique_id = f"{uid_start}_{self._element.default_name('_')}".lower()
+        self._unique_id = generate_unique_id(element, self._prefix)
         self._attr_name = element.name
 
     @property

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -16,5 +16,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["elkm1_lib"],
-  "requirements": ["elkm1-lib==2.2.13"]
+  "requirements": ["elkm1-lib==2.2.15"]
 }

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -16,5 +16,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["elkm1_lib"],
-  "requirements": ["elkm1-lib==2.2.15"]
+  "requirements": ["elkm1-lib==2.2.13"]
 }

--- a/homeassistant/components/elkm1/number.py
+++ b/homeassistant/components/elkm1/number.py
@@ -78,7 +78,7 @@ class ElkNumberSetting(ElkAttachedEntity, NumberEntity):
         else:
             self._attr_available = False
             _LOGGER.warning(
-                "Setting type for '%s' differ between the ElkM1 and the entity. Restart the integration to fix",
+                "Setting type for '%s' differs between the ElkM1 and the entity. Restart the integration to fix",
                 self.entity_id,
             )
 

--- a/homeassistant/components/elkm1/number.py
+++ b/homeassistant/components/elkm1/number.py
@@ -1,0 +1,87 @@
+"""Support for ElkM1 number entities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from elkm1_lib.const import SettingFormat
+from elkm1_lib.elements import Element
+from elkm1_lib.settings import Setting
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import ElkM1ConfigEntry
+from .entity import (
+    ElkAttachedEntity,
+    ElkEntity,
+    create_elk_entities,
+    generate_unique_id,
+)
+from .models import ELKM1Data
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ElkM1ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Elk-M1 number platform."""
+    elk_data = config_entry.runtime_data
+    elk = elk_data.elk
+    entities: list[ElkEntity] = []
+    number_settings = [
+        setting
+        for setting in cast(list[Setting], elk.settings)
+        if setting.value_format in (SettingFormat.NUMBER, SettingFormat.TIMER)
+    ]
+
+    create_elk_entities(
+        elk_data,
+        number_settings,
+        "setting",
+        ElkNumberSetting,
+        entities,
+    )
+    async_add_entities(entities)
+
+
+class ElkNumberSetting(ElkAttachedEntity, NumberEntity):
+    """Representation of an Elk-M1 Number Setting."""
+
+    _element: Setting
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 65535
+    _attr_native_step = 1
+
+    def __init__(self, element: Setting, elk: Any, elk_data: ELKM1Data) -> None:
+        """Initialize the number setting."""
+        super().__init__(element, elk, elk_data)
+        self._unique_id = generate_unique_id(
+            element, elk_data.prefix, elk_data.mac or "number"
+        )
+        if element.value_format == SettingFormat.TIMER:
+            self._attr_device_class = NumberDeviceClass.DURATION
+            self._attr_native_unit_of_measurement = UnitOfTime.SECONDS
+
+    def _element_changed(self, element: Element, changeset: dict[str, Any]) -> None:
+        # Guard against the panel possibly changing the underlying
+        # type without us knowing about the change
+        if isinstance(self._element.value, int):
+            self._attr_native_value = self._element.value
+        else:
+            self._attr_available = False
+            _LOGGER.warning(
+                "Setting type for '%s' differ between the ElkM1 and the entity. Restart the integration to fix",
+                self.entity_id,
+            )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value of the setting."""
+        self._element.set(int(value))

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -199,7 +199,9 @@ class ElkSetting(ElkSensor):
     _element: Setting
 
     def _element_changed(self, element: Element, changeset: dict[str, Any]) -> None:
-        self._attr_native_value = self._element.value
+        self._attr_native_value = (
+            None if self._element.value is None else str(self._element.value)
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/fluss/coordinator.py
+++ b/homeassistant/components/fluss/coordinator.py
@@ -1,7 +1,5 @@
 """DataUpdateCoordinator for Fluss+ integration."""
 
-from __future__ import annotations
-
 import asyncio
 from typing import Any
 

--- a/homeassistant/components/mitsubishi_comfort/__init__.py
+++ b/homeassistant/components/mitsubishi_comfort/__init__.py
@@ -1,7 +1,5 @@
 """Mitsubishi Comfort integration for Home Assistant."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 

--- a/homeassistant/components/mitsubishi_comfort/climate.py
+++ b/homeassistant/components/mitsubishi_comfort/climate.py
@@ -1,7 +1,5 @@
 """Climate entity for Mitsubishi Comfort integration."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from mitsubishi_comfort import FanSpeed, IndoorUnit, Mode, VaneDirection

--- a/homeassistant/components/mitsubishi_comfort/config_flow.py
+++ b/homeassistant/components/mitsubishi_comfort/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for Mitsubishi Comfort integration."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/homeassistant/components/mitsubishi_comfort/coordinator.py
+++ b/homeassistant/components/mitsubishi_comfort/coordinator.py
@@ -1,7 +1,5 @@
 """DataUpdateCoordinator for Mitsubishi Comfort devices."""
 
-from __future__ import annotations
-
 import logging
 
 from mitsubishi_comfort import IndoorUnit, KumoStation

--- a/homeassistant/components/mitsubishi_comfort/entity.py
+++ b/homeassistant/components/mitsubishi_comfort/entity.py
@@ -1,7 +1,5 @@
 """Base entity for Mitsubishi Comfort integration."""
 
-from __future__ import annotations
-
 from mitsubishi_comfort import IndoorUnit, KumoStation
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo

--- a/homeassistant/components/openai_conversation/tts.py
+++ b/homeassistant/components/openai_conversation/tts.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from openai import OpenAIError
 from propcache.api import cached_property
@@ -164,14 +164,15 @@ class OpenAITTSEntity(TextToSpeechEntity, OpenAIBaseLLMEntity):
         client = self.entry.runtime_data
 
         response_format = options[ATTR_PREFERRED_FORMAT]
-        if response_format not in self._supported_formats:
-            # common aliases
-            if response_format == "ogg":
-                response_format = "opus"
-            elif response_format == "raw":
-                response_format = "pcm"
-            else:
-                response_format = self.default_options[ATTR_PREFERRED_FORMAT]
+        if response_format in ("ogg", "oga"):
+            codec: Literal["mp3", "opus", "aac", "flac", "wav", "pcm"] = "opus"
+        elif response_format == "raw":
+            response_format = codec = "pcm"
+        elif response_format not in self._supported_formats:
+            response_format = self.default_options[ATTR_PREFERRED_FORMAT]
+            codec = response_format
+        else:
+            codec = response_format
 
         try:
             async with client.audio.speech.with_streaming_response.create(
@@ -180,7 +181,7 @@ class OpenAITTSEntity(TextToSpeechEntity, OpenAIBaseLLMEntity):
                 input=message,
                 instructions=str(options.get(CONF_PROMPT)),
                 speed=options.get(CONF_TTS_SPEED, RECOMMENDED_TTS_SPEED),
-                response_format=response_format,
+                response_format=codec,
             ) as response:
                 response_data = bytearray()
                 async for chunk in response.iter_bytes():

--- a/homeassistant/components/overkiz/services.py
+++ b/homeassistant/components/overkiz/services.py
@@ -1,7 +1,5 @@
 """Services for the Overkiz integration."""
 
-from __future__ import annotations
-
 import voluptuous as vol
 
 from homeassistant.components.cover import (

--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -56,6 +56,7 @@ PLATFORMS_BY_TYPE = {
     SupportedModels.HYGROMETER.value: [Platform.SENSOR],
     SupportedModels.HYGROMETER_CO2.value: [
         Platform.BUTTON,
+        Platform.NUMBER,
         Platform.SENSOR,
         Platform.SELECT,
     ],

--- a/homeassistant/components/switchbot/number.py
+++ b/homeassistant/components/switchbot/number.py
@@ -1,0 +1,79 @@
+"""Number platform for SwitchBot devices."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+import switchbot
+from switchbot import SwitchbotOperationError
+from switchbot.devices.meter_pro import MAX_TIME_OFFSET
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
+from .entity import SwitchbotEntity, exception_handler
+
+PARALLEL_UPDATES = 0
+SCAN_INTERVAL = timedelta(days=7)
+_LOGGER = logging.getLogger(__name__)
+_SECONDS_IN_MINUTE = 60
+_MAX_TIME_OFFSET_MINUTES = MAX_TIME_OFFSET // _SECONDS_IN_MINUTE
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SwitchbotConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up SwitchBot number platform."""
+    coordinator = entry.runtime_data
+
+    if isinstance(coordinator.device, switchbot.SwitchbotMeterProCO2):
+        async_add_entities(
+            [SwitchBotMeterProCO2DisplayTimeOffsetNumber(coordinator)], True
+        )
+
+
+class SwitchBotMeterProCO2DisplayTimeOffsetNumber(SwitchbotEntity, NumberEntity):
+    """Number entity to set the time offset for Meter Pro CO2 devices."""
+
+    _device: switchbot.SwitchbotMeterProCO2
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "display_time_offset"
+    _attr_native_min_value = -_MAX_TIME_OFFSET_MINUTES
+    _attr_native_max_value = _MAX_TIME_OFFSET_MINUTES
+    _attr_native_step = 1.0
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_should_poll = True
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: SwitchbotDataUpdateCoordinator) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.base_unique_id}_display_time_offset"
+
+    @exception_handler
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the time offset."""
+        _LOGGER.debug("Setting time offset to %s minutes for %s", value, self._address)
+        offset_minutes = round(value)
+        offset_seconds = offset_minutes * _SECONDS_IN_MINUTE
+        await self._device.set_time_offset(offset_seconds)
+        self._attr_native_value = offset_minutes
+        self.async_write_ha_state()
+
+    async def async_update(self) -> None:
+        """Fetch the latest time offset from the device."""
+        try:
+            offset_seconds = await self._device.get_time_offset()
+        except SwitchbotOperationError:
+            _LOGGER.debug(
+                "Failed to update time offset for %s", self._address, exc_info=True
+            )
+            return
+        self._attr_native_value = round(offset_seconds / _SECONDS_IN_MINUTE)

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -272,6 +272,11 @@
         }
       }
     },
+    "number": {
+      "display_time_offset": {
+        "name": "Display time offset"
+      }
+    },
     "select": {
       "time_format": {
         "name": "Time format",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6146,6 +6146,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "sensereo": {
+      "name": "Sensereo",
+      "iot_standards": [
+        "matter"
+      ]
+    },
     "sensibo": {
       "name": "Sensibo",
       "integration_type": "hub",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -8242,6 +8242,12 @@
         "zwave"
       ]
     },
+    "zunzunbee": {
+      "name": "Zunzunbee",
+      "iot_standards": [
+        "zigbee"
+      ]
+    },
     "zwave_js": {
       "name": "Z-Wave",
       "integration_type": "hub",

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -1,7 +1,5 @@
 """Helper to check the configuration file."""
 
-from __future__ import annotations
-
 from collections import OrderedDict
 import logging
 import os

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -40,7 +40,7 @@ hass-nabucasa==2.2.0
 hassil==3.5.0
 home-assistant-bluetooth==2.0.0
 home-assistant-frontend==20260429.2
-home-assistant-intents==2026.3.24
+home-assistant-intents==2026.5.5
 httpx==0.28.1
 ifaddr==0.2.0
 Jinja2==3.1.6

--- a/pylint/plugins/hass_async_load_fixtures.py
+++ b/pylint/plugins/hass_async_load_fixtures.py
@@ -1,7 +1,5 @@
 """Plugin for logger invocations."""
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter

--- a/pylint/plugins/hass_decorator.py
+++ b/pylint/plugins/hass_decorator.py
@@ -1,7 +1,5 @@
 """Plugin to check decorators."""
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter

--- a/pylint/plugins/hass_enforce_class_module.py
+++ b/pylint/plugins/hass_enforce_class_module.py
@@ -1,7 +1,5 @@
 """Plugin for checking if class is in correct module."""
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter

--- a/pylint/plugins/hass_enforce_config_entry_unique_id_no_ip.py
+++ b/pylint/plugins/hass_enforce_config_entry_unique_id_no_ip.py
@@ -9,8 +9,6 @@ IP/hostname-based unique IDs were the #1 unique ID review pattern, found in
 16.2% of new-integration PRs across 1,100+ analyzed PRs.
 """
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter

--- a/pylint/plugins/hass_enforce_config_flow_no_polling.py
+++ b/pylint/plugins/hass_enforce_config_flow_no_polling.py
@@ -8,8 +8,6 @@ device capabilities, and data freshness needs.
 Found in 3.5% of new-integration PRs across 1,100+ analyzed PRs, April 2026.
 """
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter

--- a/pylint/plugins/hass_enforce_greek_micro_char.py
+++ b/pylint/plugins/hass_enforce_greek_micro_char.py
@@ -1,7 +1,5 @@
 """Plugin for checking preferred coding of μ is used."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from astroid import nodes

--- a/pylint/plugins/hass_enforce_runtime_data.py
+++ b/pylint/plugins/hass_enforce_runtime_data.py
@@ -10,8 +10,6 @@ pull requests reviewed (69 occurrences), making it a high-value target for
 automated enforcement.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 from astroid import nodes

--- a/pylint/plugins/hass_enforce_sorted_platforms.py
+++ b/pylint/plugins/hass_enforce_sorted_platforms.py
@@ -1,7 +1,5 @@
 """Plugin for checking sorted platforms list."""
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter

--- a/pylint/plugins/hass_enforce_super_call.py
+++ b/pylint/plugins/hass_enforce_super_call.py
@@ -1,7 +1,5 @@
 """Plugin for checking super calls."""
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.interfaces import INFERENCE

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1,7 +1,5 @@
 """Plugin to enforce type hints on specific functions."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import Enum
 import re

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -1,7 +1,5 @@
 """Plugin for checking imports."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import re
 

--- a/pylint/plugins/hass_inheritance.py
+++ b/pylint/plugins/hass_inheritance.py
@@ -1,7 +1,5 @@
 """Plugin to enforce type hints on specific functions."""
 
-from __future__ import annotations
-
 import re
 
 from astroid import nodes

--- a/pylint/plugins/hass_logger.py
+++ b/pylint/plugins/hass_logger.py
@@ -1,7 +1,5 @@
 """Plugin for logger invocations."""
 
-from __future__ import annotations
-
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -895,6 +895,7 @@ mark-parentheses = false
 "async_timeout".msg = "use asyncio.timeout instead"
 "pytz".msg = "use zoneinfo instead"
 "tests".msg = "You should not import tests"
+"__future__.annotations".msg = "It should not be needed because Home Assistant requires Python 3.14+"
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ ha-ffmpeg==3.2.2
 hass-nabucasa==2.2.0
 hassil==3.5.0
 home-assistant-bluetooth==2.0.0
-home-assistant-intents==2026.3.24
+home-assistant-intents==2026.5.5
 httpx==0.28.1
 ifaddr==0.2.0
 infrared-protocols==2.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -892,7 +892,7 @@ elgato==5.1.2
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==2.2.13
+elkm1-lib==2.2.15
 
 # homeassistant.components.inels
 elkoep-aio-mqtt==0.1.0b4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1251,7 +1251,7 @@ holidays==0.95
 home-assistant-frontend==20260429.2
 
 # homeassistant.components.conversation
-home-assistant-intents==2026.3.24
+home-assistant-intents==2026.5.5
 
 # homeassistant.components.homekit
 homekit-audio-proxy==1.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -892,7 +892,7 @@ elgato==5.1.2
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==2.2.15
+elkm1-lib==2.2.13
 
 # homeassistant.components.inels
 elkoep-aio-mqtt==0.1.0b4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -792,7 +792,7 @@ elevenlabs==2.3.0
 elgato==5.1.2
 
 # homeassistant.components.elkm1
-elkm1-lib==2.2.15
+elkm1-lib==2.2.13
 
 # homeassistant.components.inels
 elkoep-aio-mqtt==0.1.0b4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1115,7 +1115,7 @@ holidays==0.95
 home-assistant-frontend==20260429.2
 
 # homeassistant.components.conversation
-home-assistant-intents==2026.3.24
+home-assistant-intents==2026.5.5
 
 # homeassistant.components.homekit
 homekit-audio-proxy==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -792,7 +792,7 @@ elevenlabs==2.3.0
 elgato==5.1.2
 
 # homeassistant.components.elkm1
-elkm1-lib==2.2.13
+elkm1-lib==2.2.15
 
 # homeassistant.components.inels
 elkoep-aio-mqtt==0.1.0b4

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -4,6 +4,8 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from duco.models import (
+    ApiEndpointInfo,
+    ApiInfo,
     BoardInfo,
     DiagComponent,
     DiagStatus,
@@ -49,6 +51,25 @@ def mock_board_info() -> BoardInfo:
         serial_duco_box="GHI789",
         serial_duco_comm="JKL012",
         time=1700000000,
+        public_api_version="2.5",
+        software_version="1.2.3",
+    )
+
+
+@pytest.fixture
+def mock_api_info() -> ApiInfo:
+    """Return mock API info."""
+    return ApiInfo(
+        api_version="2.5",
+        reported_api_version="2.5.1",
+        endpoints=[
+            ApiEndpointInfo(
+                url="/info",
+                query_parameters=["module", "submodule"],
+                methods=["GET"],
+                modules=["General", "Diag"],
+            )
+        ],
     )
 
 
@@ -180,6 +201,7 @@ def mock_nodes() -> list[Node]:
 
 @pytest.fixture
 def mock_duco_client(
+    mock_api_info: ApiInfo,
     mock_board_info: BoardInfo,
     mock_lan_info: LanInfo,
     mock_nodes: list[Node],
@@ -202,6 +224,7 @@ def mock_duco_client(
         ),
     ):
         client = mock_class.return_value
+        client.async_get_api_info.return_value = mock_api_info
         client.async_get_board_info.return_value = mock_board_info
         client.async_get_lan_info.return_value = mock_lan_info
         client.async_get_nodes.return_value = mock_nodes

--- a/tests/components/duco/snapshots/test_diagnostics.ambr
+++ b/tests/components/duco/snapshots/test_diagnostics.ambr
@@ -1,15 +1,19 @@
 # serializer version: 1
 # name: test_diagnostics
   dict({
+    'api_info': dict({
+      'public_api_version': '2.5',
+      'reported_api_version': '2.5.1',
+    }),
     'board_info': dict({
       'box_name': 'SILENT_CONNECT',
       'box_sub_type_name': 'Eu',
-      'public_api_version': None,
+      'public_api_version': '2.5',
       'serial_board_box': '**REDACTED**',
       'serial_board_comm': '**REDACTED**',
       'serial_duco_box': '**REDACTED**',
       'serial_duco_comm': '**REDACTED**',
-      'software_version': None,
+      'software_version': '1.2.3',
     }),
     'duco_diagnostics': list([
       dict({

--- a/tests/components/duco/test_diagnostics.py
+++ b/tests/components/duco/test_diagnostics.py
@@ -1,9 +1,11 @@
 """Tests for the Duco diagnostics."""
 
+from dataclasses import replace
 from http import HTTPStatus
 from unittest.mock import AsyncMock
 
 from duco.exceptions import DucoConnectionError
+from duco.models import ApiInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -24,7 +26,7 @@ async def test_diagnostics(
     mock_duco_client: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test diagnostics."""
+    """Test that the full diagnostics payload matches the snapshot."""
     assert (
         await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
         == snapshot
@@ -34,7 +36,12 @@ async def test_diagnostics(
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
     "failing_method",
-    ["async_get_lan_info", "async_get_diagnostics", "async_get_write_req_remaining"],
+    [
+        "async_get_api_info",
+        "async_get_lan_info",
+        "async_get_diagnostics",
+        "async_get_write_req_remaining",
+    ],
 )
 async def test_diagnostics_connection_error(
     hass: HomeAssistant,
@@ -54,3 +61,46 @@ async def test_diagnostics_connection_error(
         f"/api/diagnostics/config_entry/{mock_config_entry.entry_id}"
     )
     assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+async def test_diagnostics_without_optional_board_metadata(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test that None board fields are omitted from the diagnostics payload."""
+    # BoardInfo is a frozen dataclass, so the mock must be updated before
+    # integration setup — the coordinator stores board_info during async_setup.
+    mock_duco_client.async_get_board_info.return_value = replace(
+        mock_duco_client.async_get_board_info.return_value,
+        public_api_version=None,
+        software_version=None,
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert "public_api_version" not in diagnostics["board_info"]
+    assert "software_version" not in diagnostics["board_info"]
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_diagnostics_without_optional_api_metadata(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test diagnostics when optional API metadata is absent."""
+    mock_duco_client.async_get_api_info.return_value = ApiInfo(api_version="2.5")
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert diagnostics["api_info"] == {"public_api_version": "2.5"}

--- a/tests/components/ecovacs/test_config_flow.py
+++ b/tests/components/ecovacs/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test Ecovacs config flow."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import ssl
 from typing import Any
@@ -51,26 +51,6 @@ async def _test_user_flow(
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "auth"
-    assert not result["errors"]
-
-    return await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=user_input.auth,
-    )
-
-
-async def _test_user_flow_show_advanced_options(
-    hass: HomeAssistant,
-    user_input: _TestFnUserInput,
-) -> dict[str, Any]:
-    """Test config flow."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
-    )
-
-    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert not result["errors"]
 
@@ -90,37 +70,29 @@ async def _test_user_flow_show_advanced_options(
 
 
 @pytest.mark.parametrize(
-    ("test_fn", "test_fn_user_input", "entry_data"),
+    ("test_fn_user_input", "entry_data"),
     [
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
             VALID_ENTRY_DATA_CLOUD,
         ),
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
             VALID_ENTRY_DATA_SELF_HOSTED,
         ),
-        (
-            _test_user_flow,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-            VALID_ENTRY_DATA_CLOUD,
-        ),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted", "cloud"],
+    ids=["cloud", "self_hosted"],
 )
 async def test_user_flow(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_authenticator_authenticate: AsyncMock,
     mock_mqtt_client: Mock,
-    test_fn: Callable[[HomeAssistant, _TestFnUserInput], Awaitable[dict[str, Any]]],
     test_fn_user_input: _TestFnUserInput,
     entry_data: dict[str, Any],
 ) -> None:
     """Test the user config flow."""
-    result = await test_fn(hass, test_fn_user_input)
+    result = await _test_user_flow(hass, test_fn_user_input)
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == entry_data[CONF_USERNAME]
     assert result["data"] == entry_data
@@ -156,25 +128,18 @@ def _cannot_connect_error(user_input: dict[str, Any]) -> str:
     ids=["cannot_connect", "invalid_auth", "unknown"],
 )
 @pytest.mark.parametrize(
-    ("test_fn", "test_fn_user_input", "entry_data"),
+    ("test_fn_user_input", "entry_data"),
     [
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
             VALID_ENTRY_DATA_CLOUD,
         ),
         (
-            _test_user_flow_show_advanced_options,
             _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
             VALID_ENTRY_DATA_SELF_HOSTED_WITH_VALIDATE_CERT,
         ),
-        (
-            _test_user_flow,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-            VALID_ENTRY_DATA_CLOUD,
-        ),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted", "cloud"],
+    ids=["cloud", "self_hosted"],
 )
 async def test_user_flow_raise_error(
     hass: HomeAssistant,
@@ -185,7 +150,6 @@ async def test_user_flow_raise_error(
     reason_rest: str,
     side_effect_mqtt: Exception,
     errors_mqtt: Callable[[dict[str, Any]], str],
-    test_fn: Callable[[HomeAssistant, _TestFnUserInput], Awaitable[dict[str, Any]]],
     test_fn_user_input: _TestFnUserInput,
     entry_data: dict[str, Any],
 ) -> None:
@@ -194,7 +158,7 @@ async def test_user_flow_raise_error(
 
     # Authenticator raises error
     mock_authenticator_authenticate.side_effect = side_effect_rest
-    result = await test_fn(hass, test_fn_user_input)
+    result = await _test_user_flow(hass, test_fn_user_input)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "auth"
     assert result["errors"] == {"base": reason_rest}
@@ -240,7 +204,7 @@ async def test_user_flow_self_hosted_error(
 ) -> None:
     """Test handling selfhosted errors and custom ssl context."""
 
-    result = await _test_user_flow_show_advanced_options(
+    result = await _test_user_flow(
         hass,
         _TestFnUserInput(
             VALID_ENTRY_DATA_SELF_HOSTED
@@ -289,32 +253,21 @@ async def test_user_flow_self_hosted_error(
 
 
 @pytest.mark.parametrize(
-    ("test_fn", "test_fn_user_input"),
+    ("test_fn_user_input"),
     [
-        (
-            _test_user_flow_show_advanced_options,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-        ),
-        (
-            _test_user_flow_show_advanced_options,
-            _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
-        ),
-        (
-            _test_user_flow,
-            _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
-        ),
+        _TestFnUserInput(VALID_ENTRY_DATA_CLOUD),
+        _TestFnUserInput(VALID_ENTRY_DATA_SELF_HOSTED, _USER_STEP_SELF_HOSTED),
     ],
-    ids=["advanced_cloud", "advanced_self_hosted", "cloud"],
+    ids=["cloud", "self_hosted"],
 )
 async def test_already_exists(
     hass: HomeAssistant,
-    test_fn: Callable[[HomeAssistant, _TestFnUserInput], Awaitable[dict[str, Any]]],
     test_fn_user_input: _TestFnUserInput,
 ) -> None:
     """Test we don't allow duplicated config entries."""
     MockConfigEntry(domain=DOMAIN, data=test_fn_user_input.auth).add_to_hass(hass)
 
-    result = await test_fn(
+    result = await _test_user_flow(
         hass,
         test_fn_user_input,
     )

--- a/tests/components/mitsubishi_comfort/conftest.py
+++ b/tests/components/mitsubishi_comfort/conftest.py
@@ -1,7 +1,5 @@
 """Test fixtures for Mitsubishi Comfort integration."""
 
-from __future__ import annotations
-
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/components/mitsubishi_comfort/test_climate.py
+++ b/tests/components/mitsubishi_comfort/test_climate.py
@@ -1,7 +1,5 @@
 """Tests for the Mitsubishi Comfort climate entity."""
 
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/mitsubishi_comfort/test_config_flow.py
+++ b/tests/components/mitsubishi_comfort/test_config_flow.py
@@ -1,7 +1,5 @@
 """Tests for the Mitsubishi Comfort config flow."""
 
-from __future__ import annotations
-
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/mitsubishi_comfort/test_init.py
+++ b/tests/components/mitsubishi_comfort/test_init.py
@@ -1,7 +1,5 @@
 """Tests for the Mitsubishi Comfort integration setup."""
 
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock
 
 from mitsubishi_comfort import DeviceInfo

--- a/tests/components/openai_conversation/test_tts.py
+++ b/tests/components/openai_conversation/test_tts.py
@@ -118,6 +118,79 @@ async def test_tts(
     )
 
 
+@pytest.mark.parametrize(
+    ("preferred_format", "expected_response_format"),
+    [
+        ("ogg", "opus"),
+        ("oga", "opus"),
+        ("mp3", "mp3"),
+    ],
+)
+@pytest.mark.usefixtures("mock_init_component")
+async def test_tts_preferred_format(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_create_speech: MagicMock,
+    calls: list[ServiceCall],
+    preferred_format: str,
+    expected_response_format: str,
+) -> None:
+    """Test text to speech preferred format handling."""
+    mock_create_speech.return_value = [b"mock audio data"]
+
+    await hass.services.async_call(
+        tts.DOMAIN,
+        "speak",
+        {
+            ATTR_ENTITY_ID: "tts.openai_tts",
+            tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
+            tts.ATTR_MESSAGE: "There is a person at the front door.",
+            tts.ATTR_OPTIONS: {tts.ATTR_PREFERRED_FORMAT: preferred_format},
+        },
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    assert (
+        await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
+        == HTTPStatus.OK
+    )
+    mock_create_speech.assert_called_once_with(
+        model="gpt-4o-mini-tts",
+        voice="marin",
+        input="There is a person at the front door.",
+        instructions="",
+        speed=1.0,
+        response_format=expected_response_format,
+    )
+
+
+@pytest.mark.usefixtures("mock_init_component")
+async def test_tts_raw_preferred_format_returns_pcm(
+    hass: HomeAssistant,
+    mock_create_speech: MagicMock,
+) -> None:
+    """Test raw preferred format is returned as pcm."""
+    tts_entity = hass.data[tts.DOMAIN].get_entity("tts.openai_tts")
+    mock_create_speech.return_value = [b"mock audio data"]
+
+    result = await tts_entity.async_get_tts_audio(
+        "There is a person at the front door.",
+        "en-US",
+        {tts.ATTR_PREFERRED_FORMAT: "raw", tts.ATTR_VOICE: "marin"},
+    )
+
+    assert result == ("pcm", b"mock audio data")
+    mock_create_speech.assert_called_once_with(
+        model="gpt-4o-mini-tts",
+        voice="marin",
+        input="There is a person at the front door.",
+        instructions="",
+        speed=1.0,
+        response_format="pcm",
+    )
+
+
 @pytest.mark.usefixtures("mock_init_component")
 async def test_tts_error(
     hass: HomeAssistant,

--- a/tests/components/shelly/bluetooth/__init__.py
+++ b/tests/components/shelly/bluetooth/__init__.py
@@ -1,3 +1,1 @@
 """Bluetooth tests for Shelly integration."""
-
-from __future__ import annotations

--- a/tests/components/switchbot/test_number.py
+++ b/tests/components/switchbot/test_number.py
@@ -1,0 +1,167 @@
+"""Tests for the switchbot number platform."""
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.setup import async_setup_component
+
+from . import DOMAIN, WOMETERTHPC_SERVICE_INFO
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
+
+
+@pytest.mark.parametrize(
+    ("offset_seconds_on_device", "expected_state"),
+    [
+        (0, 0),
+        (60, 1),
+        (-60, -1),
+        (3600, 60),
+        (-3600, -60),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_meter_pro_co2_display_time_offset_initial_state(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    offset_seconds_on_device: int,
+    expected_state: int,
+) -> None:
+    """Test the display_time_offset entity gets the initial state from a MeterProCO2 device."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "switchbot.SwitchbotMeterProCO2.get_time_offset",
+        return_value=offset_seconds_on_device,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("number.test_name_display_time_offset")
+        assert state is not None
+        assert float(state.state) == expected_state
+
+
+@pytest.mark.parametrize(
+    ("time_offset", "expected_seconds_on_device"),
+    [
+        (0, 0),
+        (1, 60),
+        (-1, -60),
+        (5, 300),
+        (-5, -300),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_meter_pro_co2_set_display_time_offset(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    time_offset: int,
+    expected_seconds_on_device: int,
+) -> None:
+    """Test setting time offset on a MeterProCO2 device."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_time_offset = AsyncMock(return_value=60)
+    mock_set_time_offset = AsyncMock(return_value=True)
+
+    with (
+        patch(
+            "switchbot.SwitchbotMeterProCO2.get_time_offset",
+            mock_get_time_offset,
+        ),
+        patch(
+            "switchbot.SwitchbotMeterProCO2.set_time_offset",
+            mock_set_time_offset,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.test_name_display_time_offset",
+                ATTR_VALUE: time_offset,
+            },
+            blocking=True,
+        )
+
+        mock_set_time_offset.assert_awaited_once_with(expected_seconds_on_device)
+
+        state = hass.states.get("number.test_name_display_time_offset")
+        assert state is not None
+        assert float(state.state) == time_offset
+
+
+@pytest.mark.parametrize(
+    ("value"),
+    [
+        (300000),
+        (-300000),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_set_display_time_offset_out_of_range(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    value: int,
+) -> None:
+    """Test setting time offset with out-of-range values."""
+    await async_setup_component(hass, DOMAIN, {})
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    mock_get_time_offset = AsyncMock(return_value=0)
+    mock_set_time_offset = AsyncMock(return_value=True)
+
+    with (
+        patch(
+            "switchbot.SwitchbotMeterProCO2.get_time_offset",
+            mock_get_time_offset,
+        ),
+        patch(
+            "switchbot.SwitchbotMeterProCO2.set_time_offset",
+            mock_set_time_offset,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        with pytest.raises(
+            ServiceValidationError,
+            match=r"Value -?\d+\.0 for number\.test_name_display_time_offset is outside valid range",
+        ):
+            await hass.services.async_call(
+                NUMBER_DOMAIN,
+                SERVICE_SET_VALUE,
+                {
+                    ATTR_ENTITY_ID: "number.test_name_display_time_offset",
+                    ATTR_VALUE: value,
+                },
+                blocking=True,
+            )
+
+        mock_set_time_offset.assert_not_awaited()


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The ElkM1 settings sensor is overloaded. Break out the value to number platform. 

Docs will follow when the following features are added: break out settings to time platform, deprecate old settings sensor, and add a new action "switch_turn_on_for".

This PR is breaking out part of: https://github.com/home-assistant/core/pull/169393/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
