### PR TITLE
Add water_heater platform to Qube heat pump

### DIFF
--- a/homeassistant/components/hr_energy_qube/const.py
+++ b/homeassistant/components/hr_energy_qube/const.py
@@ -3,7 +3,12 @@
 from homeassistant.const import Platform
 
 DOMAIN = "hr_energy_qube"
-PLATFORMS = (Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH)
+PLATFORMS = (
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.WATER_HEATER,
+)
 
 DEFAULT_PORT = 502
 DEFAULT_SCAN_INTERVAL = 15

--- a/homeassistant/components/hr_energy_qube/strings.json
+++ b/homeassistant/components/hr_energy_qube/strings.json
@@ -215,7 +215,7 @@
       }
     },
     "water_heater": {
-      "dhw": {
+      "water_heater": {
         "name": "Domestic hot water"
       }
     }

--- a/homeassistant/components/hr_energy_qube/strings.json
+++ b/homeassistant/components/hr_energy_qube/strings.json
@@ -213,9 +213,17 @@
       "summer_mode": {
         "name": "Summer mode"
       }
+    },
+    "water_heater": {
+      "dhw": {
+        "name": "Domestic hot water"
+      }
     }
   },
   "exceptions": {
+    "set_temperature_failed": {
+      "message": "Failed to set the target temperature."
+    },
     "switch_command_failed": {
       "message": "Failed to send command to the heat pump."
     }

--- a/homeassistant/components/hr_energy_qube/water_heater.py
+++ b/homeassistant/components/hr_energy_qube/water_heater.py
@@ -58,7 +58,7 @@ class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
     ) -> None:
         """Initialize the water heater."""
         super().__init__(coordinator, entry)
-        self._attr_unique_id = f"{entry.entry_id}-water_heater"
+        self._attr_unique_id = entry.entry_id
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/hr_energy_qube/water_heater.py
+++ b/homeassistant/components/hr_energy_qube/water_heater.py
@@ -71,9 +71,12 @@ class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
         return self.coordinator.data.state.setpoint_dhw
 
     @property
-    def current_operation(self) -> str:
+    def current_operation(self) -> str | None:
         """Return the current operation mode."""
-        if self.coordinator.data.switches.get(DHW_BOOST_KEY):
+        boost = self.coordinator.data.switches.get(DHW_BOOST_KEY)
+        if boost is None:
+            return None
+        if boost:
             return STATE_PERFORMANCE
         return STATE_HEAT_PUMP
 

--- a/homeassistant/components/hr_energy_qube/water_heater.py
+++ b/homeassistant/components/hr_energy_qube/water_heater.py
@@ -49,7 +49,7 @@ class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
         WaterHeaterEntityFeature.TARGET_TEMPERATURE
         | WaterHeaterEntityFeature.OPERATION_MODE
     )
-    _attr_translation_key = "dhw"
+    _attr_translation_key = "water_heater"
 
     def __init__(
         self,
@@ -58,7 +58,7 @@ class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
     ) -> None:
         """Initialize the water heater."""
         super().__init__(coordinator, entry)
-        self._attr_unique_id = f"{entry.entry_id}-dhw"
+        self._attr_unique_id = f"{entry.entry_id}-water_heater"
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/hr_energy_qube/water_heater.py
+++ b/homeassistant/components/hr_energy_qube/water_heater.py
@@ -1,0 +1,116 @@
+"""Water heater platform for Qube Heat Pump."""
+
+from typing import Any
+
+from homeassistant.components.water_heater import (
+    STATE_HEAT_PUMP,
+    STATE_PERFORMANCE,
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import QubeConfigEntry
+from .const import DOMAIN
+from .coordinator import QubeCoordinator
+from .entity import QubeEntity
+
+PARALLEL_UPDATES = 1
+
+DHW_BOOST_KEY = "tapw_timeprogram_bms_forced"
+DHW_SETPOINT_KEY = "setpoint_dhw"
+DHW_MIN_TEMP = 40
+DHW_MAX_TEMP = 65
+
+OPERATION_MODES = [STATE_HEAT_PUMP, STATE_PERFORMANCE]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: QubeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Qube water heater."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities([QubeWaterHeater(coordinator, entry)])
+
+
+class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
+    """Qube DHW water heater entity."""
+
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_min_temp = DHW_MIN_TEMP
+    _attr_max_temp = DHW_MAX_TEMP
+    _attr_operation_list = OPERATION_MODES
+    _attr_supported_features = (
+        WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        | WaterHeaterEntityFeature.OPERATION_MODE
+    )
+    _attr_translation_key = "dhw"
+
+    def __init__(
+        self,
+        coordinator: QubeCoordinator,
+        entry: QubeConfigEntry,
+    ) -> None:
+        """Initialize the water heater."""
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}-dhw"
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current DHW temperature."""
+        return self.coordinator.data.state.temp_dhw
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the target DHW temperature."""
+        return self.coordinator.data.state.setpoint_dhw
+
+    @property
+    def current_operation(self) -> str:
+        """Return the current operation mode."""
+        if self.coordinator.data.switches.get(DHW_BOOST_KEY):
+            return STATE_PERFORMANCE
+        return STATE_HEAT_PUMP
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the target DHW temperature."""
+        temperature = kwargs.get("temperature")
+        if temperature is None:
+            return
+        try:
+            success = await self.coordinator.client.write_setpoint(
+                DHW_SETPOINT_KEY, temperature
+            )
+        except (ConnectionError, TimeoutError, OSError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_temperature_failed",
+            ) from err
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_temperature_failed",
+            )
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set the operation mode."""
+        boost = operation_mode == STATE_PERFORMANCE
+        try:
+            success = await self.coordinator.client.write_switch(DHW_BOOST_KEY, boost)
+        except (ConnectionError, TimeoutError, OSError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="switch_command_failed",
+            ) from err
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="switch_command_failed",
+            )
+        await self.coordinator.async_request_refresh()

--- a/tests/components/hr_energy_qube/conftest.py
+++ b/tests/components/hr_energy_qube/conftest.py
@@ -129,6 +129,7 @@ def mock_qube_client() -> Generator[MagicMock]:
             }
         )
         client.write_switch = AsyncMock(return_value=True)
+        client.write_setpoint = AsyncMock(return_value=True)
 
         yield client
 

--- a/tests/components/hr_energy_qube/conftest.py
+++ b/tests/components/hr_energy_qube/conftest.py
@@ -63,6 +63,7 @@ def mock_qube_client() -> Generator[MagicMock]:
         state.setpoint_room_cool_day = 25.0
         state.setpoint_room_cool_night = 23.0
         state.status_code = 1
+        state.setpoint_dhw = 50.0
 
         # Binary sensors - Outputs
         state.dout_srcpmp_val = True

--- a/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
+++ b/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
@@ -1,0 +1,70 @@
+# serializer version: 1
+# name: test_entities[water_heater.qube_heat_pump_domestic_hot_water-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max_temp': 65,
+      'min_temp': 40,
+      'operation_list': list([
+        'heat_pump',
+        'performance',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'water_heater',
+    'entity_category': None,
+    'entity_id': 'water_heater.qube_heat_pump_domestic_hot_water',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Domestic hot water',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Domestic hot water',
+    'platform': 'hr_energy_qube',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <WaterHeaterEntityFeature: 3>,
+    'translation_key': 'dhw',
+    'unique_id': '01JQUBEHEATPUMP00000000000-dhw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[water_heater.qube_heat_pump_domestic_hot_water-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 50.0,
+      'friendly_name': 'Qube heat pump Domestic hot water',
+      'max_temp': 65,
+      'min_temp': 40,
+      'operation_list': list([
+        'heat_pump',
+        'performance',
+      ]),
+      'operation_mode': 'heat_pump',
+      'supported_features': <WaterHeaterEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': None,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'water_heater.qube_heat_pump_domestic_hot_water',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_pump',
+  })
+# ---

--- a/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
+++ b/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
@@ -38,8 +38,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <WaterHeaterEntityFeature: 3>,
-    'translation_key': 'dhw',
-    'unique_id': '01JQUBEHEATPUMP00000000000-dhw',
+    'translation_key': 'water_heater',
+    'unique_id': '01JQUBEHEATPUMP00000000000-water_heater',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
+++ b/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
@@ -58,7 +58,7 @@
       'supported_features': <WaterHeaterEntityFeature: 3>,
       'target_temp_high': None,
       'target_temp_low': None,
-      'temperature': None,
+      'temperature': 50.0,
     }),
     'context': <ANY>,
     'entity_id': 'water_heater.qube_heat_pump_domestic_hot_water',

--- a/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
+++ b/tests/components/hr_energy_qube/snapshots/test_water_heater.ambr
@@ -39,7 +39,7 @@
     'suggested_object_id': None,
     'supported_features': <WaterHeaterEntityFeature: 3>,
     'translation_key': 'water_heater',
-    'unique_id': '01JQUBEHEATPUMP00000000000-water_heater',
+    'unique_id': '01JQUBEHEATPUMP00000000000',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/hr_energy_qube/test_water_heater.py
+++ b/tests/components/hr_energy_qube/test_water_heater.py
@@ -1,0 +1,161 @@
+"""Tests for the Qube Heat Pump water heater platform."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.water_heater import (
+    ATTR_OPERATION_MODE,
+    ATTR_TEMPERATURE,
+    DOMAIN as WATER_HEATER_DOMAIN,
+    SERVICE_SET_OPERATION_MODE,
+    SERVICE_SET_TEMPERATURE,
+    STATE_HEAT_PUMP,
+    STATE_PERFORMANCE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+ENTITY_ID = "water_heater.qube_heat_pump_domestic_hot_water"
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_qube_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test all water heater entities via snapshot."""
+    with patch(
+        "homeassistant.components.hr_energy_qube.PLATFORMS",
+        [Platform.WATER_HEATER],
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_set_temperature(
+    hass: HomeAssistant,
+    mock_qube_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting the target DHW temperature."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        WATER_HEATER_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 55},
+        blocking=True,
+    )
+
+    mock_qube_client.write_setpoint.assert_awaited_once_with("setpoint_dhw", 55)
+
+
+async def test_set_temperature_failure(
+    hass: HomeAssistant,
+    mock_qube_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set temperature raises HomeAssistantError on failure."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_qube_client.write_setpoint = AsyncMock(return_value=False)
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            WATER_HEATER_DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 55},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("operation_mode", "expected_boost"),
+    [
+        (STATE_PERFORMANCE, True),
+        (STATE_HEAT_PUMP, False),
+    ],
+)
+async def test_set_operation_mode(
+    hass: HomeAssistant,
+    mock_qube_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    operation_mode: str,
+    expected_boost: bool,
+) -> None:
+    """Test setting the operation mode."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        WATER_HEATER_DOMAIN,
+        SERVICE_SET_OPERATION_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_OPERATION_MODE: operation_mode},
+        blocking=True,
+    )
+
+    mock_qube_client.write_switch.assert_awaited_once_with(
+        "tapw_timeprogram_bms_forced", expected_boost
+    )
+
+
+async def test_current_operation_boost(
+    hass: HomeAssistant,
+    mock_qube_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test current operation reflects boost mode."""
+    mock_qube_client.read_all_switches.return_value["tapw_timeprogram_bms_forced"] = (
+        True
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["operation_mode"] == STATE_PERFORMANCE
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "return_value"),
+    [
+        (ConnectionError("Connection lost"), None),
+        (None, None),
+    ],
+)
+async def test_water_heater_unavailable_on_coordinator_error(
+    hass: HomeAssistant,
+    mock_qube_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    side_effect: Exception | None,
+    return_value: None,
+) -> None:
+    """Test water heater becomes unavailable when coordinator fails."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    mock_qube_client.get_all_data = AsyncMock(
+        side_effect=side_effect, return_value=return_value
+    )
+
+    freezer.tick(timedelta(seconds=31))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a water_heater entity to the hr_energy_qube integration for domestic hot water (DHW) control. This consolidates DHW temperature monitoring and control into a single entity instead of exposing DHW boost as a standalone switch.

- **Current temperature**: reads the DHW sensor (Modbus input register 30)
- **Target temperature**: reads and writes the user-defined DHW setpoint (Modbus holding register 173)
- **Operation modes**: heat_pump (normal) and performance (DHW boost via coil register)

As discussed in #169407, DHW boost fits better as a water_heater operation mode than a standalone switch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45217
- Link to developer documentation pull request: 
- Link to frontend pull request: 

**Note:** This PR depends on #169407 (switch platform) which adds the coordinator.switches attribute used by the water_heater to read the DHW boost coil state.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

