### PR TITLE
Fix KeyError in hydrawise

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -46,6 +46,11 @@ async def async_setup_entry(
     water_use_coordinator = HydrawiseWaterUseDataUpdateCoordinator(
         hass, config_entry, hydrawise, main_coordinator
     )
+    # async_track_zones is registered first on water_use_coordinator,
+    # so the water-use coordinator's data is in sync before
+    # callbacks below construct entities for newly added zones.
+    water_use_coordinator.async_track_zones()
+    main_coordinator.async_track_zones()
     await water_use_coordinator.async_config_entry_first_refresh()
     config_entry.runtime_data = HydrawiseUpdateCoordinators(
         main=main_coordinator,

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -116,14 +116,11 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
         if (water_use := self.water_use_coordinator) is not None and (
             water_use.data is not None
         ):
-            water_use.data = HydrawiseData(
-                user=self.data.user,
-                controllers=self.data.controllers,
-                zones=self.data.zones,
-                zone_id_to_controller=self.data.zone_id_to_controller,
-                sensors=self.data.sensors,
-                daily_water_summary=water_use.data.daily_water_summary,
-            )
+            water_use.data.user = self.data.user
+            water_use.data.controllers = self.data.controllers
+            water_use.data.zones = self.data.zones
+            water_use.data.zone_id_to_controller = self.data.zone_id_to_controller
+            water_use.data.sensors = self.data.sensors
 
         device_registry = dr.async_get(self.hass)
         devices = dr.async_entries_for_config_entry(

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -76,6 +76,7 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
             update_interval=MAIN_SCAN_INTERVAL,
         )
         self.api = api
+        self.water_use_coordinator: HydrawiseWaterUseDataUpdateCoordinator | None = None
         self.new_controllers_callbacks: list[
             Callable[[Iterable[Controller]], None]
         ] = []
@@ -108,6 +109,21 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
             # Despite what mypy thinks, this is still reachable. Without this check,
             # the test_connect_retry test in test_init.py fails.
             return  # type: ignore[unreachable]
+
+        # Sync the water_use coordinator's data references with the latest data
+        # so that callbacks below can construct entities that use the water_use
+        # coordinator and successfully resolve newly added zones.
+        if (water_use := self.water_use_coordinator) is not None and (
+            water_use.data is not None
+        ):
+            water_use.data = HydrawiseData(
+                user=self.data.user,
+                controllers=self.data.controllers,
+                zones=self.data.zones,
+                zone_id_to_controller=self.data.zone_id_to_controller,
+                sensors=self.data.sensors,
+                daily_water_summary=water_use.data.daily_water_summary,
+            )
 
         device_registry = dr.async_get(self.hass)
         devices = dr.async_entries_for_config_entry(
@@ -197,6 +213,7 @@ class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
         )
         self.api = api
         self._main_coordinator = main_coordinator
+        main_coordinator.water_use_coordinator = self
 
     async def _async_update_data(self) -> HydrawiseData:
         """Fetch the latest data from Hydrawise."""

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -76,13 +76,16 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
             update_interval=MAIN_SCAN_INTERVAL,
         )
         self.api = api
-        self.water_use_coordinator: HydrawiseWaterUseDataUpdateCoordinator | None = None
         self.new_controllers_callbacks: list[
             Callable[[Iterable[Controller]], None]
         ] = []
         self.new_zones_callbacks: list[
             Callable[[Iterable[tuple[Zone, Controller]]], None]
         ] = []
+
+    @callback
+    def async_track_zones(self) -> None:
+        """Begin tracking zone and controller add/remove on updates."""
         self.async_add_listener(self._add_remove_zones)
 
     async def _async_update_data(self) -> HydrawiseData:
@@ -109,18 +112,6 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
             # Despite what mypy thinks, this is still reachable. Without this check,
             # the test_connect_retry test in test_init.py fails.
             return  # type: ignore[unreachable]
-
-        # Sync the water_use coordinator's data references with the latest data
-        # so that callbacks below can construct entities that use the water_use
-        # coordinator and successfully resolve newly added zones.
-        if (water_use := self.water_use_coordinator) is not None and (
-            water_use.data is not None
-        ):
-            water_use.data.user = self.data.user
-            water_use.data.controllers = self.data.controllers
-            water_use.data.zones = self.data.zones
-            water_use.data.zone_id_to_controller = self.data.zone_id_to_controller
-            water_use.data.sensors = self.data.sensors
 
         device_registry = dr.async_get(self.hass)
         devices = dr.async_entries_for_config_entry(
@@ -210,7 +201,23 @@ class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
         )
         self.api = api
         self._main_coordinator = main_coordinator
-        main_coordinator.water_use_coordinator = self
+
+    @callback
+    def async_track_zones(self) -> None:
+        """Begin tracking zone and controller add/remove on updates."""
+        self._main_coordinator.async_add_listener(self._sync_data_from_main)
+
+    @callback
+    def _sync_data_from_main(self) -> None:
+        """Sync data references from the main coordinator after it updates."""
+        if self.data is None or self._main_coordinator.data is None:
+            return  # type: ignore[unreachable]
+        main_data = self._main_coordinator.data
+        self.data.user = main_data.user
+        self.data.controllers = main_data.controllers
+        self.data.zones = main_data.zones
+        self.data.zone_id_to_controller = main_data.zone_id_to_controller
+        self.data.sensors = main_data.sensors
 
     async def _async_update_data(self) -> HydrawiseData:
         """Fetch the latest data from Hydrawise."""

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -66,6 +66,12 @@ async def test_auto_add_devices(
     # 1 controller + 2 zones
     assert len(all_devices) == 3
 
+    # Sensors that use the water-use coordinator should exist for the initial zones.
+    assert hass.states.get("sensor.zone_one_daily_active_water_use") is not None
+    assert hass.states.get("sensor.zone_one_daily_active_watering_time") is not None
+    assert hass.states.get("sensor.zone_two_daily_active_water_use") is not None
+    assert hass.states.get("sensor.zone_two_daily_active_watering_time") is not None
+
     controller2 = deepcopy(controller)
     controller2.id += 10
     controller2.name += " 2"
@@ -99,6 +105,11 @@ async def test_auto_add_devices(
     )
     # 2 controllers + 4 zones
     assert len(all_devices) == 6
+
+    # Sensors that use the water-use coordinator must also be created for the
+    # newly added zones, even though the water-use coordinator hasn't refreshed.
+    assert hass.states.get("sensor.zone_one_2_daily_active_watering_time") is not None
+    assert hass.states.get("sensor.zone_two_2_daily_active_watering_time") is not None
 
 
 async def test_auto_remove_devices(


### PR DESCRIPTION
## Proposed change

Fixes a flaky `tests/components/hydrawise/test_init.py::test_auto_add_devices` test, e.g. as seen in https://github.com/home-assistant/core/actions/runs/25380264625/job/74427743302.

The Hydrawise integration uses two coordinators: a main coordinator (5-minute scan interval) and a water-use coordinator (60-minute scan interval). Each call to `HydrawiseMainDataUpdateCoordinator._async_update_data` constructs a brand-new `HydrawiseData` with new dicts for `controllers`, `zones`, `zone_id_to_controller`, etc. The water-use coordinator only refreshes its own data every 60 minutes, so between water-use refreshes its `data.zones` references the *previous* main dict and is missing any zones that were added to the main coordinator in the meantime.

When the main coordinator detected newly added zones, `_add_remove_zones` invoked the platform `new_zones_callbacks`. `sensor.py`'s callback constructed `HydrawiseSensor` entities against `coordinators.water_use`, and `HydrawiseEntity.__init__` looked up `self.zone` via `coordinator.data.zones[zone_id]` — which raised `KeyError` because water-use's data was stale. The exception broke out of the `for new_zone_callback in self.new_zones_callbacks` loop, so subsequent platform callbacks (binary_sensor / switch / valve) never ran. Whether the new zone devices ended up in the registry came down to the registration order of platform callbacks, which is non-deterministic because platforms set up concurrently via `async_forward_entry_setups` — hence the flakiness.

This PR keeps the water-use coordinator's data references in sync with main inside `_add_remove_zones`, so callbacks can resolve newly-added zones during entity construction. A back-reference (`water_use_coordinator`) is set on the main coordinator during water-use coordinator construction to avoid coupling to `runtime_data` (which isn't set until later in setup).

Verified locally: 50/50 runs of `test_auto_add_devices` pass after the fix; the full hydrawise test suite (35 tests) passes.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr