### PR TITLE
Add number entity to ElkM1 integration

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -72,6 +72,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.LIGHT,
+    Platform.NUMBER,
     Platform.SCENE,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/elkm1/entity.py
+++ b/homeassistant/components/elkm1/entity.py
@@ -47,6 +47,30 @@ def create_elk_entities(
     return entities
 
 
+def generate_unique_id(
+    element: Element, prefix: str, uniqueness: str | None = None
+) -> str:
+    """Generate a unique_id."""
+    # unique_id starts with elkm1_ iff there is no prefix
+    # it starts with elkm1m_{prefix} iff there is a prefix
+    # this is to avoid a conflict between
+    # prefix=foo, name=bar  (which would be elkm1_foo_bar)
+    #   - and -
+    # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
+    # we could have used elkm1__foo_bar for the latter, but that
+    # would have been a breaking change
+    if prefix != "":
+        uid_start = f"elkm1m_{prefix}"
+    else:
+        uid_start = "elkm1"
+
+    if uniqueness:
+        uniqueness = "_" + uniqueness.replace(":", "_")
+    else:
+        uniqueness = ""
+    return f"{uid_start}_{element.default_name('_')}{uniqueness}".lower()
+
+
 class ElkEntity(Entity):
     """Base class for all Elk entities."""
 
@@ -60,19 +84,7 @@ class ElkEntity(Entity):
         self._mac = elk_data.mac
         self._prefix = elk_data.prefix
         self._temperature_unit: str = elk_data.config["temperature_unit"]
-        # unique_id starts with elkm1_ iff there is no prefix
-        # it starts with elkm1m_{prefix} iff there is a prefix
-        # this is to avoid a conflict between
-        # prefix=foo, name=bar  (which would be elkm1_foo_bar)
-        #   - and -
-        # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
-        # we could have used elkm1__foo_bar for the latter, but that
-        # would have been a breaking change
-        if self._prefix != "":
-            uid_start = f"elkm1m_{self._prefix}"
-        else:
-            uid_start = "elkm1"
-        self._unique_id = f"{uid_start}_{self._element.default_name('_')}".lower()
+        self._unique_id = generate_unique_id(element, self._prefix)
         self._attr_name = element.name
 
     @property

--- a/homeassistant/components/elkm1/entity.py
+++ b/homeassistant/components/elkm1/entity.py
@@ -47,30 +47,6 @@ def create_elk_entities(
     return entities
 
 
-def generate_unique_id(
-    element: Element, prefix: str, uniqueness: str | None = None
-) -> str:
-    """Generate a unique_id."""
-    # unique_id starts with elkm1_ iff there is no prefix
-    # it starts with elkm1m_{prefix} iff there is a prefix
-    # this is to avoid a conflict between
-    # prefix=foo, name=bar  (which would be elkm1_foo_bar)
-    #   - and -
-    # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
-    # we could have used elkm1__foo_bar for the latter, but that
-    # would have been a breaking change
-    if prefix != "":
-        uid_start = f"elkm1m_{prefix}"
-    else:
-        uid_start = "elkm1"
-
-    if uniqueness:
-        uniqueness = "_" + uniqueness.replace(":", "_")
-    else:
-        uniqueness = ""
-    return f"{uid_start}_{element.default_name('_')}{uniqueness}".lower()
-
-
 class ElkEntity(Entity):
     """Base class for all Elk entities."""
 
@@ -84,7 +60,19 @@ class ElkEntity(Entity):
         self._mac = elk_data.mac
         self._prefix = elk_data.prefix
         self._temperature_unit: str = elk_data.config["temperature_unit"]
-        self._unique_id = generate_unique_id(element, self._prefix)
+        # unique_id starts with elkm1_ iff there is no prefix
+        # it starts with elkm1m_{prefix} iff there is a prefix
+        # this is to avoid a conflict between
+        # prefix=foo, name=bar  (which would be elkm1_foo_bar)
+        #   - and -
+        # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
+        # we could have used elkm1__foo_bar for the latter, but that
+        # would have been a breaking change
+        if self._prefix != "":
+            uid_start = f"elkm1m_{self._prefix}"
+        else:
+            uid_start = "elkm1"
+        self._unique_id = f"{uid_start}_{self._element.default_name('_')}".lower()
         self._attr_name = element.name
 
     @property

--- a/homeassistant/components/elkm1/number.py
+++ b/homeassistant/components/elkm1/number.py
@@ -1,0 +1,85 @@
+"""Support for ElkM1 number entities."""
+
+import logging
+from typing import Any, cast
+
+from elkm1_lib.const import SettingFormat
+from elkm1_lib.elements import Element
+from elkm1_lib.settings import Setting
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import ElkM1ConfigEntry
+from .entity import (
+    ElkAttachedEntity,
+    ElkEntity,
+    create_elk_entities,
+    generate_unique_id,
+)
+from .models import ELKM1Data
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ElkM1ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Elk-M1 number platform."""
+    elk_data = config_entry.runtime_data
+    elk = elk_data.elk
+    entities: list[ElkEntity] = []
+    number_settings = [
+        setting
+        for setting in cast(list[Setting], elk.settings)
+        if setting.value_format in (SettingFormat.NUMBER, SettingFormat.TIMER)
+    ]
+
+    create_elk_entities(
+        elk_data,
+        number_settings,
+        "setting",
+        ElkNumberSetting,
+        entities,
+    )
+    async_add_entities(entities)
+
+
+class ElkNumberSetting(ElkAttachedEntity, NumberEntity):
+    """Representation of an Elk-M1 Number Setting."""
+
+    _element: Setting
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 65535
+    _attr_native_step = 1
+
+    def __init__(self, element: Setting, elk: Any, elk_data: ELKM1Data) -> None:
+        """Initialize the number setting."""
+        super().__init__(element, elk, elk_data)
+        self._unique_id = generate_unique_id(
+            element, elk_data.prefix, elk_data.mac or "number"
+        )
+        if element.value_format == SettingFormat.TIMER:
+            self._attr_device_class = NumberDeviceClass.DURATION
+            self._attr_native_unit_of_measurement = UnitOfTime.SECONDS
+
+    def _element_changed(self, element: Element, changeset: dict[str, Any]) -> None:
+        # Guard against the panel possibly changing the underlying
+        # type without us knowing about the change
+        if isinstance(self._element.value, int):
+            self._attr_native_value = self._element.value
+        else:
+            self._attr_available = False
+            _LOGGER.warning(
+                "Setting type for '%s' differs between the ElkM1 and the entity. Restart the integration to fix",
+                self.entity_id,
+            )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value of the setting."""
+        self._element.set(int(value))

--- a/homeassistant/components/elkm1/number.py
+++ b/homeassistant/components/elkm1/number.py
@@ -13,12 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import ElkM1ConfigEntry
-from .entity import (
-    ElkAttachedEntity,
-    ElkEntity,
-    create_elk_entities,
-    generate_unique_id,
-)
+from .entity import ElkAttachedEntity, ElkEntity, create_elk_entities
 from .models import ELKM1Data
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,9 +56,6 @@ class ElkNumberSetting(ElkAttachedEntity, NumberEntity):
     def __init__(self, element: Setting, elk: Any, elk_data: ELKM1Data) -> None:
         """Initialize the number setting."""
         super().__init__(element, elk, elk_data)
-        self._unique_id = generate_unique_id(
-            element, elk_data.prefix, elk_data.mac or "number"
-        )
         if element.value_format == SettingFormat.TIMER:
             self._attr_device_class = NumberDeviceClass.DURATION
             self._attr_native_unit_of_measurement = UnitOfTime.SECONDS


### PR DESCRIPTION
## Proposed change

The ElkM1 settings sensor is overloaded. Break out the value to number platform. Recreated PR as I messed up a rebase (https://github.com/home-assistant/core/pull/169849)

Docs are updated for two future PRs adding a time entity and adding a new action "switch_turn_on_for". Also, there will be a PR for deprecating the existing sensor versions of Elk Settings.

This PR is breaking out part of: https://github.com/home-assistant/core/pull/169393/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45061
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
