### PR TITLE
smartthings: retain state for appliances when powered off

### DIFF
--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import FullDevice, SmartThingsConfigEntry
 from .const import INVALID_SWITCH_CATEGORIES, MAIN
 from .entity import SmartThingsEntity
+from .util import get_main_component_category
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -245,14 +246,6 @@ CAPABILITY_TO_SENSORS: dict[
         )
     },
 }
-
-
-def get_main_component_category(
-    device: FullDevice,
-) -> Category | str:
-    """Get the main component of a device."""
-    main = device.device.components[MAIN]
-    return main.user_category or main.manufacturer_category
 
 
 async def async_setup_entry(

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -121,4 +121,15 @@ INVALID_SWITCH_CATEGORIES = {
     Category.DISHWASHER,
 }
 
+APPLIANCE_CATEGORIES = {
+    Category.CLOTHING_CARE_MACHINE,
+    Category.COOKTOP,
+    Category.DISHWASHER,
+    Category.DRYER,
+    Category.MICROWAVE,
+    Category.OVEN,
+    Category.RANGE,
+    Category.WASHER,
+}
+
 UNIT_MAP = {"C": UnitOfTemperature.CELSIUS, "F": UnitOfTemperature.FAHRENHEIT}

--- a/homeassistant/components/smartthings/entity.py
+++ b/homeassistant/components/smartthings/entity.py
@@ -17,7 +17,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 from . import FullDevice
-from .const import DOMAIN, MAIN
+from .const import APPLIANCE_CATEGORIES, DOMAIN, MAIN
+from .util import get_main_component_category
 
 
 class SmartThingsEntity(Entity):
@@ -48,7 +49,7 @@ class SmartThingsEntity(Entity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device.device_id)},
         )
-        self._attr_available = device.online
+        self._attr_available = device.online or self._is_appliance()
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
@@ -69,8 +70,17 @@ class SmartThingsEntity(Entity):
         )
         self._update_attr()
 
+    def _is_appliance(self) -> bool:
+        """Return True if the device is an appliance that retains state when powered off."""
+        return get_main_component_category(self.device) in APPLIANCE_CATEGORIES
+
     def _availability_handler(self, event: DeviceHealthEvent) -> None:
-        self._attr_available = event.status != HealthStatus.OFFLINE
+        available = event.status == HealthStatus.ONLINE
+        if not available and self._is_appliance():
+            return
+        if available == self._attr_available:
+            return
+        self._attr_available = available
         self.async_write_ha_state()
 
     def _update_handler(self, event: DeviceEvent) -> None:

--- a/homeassistant/components/smartthings/entity.py
+++ b/homeassistant/components/smartthings/entity.py
@@ -75,9 +75,9 @@ class SmartThingsEntity(Entity):
         return get_main_component_category(self.device) in APPLIANCE_CATEGORIES
 
     def _availability_handler(self, event: DeviceHealthEvent) -> None:
-        available = event.status == HealthStatus.ONLINE
-        if not available and self._is_appliance():
+        if self._is_appliance() and event.status != HealthStatus.ONLINE:
             return
+        available = event.status != HealthStatus.OFFLINE
         if available == self._attr_available:
             return
         self._attr_available = available

--- a/homeassistant/components/smartthings/util.py
+++ b/homeassistant/components/smartthings/util.py
@@ -1,5 +1,7 @@
 """Utility functions for SmartThings integration."""
 
+from pysmartthings import Category
+
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity
 from homeassistant.core import HomeAssistant
@@ -10,7 +12,14 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
-from .const import DOMAIN
+from . import FullDevice
+from .const import DOMAIN, MAIN
+
+
+def get_main_component_category(device: FullDevice) -> Category | str:
+    """Get the category of the main component of a device."""
+    main = device.device.components[MAIN]
+    return main.user_category or main.manufacturer_category
 
 
 def deprecate_entity(

--- a/tests/components/smartthings/test_button.py
+++ b/tests/components/smartthings/test_button.py
@@ -10,11 +10,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.smartthings import MAIN
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    STATE_UNKNOWN,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er

--- a/tests/components/smartthings/test_button.py
+++ b/tests/components/smartthings/test_button.py
@@ -12,7 +12,6 @@ from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRE
 from homeassistant.components.smartthings import MAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     Platform,
 )
@@ -69,21 +68,25 @@ async def test_press(
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ks_microwave_0101x"])
+@pytest.mark.parametrize(
+    "health_status", [HealthStatus.OFFLINE, HealthStatus.UNHEALTHY]
+)
 async def test_availability(
     hass: HomeAssistant,
     devices: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    health_status: HealthStatus,
 ) -> None:
-    """Test availability."""
+    """Test that appliances retain their last state when powered off."""
     await setup_integration(hass, mock_config_entry)
 
     assert hass.states.get("button.microwave_stop").state == STATE_UNKNOWN
 
     await trigger_health_update(
-        hass, devices, "2bad3237-4886-e699-1b90-4a51a3d55c8a", HealthStatus.OFFLINE
+        hass, devices, "2bad3237-4886-e699-1b90-4a51a3d55c8a", health_status
     )
 
-    assert hass.states.get("button.microwave_stop").state == STATE_UNAVAILABLE
+    assert hass.states.get("button.microwave_stop").state == STATE_UNKNOWN
 
     await trigger_health_update(
         hass, devices, "2bad3237-4886-e699-1b90-4a51a3d55c8a", HealthStatus.ONLINE
@@ -98,9 +101,9 @@ async def test_availability_at_start(
     unavailable_device: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test unavailable at boot."""
+    """Test that appliances start with their last known state even when offline at boot."""
     await setup_integration(hass, mock_config_entry)
-    assert hass.states.get("button.microwave_stop").state == STATE_UNAVAILABLE
+    assert hass.states.get("button.microwave_stop").state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize("device_fixture", ["da_wm_dw_01011"])

--- a/tests/components/smartthings/test_number.py
+++ b/tests/components/smartthings/test_number.py
@@ -13,7 +13,7 @@ from homeassistant.components.number import (
     SERVICE_SET_VALUE,
 )
 from homeassistant.components.smartthings import MAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -88,21 +88,25 @@ async def test_state_update(
 
 
 @pytest.mark.parametrize("device_fixture", ["da_wm_wm_000001"])
+@pytest.mark.parametrize(
+    "health_status", [HealthStatus.OFFLINE, HealthStatus.UNHEALTHY]
+)
 async def test_availability(
     hass: HomeAssistant,
     devices: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    health_status: HealthStatus,
 ) -> None:
-    """Test availability."""
+    """Test that appliances retain their last state when powered off."""
     await setup_integration(hass, mock_config_entry)
 
     assert hass.states.get("number.washer_rinse_cycles").state == "2"
 
     await trigger_health_update(
-        hass, devices, "f984b91d-f250-9d42-3436-33f09a422a47", HealthStatus.OFFLINE
+        hass, devices, "f984b91d-f250-9d42-3436-33f09a422a47", health_status
     )
 
-    assert hass.states.get("number.washer_rinse_cycles").state == STATE_UNAVAILABLE
+    assert hass.states.get("number.washer_rinse_cycles").state == "2"
 
     await trigger_health_update(
         hass, devices, "f984b91d-f250-9d42-3436-33f09a422a47", HealthStatus.ONLINE
@@ -117,6 +121,6 @@ async def test_availability_at_start(
     unavailable_device: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test unavailable at boot."""
+    """Test that appliances start with their last known state even when offline at boot."""
     await setup_integration(hass, mock_config_entry)
-    assert hass.states.get("number.washer_rinse_cycles").state == STATE_UNAVAILABLE
+    assert hass.states.get("number.washer_rinse_cycles").state == "2"

--- a/tests/components/smartthings/test_select.py
+++ b/tests/components/smartthings/test_select.py
@@ -14,7 +14,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.components.smartthings import MAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -158,21 +158,23 @@ async def test_select_option_without_remote_control(
 
 
 @pytest.mark.parametrize("device_fixture", ["da_wm_wd_000001"])
+@pytest.mark.parametrize("health_status", [HealthStatus.OFFLINE, HealthStatus.UNHEALTHY])
 async def test_availability(
     hass: HomeAssistant,
     devices: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    health_status: HealthStatus,
 ) -> None:
-    """Test availability."""
+    """Test that appliances retain their last state when powered off."""
     await setup_integration(hass, mock_config_entry)
 
     assert hass.states.get("select.dryer").state == "stop"
 
     await trigger_health_update(
-        hass, devices, "02f7256e-8353-5bdd-547f-bd5b1647e01b", HealthStatus.OFFLINE
+        hass, devices, "02f7256e-8353-5bdd-547f-bd5b1647e01b", health_status
     )
 
-    assert hass.states.get("select.dryer").state == STATE_UNAVAILABLE
+    assert hass.states.get("select.dryer").state == "stop"
 
     await trigger_health_update(
         hass, devices, "02f7256e-8353-5bdd-547f-bd5b1647e01b", HealthStatus.ONLINE
@@ -187,9 +189,9 @@ async def test_availability_at_start(
     unavailable_device: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test unavailable at boot."""
+    """Test that appliances start with their last known state even when offline at boot."""
     await setup_integration(hass, mock_config_entry)
-    assert hass.states.get("select.dryer").state == STATE_UNAVAILABLE
+    assert hass.states.get("select.dryer").state == "stop"
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_rac_000003"])

--- a/tests/components/smartthings/test_select.py
+++ b/tests/components/smartthings/test_select.py
@@ -158,7 +158,9 @@ async def test_select_option_without_remote_control(
 
 
 @pytest.mark.parametrize("device_fixture", ["da_wm_wd_000001"])
-@pytest.mark.parametrize("health_status", [HealthStatus.OFFLINE, HealthStatus.UNHEALTHY])
+@pytest.mark.parametrize(
+    "health_status", [HealthStatus.OFFLINE, HealthStatus.UNHEALTHY]
+)
 async def test_availability(
     hass: HomeAssistant,
     devices: AsyncMock,


### PR DESCRIPTION
## Proposed change

Samsung appliances (washers, dryers, dishwashers, ovens, ranges, etc.) report `HealthStatus.OFFLINE` when physically powered off — not just when network-disconnected. Since the SmartThings integration rewrite in 2025.6, every `OFFLINE` event unconditionally marks all entities as `unavailable`, breaking automations that depend on appliance state (e.g. \"notify me when the wash is finished\").

This fix makes appliance entities retain their last-known state instead of going `unavailable` when the device powers off. Non-appliance devices (lights, switches, AC units, TVs) continue to go `unavailable` on `OFFLINE` as before — for those, `OFFLINE` means genuinely unreachable and the state is unknown.

The fix also corrects boot-time behaviour: appliances that are offline when HA starts now show their last-known state immediately, since `get_device_status()` is always called before `get_device_health()` during setup, so `_internal_state` is fully populated regardless of online status.

### Changes

- **`const.py`** — Adds `APPLIANCE_CATEGORIES` covering device categories that emit `OFFLINE` during normal power-off (`WASHER`, `DRYER`, `DISHWASHER`, `OVEN`, `RANGE`, `COOKTOP`, `MICROWAVE`, `CLOTHING_CARE_MACHINE`). Kept separate from `INVALID_SWITCH_CATEGORIES` because the sets serve different purposes and have different members.
- **`util.py`** — Promotes `get_main_component_category()` from `binary_sensor.py` into the shared utility module so `entity.py` can use it without duplicating the logic.
- **`binary_sensor.py`** — Removes the now-duplicate local definition; imports from `util.py`.
- **`entity.py`** — Adds `_is_appliance()` method; rewrites `_availability_handler` with a flat two-guard pattern that retains state for appliance devices on `OFFLINE` and `UNHEALTHY` events while avoiding spurious `async_write_ha_state()` calls; updates the constructor to initialise appliances as available at boot.
- **`test_select.py`** — Updates existing dryer availability tests to assert state is retained; parametrizes over both `HealthStatus.OFFLINE` and `HealthStatus.UNHEALTHY` to cover all non-`ONLINE` statuses.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #146959

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr