### PR TITLE
Add second audio channel for voice

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -932,6 +932,7 @@ class PipelineRun:
                 {
                     "engine": engine,
                     "metadata": asdict(metadata),
+                    "audio_processing": asdict(self.stt_provider.audio_processing),
                 },
             )
         )

--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -146,6 +146,8 @@ class EsphomeAssistSatellite(
         )
 
         self._active_pipeline_index = 0
+        self._active_audio_channel = 0
+        self._has_multi_channel_audio = False
 
     def _get_entity_id(self, suffix: str) -> str | None:
         """Return the entity id for pipeline select, etc."""
@@ -291,6 +293,9 @@ class EsphomeAssistSatellite(
                 assist_satellite.AssistSatelliteEntityFeature.START_CONVERSATION
             )
 
+        if feature_flags & VoiceAssistantFeature.MULTI_CHANNEL_AUDIO:
+            self._has_multi_channel_audio = True
+
         # Update wake word select when config is updated
         self.async_on_remove(
             self._entry_data.async_register_assist_satellite_set_wake_words_callback(
@@ -315,6 +320,18 @@ class EsphomeAssistSatellite(
 
         data_to_send: dict[str, Any] = {}
         if event_type == VoiceAssistantEventType.VOICE_ASSISTANT_STT_START:
+            if (
+                self._has_multi_channel_audio
+                and event.data
+                and (audio_processing := event.data.get("audio_processing"))
+            ):
+                # Settings come from stt SpeechAudioProcessing
+                if (audio_processing.get("prefers_auto_gain_enabled") is False) and (
+                    audio_processing.get("prefers_noise_reduction_enabled") is False
+                ):
+                    # Use non-enhanced audio
+                    self._active_audio_channel = 1
+
             self._entry_data.async_set_assist_pipeline_state(True)
         elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_STT_END:
             assert event.data is not None
@@ -533,6 +550,10 @@ class EsphomeAssistSatellite(
             # Try next wake word select
             maybe_pipeline_index += 1
 
+        # Default to audio channel 0 (enhanced)
+        # May be changed when STT_START event arrives.
+        self._active_audio_channel = 0
+
         _LOGGER.debug(
             "Running pipeline %s from %s to %s",
             self._active_pipeline_index + 1,
@@ -555,9 +576,20 @@ class EsphomeAssistSatellite(
 
         return port
 
-    async def handle_audio(self, data: bytes) -> None:
+    async def handle_audio(self, data: bytes, data2: bytes | None = None) -> None:
         """Handle incoming audio chunk from API."""
-        self._audio_queue.put_nowait(data)
+        # Default to enhanced audio (channel 0)
+        active_data = data
+
+        if (
+            self._has_multi_channel_audio
+            and (data2 is not None)
+            and (self._active_audio_channel == 1)
+        ):
+            # Non-enhanced audio (channel 1)
+            active_data = data2
+
+        self._audio_queue.put_nowait(active_data)
 
     async def handle_pipeline_stop(self, abort: bool) -> None:
         """Handle request for pipeline to stop."""

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -17,7 +17,7 @@
   "mqtt": ["esphome/discover/#"],
   "quality_scale": "platinum",
   "requirements": [
-    "aioesphomeapi==44.24.1",
+    "aioesphomeapi==45.0.0",
     "esphome-dashboard-api==1.3.0",
     "bleak-esphome==3.7.3"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -254,7 +254,7 @@ aioelectricitymaps==1.1.1
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==44.24.1
+aioesphomeapi==45.0.0
 
 # homeassistant.components.matrix
 # homeassistant.components.slack

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -245,7 +245,7 @@ aioelectricitymaps==1.1.1
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==44.24.1
+aioesphomeapi==45.0.0
 
 # homeassistant.components.matrix
 # homeassistant.components.slack

--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -17,6 +17,11 @@
     }),
     dict({
       'data': dict({
+        'audio_processing': dict({
+          'prefers_auto_gain_enabled': True,
+          'prefers_noise_reduction_enabled': True,
+          'requires_external_vad': True,
+        }),
         'engine': 'stt.mock_stt',
         'metadata': dict({
           'bit_rate': <AudioBitRates.BITRATE_16: 16>,
@@ -119,6 +124,11 @@
     }),
     dict({
       'data': dict({
+        'audio_processing': dict({
+          'prefers_auto_gain_enabled': True,
+          'prefers_noise_reduction_enabled': True,
+          'requires_external_vad': True,
+        }),
         'engine': 'stt.mock_stt',
         'metadata': dict({
           'bit_rate': <AudioBitRates.BITRATE_16: 16>,
@@ -221,6 +231,11 @@
     }),
     dict({
       'data': dict({
+        'audio_processing': dict({
+          'prefers_auto_gain_enabled': True,
+          'prefers_noise_reduction_enabled': True,
+          'requires_external_vad': True,
+        }),
         'engine': 'test',
         'metadata': dict({
           'bit_rate': <AudioBitRates.BITRATE_16: 16>,
@@ -347,6 +362,11 @@
     }),
     dict({
       'data': dict({
+        'audio_processing': dict({
+          'prefers_auto_gain_enabled': True,
+          'prefers_noise_reduction_enabled': True,
+          'requires_external_vad': True,
+        }),
         'engine': 'stt.mock_stt',
         'metadata': dict({
           'bit_rate': <AudioBitRates.BITRATE_16: 16>,
@@ -449,6 +469,11 @@
     }),
     dict({
       'data': dict({
+        'audio_processing': dict({
+          'prefers_auto_gain_enabled': True,
+          'prefers_noise_reduction_enabled': True,
+          'requires_external_vad': True,
+        }),
         'engine': 'stt.mock_stt',
         'metadata': dict({
           'bit_rate': <AudioBitRates.BITRATE_16: 16>,

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -18,6 +18,11 @@
 # ---
 # name: test_audio_pipeline.1
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,
@@ -112,6 +117,11 @@
 # ---
 # name: test_audio_pipeline_debug.1
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,
@@ -218,6 +228,11 @@
 # ---
 # name: test_audio_pipeline_with_enhancements.1
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,
@@ -334,6 +349,11 @@
 # ---
 # name: test_audio_pipeline_with_wake_word_no_timeout.3
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,
@@ -461,6 +481,11 @@
 # ---
 # name: test_device_capture.1
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,
@@ -488,6 +513,11 @@
 # ---
 # name: test_device_capture_override.1
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,
@@ -537,6 +567,11 @@
 # ---
 # name: test_device_capture_queue_full.1
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,
@@ -761,6 +796,11 @@
 # ---
 # name: test_stt_stream_failed.1
   dict({
+    'audio_processing': dict({
+      'prefers_auto_gain_enabled': True,
+      'prefers_noise_reduction_enabled': True,
+      'requires_external_vad': True,
+    }),
     'engine': 'stt.mock_stt',
     'metadata': dict({
       'bit_rate': 16,

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -2290,3 +2290,138 @@ async def test_custom_wake_words(
     # Check non-existent wake word
     req = await http_client.get("/api/esphome/wake_words/wrong_wake_word.json")
     assert req.status == HTTPStatus.NOT_FOUND
+
+
+async def test_multichannel_audio(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test that stt-start event can switch audio channels."""
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "voice_assistant_feature_flags": VoiceAssistantFeature.VOICE_ASSISTANT
+            | VoiceAssistantFeature.SPEAKER
+            | VoiceAssistantFeature.API_AUDIO
+            | VoiceAssistantFeature.MULTI_CHANNEL_AUDIO
+        },
+    )
+    await hass.async_block_till_done()
+
+    satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)
+    assert satellite is not None
+
+    pipeline_finished = asyncio.Event()
+
+    async def async_pipeline_from_audio_stream(*args, **kwargs):
+        event_callback = kwargs["event_callback"]
+
+        # STT
+        event_callback(
+            PipelineEvent(
+                type=PipelineEventType.STT_START,
+                data={
+                    "engine": "test-stt-engine",
+                    "metadata": {},
+                    "audio_processing": {
+                        # Request non-enhanced audio (channel 1)
+                        "prefers_auto_gain_enabled": False,
+                        "prefers_noise_reduction_enabled": False,
+                    },
+                },
+            )
+        )
+
+        stt_stream = kwargs["stt_stream"]
+
+        chunks = [chunk async for chunk in stt_stream]
+
+        # Verify correct channel
+        assert chunks == [b"channel 1"]
+
+        pipeline_finished.set()
+
+    with (
+        patch(
+            "homeassistant.components.assist_satellite.entity.async_pipeline_from_audio_stream",
+            new=async_pipeline_from_audio_stream,
+        ),
+    ):
+        async with asyncio.timeout(1):
+            await satellite.handle_pipeline_start(
+                conversation_id="",
+                flags=VoiceAssistantCommandFlag(0),  # stt
+                audio_settings=VoiceAssistantAudioSettings(),
+                wake_word_phrase=None,
+            )
+            await satellite.handle_audio(b"channel 0", b"channel 1")
+            await satellite.handle_pipeline_stop(abort=False)
+            await pipeline_finished.wait()
+
+
+async def test_multichannel_audio_fallback_channel_0(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test that channel 0 is used if multi-channel audio isn't supported."""
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "voice_assistant_feature_flags": VoiceAssistantFeature.VOICE_ASSISTANT
+            | VoiceAssistantFeature.SPEAKER
+            | VoiceAssistantFeature.API_AUDIO
+        },
+    )
+    await hass.async_block_till_done()
+
+    satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)
+    assert satellite is not None
+
+    pipeline_finished = asyncio.Event()
+
+    async def async_pipeline_from_audio_stream(*args, **kwargs):
+        event_callback = kwargs["event_callback"]
+
+        # STT
+        event_callback(
+            PipelineEvent(
+                type=PipelineEventType.STT_START,
+                data={
+                    "engine": "test-stt-engine",
+                    "metadata": {},
+                    "audio_processing": {
+                        # Request non-enhanced audio (channel 1)
+                        "prefers_auto_gain_enabled": False,
+                        "prefers_noise_reduction_enabled": False,
+                    },
+                },
+            )
+        )
+
+        stt_stream = kwargs["stt_stream"]
+
+        chunks = [chunk async for chunk in stt_stream]
+
+        # Non-enhanced audio (channel 1) was requested, but it isn't supported.
+        assert chunks == [b"channel 0"]
+
+        pipeline_finished.set()
+
+    with (
+        patch(
+            "homeassistant.components.assist_satellite.entity.async_pipeline_from_audio_stream",
+            new=async_pipeline_from_audio_stream,
+        ),
+    ):
+        async with asyncio.timeout(1):
+            await satellite.handle_pipeline_start(
+                conversation_id="",
+                flags=VoiceAssistantCommandFlag(0),  # stt
+                audio_settings=VoiceAssistantAudioSettings(),
+                wake_word_phrase=None,
+            )
+            await satellite.handle_audio(b"channel 0", b"channel 1")
+            await satellite.handle_pipeline_stop(abort=False)
+            await pipeline_finished.wait()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**NOTE:** This PR includes a bump of `aioesphomeapi` that **MUST** occur at the same time because of a breaking change to the `handle_audio` method.

Adds a second audio channel to voice API audio. This allows for providing the best audio for different parts of the voice pipeline: https://github.com/home-assistant/architecture/discussions/1364

This code assumes that channel 0 (the default) contains "enhanced" audio with automatic gain control, noise suppression, etc. and that channel 1 (new) contains "unenhanced" audio. 

When the voice assistant has the `MULTI_CHANNEL_AUDIO` feature flag, a second "unenhanced" audio channel may be preset as `data2` in the `handle_audio` method of the ESPHome Assist Satellite entity. The `STT_START` voice event is checked for the audio preferences of the pipeline's speech-to-text entity. If the `stt` entity prefers **not** to have automatic gain control and noise suppression, then channel 1 is selected for the pipeline run.

- esphome PR - https://github.com/esphome/esphome/pull/16265
- aioesphomeapi PR - https://github.com/esphome/aioesphomeapi/pull/1625

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
