### PR TITLE
Migrate ZBT-1 and ZBT-2 to use serial number for unique_id

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/__init__.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/__init__.py
@@ -147,9 +147,7 @@ async def async_migrate_entry(
                     serial_number,
                     config_entry.entry_id,
                 )
-                hass.async_create_task(
-                    hass.config_entries.async_remove(duplicate.entry_id)
-                )
+                await hass.config_entries.async_remove(duplicate.entry_id)
 
             # Replace the synthetic unique ID with the USB serial number
             hass.config_entries.async_update_entry(

--- a/homeassistant/components/homeassistant_connect_zbt2/__init__.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DEVICE, DOMAIN, NABU_CASA_FIRMWARE_RELEASES_URL
+from .const import DEVICE, DOMAIN, NABU_CASA_FIRMWARE_RELEASES_URL, SERIAL_NUMBER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,3 +95,36 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, ["switch", "update"])
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: HomeAssistantConnectZBT2ConfigEntry
+) -> bool:
+    """Migrate old entry."""
+
+    _LOGGER.debug(
+        "Migrating from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    if config_entry.version == 1:
+        if config_entry.minor_version == 1:
+            # Replace the synthetic unique ID with the USB serial number
+            hass.config_entries.async_update_entry(
+                config_entry,
+                unique_id=config_entry.data[SERIAL_NUMBER],
+                version=1,
+                minor_version=2,
+            )
+
+        _LOGGER.debug(
+            "Migration to version %s.%s successful",
+            config_entry.version,
+            config_entry.minor_version,
+        )
+
+        return True
+
+    # This means the user has downgraded from a future version
+    return False

--- a/homeassistant/components/homeassistant_connect_zbt2/__init__.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.components.homeassistant_hardware.coordinator import (
     FirmwareUpdateCoordinator,
 )
 from homeassistant.components.usb import USBDevice, async_register_port_event_callback
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
@@ -118,27 +118,38 @@ async def async_migrate_entry(
 
             # Installations ended up with multiple config entries per physical adapter
             # in 2026.5.0 and 2026.5.1. We need to delete the older entry.
-            same_serial = [
+            duplicates = [
                 entry
                 for entry in hass.config_entries.async_entries(DOMAIN)
                 if entry.data.get(SERIAL_NUMBER) == serial_number
             ]
             canonical = max(
-                same_serial,
-                key=lambda e: (e.minor_version, e.modified_at, e.entry_id),
+                duplicates,
+                key=lambda e: (
+                    e.source != SOURCE_IGNORE,
+                    e.disabled_by is None,
+                    e.minor_version,
+                    e.modified_at,
+                    e.entry_id,
+                ),
             )
 
             if canonical.entry_id != config_entry.entry_id:
+                # The canonical entry's migration will remove this duplicate.
+                return False
+
+            for duplicate in duplicates:
+                if duplicate.entry_id == config_entry.entry_id:
+                    continue
                 _LOGGER.debug(
                     "Removing duplicate config entry %s for serial %s in favor of %s",
-                    config_entry.entry_id,
+                    duplicate.entry_id,
                     serial_number,
-                    canonical.entry_id,
+                    config_entry.entry_id,
                 )
                 hass.async_create_task(
-                    hass.config_entries.async_remove(config_entry.entry_id)
+                    hass.config_entries.async_remove(duplicate.entry_id)
                 )
-                return False
 
             # Replace the synthetic unique ID with the USB serial number
             hass.config_entries.async_update_entry(

--- a/homeassistant/components/homeassistant_connect_zbt2/__init__.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/__init__.py
@@ -108,6 +108,10 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if config_entry.version == 1:
         if config_entry.minor_version == 1:
             # Replace the synthetic unique ID with the USB serial number

--- a/homeassistant/components/homeassistant_connect_zbt2/__init__.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/__init__.py
@@ -114,10 +114,36 @@ async def async_migrate_entry(
 
     if config_entry.version == 1:
         if config_entry.minor_version == 1:
+            serial_number = config_entry.data[SERIAL_NUMBER]
+
+            # Installations ended up with multiple config entries per physical adapter
+            # in 2026.5.0 and 2026.5.1. We need to delete the older entry.
+            same_serial = [
+                entry
+                for entry in hass.config_entries.async_entries(DOMAIN)
+                if entry.data.get(SERIAL_NUMBER) == serial_number
+            ]
+            canonical = max(
+                same_serial,
+                key=lambda e: (e.minor_version, e.modified_at, e.entry_id),
+            )
+
+            if canonical.entry_id != config_entry.entry_id:
+                _LOGGER.debug(
+                    "Removing duplicate config entry %s for serial %s in favor of %s",
+                    config_entry.entry_id,
+                    serial_number,
+                    canonical.entry_id,
+                )
+                hass.async_create_task(
+                    hass.config_entries.async_remove(config_entry.entry_id)
+                )
+                return False
+
             # Replace the synthetic unique ID with the USB serial number
             hass.config_entries.async_update_entry(
                 config_entry,
-                unique_id=config_entry.data[SERIAL_NUMBER],
+                unique_id=serial_number,
                 version=1,
                 minor_version=2,
             )

--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -14,10 +14,7 @@ from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
 )
-from homeassistant.components.usb import (
-    usb_service_info_from_device,
-    usb_unique_id_from_service_info,
-)
+from homeassistant.components.usb import usb_service_info_from_device
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigEntryBaseFlow,
@@ -112,7 +109,7 @@ class HomeAssistantConnectZBT2ConfigFlow(
     """Handle a config flow for Home Assistant Connect ZBT-2."""
 
     VERSION = 1
-    MINOR_VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the config flow."""
@@ -130,14 +127,12 @@ class HomeAssistantConnectZBT2ConfigFlow(
 
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle usb discovery."""
-        unique_id = usb_unique_id_from_service_info(discovery_info)
-
         discovery_info.device = await self.hass.async_add_executor_job(
             usb.get_serial_by_id, discovery_info.device
         )
 
         try:
-            await self.async_set_unique_id(unique_id)
+            await self.async_set_unique_id(discovery_info.serial_number)
         finally:
             self._abort_if_unique_id_configured(updates={DEVICE: discovery_info.device})
 
@@ -155,9 +150,10 @@ class HomeAssistantConnectZBT2ConfigFlow(
         """Handle import from ZHA/OTBR firmware notification."""
         assert fw_discovery_info["usb_device"] is not None
         usb_info = usb_service_info_from_device(fw_discovery_info["usb_device"])
-        unique_id = usb_unique_id_from_service_info(usb_info)
 
-        if await self.async_set_unique_id(unique_id, raise_on_progress=False):
+        if await self.async_set_unique_id(
+            usb_info.serial_number, raise_on_progress=False
+        ):
             self._abort_if_unique_id_configured(updates={DEVICE: usb_info.device})
 
         self._usb_info = usb_info

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -123,6 +123,10 @@ async def async_migrate_entry(
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if config_entry.version == 1:
         if config_entry.minor_version == 1:
             # Add-on startup with type service get started before Core, always (e.g. the

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -194,6 +194,15 @@ async def async_migrate_entry(
                     minor_version=4,
                 )
 
+        if config_entry.minor_version == 4:
+            # Replace the synthetic unique ID with the USB serial number
+            hass.config_entries.async_update_entry(
+                config_entry,
+                unique_id=config_entry.data[SERIAL_NUMBER],
+                version=1,
+                minor_version=5,
+            )
+
         _LOGGER.debug(
             "Migration to version %s.%s successful",
             config_entry.version,

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -232,9 +232,7 @@ async def async_migrate_entry(
                     serial_number,
                     config_entry.entry_id,
                 )
-                hass.async_create_task(
-                    hass.config_entries.async_remove(duplicate.entry_id)
-                )
+                await hass.config_entries.async_remove(duplicate.entry_id)
 
             # Replace the synthetic unique ID with the USB serial number
             hass.config_entries.async_update_entry(

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.components.usb import (
     async_register_port_event_callback,
     async_scan_serial_ports,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
@@ -203,26 +203,38 @@ async def async_migrate_entry(
 
             # Installations ended up with multiple config entries per physical adapter
             # in 2026.5.0 and 2026.5.1. We need to delete the older entry.
-            same_serial = [
+            duplicates = [
                 entry
                 for entry in hass.config_entries.async_entries(DOMAIN)
                 if entry.data.get(SERIAL_NUMBER) == serial_number
             ]
             canonical = max(
-                same_serial,
-                key=lambda e: (e.minor_version, e.modified_at, e.entry_id),
+                duplicates,
+                key=lambda e: (
+                    e.source != SOURCE_IGNORE,
+                    e.disabled_by is None,
+                    e.minor_version,
+                    e.modified_at,
+                    e.entry_id,
+                ),
             )
+
             if canonical.entry_id != config_entry.entry_id:
+                # The canonical entry's migration will remove this duplicate.
+                return False
+
+            for duplicate in duplicates:
+                if duplicate.entry_id == config_entry.entry_id:
+                    continue
                 _LOGGER.warning(
                     "Removing duplicate config entry %s for serial %s in favor of %s",
-                    config_entry.entry_id,
+                    duplicate.entry_id,
                     serial_number,
-                    canonical.entry_id,
+                    config_entry.entry_id,
                 )
                 hass.async_create_task(
-                    hass.config_entries.async_remove(config_entry.entry_id)
+                    hass.config_entries.async_remove(duplicate.entry_id)
                 )
-                return False
 
             # Replace the synthetic unique ID with the USB serial number
             hass.config_entries.async_update_entry(

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -199,10 +199,35 @@ async def async_migrate_entry(
                 )
 
         if config_entry.minor_version == 4:
+            serial_number = config_entry.data[SERIAL_NUMBER]
+
+            # Installations ended up with multiple config entries per physical adapter
+            # in 2026.5.0 and 2026.5.1. We need to delete the older entry.
+            same_serial = [
+                entry
+                for entry in hass.config_entries.async_entries(DOMAIN)
+                if entry.data.get(SERIAL_NUMBER) == serial_number
+            ]
+            canonical = max(
+                same_serial,
+                key=lambda e: (e.minor_version, e.modified_at, e.entry_id),
+            )
+            if canonical.entry_id != config_entry.entry_id:
+                _LOGGER.warning(
+                    "Removing duplicate config entry %s for serial %s in favor of %s",
+                    config_entry.entry_id,
+                    serial_number,
+                    canonical.entry_id,
+                )
+                hass.async_create_task(
+                    hass.config_entries.async_remove(config_entry.entry_id)
+                )
+                return False
+
             # Replace the synthetic unique ID with the USB serial number
             hass.config_entries.async_update_entry(
                 config_entry,
-                unique_id=config_entry.data[SERIAL_NUMBER],
+                unique_id=serial_number,
                 version=1,
                 minor_version=5,
             )

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -17,10 +17,7 @@ from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
 )
-from homeassistant.components.usb import (
-    usb_service_info_from_device,
-    usb_unique_id_from_service_info,
-)
+from homeassistant.components.usb import usb_service_info_from_device
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigEntryBaseFlow,
@@ -128,7 +125,7 @@ class HomeAssistantSkyConnectConfigFlow(
     """Handle a config flow for Home Assistant SkyConnect."""
 
     VERSION = 1
-    MINOR_VERSION = 4
+    MINOR_VERSION = 5
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the config flow."""
@@ -152,9 +149,7 @@ class HomeAssistantSkyConnectConfigFlow(
 
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle usb discovery."""
-        unique_id = usb_unique_id_from_service_info(discovery_info)
-
-        if await self.async_set_unique_id(unique_id):
+        if await self.async_set_unique_id(discovery_info.serial_number):
             self._abort_if_unique_id_configured(updates={DEVICE: discovery_info.device})
 
         discovery_info.device = await self.hass.async_add_executor_job(
@@ -180,9 +175,10 @@ class HomeAssistantSkyConnectConfigFlow(
         """Handle import from ZHA/OTBR firmware notification."""
         assert fw_discovery_info["usb_device"] is not None
         usb_info = usb_service_info_from_device(fw_discovery_info["usb_device"])
-        unique_id = usb_unique_id_from_service_info(usb_info)
 
-        if await self.async_set_unique_id(unique_id, raise_on_progress=False):
+        if await self.async_set_unique_id(
+            usb_info.serial_number, raise_on_progress=False
+        ):
             self._abort_if_unique_id_configured(updates={DEVICE: usb_info.device})
 
         self._usb_info = usb_info

--- a/tests/components/homeassistant_connect_zbt2/snapshots/test_diagnostics.ambr
+++ b/tests/components/homeassistant_connect_zbt2/snapshots/test_diagnostics.ambr
@@ -16,7 +16,7 @@
       'discovery_keys': dict({
       }),
       'domain': 'homeassistant_connect_zbt2',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,
@@ -25,7 +25,7 @@
       'subentries': list([
       ]),
       'title': 'Mock Title',
-      'unique_id': None,
+      'unique_id': '80B54EEFAE18',
       'version': 1,
     }),
   })

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -425,13 +425,8 @@ async def test_duplicate_discovery_updates_usb_path(hass: HomeAssistant) -> None
             "vid": USB_DATA_ZBT2.vid,
         },
         version=1,
-        minor_version=1,
-        unique_id=(
-            f"{USB_DATA_ZBT2.vid}:{USB_DATA_ZBT2.pid}_"
-            f"{USB_DATA_ZBT2.serial_number}_"
-            f"{USB_DATA_ZBT2.manufacturer}_"
-            f"{USB_DATA_ZBT2.description}"
-        ),
+        minor_version=2,
+        unique_id=USB_DATA_ZBT2.serial_number,
     )
     config_entry.add_to_hass(hass)
 
@@ -522,12 +517,7 @@ async def test_firmware_callback_updates_existing_entry(hass: HomeAssistant) -> 
             "manufacturer": USB_DATA_ZBT2.manufacturer,
             "product": USB_DATA_ZBT2.description,
         },
-        unique_id=(
-            f"{USB_DATA_ZBT2.vid}:{USB_DATA_ZBT2.pid}_"
-            f"{USB_DATA_ZBT2.serial_number}_"
-            f"{USB_DATA_ZBT2.manufacturer}_"
-            f"{USB_DATA_ZBT2.description}"
-        ),
+        unique_id=USB_DATA_ZBT2.serial_number,
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/homeassistant_connect_zbt2/test_init.py
+++ b/tests/components/homeassistant_connect_zbt2/test_init.py
@@ -7,7 +7,11 @@ import pytest
 
 from homeassistant.components.homeassistant_connect_zbt2.const import DOMAIN
 from homeassistant.components.usb import DOMAIN as USB_DOMAIN, USBDevice
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import (
+    SOURCE_IGNORE,
+    ConfigEntryDisabler,
+    ConfigEntryState,
+)
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -169,6 +173,65 @@ async def test_config_entry_migration_v2_collapses_duplicates(
     assert unique_entry.unique_id == serial_number
     assert unique_entry.data == newer["data"]
     assert hass.config_entries.async_get_entry(older_entry.entry_id) is None
+
+
+@pytest.mark.parametrize(
+    ("sibling_source", "sibling_disabled_by"),
+    [
+        (SOURCE_IGNORE, None),
+        ("usb", ConfigEntryDisabler.USER),
+    ],
+)
+async def test_config_entry_migration_v2_prefers_active_entry(
+    hass: HomeAssistant,
+    sibling_source: str,
+    sibling_disabled_by: ConfigEntryDisabler | None,
+) -> None:
+    """Test v1.2 migration prefers an active entry over ignored/disabled siblings."""
+    serial_number = "80B54EEFAE18"
+    active_data = {
+        "device": "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_80B54EEFAE18-if01-port0",
+        "vid": "303A",
+        "pid": "4001",
+        "serial_number": serial_number,
+        "manufacturer": "Nabu Casa",
+        "product": "ZBT-2",
+        "firmware": "ezsp",
+        "firmware_version": "7.4.4.0",
+    }
+
+    active_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="303A:4001_80B54EEFAE18_Nabu Casa_ZBT-2",
+        source="usb",
+        data=active_data,
+        version=1,
+        minor_version=1,
+    )
+    active_entry.add_to_hass(hass)
+
+    sibling_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=serial_number,
+        source=sibling_source,
+        disabled_by=sibling_disabled_by,
+        data=dict(active_data),
+        version=1,
+        minor_version=2,
+    )
+    sibling_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_connect_zbt2.os.path.exists",
+        return_value=True,
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    assert hass.config_entries.async_get_entry(active_entry.entry_id) is not None
+    assert hass.config_entries.async_get_entry(sibling_entry.entry_id) is None
+    assert active_entry.minor_version == 2
+    assert active_entry.unique_id == serial_number
 
 
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:

--- a/tests/components/homeassistant_connect_zbt2/test_init.py
+++ b/tests/components/homeassistant_connect_zbt2/test_init.py
@@ -18,6 +18,40 @@ from tests.components.usb import async_request_scan, patch_scanned_serial_ports
 from tests.components.usb.conftest import force_usb_polling_watcher  # noqa: F401
 
 
+async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
+    """Test migrating config entries from v1.1 to v1.2 to use the serial number as unique ID."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="303A:4001_80B54EEFAE18_Nabu Casa_ZBT-2",
+        data={
+            "device": "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_80B54EEFAE18-if01-port0",
+            "vid": "303A",
+            "pid": "4001",
+            "serial_number": "80B54EEFAE18",
+            "manufacturer": "Nabu Casa",
+            "product": "ZBT-2",
+            "firmware": "ezsp",
+            "firmware_version": "7.4.4.0",
+        },
+        version=1,
+        minor_version=1,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_connect_zbt2.os.path.exists",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.version == 1
+    assert config_entry.minor_version == 2
+    assert config_entry.unique_id == "80B54EEFAE18"
+
+
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
     """Test setup failing when the USB port is missing."""
 

--- a/tests/components/homeassistant_connect_zbt2/test_init.py
+++ b/tests/components/homeassistant_connect_zbt2/test_init.py
@@ -52,6 +52,125 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
     assert config_entry.unique_id == "80B54EEFAE18"
 
 
+@pytest.mark.parametrize(
+    ("older", "newer", "serial_number"),
+    [
+        # Same physical adapter, different unique IDs because the `product` field
+        # differed between HA versions that built the ID from `port.product` vs
+        # `port.description`
+        (
+            {
+                "unique_id": "303A:831A_DCB4D90BBCE4_Nabu Casa_ZBT-2 - Nabu Casa ZBT-2",
+                "source": "usb",
+                "data": {
+                    "device": "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_DCB4D90BBCE4-if00",
+                    "firmware": "ezsp",
+                    "firmware_version": "7.5.1.0 build 0 (20260224005837)",
+                    "manufacturer": "Nabu Casa",
+                    "pid": "831A",
+                    "product": "ZBT-2 - Nabu Casa ZBT-2",
+                    "serial_number": "DCB4D90BBCE4",
+                    "vid": "303A",
+                },
+            },
+            {
+                "unique_id": "303A:831A_DCB4D90BBCE4_Nabu Casa_ZBT-2",
+                "source": "import",
+                "data": {
+                    "device": "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_DCB4D90BBCE4-if00",
+                    "firmware": "ezsp",
+                    "firmware_version": "7.5.1.0 build 0 (20260224005837)",
+                    "manufacturer": "Nabu Casa",
+                    "pid": "831A",
+                    "product": "ZBT-2",
+                    "serial_number": "DCB4D90BBCE4",
+                    "vid": "303A",
+                },
+            },
+            "DCB4D90BBCE4",
+        ),
+        # Two entries with identical unique IDs for the same adapter
+        (
+            {
+                "unique_id": "303A:831A_DCB4D910DBB4_Nabu_Casa_ZBT-2",
+                "source": "usb",
+                "data": {
+                    "device": "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_DCB4D910DBB4-if00",
+                    "firmware": "ezsp",
+                    "firmware_version": "7.5.1.0 build 0 (20260224005837)",
+                    "manufacturer": "Nabu Casa",
+                    "pid": "831A",
+                    "product": "ZBT-2",
+                    "serial_number": "DCB4D910DBB4",
+                    "vid": "303A",
+                },
+            },
+            {
+                "unique_id": "303A:831A_DCB4D910DBB4_Nabu_Casa_ZBT-2",
+                "source": "import",
+                "data": {
+                    "device": "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_DCB4D910DBB4-if00",
+                    "firmware": "spinel",
+                    "firmware_version": (
+                        "SL-OPENTHREAD/2.7.2.0_GitHub-fb0446f53;"
+                        " EFR32; Jan 11 2026 17:52:09"
+                    ),
+                    "manufacturer": "Nabu Casa",
+                    "pid": "831A",
+                    "product": "ZBT-2",
+                    "serial_number": "DCB4D910DBB4",
+                    "vid": "303A",
+                },
+            },
+            "DCB4D910DBB4",
+        ),
+    ],
+)
+async def test_config_entry_migration_v2_collapses_duplicates(
+    hass: HomeAssistant,
+    older: dict,
+    newer: dict,
+    serial_number: str,
+) -> None:
+    """Test that v1.2 migration removes duplicate entries sharing a serial number."""
+
+    older_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=older["unique_id"],
+        source=older["source"],
+        data=older["data"],
+        version=1,
+        minor_version=1,
+    )
+    older_entry.add_to_hass(hass)
+
+    newer_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=newer["unique_id"],
+        source=newer["source"],
+        data=newer["data"],
+        version=1,
+        minor_version=1,
+    )
+    newer_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_connect_zbt2.os.path.exists",
+        return_value=True,
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    remaining_entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(remaining_entries) == 1
+    unique_entry = remaining_entries[0]
+    assert unique_entry.entry_id == newer_entry.entry_id
+    assert unique_entry.minor_version == 2
+    assert unique_entry.unique_id == serial_number
+    assert unique_entry.data == newer["data"]
+    assert hass.config_entries.async_get_entry(older_entry.entry_id) is None
+
+
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
     """Test setup failing when the USB port is missing."""
 

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -529,12 +529,7 @@ async def test_duplicate_usb_discovery_aborts_early(
             "serial_number": usb_data.serial_number,
             "vid": usb_data.vid,
         },
-        unique_id=(
-            f"{usb_data.vid}:{usb_data.pid}_"
-            f"{usb_data.serial_number}_"
-            f"{usb_data.manufacturer}_"
-            f"{usb_data.description}"
-        ),
+        unique_id=usb_data.serial_number,
     )
     config_entry.add_to_hass(hass)
 
@@ -576,12 +571,7 @@ async def test_firmware_callback_updates_existing_entry(
             "description": usb_data.description,
             "product": usb_data.description,
         },
-        unique_id=(
-            f"{usb_data.vid}:{usb_data.pid}_"
-            f"{usb_data.serial_number}_"
-            f"{usb_data.manufacturer}_"
-            f"{usb_data.description}"
-        ),
+        unique_id=usb_data.serial_number,
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/homeassistant_sky_connect/test_hardware.py
+++ b/tests/components/homeassistant_sky_connect/test_hardware.py
@@ -20,10 +20,10 @@ CONFIG_ENTRY_DATA = {
 }
 
 CONFIG_ENTRY_DATA_2 = {
-    "device": "/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+    "device": "/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_3c0ed67c628beb11b1cd64a0f320645d-if00-port0",
     "vid": "10C4",
     "pid": "EA60",
-    "serial_number": "9e2adbd75b8beb119fe564a0f320645d",
+    "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
     "manufacturer": "Nabu Casa",
     "product": "Home Assistant Connect ZBT-1",
     "firmware": "ezsp",
@@ -106,7 +106,7 @@ async def test_hardware_info(
                 "dongle": {
                     "vid": "10C4",
                     "pid": "EA60",
-                    "serial_number": "9e2adbd75b8beb119fe564a0f320645d",
+                    "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
                     "manufacturer": "Nabu Casa",
                     "description": "Home Assistant Connect ZBT-1",
                 },

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -79,6 +79,145 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
+@pytest.mark.parametrize(
+    ("older", "newer", "serial_number"),
+    [
+        # Same physical dongle, different unique IDs
+        (
+            {
+                "unique_id": (
+                    "10C4:EA60_9e2adbd75b8beb119fe564a0f320645d_Nabu Casa"
+                    "_SkyConnect v1.0 - Nabu Casa SkyConnect"
+                ),
+                "source": "usb",
+                "data": {
+                    "description": "SkyConnect v1.0",
+                    "device": (
+                        "/dev/serial/by-id/"
+                        "usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+                    ),
+                    "vid": "10C4",
+                    "pid": "EA60",
+                    "serial_number": "9e2adbd75b8beb119fe564a0f320645d",
+                    "manufacturer": "Nabu Casa",
+                    "product": "SkyConnect v1.0 - Nabu Casa SkyConnect",
+                    "firmware": "ezsp",
+                    "firmware_version": "7.4.4.0",
+                },
+            },
+            {
+                "unique_id": (
+                    "10C4:EA60_9e2adbd75b8beb119fe564a0f320645d_Nabu Casa_SkyConnect v1.0"
+                ),
+                "source": "import",
+                "data": {
+                    "description": "SkyConnect v1.0",
+                    "device": (
+                        "/dev/serial/by-id/"
+                        "usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+                    ),
+                    "vid": "10C4",
+                    "pid": "EA60",
+                    "serial_number": "9e2adbd75b8beb119fe564a0f320645d",
+                    "manufacturer": "Nabu Casa",
+                    "product": "SkyConnect v1.0",
+                    "firmware": "ezsp",
+                    "firmware_version": "7.4.4.0",
+                },
+            },
+            "9e2adbd75b8beb119fe564a0f320645d",
+        ),
+        # Two entries with identical unique IDs for the same dongle
+        (
+            {
+                "unique_id": (
+                    "10C4:EA60_3c0ed67c628beb11b1cd64a0f320645d_Nabu_Casa_SkyConnect v1.0"
+                ),
+                "source": "usb",
+                "data": {
+                    "description": "SkyConnect v1.0",
+                    "device": (
+                        "/dev/serial/by-id/"
+                        "usb-Nabu_Casa_SkyConnect_v1.0_3c0ed67c628beb11b1cd64a0f320645d-if00-port0"
+                    ),
+                    "vid": "10C4",
+                    "pid": "EA60",
+                    "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
+                    "manufacturer": "Nabu Casa",
+                    "product": "SkyConnect v1.0",
+                    "firmware": "ezsp",
+                    "firmware_version": "7.4.4.0",
+                },
+            },
+            {
+                "unique_id": (
+                    "10C4:EA60_3c0ed67c628beb11b1cd64a0f320645d_Nabu_Casa_SkyConnect v1.0"
+                ),
+                "source": "import",
+                "data": {
+                    "description": "SkyConnect v1.0",
+                    "device": (
+                        "/dev/serial/by-id/"
+                        "usb-Nabu_Casa_SkyConnect_v1.0_3c0ed67c628beb11b1cd64a0f320645d-if00-port0"
+                    ),
+                    "vid": "10C4",
+                    "pid": "EA60",
+                    "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
+                    "manufacturer": "Nabu Casa",
+                    "product": "SkyConnect v1.0",
+                    "firmware": "spinel",
+                    "firmware_version": "SL-OPENTHREAD/2.7.2.0_GitHub-fb0446f53; EFR32",
+                },
+            },
+            "3c0ed67c628beb11b1cd64a0f320645d",
+        ),
+    ],
+)
+async def test_config_entry_migration_v5_collapses_duplicates(
+    hass: HomeAssistant,
+    older: dict,
+    newer: dict,
+    serial_number: str,
+) -> None:
+    """Test that v1.5 migration removes duplicate entries sharing a serial number."""
+
+    older_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=older["unique_id"],
+        source=older["source"],
+        data=older["data"],
+        version=1,
+        minor_version=4,
+    )
+    older_entry.add_to_hass(hass)
+
+    newer_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=newer["unique_id"],
+        source=newer["source"],
+        data=newer["data"],
+        version=1,
+        minor_version=4,
+    )
+    newer_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_sky_connect.os.path.exists",
+        return_value=True,
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    remaining = hass.config_entries.async_entries(DOMAIN)
+    assert len(remaining) == 1
+    unique_entry = remaining[0]
+    assert unique_entry.entry_id == newer_entry.entry_id
+    assert unique_entry.minor_version == 5
+    assert unique_entry.unique_id == serial_number
+    assert unique_entry.data == newer["data"]
+    assert hass.config_entries.async_get_entry(older_entry.entry_id) is None
+
+
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
     """Test setup failing when the USB port is missing."""
 

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -62,7 +62,8 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(config_entry.entry_id)
 
     assert config_entry.version == 1
-    assert config_entry.minor_version == 4
+    assert config_entry.minor_version == 5
+    assert config_entry.unique_id == "3c0ed67c628beb11b1cd64a0f320645d"
     assert config_entry.data == {
         "description": "SkyConnect v1.0",
         "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
@@ -282,12 +283,19 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
 
     updated_entry = hass.config_entries.async_get_entry(fixable_entry.entry_id)
     assert updated_entry is not None
+    assert updated_entry.minor_version == 5
+    assert updated_entry.unique_id == "4f5f3b26d59f8714a78b599690741999"
     assert updated_entry.data[VID] == "10C4"
     assert updated_entry.data[PID] == "EA60"
     assert updated_entry.data[SERIAL_NUMBER] == "4f5f3b26d59f8714a78b599690741999"
     assert updated_entry.data[MANUFACTURER] == "Nabu Casa"
     assert updated_entry.data[PRODUCT] == "SkyConnect v1.0"
     assert updated_entry.data[DESCRIPTION] == "SkyConnect v1.0"
+
+    migrated_new_entry = hass.config_entries.async_get_entry(new_entry.entry_id)
+    assert migrated_new_entry is not None
+    assert migrated_new_entry.minor_version == 5
+    assert migrated_new_entry.unique_id == "9e2adbd75b8beb119fe564a0f320645d"
 
     untouched_bad_entry = hass.config_entries.async_get_entry(bad_entry.entry_id)
     assert untouched_bad_entry.minor_version == 3

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -19,7 +19,11 @@ from homeassistant.components.homeassistant_sky_connect.const import (
     VID,
 )
 from homeassistant.components.usb import DOMAIN as USB_DOMAIN, USBDevice
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import (
+    SOURCE_IGNORE,
+    ConfigEntryDisabler,
+    ConfigEntryState,
+)
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -216,6 +220,71 @@ async def test_config_entry_migration_v5_collapses_duplicates(
     assert unique_entry.unique_id == serial_number
     assert unique_entry.data == newer["data"]
     assert hass.config_entries.async_get_entry(older_entry.entry_id) is None
+
+
+@pytest.mark.parametrize(
+    ("sibling_source", "sibling_disabled_by"),
+    [
+        (SOURCE_IGNORE, None),
+        ("usb", ConfigEntryDisabler.USER),
+    ],
+)
+async def test_config_entry_migration_v5_prefers_active_entry(
+    hass: HomeAssistant,
+    sibling_source: str,
+    sibling_disabled_by: ConfigEntryDisabler | None,
+) -> None:
+    """Test v1.5 migration prefers an active entry over ignored/disabled siblings."""
+    serial_number = "9e2adbd75b8beb119fe564a0f320645d"
+    active_data = {
+        "description": "SkyConnect v1.0",
+        "device": (
+            "/dev/serial/by-id/"
+            "usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+        ),
+        "vid": "10C4",
+        "pid": "EA60",
+        "serial_number": serial_number,
+        "manufacturer": "Nabu Casa",
+        "product": "SkyConnect v1.0",
+        "firmware": "ezsp",
+        "firmware_version": "7.4.4.0",
+    }
+
+    active_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=(
+            "10C4:EA60_9e2adbd75b8beb119fe564a0f320645d_Nabu Casa_SkyConnect v1.0"
+        ),
+        source="usb",
+        data=active_data,
+        version=1,
+        minor_version=4,
+    )
+    active_entry.add_to_hass(hass)
+
+    sibling_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=serial_number,
+        source=sibling_source,
+        disabled_by=sibling_disabled_by,
+        data=dict(active_data),
+        version=1,
+        minor_version=5,
+    )
+    sibling_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_sky_connect.os.path.exists",
+        return_value=True,
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    assert hass.config_entries.async_get_entry(active_entry.entry_id) is not None
+    assert hass.config_entries.async_get_entry(sibling_entry.entry_id) is None
+    assert active_entry.minor_version == 5
+    assert active_entry.unique_id == serial_number
 
 
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate the ZBT-1 and ZBT-2 integrations to only use the USB device serial number for the config entry unique ID. All other info (VID, PID, product, manufacturer, etc.) should be ignored.

The VID:PID are not necessarily stable and we currently use `description` within Home Assistant as part of the unique ID. This isn't ideal, `description` is not intuitively computed and really should be `product` for practically any USB device used in Core.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes
- This PR is related to issue: #169490, #169974
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
