### PR TITLE
Enable strict typing for device_sun_light_trigger

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -163,6 +163,7 @@ homeassistant.components.default_config.*
 homeassistant.components.demo.*
 homeassistant.components.derivative.*
 homeassistant.components.device_automation.*
+homeassistant.components.device_sun_light_trigger.*
 homeassistant.components.device_tracker.*
 homeassistant.components.devolo_home_control.*
 homeassistant.components.devolo_home_network.*

--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -1,8 +1,9 @@
 """Support to turn on lights based on the states."""
 
-from datetime import timedelta
-from functools import partial
+from collections.abc import Callable, Coroutine
+from datetime import datetime, timedelta
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -76,7 +77,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     light_profile = conf[CONF_LIGHT_PROFILE]
     device_group = conf.get(CONF_DEVICE_GROUP)
 
-    async def activate_on_start(_):
+    async def activate_on_start(_event: Event[Any] | None) -> None:
         """Activate automation."""
         await activate_automation(
             hass, device_group, light_group, light_profile, disable_turn_off
@@ -90,9 +91,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def activate_automation(  # noqa: C901
-    hass, device_group, light_group, light_profile, disable_turn_off
-):
+async def activate_automation(
+    hass: HomeAssistant,
+    device_group: str | None,
+    light_group: str | None,
+    light_profile: str,
+    disable_turn_off: bool,
+) -> None:
     """Activate the automation."""
     logger = logging.getLogger(__name__)
 
@@ -121,28 +126,24 @@ async def activate_automation(  # noqa: C901
         return
 
     @callback
-    def anyone_home():
+    def anyone_home() -> bool:
         """Test if anyone is home."""
         return any(device_tracker_is_on(hass, dt_id) for dt_id in device_entity_ids)
 
     @callback
-    def any_light_on():
+    def any_light_on() -> bool:
         """Test if any light on."""
         return any(light_is_on(hass, light_id) for light_id in light_ids)
 
-    def calc_time_for_light_when_sunset():
+    def calc_time_for_light_when_sunset() -> datetime:
         """Calculate the time when to start fading lights in when sun sets.
-
-        Returns None if no next_setting data available.
 
         Async friendly.
         """
         next_setting = get_astral_event_next(hass, SUN_EVENT_SUNSET)
-        if not next_setting:
-            return None
         return next_setting - LIGHT_TRANSITION_TIME * len(light_ids)
 
-    async def async_turn_on_before_sunset(light_id):
+    async def async_turn_on_before_sunset(light_id: str) -> None:
         """Turn on lights."""
         if not anyone_home() or light_is_on(hass, light_id):
             return
@@ -157,10 +158,12 @@ async def activate_automation(  # noqa: C901
         )
 
     @callback
-    def async_turn_on_factory(light_id):
+    def async_turn_on_factory(
+        light_id: str,
+    ) -> Callable[[datetime], Coroutine[Any, Any, None]]:
         """Generate turn on callbacks as factory."""
 
-        async def async_turn_on_light(now):
+        async def async_turn_on_light(_now: datetime) -> None:
             """Turn on specific light."""
             await async_turn_on_before_sunset(light_id)
 
@@ -169,15 +172,13 @@ async def activate_automation(  # noqa: C901
     # Track every time sun rises so we can schedule a time-based
     # pre-sun set event
     @callback
-    def schedule_light_turn_on(now):
+    def schedule_light_turn_on(_now: datetime | None) -> None:
         """Turn on all the lights at the moment sun sets.
 
         We will schedule to have each light start after one another
         and slowly transition in.
         """
         start_point = calc_time_for_light_when_sunset()
-        if not start_point:
-            return
 
         for index, light_id in enumerate(light_ids):
             async_track_point_in_utc_time(
@@ -197,15 +198,15 @@ async def activate_automation(  # noqa: C901
 
     @callback
     def check_light_on_dev_state_change(
-        from_state: str, to_state: str, event: Event[EventStateChangedData]
+        event: Event[EventStateChangedData],
     ) -> None:
         """Handle tracked device state changes."""
         event_data = event.data
         if (
             (old_state := event_data["old_state"]) is None
             or (new_state := event_data["new_state"]) is None
-            or old_state.state != from_state
-            or new_state.state != to_state
+            or old_state.state != STATE_NOT_HOME
+            or new_state.state != STATE_HOME
         ):
             return
 
@@ -232,9 +233,7 @@ async def activate_automation(  # noqa: C901
         # if someone would be home?
         # Check this by seeing if current time is later then the point
         # in time when we would start putting the lights on.
-        elif start_point and start_point < now < get_astral_event_next(
-            hass, SUN_EVENT_SUNSET
-        ):
+        elif start_point < now < get_astral_event_next(hass, SUN_EVENT_SUNSET):
             # Check for every light if it would be on if someone was home
             # when the fading in started and turn it on if so
             for index, light_id in enumerate(light_ids):
@@ -253,14 +252,16 @@ async def activate_automation(  # noqa: C901
     async_track_state_change_event(
         hass,
         device_entity_ids,
-        partial(check_light_on_dev_state_change, STATE_NOT_HOME, STATE_HOME),
+        check_light_on_dev_state_change,
     )
 
     if disable_turn_off:
         return
 
     @callback
-    def turn_off_lights_when_all_leave(entity, old_state, new_state):
+    def turn_off_lights_when_all_leave(
+        _event: Event[EventStateChangedData],
+    ) -> None:
         """Handle device group state change."""
         # Make sure there is not someone home
         if anyone_home():
@@ -280,7 +281,7 @@ async def activate_automation(  # noqa: C901
     async_track_state_change_event(
         hass,
         device_entity_ids,
-        partial(turn_off_lights_when_all_leave, STATE_HOME, STATE_NOT_HOME),
+        turn_off_lights_when_all_leave,
     )
 
     return

--- a/mypy.ini
+++ b/mypy.ini
@@ -1384,6 +1384,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.device_sun_light_trigger.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.device_tracker.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Changes add the device_sun_light_trigger integration to .strict_typing, adding the required missing type annotations for strict mypy checking.

PR #163421 was a previous stale attempt at this task; some work is done similarly but additional changes have been made to account for issues within the PR and with testing:
- Added imports for Callable, Coroutine, and typing to help with annotations and the callback factory.
- Removed partial import as it is now unused.
- Added typing annotations for all necessary callbacks.
- activate_on_start: startup event argument is unused so it is underscored.
- calc_time_for_light_when_sunset: slightly modified helper to only return datetime. Unnecessary None handling was removed.
- check_light_on_dev_state_change: modified to align with the event callback signature expected by async_track_state_change_event.
- turn_off_lights_when_all_leave: removed partial wrapping for callbacks that can directly accept the state changed event.

No runtime behaviors are intended, however I understand if some of the changes are slightly out-of-sccope from the intended strict typing implementation. I am happy to separate this into multiple PRs if required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

## Testing

Ran locally:

- python3 -m script.hassfest
- python -m mypy homeassistant/components/device_sun_light_trigger
- ruff check homeassistant/components/device_sun_light_trigger
- ruff format homeassistant/components/device_sun_light_trigger

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
