### PR TITLE
Exclude incompatible entities from humidity automations

### DIFF
--- a/homeassistant/components/humidity/condition.py
+++ b/homeassistant/components/humidity/condition.py
@@ -14,9 +14,9 @@ from homeassistant.components.weather import (
     DOMAIN as WEATHER_DOMAIN,
 )
 from homeassistant.const import PERCENTAGE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.automation import DomainSpec
-from homeassistant.helpers.condition import Condition, make_entity_numerical_condition
+from homeassistant.helpers.condition import Condition, EntityNumericalConditionBase
 
 HUMIDITY_DOMAIN_SPECS = {
     CLIMATE_DOMAIN: DomainSpec(
@@ -31,8 +31,31 @@ HUMIDITY_DOMAIN_SPECS = {
     ),
 }
 
+
+class HumidityCondition(EntityNumericalConditionBase):
+    """Condition for humidity value across multiple domains."""
+
+    _domain_specs = HUMIDITY_DOMAIN_SPECS
+    _valid_unit = PERCENTAGE
+
+    def _should_include(self, state: State) -> bool:
+        """Skip attribute-source entities that lack the humidity attribute.
+
+        Mirrors the humidity trigger: for climate / humidifier / weather
+        (attribute-based), the entity is filtered when the source attribute
+        is absent; sensor entities (state-value-based) fall through to the
+        base impl.
+        """
+        if not super()._should_include(state):
+            return False
+        domain_spec = self._domain_specs[state.domain]
+        if domain_spec.value_source is None:
+            return True
+        return state.attributes.get(domain_spec.value_source) is not None
+
+
 CONDITIONS: dict[str, type[Condition]] = {
-    "is_value": make_entity_numerical_condition(HUMIDITY_DOMAIN_SPECS, PERCENTAGE),
+    "is_value": HumidityCondition,
 }
 
 

--- a/homeassistant/components/humidity/trigger.py
+++ b/homeassistant/components/humidity/trigger.py
@@ -13,12 +13,13 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_HUMIDITY,
     DOMAIN as WEATHER_DOMAIN,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
+    EntityNumericalStateChangedTriggerBase,
+    EntityNumericalStateCrossedThresholdTriggerBase,
+    EntityNumericalStateTriggerBase,
     Trigger,
-    make_entity_numerical_state_changed_trigger,
-    make_entity_numerical_state_crossed_threshold_trigger,
 )
 
 HUMIDITY_DOMAIN_SPECS: dict[str, DomainSpec] = {
@@ -36,13 +37,46 @@ HUMIDITY_DOMAIN_SPECS: dict[str, DomainSpec] = {
     ),
 }
 
+
+class _HumidityTriggerMixin(EntityNumericalStateTriggerBase):
+    """Mixin for humidity triggers providing entity filtering."""
+
+    _domain_specs = HUMIDITY_DOMAIN_SPECS
+    _valid_unit = "%"
+
+    def _should_include(self, state: State) -> bool:
+        """Skip attribute-source entities that lack the humidity attribute.
+
+        For domains whose tracked value comes from an attribute
+        (climate / humidifier / weather), require the attribute to be
+        present; otherwise the all/count check would treat an entity that
+        cannot report a humidity as a non-match and block behavior=last.
+        Sensor entities source their value from `state.state`, so they
+        fall through to the base impl.
+        """
+        if not super()._should_include(state):
+            return False
+        domain_spec = self._domain_specs[state.domain]
+        if domain_spec.value_source is None:
+            return True
+        return state.attributes.get(domain_spec.value_source) is not None
+
+
+class HumidityChangedTrigger(
+    _HumidityTriggerMixin, EntityNumericalStateChangedTriggerBase
+):
+    """Trigger for humidity value changes across multiple domains."""
+
+
+class HumidityCrossedThresholdTrigger(
+    _HumidityTriggerMixin, EntityNumericalStateCrossedThresholdTriggerBase
+):
+    """Trigger for humidity value crossing a threshold across multiple domains."""
+
+
 TRIGGERS: dict[str, type[Trigger]] = {
-    "changed": make_entity_numerical_state_changed_trigger(
-        HUMIDITY_DOMAIN_SPECS, valid_unit="%"
-    ),
-    "crossed_threshold": make_entity_numerical_state_crossed_threshold_trigger(
-        HUMIDITY_DOMAIN_SPECS, valid_unit="%"
-    ),
+    "changed": HumidityChangedTrigger,
+    "crossed_threshold": HumidityCrossedThresholdTrigger,
 }
 
 

--- a/tests/components/humidity/test_condition.py
+++ b/tests/components/humidity/test_condition.py
@@ -179,6 +179,7 @@ async def test_humidity_sensor_condition_behavior_all(
         "humidity.is_value",
         HVACMode.AUTO,
         CLIMATE_ATTR_CURRENT_HUMIDITY,
+        attribute_required=True,
     ),
 )
 async def test_humidity_climate_condition_behavior_any(
@@ -215,6 +216,7 @@ async def test_humidity_climate_condition_behavior_any(
         "humidity.is_value",
         HVACMode.AUTO,
         CLIMATE_ATTR_CURRENT_HUMIDITY,
+        attribute_required=True,
     ),
 )
 async def test_humidity_climate_condition_behavior_all(
@@ -251,6 +253,7 @@ async def test_humidity_climate_condition_behavior_all(
         "humidity.is_value",
         STATE_ON,
         HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
+        attribute_required=True,
     ),
 )
 async def test_humidity_humidifier_condition_behavior_any(
@@ -287,6 +290,7 @@ async def test_humidity_humidifier_condition_behavior_any(
         "humidity.is_value",
         STATE_ON,
         HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
+        attribute_required=True,
     ),
 )
 async def test_humidity_humidifier_condition_behavior_all(
@@ -323,6 +327,7 @@ async def test_humidity_humidifier_condition_behavior_all(
         "humidity.is_value",
         "sunny",
         ATTR_WEATHER_HUMIDITY,
+        attribute_required=True,
     ),
 )
 async def test_humidity_weather_condition_behavior_any(
@@ -359,6 +364,7 @@ async def test_humidity_weather_condition_behavior_any(
         "humidity.is_value",
         "sunny",
         ATTR_WEATHER_HUMIDITY,
+        attribute_required=True,
     ),
 )
 async def test_humidity_weather_condition_behavior_all(

--- a/tests/components/humidity/test_trigger.py
+++ b/tests/components/humidity/test_trigger.py
@@ -240,12 +240,16 @@ async def test_humidity_trigger_sensor_crossed_threshold_behavior_last(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_numerical_attribute_changed_trigger_states(
-            "humidity.changed", HVACMode.AUTO, CLIMATE_ATTR_CURRENT_HUMIDITY
+            "humidity.changed",
+            HVACMode.AUTO,
+            CLIMATE_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "humidity.crossed_threshold",
             HVACMode.AUTO,
             CLIMATE_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -284,6 +288,7 @@ async def test_humidity_trigger_climate_behavior_any(
             "humidity.crossed_threshold",
             HVACMode.AUTO,
             CLIMATE_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -322,6 +327,7 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_first(
             "humidity.crossed_threshold",
             HVACMode.AUTO,
             CLIMATE_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -360,12 +366,16 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_last(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_numerical_attribute_changed_trigger_states(
-            "humidity.changed", STATE_ON, HUMIDIFIER_ATTR_CURRENT_HUMIDITY
+            "humidity.changed",
+            STATE_ON,
+            HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "humidity.crossed_threshold",
             STATE_ON,
             HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -404,6 +414,7 @@ async def test_humidity_trigger_humidifier_behavior_any(
             "humidity.crossed_threshold",
             STATE_ON,
             HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -442,6 +453,7 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_first(
             "humidity.crossed_threshold",
             STATE_ON,
             HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -480,12 +492,16 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_last(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_numerical_attribute_changed_trigger_states(
-            "humidity.changed", "sunny", ATTR_WEATHER_HUMIDITY
+            "humidity.changed",
+            "sunny",
+            ATTR_WEATHER_HUMIDITY,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "humidity.crossed_threshold",
             "sunny",
             ATTR_WEATHER_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -524,6 +540,7 @@ async def test_humidity_trigger_weather_behavior_any(
             "humidity.crossed_threshold",
             "sunny",
             ATTR_WEATHER_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )
@@ -562,6 +579,7 @@ async def test_humidity_trigger_weather_crossed_threshold_behavior_first(
             "humidity.crossed_threshold",
             "sunny",
             ATTR_WEATHER_HUMIDITY,
+            attribute_required=True,
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exclude incompatible entities from humidity automations

This means climate, humidifier and weather entities without humidity attribute won't block `last` checks for triggers or `all` checks for conditions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
