### PR TITLE
Exclude incompatible entities from temperature automations

### DIFF
--- a/homeassistant/components/temperature/condition.py
+++ b/homeassistant/components/temperature/condition.py
@@ -46,6 +46,21 @@ class TemperatureCondition(EntityNumericalConditionWithUnitBase):
     _domain_specs = TEMPERATURE_DOMAIN_SPECS
     _unit_converter = TemperatureConverter
 
+    def _should_include(self, state: State) -> bool:
+        """Skip attribute-source entities that lack the temperature attribute.
+
+        Mirrors the temperature trigger: for climate / water_heater /
+        weather (attribute-based), the entity is filtered when the source
+        attribute is absent; sensor entities (state-value-based) fall
+        through to the base impl.
+        """
+        if not super()._should_include(state):
+            return False
+        domain_spec = self._domain_specs[state.domain]
+        if domain_spec.value_source is None:
+            return True
+        return state.attributes.get(domain_spec.value_source) is not None
+
     def _get_entity_unit(self, entity_state: State) -> str | None:
         """Get the temperature unit of an entity from its state."""
         if entity_state.domain == SENSOR_DOMAIN:

--- a/homeassistant/components/temperature/trigger.py
+++ b/homeassistant/components/temperature/trigger.py
@@ -46,6 +46,23 @@ class _TemperatureTriggerMixin(EntityNumericalStateTriggerWithUnitBase):
     _domain_specs = TEMPERATURE_DOMAIN_SPECS
     _unit_converter = TemperatureConverter
 
+    def _should_include(self, state: State) -> bool:
+        """Skip attribute-source entities that lack the temperature attribute.
+
+        For domains whose tracked value comes from an attribute
+        (climate / water_heater / weather), require the attribute to be
+        present; otherwise the all/count check would treat an entity that
+        cannot report a temperature as a non-match and block behavior=last.
+        Sensor entities source their value from `state.state`, so they
+        fall through to the base impl.
+        """
+        if not super()._should_include(state):
+            return False
+        domain_spec = self._domain_specs[state.domain]
+        if domain_spec.value_source is None:
+            return True
+        return state.attributes.get(domain_spec.value_source) is not None
+
     def _get_entity_unit(self, state: State) -> str | None:
         """Get the temperature unit of an entity from its state."""
         if state.domain == SENSOR_DOMAIN:

--- a/tests/components/temperature/test_condition.py
+++ b/tests/components/temperature/test_condition.py
@@ -180,6 +180,7 @@ async def test_temperature_sensor_condition_behavior_all(
         HVACMode.AUTO,
         "current_temperature",
         threshold_unit=UnitOfTemperature.CELSIUS,
+        attribute_required=True,
     ),
 )
 async def test_temperature_climate_condition_behavior_any(
@@ -217,6 +218,7 @@ async def test_temperature_climate_condition_behavior_any(
         HVACMode.AUTO,
         "current_temperature",
         threshold_unit=UnitOfTemperature.CELSIUS,
+        attribute_required=True,
     ),
 )
 async def test_temperature_climate_condition_behavior_all(
@@ -254,6 +256,7 @@ async def test_temperature_climate_condition_behavior_all(
         "eco",
         "current_temperature",
         threshold_unit=UnitOfTemperature.CELSIUS,
+        attribute_required=True,
     ),
 )
 async def test_temperature_water_heater_condition_behavior_any(
@@ -291,6 +294,7 @@ async def test_temperature_water_heater_condition_behavior_any(
         "eco",
         "current_temperature",
         threshold_unit=UnitOfTemperature.CELSIUS,
+        attribute_required=True,
     ),
 )
 async def test_temperature_water_heater_condition_behavior_all(
@@ -329,6 +333,7 @@ async def test_temperature_water_heater_condition_behavior_all(
         "temperature",
         threshold_unit=UnitOfTemperature.CELSIUS,
         unit_attributes=_WEATHER_UNIT_ATTRIBUTES,
+        attribute_required=True,
     ),
 )
 async def test_temperature_weather_condition_behavior_any(
@@ -367,6 +372,7 @@ async def test_temperature_weather_condition_behavior_any(
         "temperature",
         threshold_unit=UnitOfTemperature.CELSIUS,
         unit_attributes=_WEATHER_UNIT_ATTRIBUTES,
+        attribute_required=True,
     ),
 )
 async def test_temperature_weather_condition_behavior_all(

--- a/tests/components/temperature/test_trigger.py
+++ b/tests/components/temperature/test_trigger.py
@@ -263,12 +263,14 @@ async def test_temperature_trigger_sensor_crossed_threshold_behavior_last(
             HVACMode.AUTO,
             CLIMATE_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "temperature.crossed_threshold",
             HVACMode.AUTO,
             CLIMATE_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
     ],
 )
@@ -308,6 +310,7 @@ async def test_temperature_trigger_climate_behavior_any(
             HVACMode.AUTO,
             CLIMATE_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
     ],
 )
@@ -347,6 +350,7 @@ async def test_temperature_trigger_climate_crossed_threshold_behavior_first(
             HVACMode.AUTO,
             CLIMATE_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
     ],
 )
@@ -389,12 +393,14 @@ async def test_temperature_trigger_climate_crossed_threshold_behavior_last(
             "eco",
             WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "temperature.crossed_threshold",
             "eco",
             WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
     ],
 )
@@ -434,6 +440,7 @@ async def test_temperature_trigger_water_heater_behavior_any(
             "eco",
             WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
     ],
 )
@@ -473,6 +480,7 @@ async def test_temperature_trigger_water_heater_crossed_threshold_behavior_first
             "eco",
             WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
+            attribute_required=True,
         ),
     ],
 )
@@ -516,6 +524,7 @@ async def test_temperature_trigger_water_heater_crossed_threshold_behavior_last(
             ATTR_WEATHER_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
             unit_attributes=_WEATHER_UNIT_ATTRIBUTES,
+            attribute_required=True,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "temperature.crossed_threshold",
@@ -523,6 +532,7 @@ async def test_temperature_trigger_water_heater_crossed_threshold_behavior_last(
             ATTR_WEATHER_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
             unit_attributes=_WEATHER_UNIT_ATTRIBUTES,
+            attribute_required=True,
         ),
     ],
 )
@@ -563,6 +573,7 @@ async def test_temperature_trigger_weather_behavior_any(
             ATTR_WEATHER_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
             unit_attributes=_WEATHER_UNIT_ATTRIBUTES,
+            attribute_required=True,
         ),
     ],
 )
@@ -603,6 +614,7 @@ async def test_temperature_trigger_weather_crossed_threshold_behavior_first(
             ATTR_WEATHER_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
             unit_attributes=_WEATHER_UNIT_ATTRIBUTES,
+            attribute_required=True,
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exclude incompatible entities from temperature automations

This means climate, water_heater and weather entities without temperature attribute won't block `last` checks for triggers or `all` checks for conditions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
