### PR TITLE
Fix hassio auth IndexError on Supervisor Unix socket requests

### DIFF
--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.auth.models import User
 from homeassistant.auth.providers import homeassistant as auth_ha
 from homeassistant.components.http import KEY_HASS, KEY_HASS_USER, HomeAssistantView
+from homeassistant.components.http.const import is_supervisor_unix_socket_request
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
@@ -41,14 +42,18 @@ class HassIOBaseAuth(HomeAssistantView):
 
     def _check_access(self, request: web.Request) -> None:
         """Check if this call is from Supervisor."""
-        # Check caller IP
-        hassio_ip = os.environ["SUPERVISOR"].split(":")[0]
-        assert request.transport
-        if ip_address(request.transport.get_extra_info("peername")[0]) != ip_address(
-            hassio_ip
-        ):
-            _LOGGER.error("Invalid auth request from %s", request.remote)
-            raise HTTPUnauthorized
+        # Requests over the Supervisor Unix socket are authenticated by the
+        # http auth middleware as the Supervisor user, so the caller-IP check
+        # below does not apply (and would crash, since `peername` is empty for
+        # Unix sockets). The user-ID check still runs to ensure only the
+        # Supervisor user can reach this endpoint.
+        if not is_supervisor_unix_socket_request(request):
+            hassio_ip = os.environ["SUPERVISOR"].split(":")[0]
+            assert request.transport
+            peername = request.transport.get_extra_info("peername")
+            if not peername or ip_address(peername[0]) != ip_address(hassio_ip):
+                _LOGGER.error("Invalid auth request from %s", request.remote)
+                raise HTTPUnauthorized
 
         # Check caller token
         if request[KEY_HASS_USER].id != self.user.id:

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -1,11 +1,17 @@
 """The tests for the hassio component."""
 
 from http import HTTPStatus
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from aiohttp.test_utils import TestClient
+from aiohttp.web_exceptions import HTTPUnauthorized
+import pytest
 
 from homeassistant.auth.providers.homeassistant import InvalidAuth
+from homeassistant.components.hassio.auth import HassIOBaseAuth
+from homeassistant.components.hassio.const import DATA_CONFIG_STORE
+from homeassistant.components.http import KEY_HASS_USER
+from homeassistant.core import HomeAssistant
 
 
 async def test_auth_success(hassio_client_supervisor: TestClient) -> None:
@@ -160,6 +166,46 @@ async def test_password_fails_no_auth(hassio_noauth_client: TestClient) -> None:
 
     # Check we got right response
     assert resp.status == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize(
+    ("peername", "unix_socket"),
+    [
+        # Unix socket transports report an empty string for peername. Before
+        # the fix this raised IndexError on `peername[0]`.
+        ("", True),
+        # Defensive: a TCP transport with no peername at all should be
+        # rejected, not crash.
+        (None, False),
+    ],
+)
+async def test_check_access_unix_socket_or_missing_peername(
+    hass: HomeAssistant,
+    hassio_stubs: None,
+    peername: str | None,
+    unix_socket: bool,
+) -> None:
+    """Test _check_access handles Unix socket requests and missing peername."""
+    hassio_user_id = hass.data[DATA_CONFIG_STORE].data.hassio_user
+    assert hassio_user_id is not None
+    user = await hass.auth.async_get_user(hassio_user_id)
+    assert user is not None
+
+    auth_view = HassIOBaseAuth(hass, user)
+
+    request = MagicMock()
+    request.transport.get_extra_info.return_value = peername
+    request.__getitem__.side_effect = lambda key: user if key is KEY_HASS_USER else None
+
+    with patch(
+        "homeassistant.components.hassio.auth.is_supervisor_unix_socket_request",
+        return_value=unix_socket,
+    ):
+        if unix_socket:
+            auth_view._check_access(request)
+        else:
+            with pytest.raises(HTTPUnauthorized):
+                auth_view._check_access(request)
 
 
 async def test_password_no_user(hassio_client_supervisor: TestClient) -> None:

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -168,44 +168,51 @@ async def test_password_fails_no_auth(hassio_noauth_client: TestClient) -> None:
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-@pytest.mark.parametrize(
-    ("peername", "unix_socket"),
-    [
-        # Unix socket transports report an empty string for peername. Before
-        # the fix this raised IndexError on `peername[0]`.
-        ("", True),
-        # Defensive: a TCP transport with no peername at all should be
-        # rejected, not crash.
-        (None, False),
-    ],
-)
-async def test_check_access_unix_socket_or_missing_peername(
-    hass: HomeAssistant,
-    hassio_stubs: None,
-    peername: str | None,
-    unix_socket: bool,
-) -> None:
-    """Test _check_access handles Unix socket requests and missing peername."""
+async def _supervisor_user_request(
+    hass: HomeAssistant, peername: str | tuple[str, int] | None
+) -> tuple[HassIOBaseAuth, MagicMock]:
+    """Build a HassIOBaseAuth view and a mock request for the Supervisor user."""
     hassio_user_id = hass.data[DATA_CONFIG_STORE].data.hassio_user
     assert hassio_user_id is not None
     user = await hass.auth.async_get_user(hassio_user_id)
     assert user is not None
 
     auth_view = HassIOBaseAuth(hass, user)
-
     request = MagicMock()
     request.transport.get_extra_info.return_value = peername
     request.__getitem__.side_effect = lambda key: user if key is KEY_HASS_USER else None
+    return auth_view, request
+
+
+@pytest.mark.usefixtures("hassio_stubs")
+async def test_check_access_unix_socket_request(hass: HomeAssistant) -> None:
+    """Test _check_access bypasses the IP check for Unix socket requests.
+
+    Unix socket transports report an empty string for peername; before the
+    fix this raised IndexError on `peername[0]`.
+    """
+    auth_view, request = await _supervisor_user_request(hass, peername="")
 
     with patch(
         "homeassistant.components.hassio.auth.is_supervisor_unix_socket_request",
-        return_value=unix_socket,
+        return_value=True,
     ):
-        if unix_socket:
-            auth_view._check_access(request)
-        else:
-            with pytest.raises(HTTPUnauthorized):
-                auth_view._check_access(request)
+        auth_view._check_access(request)
+
+
+@pytest.mark.usefixtures("hassio_stubs")
+async def test_check_access_rejects_missing_peername(hass: HomeAssistant) -> None:
+    """Test _check_access rejects TCP requests with no peername instead of crashing."""
+    auth_view, request = await _supervisor_user_request(hass, peername=None)
+
+    with (
+        patch(
+            "homeassistant.components.hassio.auth.is_supervisor_unix_socket_request",
+            return_value=False,
+        ),
+        pytest.raises(HTTPUnauthorized),
+    ):
+        auth_view._check_access(request)
 
 
 async def test_password_no_user(hassio_client_supervisor: TestClient) -> None:

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -1,6 +1,5 @@
 """The tests for the hassio component."""
 
-from collections.abc import Callable
 from contextlib import AbstractContextManager, ExitStack as DefaultContext
 from http import HTTPStatus
 from unittest.mock import MagicMock, Mock, patch
@@ -9,11 +8,9 @@ from aiohttp.test_utils import TestClient
 from aiohttp.web_exceptions import HTTPUnauthorized
 import pytest
 
-from homeassistant.auth.models import User
 from homeassistant.auth.providers.homeassistant import InvalidAuth
 from homeassistant.components.hassio.auth import HassIOBaseAuth
 from homeassistant.components.hassio.const import DATA_CONFIG_STORE
-from homeassistant.components.http import KEY_HASS_USER
 from homeassistant.core import HomeAssistant
 
 
@@ -172,24 +169,14 @@ async def test_password_fails_no_auth(hassio_noauth_client: TestClient) -> None:
 
 
 @pytest.mark.parametrize(
-    ("peername", "unix_socket", "request_getitem", "expectation"),
+    ("peername", "unix_socket", "expectation"),
     [
         # Unix socket transports report an empty string for peername. Before
         # the fix this raised IndexError on `peername[0]`.
-        (
-            "",
-            True,
-            lambda user, key: user if key == KEY_HASS_USER else None,
-            DefaultContext(),
-        ),
+        ("", True, DefaultContext()),
         # Defensive: a TCP transport with no peername at all should be
         # rejected, not crash.
-        (
-            None,
-            False,
-            lambda user, key: user if key == KEY_HASS_USER else None,
-            pytest.raises(HTTPUnauthorized),
-        ),
+        (None, False, pytest.raises(HTTPUnauthorized)),
     ],
 )
 @pytest.mark.usefixtures("hassio_stubs")
@@ -197,7 +184,6 @@ async def test_check_access_unix_socket_or_missing_peername(
     hass: HomeAssistant,
     peername: str | None,
     unix_socket: bool,
-    request_getitem: Callable[[User, str], User | None],
     expectation: AbstractContextManager,
 ) -> None:
     """Test _check_access handles Unix socket requests and missing peername."""
@@ -209,7 +195,7 @@ async def test_check_access_unix_socket_or_missing_peername(
     auth_view = HassIOBaseAuth(hass, user)
     request = MagicMock()
     request.transport.get_extra_info.return_value = peername
-    request.__getitem__.side_effect = lambda key: request_getitem(user, key)
+    request.__getitem__.return_value = user
 
     with (
         patch(

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -1,5 +1,7 @@
 """The tests for the hassio component."""
 
+from collections.abc import Callable
+from contextlib import AbstractContextManager, ExitStack as DefaultContext
 from http import HTTPStatus
 from unittest.mock import MagicMock, Mock, patch
 
@@ -7,6 +9,7 @@ from aiohttp.test_utils import TestClient
 from aiohttp.web_exceptions import HTTPUnauthorized
 import pytest
 
+from homeassistant.auth.models import User
 from homeassistant.auth.providers.homeassistant import InvalidAuth
 from homeassistant.components.hassio.auth import HassIOBaseAuth
 from homeassistant.components.hassio.const import DATA_CONFIG_STORE
@@ -168,10 +171,36 @@ async def test_password_fails_no_auth(hassio_noauth_client: TestClient) -> None:
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-async def _supervisor_user_request(
-    hass: HomeAssistant, peername: str | tuple[str, int] | None
-) -> tuple[HassIOBaseAuth, MagicMock]:
-    """Build a HassIOBaseAuth view and a mock request for the Supervisor user."""
+@pytest.mark.parametrize(
+    ("peername", "unix_socket", "request_getitem", "expectation"),
+    [
+        # Unix socket transports report an empty string for peername. Before
+        # the fix this raised IndexError on `peername[0]`.
+        (
+            "",
+            True,
+            lambda user, key: user if key is KEY_HASS_USER else None,
+            DefaultContext(),
+        ),
+        # Defensive: a TCP transport with no peername at all should be
+        # rejected, not crash.
+        (
+            None,
+            False,
+            lambda user, key: user if key is KEY_HASS_USER else None,
+            pytest.raises(HTTPUnauthorized),
+        ),
+    ],
+)
+@pytest.mark.usefixtures("hassio_stubs")
+async def test_check_access_unix_socket_or_missing_peername(
+    hass: HomeAssistant,
+    peername: str | None,
+    unix_socket: bool,
+    request_getitem: Callable[[User, str], User | None],
+    expectation: AbstractContextManager,
+) -> None:
+    """Test _check_access handles Unix socket requests and missing peername."""
     hassio_user_id = hass.data[DATA_CONFIG_STORE].data.hassio_user
     assert hassio_user_id is not None
     user = await hass.auth.async_get_user(hassio_user_id)
@@ -180,37 +209,14 @@ async def _supervisor_user_request(
     auth_view = HassIOBaseAuth(hass, user)
     request = MagicMock()
     request.transport.get_extra_info.return_value = peername
-    request.__getitem__.side_effect = lambda key: user if key is KEY_HASS_USER else None
-    return auth_view, request
-
-
-@pytest.mark.usefixtures("hassio_stubs")
-async def test_check_access_unix_socket_request(hass: HomeAssistant) -> None:
-    """Test _check_access bypasses the IP check for Unix socket requests.
-
-    Unix socket transports report an empty string for peername; before the
-    fix this raised IndexError on `peername[0]`.
-    """
-    auth_view, request = await _supervisor_user_request(hass, peername="")
-
-    with patch(
-        "homeassistant.components.hassio.auth.is_supervisor_unix_socket_request",
-        return_value=True,
-    ):
-        auth_view._check_access(request)
-
-
-@pytest.mark.usefixtures("hassio_stubs")
-async def test_check_access_rejects_missing_peername(hass: HomeAssistant) -> None:
-    """Test _check_access rejects TCP requests with no peername instead of crashing."""
-    auth_view, request = await _supervisor_user_request(hass, peername=None)
+    request.__getitem__.side_effect = lambda key: request_getitem(user, key)
 
     with (
         patch(
             "homeassistant.components.hassio.auth.is_supervisor_unix_socket_request",
-            return_value=False,
+            return_value=unix_socket,
         ),
-        pytest.raises(HTTPUnauthorized),
+        expectation,
     ):
         auth_view._check_access(request)
 

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -179,7 +179,7 @@ async def test_password_fails_no_auth(hassio_noauth_client: TestClient) -> None:
         (
             "",
             True,
-            lambda user, key: user if key is KEY_HASS_USER else None,
+            lambda user, key: user if key == KEY_HASS_USER else None,
             DefaultContext(),
         ),
         # Defensive: a TCP transport with no peername at all should be
@@ -187,7 +187,7 @@ async def test_password_fails_no_auth(hassio_noauth_client: TestClient) -> None:
         (
             None,
             False,
-            lambda user, key: user if key is KEY_HASS_USER else None,
+            lambda user, key: user if key == KEY_HASS_USER else None,
             pytest.raises(HTTPUnauthorized),
         ),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Requests over the Supervisor Unix socket (added in #163907) are authenticated by the http auth middleware as the Supervisor user, but have an empty `peername` on the transport. The hassio auth view's `_check_access` did a TCP-style `peername[0]` IP comparison and crashed with `IndexError: string index out of range`.

Skip the IP check when the request comes via the Supervisor Unix socket — the socket is the trust boundary and the existing user-ID check ensures only the Supervisor user can reach the endpoint. Also guard against a missing peername on TCP transports (reject rather than crash).

This is related to #163907.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
