### PR TITLE
Remove name field from met config flow

### DIFF
--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -72,7 +72,7 @@ async def async_migrate_entry(
         data = dict(config_entry.data)
         title = config_entry.title
         if name := data.pop(CONF_NAME, None):
-            title = name
+            title = title or name
 
         hass.config_entries.async_update_entry(
             config_entry,

--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from homeassistant.const import Platform
+from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -59,6 +59,29 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: MetWeatherConfigEntry
+) -> bool:
+    """Migrate old config entry."""
+    if config_entry.version > 1:
+        return False
+
+    if config_entry.version == 1 and config_entry.minor_version < 2:
+        data = dict(config_entry.data)
+        title = config_entry.title
+        if name := data.pop(CONF_NAME, None):
+            title = name
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data=data,
+            title=title,
+            minor_version=2,
+        )
+
+    return True
 
 
 async def cleanup_old_device(hass: HomeAssistant) -> None:

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -103,6 +103,7 @@ class MetConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for Met component."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -163,7 +164,7 @@ class MetOptionsFlowHandler(OptionsFlowWithReload):
             # Update config entry with data from user input while preserving
             # existing fields such as legacy stored names.
             self.hass.config_entries.async_update_entry(self.config_entry, data=data)
-            return self.async_create_entry(title="", data=data)
+            return self.async_create_entry(title=self.config_entry.title, data=data)
 
         return self.async_show_form(
             step_id="init",

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -159,8 +159,9 @@ class MetOptionsFlowHandler(OptionsFlowWithReload):
         """Configure options for Met."""
 
         if user_input is not None:
-            data = _location_data(user_input)
-            # Update config entry with data from user input
+            data = {**self.config_entry.data, **_location_data(user_input)}
+            # Update config entry with data from user input while preserving
+            # existing fields such as legacy stored names.
             self.hass.config_entries.async_update_entry(self.config_entry, data=data)
             return self.async_create_entry(title="", data=data)
 

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_ELEVATION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_NAME,
     UnitOfLength,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -32,6 +31,15 @@ from .const import (
     DOMAIN,
     HOME_LOCATION_NAME,
 )
+
+
+def _location_data(user_input: dict[str, Any]) -> dict[str, Any]:
+    """Return config entry data for a fixed location."""
+    return {
+        CONF_LATITUDE: user_input[CONF_LATITUDE],
+        CONF_LONGITUDE: user_input[CONF_LONGITUDE],
+        CONF_ELEVATION: user_input[CONF_ELEVATION],
+    }
 
 
 @callback
@@ -56,7 +64,6 @@ def _get_data_schema(
     if config_entry is None or config_entry.data.get(CONF_TRACK_HOME, False):
         return vol.Schema(
             {
-                vol.Required(CONF_NAME, default=HOME_LOCATION_NAME): str,
                 vol.Required(CONF_LATITUDE, default=hass.config.latitude): cv.latitude,
                 vol.Required(
                     CONF_LONGITUDE, default=hass.config.longitude
@@ -74,7 +81,6 @@ def _get_data_schema(
     # Not tracking home, default values come from config entry
     return vol.Schema(
         {
-            vol.Required(CONF_NAME, default=config_entry.data.get(CONF_NAME)): str,
             vol.Required(
                 CONF_LATITUDE, default=config_entry.data.get(CONF_LATITUDE)
             ): cv.latitude,
@@ -105,14 +111,13 @@ class MetConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
+            data = _location_data(user_input)
             if (
-                f"{user_input.get(CONF_LATITUDE)}-{user_input.get(CONF_LONGITUDE)}"
+                f"{data[CONF_LATITUDE]}-{data[CONF_LONGITUDE]}"
                 not in configured_instances(self.hass)
             ):
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
-                )
-            errors[CONF_NAME] = "already_configured"
+                return self.async_create_entry(title="", data=data)
+            errors["base"] = "already_configured"
 
         return self.async_show_form(
             step_id="user",
@@ -154,13 +159,10 @@ class MetOptionsFlowHandler(OptionsFlowWithReload):
         """Configure options for Met."""
 
         if user_input is not None:
+            data = _location_data(user_input)
             # Update config entry with data from user input
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=user_input
-            )
-            return self.async_create_entry(
-                title=self.config_entry.title, data=user_input
-            )
+            self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+            return self.async_create_entry(title="", data=data)
 
         return self.async_show_form(
             step_id="init",

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -160,9 +160,7 @@ class MetOptionsFlowHandler(OptionsFlowWithReload):
         """Configure options for Met."""
 
         if user_input is not None:
-            data = {**self.config_entry.data, **_location_data(user_input)}
-            # Update config entry with data from user input while preserving
-            # existing fields such as legacy stored names.
+            data = _location_data(user_input)
             self.hass.config_entries.async_update_entry(self.config_entry, data=data)
             return self.async_create_entry(title=self.config_entry.title, data=data)
 

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow to configure Met component."""
 
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -28,6 +29,7 @@ from .const import (
     CONF_TRACK_HOME,
     DEFAULT_HOME_LATITUDE,
     DEFAULT_HOME_LONGITUDE,
+    DEFAULT_NAME,
     DOMAIN,
     HOME_LOCATION_NAME,
 )
@@ -40,6 +42,22 @@ def _location_data(user_input: dict[str, Any]) -> dict[str, Any]:
         CONF_LONGITUDE: user_input[CONF_LONGITUDE],
         CONF_ELEVATION: user_input[CONF_ELEVATION],
     }
+
+
+def _fixed_location_title(data: Mapping[str, Any]) -> str:
+    """Return the generated title for a fixed location."""
+    return f"{DEFAULT_NAME} ({data[CONF_LATITUDE]}, {data[CONF_LONGITUDE]})"
+
+
+def _should_update_generated_title(config_entry: ConfigEntry) -> bool:
+    """Return if the entry title still matches an integration-generated title."""
+    if not config_entry.title:
+        return True
+
+    if config_entry.data.get(CONF_TRACK_HOME, False):
+        return config_entry.title == HOME_LOCATION_NAME
+
+    return config_entry.title == _fixed_location_title(config_entry.data)
 
 
 @callback
@@ -117,7 +135,9 @@ class MetConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 f"{data[CONF_LATITUDE]}-{data[CONF_LONGITUDE]}"
                 not in configured_instances(self.hass)
             ):
-                return self.async_create_entry(title="", data=data)
+                return self.async_create_entry(
+                    title=_fixed_location_title(data), data=data
+                )
             errors["base"] = "already_configured"
 
         return self.async_show_form(
@@ -161,8 +181,15 @@ class MetOptionsFlowHandler(OptionsFlowWithReload):
 
         if user_input is not None:
             data = _location_data(user_input)
-            self.hass.config_entries.async_update_entry(self.config_entry, data=data)
-            return self.async_create_entry(title=self.config_entry.title, data=data)
+            title = (
+                _fixed_location_title(data)
+                if _should_update_generated_title(self.config_entry)
+                else self.config_entry.title
+            )
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=data, title=title
+            )
+            return self.async_create_entry(title=title, data=data)
 
         return self.async_show_form(
             step_id="init",

--- a/homeassistant/components/met/const.py
+++ b/homeassistant/components/met/const.py
@@ -38,6 +38,8 @@ from homeassistant.components.weather import (
 
 DOMAIN = "met"
 
+DEFAULT_NAME = "Met.no"
+
 HOME_LOCATION_NAME = "Home"
 
 CONF_TRACK_HOME = "track_home"

--- a/homeassistant/components/met/strings.json
+++ b/homeassistant/components/met/strings.json
@@ -11,8 +11,7 @@
         "data": {
           "elevation": "[%key:common::config_flow::data::elevation%]",
           "latitude": "[%key:common::config_flow::data::latitude%]",
-          "longitude": "[%key:common::config_flow::data::longitude%]",
-          "name": "[%key:common::config_flow::data::name%]"
+          "longitude": "[%key:common::config_flow::data::longitude%]"
         },
         "description": "Meteorologisk institutt",
         "title": "[%key:common::config_flow::data::location%]"
@@ -30,8 +29,7 @@
         "data": {
           "elevation": "[%key:common::config_flow::data::elevation%]",
           "latitude": "[%key:common::config_flow::data::latitude%]",
-          "longitude": "[%key:common::config_flow::data::longitude%]",
-          "name": "[%key:common::config_flow::data::name%]"
+          "longitude": "[%key:common::config_flow::data::longitude%]"
         },
         "title": "[%key:common::config_flow::data::location%]"
       }

--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -40,14 +40,13 @@ from .const import (
     ATTR_MAP,
     CONDITIONS_MAP,
     CONF_TRACK_HOME,
+    DEFAULT_NAME,
     DOMAIN,
     FORECAST_MAP,
 )
 from .coordinator import MetDataUpdateCoordinator, MetWeatherConfigEntry
 
 PARALLEL_UPDATES = 0
-
-DEFAULT_NAME = "Met.no"
 
 
 async def async_setup_entry(
@@ -59,14 +58,14 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entity_registry = er.async_get(hass)
 
-    name: str | None
+    device_name: str
     is_metric = hass.config.units is METRIC_SYSTEM
     if config_entry.data.get(CONF_TRACK_HOME, False):
-        name = hass.config.location_name
+        device_name = hass.config.location_name
     else:
-        name = config_entry.title or DEFAULT_NAME
+        device_name = config_entry.title or DEFAULT_NAME
 
-    entities = [MetWeather(coordinator, config_entry, name, is_metric)]
+    entities = [MetWeather(coordinator, config_entry, device_name, is_metric)]
 
     # Remove hourly entity from legacy config entries
     if hourly_entity_id := entity_registry.async_get_entity_id(
@@ -106,6 +105,7 @@ class MetWeather(SingleCoordinatorWeatherEntity[MetDataUpdateCoordinator]):
         "Meteorological Institute."
     )
     _attr_has_entity_name = True
+    _attr_name = None
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
     _attr_native_pressure_unit = UnitOfPressure.HPA
@@ -118,7 +118,7 @@ class MetWeather(SingleCoordinatorWeatherEntity[MetDataUpdateCoordinator]):
         self,
         coordinator: MetDataUpdateCoordinator,
         config_entry: MetWeatherConfigEntry,
-        name: str,
+        device_name: str,
         is_metric: bool,
     ) -> None:
         """Initialise the platform with a data instance and site."""
@@ -127,15 +127,14 @@ class MetWeather(SingleCoordinatorWeatherEntity[MetDataUpdateCoordinator]):
         self._config = config_entry.data
         self._is_metric = is_metric
         self._attr_device_info = DeviceInfo(
-            name="Forecast",
+            name=device_name,
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, config_entry.entry_id)},
-            manufacturer="Met.no",
+            manufacturer=DEFAULT_NAME,
             model="Forecast",
             configuration_url="https://www.met.no/en",
         )
         self._attr_track_home = self._config.get(CONF_TRACK_HOME, False)
-        self._attr_name = name
 
     @property
     def condition(self) -> str | None:

--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -1,7 +1,7 @@
 """Support for Met.no weather service."""
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
@@ -23,7 +23,6 @@ from homeassistant.components.weather import (
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    CONF_NAME,
     UnitOfPrecipitationDepth,
     UnitOfPressure,
     UnitOfSpeed,
@@ -65,9 +64,7 @@ async def async_setup_entry(
     if config_entry.data.get(CONF_TRACK_HOME, False):
         name = hass.config.location_name
     else:
-        name = config_entry.data.get(CONF_NAME, DEFAULT_NAME)
-        if TYPE_CHECKING:
-            assert isinstance(name, str)
+        name = config_entry.title or DEFAULT_NAME
 
     entities = [MetWeather(coordinator, config_entry, name, is_metric)]
 

--- a/tests/components/met/__init__.py
+++ b/tests/components/met/__init__.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from homeassistant.components.met.const import CONF_TRACK_HOME, DOMAIN
-from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -14,7 +14,6 @@ async def init_integration(
 ) -> MockConfigEntry:
     """Set up the Met integration in Home Assistant."""
     entry_data = {
-        CONF_NAME: "test",
         CONF_LATITUDE: 0,
         CONF_LONGITUDE: 1.0,
         CONF_ELEVATION: 1.0,

--- a/tests/components/met/__init__.py
+++ b/tests/components/met/__init__.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.met.const import CONF_TRACK_HOME, DOMAIN
+from homeassistant.components.met.const import (
+    CONF_TRACK_HOME,
+    DOMAIN,
+    HOME_LOCATION_NAME,
+)
 from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 
@@ -22,7 +26,12 @@ async def init_integration(
     if track_home:
         entry_data = {CONF_TRACK_HOME: True}
 
-    entry = MockConfigEntry(domain=DOMAIN, data=entry_data)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+        title=HOME_LOCATION_NAME if track_home else "",
+        minor_version=2,
+    )
     with patch(
         "homeassistant.components.met.coordinator.metno.MetWeatherData.fetching_data",
         return_value=True,

--- a/tests/components/met/__init__.py
+++ b/tests/components/met/__init__.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant.components.met.const import (
     CONF_TRACK_HOME,
+    DEFAULT_NAME,
     DOMAIN,
     HOME_LOCATION_NAME,
 )
@@ -14,7 +15,7 @@ from tests.common import MockConfigEntry
 
 
 async def init_integration(
-    hass: HomeAssistant, track_home: bool = False
+    hass: HomeAssistant, track_home: bool = False, title: str | None = None
 ) -> MockConfigEntry:
     """Set up the Met integration in Home Assistant."""
     entry_data = {
@@ -29,7 +30,13 @@ async def init_integration(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=entry_data,
-        title=HOME_LOCATION_NAME if track_home else "",
+        title=(
+            title
+            if title is not None
+            else HOME_LOCATION_NAME
+            if track_home
+            else f"{DEFAULT_NAME} (0, 1.0)"
+        ),
         minor_version=2,
     )
     with patch(

--- a/tests/components/met/snapshots/test_diagnostics.ambr
+++ b/tests/components/met/snapshots/test_diagnostics.ambr
@@ -13,7 +13,6 @@
       'elevation': 1.0,
       'latitude': '**REDACTED**',
       'longitude': '**REDACTED**',
-      'name': 'test',
     }),
   })
 # ---

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -7,7 +7,11 @@ from unittest.mock import ANY, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.met.const import DOMAIN, HOME_LOCATION_NAME
+from homeassistant.components.met.const import (
+    CONF_TRACK_HOME,
+    DOMAIN,
+    HOME_LOCATION_NAME,
+)
 from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.core_config import async_process_ha_core_config
@@ -166,6 +170,37 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == ""
     assert result["data"] == update_data
+    weatherdatamock.assert_called_with(
+        {"lat": "12", "lon": "23", "msl": "456"}, ANY, api_url=ANY
+    )
+
+
+@pytest.mark.disable_autouse_fixture
+async def test_options_flow_tracking_home_entry_uses_fixed_location(
+    hass: HomeAssistant,
+) -> None:
+    """Test options flow switches a home-tracking entry to a fixed location."""
+    update_data = {
+        CONF_LATITUDE: 12,
+        CONF_LONGITUDE: 23,
+        CONF_ELEVATION: 456,
+    }
+
+    entry = await init_integration(hass, track_home=True)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.met.coordinator.metno.MetWeatherData"
+    ) as weatherdatamock:
+        result = await hass.config_entries.options.async_init(
+            entry.entry_id, data=update_data
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == update_data
+    assert entry.data == update_data
+    assert CONF_TRACK_HOME not in entry.data
     weatherdatamock.assert_called_with(
         {"lat": "12", "lon": "23", "msl": "456"}, ANY, api_url=ANY
     )

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -8,7 +8,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.met.const import DOMAIN, HOME_LOCATION_NAME
-from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.data_entry_flow import FlowResultType
@@ -56,7 +56,6 @@ async def test_flow_with_home_location(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
     default_data = result["data_schema"]({})
-    assert default_data["name"] == HOME_LOCATION_NAME
     assert default_data["latitude"] == 1
     assert default_data["longitude"] == 2
     assert default_data["elevation"] == 3
@@ -65,7 +64,6 @@ async def test_flow_with_home_location(hass: HomeAssistant) -> None:
 async def test_create_entry(hass: HomeAssistant) -> None:
     """Test create entry from user input."""
     test_data = {
-        "name": "home",
         CONF_LONGITUDE: 0,
         CONF_LATITUDE: 0,
         CONF_ELEVATION: 0,
@@ -76,7 +74,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "home"
+    assert result["title"] == ""
     assert result["data"] == test_data
 
 
@@ -88,12 +86,11 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """
     first_entry = MockConfigEntry(
         domain="met",
-        data={"name": "home", CONF_LATITUDE: 0, CONF_LONGITUDE: 0, CONF_ELEVATION: 0},
+        data={CONF_LATITUDE: 0, CONF_LONGITUDE: 0, CONF_ELEVATION: 0},
     )
     first_entry.add_to_hass(hass)
 
     test_data = {
-        "name": "home",
         CONF_LONGITUDE: 0,
         CONF_LATITUDE: 0,
         CONF_ELEVATION: 0,
@@ -104,7 +101,7 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"]["name"] == "already_configured"
+    assert result["errors"]["base"] == "already_configured"
 
 
 async def test_onboarding_step(hass: HomeAssistant) -> None:
@@ -122,7 +119,7 @@ async def test_onboarding_step(hass: HomeAssistant) -> None:
     ("latitude", "longitude"), [(52.3731339, 4.8903147), (0.0, 0.0)]
 )
 async def test_onboarding_step_abort_no_home(
-    hass: HomeAssistant, latitude, longitude
+    hass: HomeAssistant, latitude: float, longitude: float
 ) -> None:
     """Test entry not created when default step fails."""
     await async_process_ha_core_config(
@@ -145,7 +142,6 @@ async def test_onboarding_step_abort_no_home(
 async def test_options_flow(hass: HomeAssistant) -> None:
     """Test show options form."""
     update_data = {
-        CONF_NAME: "test",
         CONF_LATITUDE: 12,
         CONF_LONGITUDE: 23,
         CONF_ELEVATION: 456,
@@ -168,7 +164,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Mock Title"
+    assert result["title"] == ""
     assert result["data"] == update_data
     weatherdatamock.assert_called_with(
         {"lat": "12", "lon": "23", "msl": "456"}, ANY, api_url=ANY

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.met.const import (
     CONF_TRACK_HOME,
+    DEFAULT_NAME,
     DOMAIN,
     HOME_LOCATION_NAME,
 )
@@ -78,7 +79,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == ""
+    assert result["title"] == f"{DEFAULT_NAME} (0, 0)"
     assert result["data"] == test_data
 
 
@@ -168,8 +169,69 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == ""
+    assert result["title"] == f"{DEFAULT_NAME} (12, 23)"
+    assert entry.title == f"{DEFAULT_NAME} (12, 23)"
     assert result["data"] == update_data
+    weatherdatamock.assert_called_with(
+        {"lat": "12", "lon": "23", "msl": "456"}, ANY, api_url=ANY
+    )
+
+
+@pytest.mark.disable_autouse_fixture
+async def test_options_flow_updates_generated_fixed_location_title(
+    hass: HomeAssistant,
+) -> None:
+    """Test options flow updates a generated fixed-location title."""
+    update_data = {
+        CONF_LATITUDE: 12,
+        CONF_LONGITUDE: 23,
+        CONF_ELEVATION: 456,
+    }
+
+    entry = await init_integration(hass)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.met.coordinator.metno.MetWeatherData"
+    ) as weatherdatamock:
+        result = await hass.config_entries.options.async_init(
+            entry.entry_id, data=update_data
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"{DEFAULT_NAME} (12, 23)"
+    assert entry.title == f"{DEFAULT_NAME} (12, 23)"
+    assert entry.data == update_data
+    weatherdatamock.assert_called_with(
+        {"lat": "12", "lon": "23", "msl": "456"}, ANY, api_url=ANY
+    )
+
+
+@pytest.mark.disable_autouse_fixture
+async def test_options_flow_preserves_custom_title(hass: HomeAssistant) -> None:
+    """Test options flow preserves a user-customized title."""
+    update_data = {
+        CONF_LATITUDE: 12,
+        CONF_LONGITUDE: 23,
+        CONF_ELEVATION: 456,
+    }
+
+    entry = await init_integration(hass, title="Custom title")
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.met.coordinator.metno.MetWeatherData"
+    ) as weatherdatamock:
+        result = await hass.config_entries.options.async_init(
+            entry.entry_id, data=update_data
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Custom title"
+    assert entry.title == "Custom title"
+    assert entry.data == update_data
     weatherdatamock.assert_called_with(
         {"lat": "12", "lon": "23", "msl": "456"}, ANY, api_url=ANY
     )
@@ -198,6 +260,8 @@ async def test_options_flow_tracking_home_entry_uses_fixed_location(
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"{DEFAULT_NAME} (12, 23)"
+    assert entry.title == f"{DEFAULT_NAME} (12, 23)"
     assert result["data"] == update_data
     assert entry.data == update_data
     assert CONF_TRACK_HOME not in entry.data

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -84,11 +84,21 @@ async def test_removing_incorrect_devices(
     assert "Removing improper device Forecast_legacy" in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("title", "expected_title", "entity_id"),
+    [
+        ("", "Somewhere", "weather.forecast_somewhere"),
+        ("Custom title", "Custom title", "weather.forecast_custom_title"),
+    ],
+)
 async def test_migrate_name_to_title(
     hass: HomeAssistant,
     mock_weather: MagicMock,
+    title: str,
+    expected_title: str,
+    entity_id: str,
 ) -> None:
-    """Test legacy stored names migrate to the config entry title."""
+    """Test legacy stored names migrate to the config entry title when needed."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         source=SOURCE_USER,
@@ -98,7 +108,7 @@ async def test_migrate_name_to_title(
             CONF_LONGITUDE: 20,
             CONF_ELEVATION: 0,
         },
-        title="",
+        title=title,
         minor_version=1,
     )
     entry.add_to_hass(hass)
@@ -108,10 +118,10 @@ async def test_migrate_name_to_title(
 
     assert entry.version == 1
     assert entry.minor_version == 2
-    assert entry.title == "Somewhere"
+    assert entry.title == expected_title
     assert entry.data == {
         CONF_LATITUDE: 10,
         CONF_LONGITUDE: 20,
         CONF_ELEVATION: 0,
     }
-    assert hass.states.async_entity_ids("weather") == ["weather.forecast_somewhere"]
+    assert hass.states.async_entity_ids("weather") == [entity_id]

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -1,5 +1,7 @@
 """Test the Met integration init."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from homeassistant.components.met.const import (
@@ -7,12 +9,15 @@ from homeassistant.components.met.const import (
     DEFAULT_HOME_LONGITUDE,
     DOMAIN,
 )
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
+from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.helpers import device_registry as dr
 
 from . import init_integration
+
+from tests.common import MockConfigEntry
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:
@@ -56,7 +61,7 @@ async def test_removing_incorrect_devices(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     caplog: pytest.LogCaptureFixture,
-    mock_weather,
+    mock_weather: MagicMock,
 ) -> None:
     """Test we remove incorrect devices."""
     entry = await init_integration(hass)
@@ -77,3 +82,36 @@ async def test_removing_incorrect_devices(
     assert not device_registry.async_get_device(identifiers={(DOMAIN,)})
     assert device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
     assert "Removing improper device Forecast_legacy" in caplog.text
+
+
+async def test_migrate_name_to_title(
+    hass: HomeAssistant,
+    mock_weather: MagicMock,
+) -> None:
+    """Test legacy stored names migrate to the config entry title."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={
+            CONF_NAME: "Somewhere",
+            CONF_LATITUDE: 10,
+            CONF_LONGITUDE: 20,
+            CONF_ELEVATION: 0,
+        },
+        title="",
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 1
+    assert entry.minor_version == 2
+    assert entry.title == "Somewhere"
+    assert entry.data == {
+        CONF_LATITUDE: 10,
+        CONF_LONGITUDE: 20,
+        CONF_ELEVATION: 0,
+    }
+    assert hass.states.async_entity_ids("weather") == ["weather.forecast_somewhere"]

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -87,8 +87,8 @@ async def test_removing_incorrect_devices(
 @pytest.mark.parametrize(
     ("title", "expected_title", "entity_id"),
     [
-        ("", "Somewhere", "weather.forecast_somewhere"),
-        ("Custom title", "Custom title", "weather.forecast_custom_title"),
+        ("", "Somewhere", "weather.somewhere"),
+        ("Custom title", "Custom title", "weather.custom_title"),
     ],
 )
 async def test_migrate_name_to_title(

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from homeassistant import config_entries
 from homeassistant.components.met import DOMAIN
+from homeassistant.components.met.const import DEFAULT_NAME
 from homeassistant.components.weather import (
     ATTR_CONDITION_CLOUDY,
     ATTR_WEATHER_DEW_POINT,
@@ -15,6 +16,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
     DOMAIN as WEATHER_DOMAIN,
 )
+from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -71,6 +73,18 @@ async def test_weather(hass: HomeAssistant, mock_weather: MagicMock) -> None:
     assert state.attributes[ATTR_WEATHER_WIND_BEARING] == 90
     assert state.attributes[ATTR_WEATHER_DEW_POINT] == 12.1
     assert state.attributes[ATTR_WEATHER_UV_INDEX] == 1.1
+
+
+async def test_fixed_location_uses_entry_title_as_main_entity_name(
+    hass: HomeAssistant, mock_weather: MagicMock
+) -> None:
+    """Test fixed-location weather entity uses the entry title as the entity name."""
+    await init_integration(hass)
+
+    state = hass.states.get("weather.met_no_0_1_0")
+
+    assert state
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{DEFAULT_NAME} (0, 1.0)"
 
 
 async def test_tracking_home(hass: HomeAssistant, mock_weather: MagicMock) -> None:
@@ -146,5 +160,5 @@ async def test_remove_hourly_entity(
         data={"latitude": 10, "longitude": 20, "elevation": 0},
     )
     await hass.async_block_till_done()
-    assert hass.states.async_entity_ids("weather") == ["weather.forecast_met_no"]
-    assert list(entity_registry.entities.keys()) == ["weather.forecast_met_no"]
+    assert hass.states.async_entity_ids("weather") == ["weather.met_no_10_20"]
+    assert list(entity_registry.entities.keys()) == ["weather.met_no_10_20"]

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -1,5 +1,7 @@
 """Test Met weather entity."""
 
+from unittest.mock import MagicMock
+
 from homeassistant import config_entries
 from homeassistant.components.met import DOMAIN
 from homeassistant.components.weather import (
@@ -20,7 +22,9 @@ from . import init_integration
 
 
 async def test_new_config_entry(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_weather: MagicMock,
 ) -> None:
     """Test the expected entities are created."""
     await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
@@ -32,7 +36,9 @@ async def test_new_config_entry(
 
 
 async def test_legacy_config_entry(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_weather: MagicMock,
 ) -> None:
     """Test the expected entities are created."""
     entity_registry.async_get_or_create(
@@ -48,7 +54,7 @@ async def test_legacy_config_entry(
     assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 1
 
 
-async def test_weather(hass: HomeAssistant, mock_weather) -> None:
+async def test_weather(hass: HomeAssistant, mock_weather: MagicMock) -> None:
     """Test states of the weather."""
 
     await init_integration(hass)
@@ -67,7 +73,7 @@ async def test_weather(hass: HomeAssistant, mock_weather) -> None:
     assert state.attributes[ATTR_WEATHER_UV_INDEX] == 1.1
 
 
-async def test_tracking_home(hass: HomeAssistant, mock_weather) -> None:
+async def test_tracking_home(hass: HomeAssistant, mock_weather: MagicMock) -> None:
     """Test we track home."""
     await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
     await hass.async_block_till_done()
@@ -91,13 +97,13 @@ async def test_tracking_home(hass: HomeAssistant, mock_weather) -> None:
     assert len(hass.states.async_entity_ids("weather")) == 0
 
 
-async def test_not_tracking_home(hass: HomeAssistant, mock_weather) -> None:
+async def test_not_tracking_home(hass: HomeAssistant, mock_weather: MagicMock) -> None:
     """Test when we not track home."""
 
     await hass.config_entries.flow.async_init(
         "met",
         context={"source": config_entries.SOURCE_USER},
-        data={"name": "Somewhere", "latitude": 10, "longitude": 20, "elevation": 0},
+        data={"latitude": 10, "longitude": 20, "elevation": 0},
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids("weather")) == 1
@@ -116,7 +122,9 @@ async def test_not_tracking_home(hass: HomeAssistant, mock_weather) -> None:
 
 
 async def test_remove_hourly_entity(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_weather: MagicMock,
 ) -> None:
     """Test removing the hourly entity."""
 
@@ -135,8 +143,8 @@ async def test_remove_hourly_entity(
     await hass.config_entries.flow.async_init(
         "met",
         context={"source": config_entries.SOURCE_USER},
-        data={"name": "Somewhere", "latitude": 10, "longitude": 20, "elevation": 0},
+        data={"latitude": 10, "longitude": 20, "elevation": 0},
     )
     await hass.async_block_till_done()
-    assert hass.states.async_entity_ids("weather") == ["weather.forecast_somewhere"]
-    assert list(entity_registry.entities.keys()) == ["weather.forecast_somewhere"]
+    assert hass.states.async_entity_ids("weather") == ["weather.forecast_met_no"]
+    assert list(entity_registry.entities.keys()) == ["weather.forecast_met_no"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove name field from met config flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168936
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
