### PR TITLE
Remove not used `None` defaults on MQTT publish API

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -128,8 +128,8 @@ def publish(
     hass: HomeAssistant,
     topic: str,
     payload: PublishPayloadType,
-    qos: int | None = 0,
-    retain: bool | None = False,
+    qos: int = 0,
+    retain: bool = False,
     encoding: str | None = DEFAULT_ENCODING,
 ) -> None:
     """Publish message to a MQTT topic."""
@@ -140,8 +140,8 @@ async def async_publish(
     hass: HomeAssistant,
     topic: str,
     payload: PublishPayloadType,
-    qos: int | None = 0,
-    retain: bool | None = False,
+    qos: int = 0,
+    retain: bool = False,
     encoding: str | None = DEFAULT_ENCODING,
 ) -> None:
     """Publish message to a MQTT topic."""
@@ -181,9 +181,7 @@ async def async_publish(
                 )
                 return
 
-    await mqtt_data.client.async_publish(
-        topic, outgoing_payload, qos or 0, retain or False
-    )
+    await mqtt_data.client.async_publish(topic, outgoing_payload, qos, retain)
 
 
 @callback

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -186,9 +186,12 @@ async def async_publish(
     # Check for fallback to `None` values can be removed with HA Core 2027.6
     if qos is None or retain is None:
         _LOGGER.warning(  # type: ignore[unreachable]
-            "Using None values for qos or retain on the MQTT aysnc_publish API is "
-            "deprecated. The qos should be of type `int`, and `retain` of type `bool`. "
-            "This will stop working with HA Core 2027.6"
+            "Using `None` values for qos or retain on the MQTT async_publish API is "
+            "deprecated. The `qos` arg should be of type `int`, and the `retain` arg "
+            "of type `bool`. This will stop working with HA Core 2027.6. "
+            "Got qos=%s, retain=%s",
+            qos,
+            retain,
         )
         qos = qos or 0
         retain = retain or False

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -187,11 +187,12 @@ async def async_publish(
     # Check for fallback to `None` values can be removed with HA Core 2027.6
     if qos is None or retain is None:
         report_usage(  # type: ignore[unreachable]
-            "received a call to the MQTT publish API from a custom integration "
-            "with a `None` value  for qos or retain argument. The `qos` argument should "
-            "be of type `int`, and the `retain` argument of type `bool`.",
+            "that calls the MQTT publish API with `None` for qos or retain. "
+            "The `qos` argument must be an `int`, "
+            "and the `retain` argument must be a `bool`",
             breaks_in_ha_version="2027.6.0",
             core_behavior=ReportBehavior.LOG,
+            exclude_integrations={DOMAIN},
         )
         qos = qos or 0
         retain = retain or False

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -181,6 +181,18 @@ async def async_publish(
                 )
                 return
 
+    # Passing None for qos or retain args was deprecated.
+    # Custom integrations should update there code.
+    # Check for fallback to `None` values can be removed with HA Core 2027.6
+    if qos is None or retain is None:
+        _LOGGER.warning(  # type: ignore[unreachable]
+            "Using None values for qos or retain on the MQTT aysnc_publish API is "
+            "deprecated. The qos should be of type `int`, and `retain` of type `bool`. "
+            "This will stop working with HA Core 2027.6"
+        )
+        qos = qos or 0
+        retain = retain or False
+
     await mqtt_data.client.async_publish(topic, outgoing_payload, qos, retain)
 
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.importlib import async_import_module
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
@@ -185,13 +186,12 @@ async def async_publish(
     # Custom integrations should update there code.
     # Check for fallback to `None` values can be removed with HA Core 2027.6
     if qos is None or retain is None:
-        _LOGGER.warning(  # type: ignore[unreachable]
-            "Using `None` values for qos or retain on the MQTT async_publish API is "
-            "deprecated. The `qos` arg should be of type `int`, and the `retain` arg "
-            "of type `bool`. This will stop working with HA Core 2027.6. "
-            "Got qos=%s, retain=%s",
-            qos,
-            retain,
+        report_usage(  # type: ignore[unreachable]
+            "received a call to the MQTT publish API from a custom integration "
+            "with a `None` value  for qos or retain argument. The `qos` argument should "
+            "be of type `int`, and the `retain` argument of type `bool`.",
+            breaks_in_ha_version="2027.6.0",
+            core_behavior=ReportBehavior.LOG,
         )
         qos = qos or 0
         retain = retain or False

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -42,8 +42,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _publish(
         topic: str,
         payload: mqtt.PublishPayloadType,
-        qos: int | None,
-        retain: bool | None,
+        qos: int,
+        retain: bool,
     ) -> None:
         await mqtt.async_publish(hass, topic, payload, qos, retain)
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -449,6 +449,29 @@ async def test_publish_function_with_bad_encoding_conditions(
     )
 
 
+@pytest.mark.parametrize(("qos", "retain"), [(None, None), (0, None), (None, False)])
+async def test_publish_api_with_falback_to_none(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    qos: int | None,
+    retain: bool | None,
+) -> None:
+    """Test MQTT publish API function with None as fallback for QoS or Retain."""
+    mqtt_mock = await mqtt_mock_entry()
+    await mqtt.async_publish(hass, "some-topic", "test-payload", qos=qos, retain=retain)
+    assert (
+        "Using `None` values for qos or retain on "
+        "the MQTT async_publish API is deprecated." in caplog.text
+    )
+    async_publish_mock: MagicMock = mqtt_mock.async_publish
+    assert len(async_publish_mock.mock_calls) == 1
+    assert async_publish_mock.mock_calls[0][1][0] == "some-topic"
+    assert async_publish_mock.mock_calls[0][1][1] == "test-payload"
+    assert async_publish_mock.mock_calls[0][1][2] == 0
+    assert async_publish_mock.mock_calls[0][1][3] is False
+
+
 def test_validate_topic() -> None:
     """Test topic name/filter validation."""
     # Invalid UTF-8, must not contain U+D800 to U+DFFF.

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -461,10 +461,9 @@ async def test_publish_api_with_falback_to_none(
     mqtt_mock = await mqtt_mock_entry()
     await mqtt.async_publish(hass, "some-topic", "test-payload", qos=qos, retain=retain)
     assert (
-        "Detected that integration 'mqtt' received a call to the MQTT publish API from "
-        "a custom integration with a `None` value  for qos or retain argument. The "
-        "`qos` argument should be of type `int`, and the `retain` argument of type "
-        "`bool`." in caplog.text
+        "Detected code that that calls the MQTT publish API with `None` for "
+        "qos or retain. The `qos` argument must be an `int`, and the `retain` "
+        "argument must be a `bool`." in caplog.text
     )
     async_publish_mock: MagicMock = mqtt_mock.async_publish
     assert len(async_publish_mock.mock_calls) == 1

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -461,8 +461,10 @@ async def test_publish_api_with_falback_to_none(
     mqtt_mock = await mqtt_mock_entry()
     await mqtt.async_publish(hass, "some-topic", "test-payload", qos=qos, retain=retain)
     assert (
-        "Using `None` values for qos or retain on "
-        "the MQTT async_publish API is deprecated." in caplog.text
+        "Detected that integration 'mqtt' received a call to the MQTT publish API from "
+        "a custom integration with a `None` value  for qos or retain argument. The "
+        "`qos` argument should be of type `int`, and the `retain` argument of type "
+        "`bool`." in caplog.text
     )
     async_publish_mock: MagicMock = mqtt_mock.async_publish
     assert len(async_publish_mock.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove not used `None` defaults on MQTT publish API

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3088
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
