### PR TITLE
Bump homematicip to 2.10.0

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.9.0"]
+  "requirements": ["homematicip==2.10.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1260,7 +1260,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.9.0
+homematicip==2.10.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1124,7 +1124,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.9.0
+homematicip==2.10.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0


### PR DESCRIPTION
## Proposed change

Bumps `homematicip` from 2.9.0 to 2.10.0.

Highlights of the new release:

### Added
- **Websocket staleness detection** (new public API): `home.set_on_websocket_stale_handler(handler)` fires when the websocket reports connected but no messages have arrived past warning (5 min) or error (30 min) thresholds. Complements the existing 8h `MESSAGE_STALE_TIMEOUT` reconnect safety net by surfacing the condition much earlier.

  This was extracted from the staleness-polling logic added to `homematicip_cloud` in #169526, per @edenhaus's review feedback that the detection belongs in the library, not in the integration. The `homematicip_cloud` switch to consume the new callback ships in a follow-up PR on top of this bump.

### Fixed
- `set_pin_async` leaking the old PIN into the connection's persistent headers
- SSL verification not actually disabled when `enforce_ssl=False` (REST + websocket)
- Race condition in `Buckets.wait_and_take` where concurrent callers could oversubscribe the rate-limit bucket
- Duplicate `functionalHome` entries accumulating on repeated state updates for unknown solution types
- Python 3.14 compatibility in sync wrappers
- Door-lock `authorizationPin` leaking into debug logs (added to redaction set)
- Several `_supportedFeatureAttributeMap` entries that were bare strings instead of lists, so attributes like `colorTemperature` and the particulate-matter / temperature-humidity sensor error flags were never actually set on devices
- `DoorLockDrive.set_lock_state` and `HeatingCoolingProfile.update_profile` sync wrappers dropping the async return value

### Changed
- Public API typing tightened (`get_security_zones_activation` returns `tuple[bool, bool]`; type hints on `init_async`, `init_with_context`, `set_location_async`)

### Deprecated
- `init_async(lookup=False)` / `init(lookup=False)`: parameter was documented but ignored. A `DeprecationWarning` now fires.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #169526 (consumer PR that triggered the library refactor)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Full changelog: https://github.com/hahn-th/homematicip-rest-api/releases/tag/2.10.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [x] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr