### PR TITLE
Purge orphaned registry records with null timestamps

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1682,6 +1682,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         now_time = time.time()
         for deleted_device in list(self.deleted_devices.values()):
             if deleted_device.orphaned_timestamp is None:
+                if not deleted_device.config_entries:
+                    del self.deleted_devices[deleted_device.id]
+                    self.async_schedule_save()
                 continue
 
             if (
@@ -1689,6 +1692,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 < now_time
             ):
                 del self.deleted_devices[deleted_device.id]
+                self.async_schedule_save()
 
     @callback
     def async_clear_area_id(self, area_id: str) -> None:

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -2221,6 +2221,9 @@ class EntityRegistry(BaseRegistry):
         now_time = time.time()
         for key, deleted_entity in list(self.deleted_entities.items()):
             if (orphaned_timestamp := deleted_entity.orphaned_timestamp) is None:
+                if deleted_entity.config_entry_id is None:
+                    self.deleted_entities.pop(key)
+                    self.async_schedule_save()
                 continue
 
             if orphaned_timestamp + ORPHANED_ENTITY_KEEP_SECONDS < now_time:

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1931,6 +1931,38 @@ async def test_deleted_device_removing_config_entries(
     assert entry3.id != entry4.id
 
 
+async def test_purge_orphaned_deleted_device_with_legacy_null_timestamp(
+    device_registry: dr.DeviceRegistry, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test orphaned deleted devices with legacy null timestamps are purged."""
+    entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    device_registry.async_remove_device(entry.id)
+    device_registry.async_clear_config_entry(mock_config_entry.entry_id)
+
+    deleted_entry = device_registry.deleted_devices.get_entry(
+        {("bridgeid", "0123")}, None
+    )
+    assert deleted_entry is not None
+    assert deleted_entry.config_entries == set()
+
+    device_registry.deleted_devices[deleted_entry.id] = attr.evolve(
+        deleted_entry, orphaned_timestamp=None
+    )
+
+    with patch.object(device_registry, "async_schedule_save") as mock_schedule_save:
+        device_registry.async_purge_expired_orphaned_devices()
+        mock_schedule_save.assert_called_once()
+
+    assert len(device_registry.deleted_devices) == 0
+
+
 async def test_removing_config_subentries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
@@ -3764,8 +3796,12 @@ async def test_cleanup_device_registry_removes_expired_orphaned_devices(
 
     future_time = time.time() + dr.ORPHANED_DEVICE_KEEP_SECONDS + 1
 
-    with patch("time.time", return_value=future_time):
+    with (
+        patch("time.time", return_value=future_time),
+        patch.object(device_registry, "async_schedule_save") as mock_schedule_save,
+    ):
         dr.async_cleanup(hass, device_registry, entity_registry)
+        assert mock_schedule_save.call_count == 3
 
     assert len(device_registry.devices) == 0
     assert len(device_registry.deleted_devices) == 0

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -4010,6 +4010,25 @@ async def test_restore_entity(
     assert update_events[16].data == {"action": "create", "entity_id": "light.hue_1234"}
 
 
+async def test_purge_orphaned_deleted_entity_with_legacy_null_timestamp(
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test orphaned deleted entities with legacy null timestamps are purged."""
+    entry = entity_registry.async_get_or_create("light", "hue", "1234")
+    entity_registry.async_remove(entry.entity_id)
+    assert len(entity_registry.deleted_entities) == 1
+
+    key = ("light", "hue", "1234")
+    deleted_entry = entity_registry.deleted_entities[key]
+    entity_registry.deleted_entities[key] = attr.evolve(
+        deleted_entry, orphaned_timestamp=None
+    )
+
+    entity_registry.async_purge_expired_orphaned_entities()
+
+    assert len(entity_registry.deleted_entities) == 0
+
+
 @pytest.mark.parametrize(
     ("entity_disabled_by"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Deleted entity and device registry records that were already orphaned but still
had a null `orphaned_timestamp` are now removed by the normal purge pass instead
of staying in the registries indefinitely.

The device purge path now also schedules a save after removing expired orphaned
records, so the cleanup is persisted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130210
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
