### PR TITLE
Add SmartThings display lighting switch for legacy Samsung A/Cs

### DIFF
--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -70,6 +70,21 @@ class SmartThingsDishwasherWashingOptionSwitchEntityDescription(
     off_key: str | bool = False
 
 
+@dataclass(frozen=True, kw_only=True)
+class SmartThingsExecuteSwitchEntityDescription(SwitchEntityDescription):
+    """Describe a SmartThings switch entity that uses the execute command.
+
+    For devices that don't expose a standard capability but can still be
+    controlled via the execute command with specific arguments.
+    """
+
+    required_capability: (
+        Capability  # Gate to prevent creating switches on incompatible devices
+    )
+    on_argument: list[Any]
+    off_argument: list[Any]
+
+
 SWITCH = SmartThingsSwitchEntityDescription(
     key=Capability.SWITCH,
     status_attribute=Attribute.SWITCH,
@@ -305,6 +320,22 @@ DISHWASHER_WASHING_OPTIONS_TO_SWITCHES: dict[
     ),
 }
 
+# Workaround switches for devices that lack the standard capability
+# but can still be controlled via execute commands
+EXECUTE_WORKAROUND_SWITCHES: dict[
+    Capability | str, SmartThingsExecuteSwitchEntityDescription
+] = {
+    # Note: API arguments are reversed - "Light_Off" option turns the light ON
+    Capability.SAMSUNG_CE_AIR_CONDITIONER_LIGHTING: SmartThingsExecuteSwitchEntityDescription(
+        key=Capability.SAMSUNG_CE_AIR_CONDITIONER_LIGHTING,
+        translation_key="display_lighting",
+        required_capability=Capability.AIR_CONDITIONER_MODE,
+        on_argument=["/mode/vs/0", {"x.com.samsung.da.options": ["Light_Off"]}],
+        off_argument=["/mode/vs/0", {"x.com.samsung.da.options": ["Light_On"]}],
+        entity_category=EntityCategory.CONFIG,
+    ),
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -361,6 +392,18 @@ async def async_setup_entry(
             ].value,
         )
         if attribute in DISHWASHER_WASHING_OPTIONS_TO_SWITCHES
+    )
+    entities.extend(
+        SmartThingsExecuteSwitch(
+            entry_data.client,
+            device,
+            description,
+        )
+        for device in entry_data.devices.values()
+        for missing_capability, description in EXECUTE_WORKAROUND_SWITCHES.items()
+        if Capability.EXECUTE in device.status[MAIN]
+        and description.required_capability in device.status[MAIN]
+        and missing_capability not in device.status[MAIN]
     )
     entity_registry = er.async_get(hass)
     for device in entry_data.devices.values():
@@ -583,3 +626,38 @@ class SmartThingsDishwasherWashingOptionSwitch(SmartThingsCommandSwitch):
     @override
     def _current_state(self) -> Any:
         return super()._current_state()["value"]
+
+
+class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity):
+    """Define a SmartThings switch that uses the execute command."""
+
+    entity_description: SmartThingsExecuteSwitchEntityDescription
+
+    def __init__(
+        self,
+        client: SmartThings,
+        device: FullDevice,
+        entity_description: SmartThingsExecuteSwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(client, device, {Capability.EXECUTE})
+        self.entity_description = entity_description
+        self._attr_unique_id = (
+            f"{device.device.device_id}_{MAIN}_{entity_description.key}"
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self.execute_device_command(
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            self.entity_description.off_argument,
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self.execute_device_command(
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            self.entity_description.on_argument,
+        )

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -10,11 +10,12 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import FullDevice, SmartThingsConfigEntry
 from .const import INVALID_SWITCH_CATEGORIES, MAIN
@@ -628,10 +629,19 @@ class SmartThingsDishwasherWashingOptionSwitch(SmartThingsCommandSwitch):
         return super()._current_state()["value"]
 
 
-class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity):
-    """Define a SmartThings switch that uses the execute command."""
+class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity, RestoreEntity):
+    """Define a SmartThings switch that uses the execute command.
+
+    The cloud does not propagate state for these legacy execute commands, so
+    state is tracked optimistically: we remember what we last commanded and
+    restore that across HA restarts via RestoreEntity. assumed_state=True
+    advertises this to the user — the UI shows two buttons and an "Assumed"
+    badge, and external changes (e.g. via the SmartThings mobile app) will
+    drift out of sync.
+    """
 
     entity_description: SmartThingsExecuteSwitchEntityDescription
+    _attr_assumed_state = True
 
     def __init__(
         self,
@@ -646,6 +656,12 @@ class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity):
             f"{device.device.device_id}_{MAIN}_{entity_description.key}"
         )
 
+    async def async_added_to_hass(self) -> None:
+        """Restore last known state from prior HA session."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.execute_device_command(
@@ -653,6 +669,8 @@ class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity):
             Command.EXECUTE,
             self.entity_description.off_argument,
         )
+        self._attr_is_on = False
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
@@ -661,3 +679,5 @@ class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity):
             Command.EXECUTE,
             self.entity_description.on_argument,
         )
+        self._attr_is_on = True
+        self.async_write_ha_state()

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -659,12 +659,14 @@ class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity, RestoreEntity):
             f"{device.device.device_id}_{MAIN}_{entity_description.key}"
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore last known state from prior HA session."""
         await super().async_added_to_hass()
         if (last_state := await self.async_get_last_state()) is not None:
             self._attr_is_on = last_state.state == STATE_ON
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.execute_device_command(
@@ -675,6 +677,7 @@ class SmartThingsExecuteSwitch(SmartThingsEntity, SwitchEntity, RestoreEntity):
         self._attr_is_on = False
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.execute_device_command(

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -327,6 +327,8 @@ EXECUTE_WORKAROUND_SWITCHES: dict[
     Capability | str, SmartThingsExecuteSwitchEntityDescription
 ] = {
     # Note: API arguments are reversed - "Light_Off" option turns the light ON
+    # Disabled by default: not all matching devices have a panel LED, and we
+    # cannot detect this from capabilities alone; users opt in per device.
     Capability.SAMSUNG_CE_AIR_CONDITIONER_LIGHTING: SmartThingsExecuteSwitchEntityDescription(
         key=Capability.SAMSUNG_CE_AIR_CONDITIONER_LIGHTING,
         translation_key="display_lighting",
@@ -334,6 +336,7 @@ EXECUTE_WORKAROUND_SWITCHES: dict[
         on_argument=["/mode/vs/0", {"x.com.samsung.da.options": ["Light_Off"]}],
         off_argument=["/mode/vs/0", {"x.com.samsung.da.options": ["Light_On"]}],
         entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
     ),
 }
 

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -2399,3 +2399,54 @@
     'state': 'off',
   })
 # ---
+# name: test_execute_workaround_switch_enabled_snapshot[da_ac_ehs_01001][da_ac_ehs_01001][switch.heat_pump_display_lighting-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.heat_pump_display_lighting',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Display lighting',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Display lighting',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'display_lighting',
+    'unique_id': '4165c51e-bf6b-c5b6-fd53-127d6248754b_main_samsungce.airConditionerLighting',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_execute_workaround_switch_enabled_snapshot[da_ac_ehs_01001][da_ac_ehs_01001][switch.heat_pump_display_lighting-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'assumed_state': True,
+      'friendly_name': 'Heat pump Display lighting',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.heat_pump_display_lighting',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -2439,8 +2439,8 @@
 # name: test_execute_workaround_switch_enabled_snapshot[da_ac_ehs_01001][da_ac_ehs_01001][switch.heat_pump_display_lighting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'assumed_state': True,
-      'friendly_name': 'Heat pump Display lighting',
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Heat pump Display lighting',
     }),
     'context': <ANY>,
     'entity_id': 'switch.heat_pump_display_lighting',

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -649,20 +649,45 @@ _EHS_LIGHTING_UNIQUE_ID = (
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_ehs_01001"])
-async def test_execute_workaround_switch_entity_created(
+async def test_execute_workaround_switch_enabled_snapshot(
     hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
     devices: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test display lighting switch created via execute workaround for heat pump lacking native lighting capability."""
+    """Snapshot the execute workaround switch as it appears once enabled by the user."""
     await setup_integration(hass, mock_config_entry)
 
     entity_id = entity_registry.async_get_entity_id(
         SWITCH_DOMAIN, DOMAIN, _EHS_LIGHTING_UNIQUE_ID
     )
     assert entity_id is not None
-    assert hass.states.get(entity_id) is not None
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    snapshot_smartthings_entities(hass, entity_registry, snapshot, Platform.SWITCH)
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_ehs_01001"])
+async def test_execute_workaround_switch_disabled_by_default(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test execute workaround switch is registered but disabled - user opts in per device."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, _EHS_LIGHTING_UNIQUE_ID
+    )
+    assert entity_id is not None
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get(entity_id) is None
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_ehs_01001"])

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -687,7 +687,7 @@ async def test_execute_workaround_switch_turn_on_off(
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     action: str,
-    expected_argument: list[str],
+    expected_argument: list[str | dict[str, list[str]]],
     expected_state: str,
 ) -> None:
     """Test execute workaround switch uses reversed API arguments and updates state optimistically."""

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -641,3 +641,106 @@ async def test_turn_on_with_wrong_dishwasher_cycle(
             blocking=True,
         )
     devices.execute_device_command.assert_not_called()
+
+
+_EHS_LIGHTING_UNIQUE_ID = (
+    "4165c51e-bf6b-c5b6-fd53-127d6248754b_main_samsungce.airConditionerLighting"
+)
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_ehs_01001"])
+async def test_execute_workaround_switch_entity_created(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test display lighting switch created via execute workaround for heat pump lacking native lighting capability."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, _EHS_LIGHTING_UNIQUE_ID
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_ehs_01001"])
+@pytest.mark.parametrize(
+    ("action", "expected_argument"),
+    [
+        (SERVICE_TURN_ON, ["/mode/vs/0", {"x.com.samsung.da.options": ["Light_Off"]}]),
+        (
+            SERVICE_TURN_OFF,
+            ["/mode/vs/0", {"x.com.samsung.da.options": ["Light_On"]}],
+        ),
+    ],
+)
+async def test_execute_workaround_switch_turn_on_off(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    action: str,
+    expected_argument: list[str],
+) -> None:
+    """Test execute workaround switch uses reversed API arguments (Light_Off=on, Light_On=off)."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, _EHS_LIGHTING_UNIQUE_ID
+    )
+    assert entity_id is not None
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        action,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    devices.execute_device_command.assert_called_once_with(
+        "4165c51e-bf6b-c5b6-fd53-127d6248754b",
+        Capability.EXECUTE,
+        Command.EXECUTE,
+        MAIN,
+        expected_argument,
+    )
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_rac_01001"])
+async def test_execute_workaround_switch_not_created_when_capability_exists(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test display lighting uses native lighting capability when available, not execute workaround."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert (
+        entity_registry.async_get_entity_id(
+            SWITCH_DOMAIN,
+            DOMAIN,
+            "4ece486b-89db-f06a-d54d-748b676b4d8e_main_samsungce.airConditionerLighting",
+        )
+        is None
+    )
+    assert any(
+        entry.translation_key == "display_lighting"
+        and entry.unique_id.startswith("4ece486b-89db-f06a-d54d-748b676b4d8e_")
+        for entry in entity_registry.entities.values()
+    )
+
+
+@pytest.mark.parametrize("device_fixture", ["da_wm_wm_000001"])
+async def test_execute_workaround_switch_not_created_without_required_capability(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test display lighting not created for washer lacking AIR_CONDITIONER_MODE capability."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert not any(
+        "display_lighting" in entity_id for entity_id in entity_registry.entities
+    )

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -34,7 +34,7 @@ from . import (
     trigger_update,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, mock_restore_cache
 
 
 async def test_all_entities(
@@ -667,12 +667,17 @@ async def test_execute_workaround_switch_entity_created(
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_ehs_01001"])
 @pytest.mark.parametrize(
-    ("action", "expected_argument"),
+    ("action", "expected_argument", "expected_state"),
     [
-        (SERVICE_TURN_ON, ["/mode/vs/0", {"x.com.samsung.da.options": ["Light_Off"]}]),
+        (
+            SERVICE_TURN_ON,
+            ["/mode/vs/0", {"x.com.samsung.da.options": ["Light_Off"]}],
+            STATE_ON,
+        ),
         (
             SERVICE_TURN_OFF,
             ["/mode/vs/0", {"x.com.samsung.da.options": ["Light_On"]}],
+            STATE_OFF,
         ),
     ],
 )
@@ -683,14 +688,23 @@ async def test_execute_workaround_switch_turn_on_off(
     entity_registry: er.EntityRegistry,
     action: str,
     expected_argument: list[str],
+    expected_state: str,
 ) -> None:
-    """Test execute workaround switch uses reversed API arguments (Light_Off=on, Light_On=off)."""
+    """Test execute workaround switch uses reversed API arguments and updates state optimistically."""
     await setup_integration(hass, mock_config_entry)
 
     entity_id = entity_registry.async_get_entity_id(
         SWITCH_DOMAIN, DOMAIN, _EHS_LIGHTING_UNIQUE_ID
     )
     assert entity_id is not None
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["assumed_state"] is True
+
     await hass.services.async_call(
         SWITCH_DOMAIN,
         action,
@@ -704,6 +718,40 @@ async def test_execute_workaround_switch_turn_on_off(
         MAIN,
         expected_argument,
     )
+    assert hass.states.get(entity_id).state == expected_state
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_ehs_01001"])
+@pytest.mark.parametrize("restored_state", [STATE_ON, STATE_OFF])
+async def test_execute_workaround_switch_restores_state(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    restored_state: str,
+) -> None:
+    """Test execute workaround switch restores last known state across HA restart."""
+    entity_registry.async_get_or_create(
+        SWITCH_DOMAIN,
+        DOMAIN,
+        _EHS_LIGHTING_UNIQUE_ID,
+        suggested_object_id="klimatyzator_korytarz_display_lighting",
+        disabled_by=None,
+    )
+    mock_restore_cache(
+        hass,
+        [State("switch.klimatyzator_korytarz_display_lighting", restored_state)],
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, _EHS_LIGHTING_UNIQUE_ID
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == restored_state
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_rac_01001"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `display_lighting` switch entity for legacy Samsung A/C devices that
lack the typed `samsungce.airConditionerLighting` capability but still expose
the panel LED through Samsung's proprietary OCF `execute` command — the same
mechanism the SmartThings mobile app uses for those models.

The switch sends `execute("/mode/vs/0", {"x.com.samsung.da.options": [...]})`:

- `Light_Off` → turns the panel LED **on** (Samsung quirk: argument names are
  inverted)
- `Light_On` → turns the panel LED **off**

This is a continuation of #161236, with the design rebuilt to address
[@joostlek][joostlek-review]'s review feedback on scoping ("how do we make
sure we only add this to devices that need this") and on state handling
("we should keep some assumed state, as we don't know for sure if it
worked or not"):

- **Disabled by default.** The entity is registered with
  `entity_registry_enabled_default=False`, so users opt in per device by
  enabling it in the entity registry. The capability gate
  (`AIR_CONDITIONER_MODE` present, `samsungce.airConditionerLighting` absent)
  matches a broad class of Samsung A/Cs — including some commercial cassette
  units and EHS heat-pump sub-devices that have no panel LED to control —
  and we cannot tell them apart from capabilities alone, so we let the user
  decide.
- **`assumed_state=True` + `RestoreEntity` + optimistic update.** The cloud
  does not propagate state for these legacy execute commands, so we follow
  the same pattern HA uses for other write-only entities (broadlink RF/IR,
  MQTT switch without a `state_topic`, command_line, KNX without a state
  group address): mark `assumed_state=True` so the UI honestly shows two
  buttons with an "Assumed" badge, restore the last commanded value across
  HA restarts via `RestoreEntity`, and optimistically update `is_on` after
  the command succeeds.

Confirmed working on three real Samsung WindFree (`ARTIK051_PRAC_20K`-class)
A/Cs in my home.

<img width="1328" height="1210" alt="image" src="https://github.com/user-attachments/assets/e1573a86-f44b-4e02-a540-1aabb7a2525a" />

[joostlek-review]: https://github.com/home-assistant/core/pull/161236#pullrequestreview-3870561759

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148686
- This PR is related to issue: replaces #161236 (closed without merge by
  @emontnemery for lack of author response)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Sources for the OCF execute payload:

- [SmartThings community: "REST API for display/light on Samsung Windfree
  AC"](https://community.smartthings.com/t/rest-api-for-display-light-on-samsung-windfree-ac/195928)
  — origin of the payload, inverted-semantics confirmation, working model
  `AR09RXPXBWKNEU`.
- [`veista/smartthings`](https://github.com/veista/smartthings/blob/master/custom_components/smartthings/switch.py)
  — long-running HA fork that ships this exact payload (lines ~105-133).
- [SmartThings community: "Keep the light display OFF when AC turns
  ON?"](https://community.smartthings.com/t/keep-the-light-display-off-when-ac-turns-on/283628)
  — `ARTIK051_PRAC_20K` confirmed.

Commits in this PR (kept separate so reviewers can follow each concern):

1. **Support execute command workaround for AC display lighting switches**
   — original PR's logic (dict-keyed `EXECUTE_WORKAROUND_SWITCHES`,
   `SmartThingsExecuteSwitchEntityDescription`, capability gates, full test
   suite incl. snapshot).
2. **Disable display lighting workaround entity by default** — addresses
   the scoping concern.
3. **Track optimistic state for execute workaround switch** — addresses the
   state-handling concern (`assumed_state=True`, `RestoreEntity`, optimistic
   update).

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
