### PR TITLE
Remove name field from pvpc_hourly_pricing config flow #168955

### DIFF
--- a/homeassistant/components/pvpc_hourly_pricing/config_flow.py
+++ b/homeassistant/components/pvpc_hourly_pricing/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlowWithReload,
 )
-from homeassistant.const import CONF_API_TOKEN, CONF_NAME
+from homeassistant.const import CONF_API_TOKEN
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
@@ -65,9 +65,8 @@ class TariffSelectorConfigFlow(ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
             if not user_input[CONF_USE_API_TOKEN]:
                 return self.async_create_entry(
-                    title=user_input[CONF_NAME],
+                    title=DEFAULT_NAME,
                     data={
-                        CONF_NAME: user_input[CONF_NAME],
                         ATTR_TARIFF: user_input[ATTR_TARIFF],
                         ATTR_POWER: user_input[ATTR_POWER],
                         ATTR_POWER_P3: user_input[ATTR_POWER_P3],
@@ -75,7 +74,7 @@ class TariffSelectorConfigFlow(ConfigFlow, domain=DOMAIN):
                     },
                 )
 
-            self._name = user_input[CONF_NAME]
+            self._name = DEFAULT_NAME
             self._tariff = user_input[ATTR_TARIFF]
             self._power = user_input[ATTR_POWER]
             self._power_p3 = user_input[ATTR_POWER_P3]
@@ -84,7 +83,6 @@ class TariffSelectorConfigFlow(ConfigFlow, domain=DOMAIN):
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
                 vol.Required(ATTR_TARIFF, default=DEFAULT_TARIFF): VALID_TARIFF,
                 vol.Required(ATTR_POWER, default=DEFAULT_POWER_KW): VALID_POWER,
                 vol.Required(ATTR_POWER_P3, default=DEFAULT_POWER_KW): VALID_POWER,
@@ -133,7 +131,6 @@ class TariffSelectorConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         data = {
-            CONF_NAME: self._name,
             ATTR_TARIFF: self._tariff,
             ATTR_POWER: self._power,
             ATTR_POWER_P3: self._power_p3,
@@ -153,7 +150,7 @@ class TariffSelectorConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle re-authentication with ESIOS Token."""
         self._api_token = entry_data.get(CONF_API_TOKEN)
         self._use_api_token = self._api_token is not None
-        self._name = entry_data[CONF_NAME]
+        self._name = DEFAULT_NAME
         self._tariff = entry_data[ATTR_TARIFF]
         self._power = entry_data[ATTR_POWER]
         self._power_p3 = entry_data[ATTR_POWER_P3]

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.pvpc_hourly_pricing.const import (
     DOMAIN,
     TARIFFS,
 )
-from homeassistant.const import CONF_API_TOKEN, CONF_NAME
+from homeassistant.const import CONF_API_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
@@ -45,7 +45,6 @@ async def test_config_flow(
     freezer.move_to(_MOCK_TIME_VALID_RESPONSES)
     await hass.config.async_set_time_zone("Europe/Madrid")
     tst_config = {
-        CONF_NAME: "test",
         ATTR_TARIFF: TARIFFS[1],
         ATTR_POWER: 4.6,
         ATTR_POWER_P3: 5.75,
@@ -183,7 +182,6 @@ async def test_reauth(
     freezer.move_to(_MOCK_TIME_BAD_AUTH_RESPONSES)
     await hass.config.async_set_time_zone("Europe/Madrid")
     tst_config = {
-        CONF_NAME: "test",
         ATTR_TARIFF: TARIFFS[1],
         ATTR_POWER: 4.6,
         ATTR_POWER_P3: 5.75,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the name field from the config flow, per the `hass-config-flow-name-field` pylint rule.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168955
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45554
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
