### PR TITLE
Bump homematicip to 2.11.0

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.10.0"]
+  "requirements": ["homematicip==2.11.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1260,7 +1260,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.10.0
+homematicip==2.11.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1124,7 +1124,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.10.0
+homematicip==2.11.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0


### PR DESCRIPTION
## Proposed change

Bumps the `homematicip` library from 2.10.0 to 2.11.0.

2.11.0 adds three post-reconnect recovery helpers on `AsyncHome`:
- `wait_for_websocket_connection_async(...)`: bounded best-effort wait for `websocket_is_connected()`.
- `get_current_state_async_with_retry(...)`: exponential-backoff retry around `get_current_state_async`. Re-raises `HmipAuthenticationError`, `HomeNotInitializedError`, and `asyncio.CancelledError`; retries on `HmipConnectionError` and unforeseen exceptions.
- `refresh_state_after_reconnect_async(...)`: convenience wrapper combining the wait and the retrying refresh.

Drop-in upgrade: no API surface from 2.10.0 was removed or changed.

This bump unblocks #169526, where the new helpers let us move the bare `except Exception:` recovery loop out of the integration and into the library, addressing @edenhaus's review feedback.

Library release: https://github.com/hahn-th/homematicip-rest-api/releases/tag/2.11.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #169526
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to this PR description.

If the code does not interact with devices:

- [ ] Tests have been added to verify that the new code works.

I have reviewed two other open pull requests:

- [x] I have reviewed two other open pull requests in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/development_guidelines#creating-a-good-pull-request