### PR TITLE
Remove area from LLM system prompt and provide in a tool

### DIFF
--- a/homeassistant/components/homeassistant/llm.py
+++ b/homeassistant/components/homeassistant/llm.py
@@ -15,6 +15,7 @@ from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
     entity_registry as er,
+    floor_registry as fr,
     intent,
 )
 from homeassistant.helpers.llm import (
@@ -281,14 +282,90 @@ class GetLiveContextTool(Tool):
         }
 
 
+class GetCurrentLocationTool(Tool):
+    """Tool for getting the area (and floor) of the requesting device."""
+
+    name = "GetCurrentLocation"
+    description = (
+        "Returns the user's current area, and floor when set. "
+        "Call this to resolve the area when a request names a generic "
+        "device without specifying one."
+    )
+
+    @override
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: ToolInput,
+        llm_context: LLMContext,
+    ) -> JsonObjectType:
+        """Get the area and floor of the requesting device."""
+        if not llm_context.device_id:
+            return {
+                "success": False,
+                "error": "This request is not associated with a device",
+            }
+
+        device = dr.async_get(hass).async_get(llm_context.device_id)
+        if device is None:
+            return {
+                "success": False,
+                "error": "The requesting device was not found",
+            }
+        if device.area_id is None:
+            return {
+                "success": False,
+                "error": "The requesting device is not assigned to an area",
+            }
+
+        area = ar.async_get(hass).async_get_area(device.area_id)
+        if area is None:
+            return {
+                "success": False,
+                "error": "The area assigned to the requesting device was not found",
+            }
+
+        result: dict[str, Any] = {"area": area.name}
+        if area.floor_id and (
+            floor := fr.async_get(hass).async_get_floor(area.floor_id)
+        ):
+            result["floor"] = floor.name
+
+        return {"success": True, "result": result}
+
+
+GENERIC_DEVICE_WITH_AREA_PROMPT = (
+    "When a request names a generic device without an area, "
+    "treat it as the user's current area and call "
+    "`GetCurrentLocation` to resolve it before targeting."
+)
+GENERIC_DEVICE_WITHOUT_AREA_PROMPT = (
+    "When a request names a generic device without an area, "
+    "ask the user to specify which area they mean before targeting."
+)
+
+
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
 ) -> LLMTools | None:
-    """Return the GetLiveContext tool.
+    """Return the homeassistant integration's LLM tools.
 
-    The tool is always offered; it reports when nothing is exposed at call time.
+    GetLiveContext is always offered and reports when nothing is exposed at
+    call time. GetCurrentLocation is offered only when the request carries a
+    device_id, and the prompt directs the model to resolve the current area
+    through it rather than embedding a per-device area in the system prompt,
+    which keeps the prompt cacheable across speakers.
     """
     if api_id != LLM_API_ASSIST:
         return None
-    return LLMTools(tools=[GetLiveContextTool()])
+
+    tools: list[Tool] = [GetLiveContextTool()]
+
+    if llm_context.device_id:
+        tools.append(GetCurrentLocationTool())
+        prompt = GENERIC_DEVICE_WITH_AREA_PROMPT
+    else:
+        prompt = GENERIC_DEVICE_WITHOUT_AREA_PROMPT
+
+    return LLMTools(tools=tools, prompt=prompt)

--- a/tests/components/homeassistant/test_llm.py
+++ b/tests/components/homeassistant/test_llm.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
     entity_registry as er,
+    floor_registry as fr,
     llm,
 )
 from homeassistant.setup import async_setup_component
@@ -78,6 +79,100 @@ async def test_get_live_context_tool(hass: HomeAssistant) -> None:
     )
     assert response["success"] is True
     assert "Kitchen Light" in response["result"]
+
+
+def _location_context(device_id: str | None) -> llm.LLMContext:
+    """Return an LLM context bound to a specific device."""
+    return llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=device_id,
+    )
+
+
+async def test_get_current_location_not_offered_without_device(
+    hass: HomeAssistant,
+) -> None:
+    """Test GetCurrentLocation and its prompt depend on a device_id being set."""
+    without_device = await llm_component.async_get_tools(
+        hass, _location_context(None), "assist"
+    )
+    assert "GetCurrentLocation" not in [tool.name for tool in without_device.tools]
+    assert without_device.prompt == ha_llm.GENERIC_DEVICE_WITHOUT_AREA_PROMPT
+
+    with_device = await llm_component.async_get_tools(
+        hass, _location_context("some-device"), "assist"
+    )
+    assert "GetCurrentLocation" in [tool.name for tool in with_device.tools]
+    assert with_device.prompt == ha_llm.GENERIC_DEVICE_WITH_AREA_PROMPT
+
+
+async def test_get_current_location_tool(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test the GetCurrentLocation tool resolves the device's area and floor."""
+    entry = MockConfigEntry(title=None)
+    entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={("test", "abc")},
+    )
+
+    llm_context = _location_context(device.id)
+    result = await llm_component.async_get_tools(hass, llm_context, "assist")
+    tool = next(tool for tool in result.tools if tool.name == "GetCurrentLocation")
+
+    async def _get_location(context: llm.LLMContext) -> dict:
+        return await tool.async_call(
+            hass, llm.ToolInput("GetCurrentLocation", {}), context
+        )
+
+    # Device with no area
+    assert await _get_location(llm_context) == {
+        "success": False,
+        "error": "The requesting device is not assigned to an area",
+    }
+
+    # Unknown device_id
+    assert await _get_location(_location_context("does-not-exist")) == {
+        "success": False,
+        "error": "The requesting device was not found",
+    }
+
+    # No device_id at all
+    assert await _get_location(_location_context(None)) == {
+        "success": False,
+        "error": "This request is not associated with a device",
+    }
+
+    # Device in an area without a floor
+    area = area_registry.async_create("Kitchen")
+    device_registry.async_update_device(device.id, area_id=area.id)
+    assert await _get_location(llm_context) == {
+        "success": True,
+        "result": {"area": "Kitchen"},
+    }
+
+    # Area looked up but missing from the registry
+    device_registry.async_update_device(device.id, area_id="does-not-exist")
+    assert await _get_location(llm_context) == {
+        "success": False,
+        "error": "The area assigned to the requesting device was not found",
+    }
+
+    # Device in an area with a floor
+    device_registry.async_update_device(device.id, area_id=area.id)
+    floor = floor_registry.async_create("Ground")
+    area_registry.async_update(area.id, floor_id=floor.floor_id)
+    assert await _get_location(llm_context) == {
+        "success": True,
+        "result": {"area": "Kitchen", "floor": "Ground"},
+    }
 
 
 async def test_get_exposed_entities_timestamp_conversion(hass: HomeAssistant) -> None:


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, the primary information that breaks the prompt cache between satellites is the area. This means that if a user wants to keep each of their satellites responding as fast as possible by using prompt caching, then they must have separate cache slots for each satellite. Otherwise as the area changes between satellites it requires reprocessing the remaining system prompt and full list of tools.

This PR removes the area from the system prompt and instead provides a GetCurrentLocation tool which provides the area and floor (if available). This tool makes it so only a single cache slot is needed to maintain prompt cache between all satellite devices, and creates a more natural way for the LLM to get context about what the user is asking.

I ran the homeassistant eval dataset to confirm that there was no degradation in performance, and it looks like there is a slight improvement in performance:

### Gemma4 (2026.2.3 eval)

**Assist:**

```
- model_id: gemma4-26b-a4b
  good_percent: 86.3%
  confidence_interval: 3.1%
  good: 397
  total: 460
```

And an example test ran with time: duration_ms: 2125.571

**Questions:**

```
- model_id: gemma4-26b-a4b
  good_percent: 97.0%
  confidence_interval: 1.7%
  good: 359
  total: 370
```

### Gemma4 (this PR eval)

**Assist:**

```
- model_id: gemma4-26b-a4b
  good_percent: 87.0%
  confidence_interval: 3.1%
  good: 400
  total: 460
```

the same example test ran much faster due to improve prompt caching: duration_ms: 1144.689

**Questions:**

```
- model_id: gemma4-26b-a4b
  good_percent: 99.7%
  confidence_interval: 0.5%
  good: 369
  total: 370
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #165118
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
