### PR TITLE
Validate device info string fields in the registry

### DIFF
--- a/homeassistant/components/broadlink/entity.py
+++ b/homeassistant/components/broadlink/entity.py
@@ -64,5 +64,7 @@ class BroadlinkEntity(Entity):
             manufacturer=device.api.manufacturer,
             model=device.api.model,
             name=device.name,
-            sw_version=device.fw_version,
+            sw_version=str(device.fw_version)
+            if device.fw_version is not None
+            else None,
         )

--- a/homeassistant/components/slide_local/entity.py
+++ b/homeassistant/components/slide_local/entity.py
@@ -20,8 +20,8 @@ class SlideEntity(CoordinatorEntity[SlideCoordinator]):
             manufacturer="Innovation in Motion",
             connections={(dr.CONNECTION_NETWORK_MAC, coordinator.data["mac"])},
             name=coordinator.data["device_name"],
-            sw_version=coordinator.api_version,
-            hw_version=coordinator.data["board_rev"],
+            sw_version=str(coordinator.api_version),
+            hw_version=str(coordinator.data["board_rev"]),
             serial_number=coordinator.data["mac"],
             configuration_url=f"http://{coordinator.host}",
         )

--- a/homeassistant/components/smarty/coordinator.py
+++ b/homeassistant/components/smarty/coordinator.py
@@ -36,8 +36,8 @@ class SmartyCoordinator(DataUpdateCoordinator[None]):
     async def _async_setup(self) -> None:
         if not await self.hass.async_add_executor_job(self.client.update):
             raise UpdateFailed("Failed to update Smarty data")
-        self.software_version = self.client.get_software_version()
-        self.configuration_version = self.client.get_configuration_version()
+        self.software_version = str(self.client.get_software_version())
+        self.configuration_version = str(self.client.get_configuration_version())
 
     async def _async_update_data(self) -> None:
         """Fetch data from Smarty."""

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -258,7 +258,7 @@ def _determine_device_info_type(
     return device_info_type
 
 
-class _DeviceInfoFields(TypedDict):
+class _ValidatedDeviceInfoFields(TypedDict):
     """Device info fields validated on create and update."""
 
     configuration_url: str | URL | None | UndefinedType
@@ -276,7 +276,12 @@ _cached_parse_url = lru_cache(maxsize=512)(URL)
 
 def _validate_str(name: str, value: Any) -> str | None | UndefinedType:
     """Validate that a device registry string field has correct type."""
-    if value is UNDEFINED or value is None or isinstance(value, str):
+    if (
+        value is UNDEFINED
+        or value is None
+        or type(value) is str  # fast path for exact str
+        or isinstance(value, str)
+    ):
         return value
     report_usage(
         f"passes a non-string value of type {type(value).__name__} "
@@ -288,8 +293,8 @@ def _validate_str(name: str, value: Any) -> str | None | UndefinedType:
 
 
 def _validate_device_info_fields(
-    **fields: Unpack[_DeviceInfoFields],
-) -> _DeviceInfoFields:
+    **fields: Unpack[_ValidatedDeviceInfoFields],
+) -> _ValidatedDeviceInfoFields:
     """Validate device-info field values."""
     configuration_url = fields["configuration_url"]
     url: URL | None = None

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from functools import lru_cache
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Unpack
 
 import attr
 from yarl import URL
@@ -222,11 +222,11 @@ class DeviceConnectionCollisionError(DeviceCollisionError):
         )
 
 
-def _validate_device_info(
+def _determine_device_info_type(
     config_entry: ConfigEntry,
     device_info: DeviceInfo,
 ) -> str:
-    """Process a device info."""
+    """Determine the type of a device info."""
     keys = set(device_info)
 
     # If no keys or not enough info to match up, abort
@@ -258,22 +258,61 @@ def _validate_device_info(
     return device_info_type
 
 
+class _DeviceInfoFields(TypedDict):
+    """Device info fields validated on create and update."""
+
+    configuration_url: str | URL | None | UndefinedType
+    hw_version: str | None | UndefinedType
+    manufacturer: str | None | UndefinedType
+    model: str | None | UndefinedType
+    model_id: str | None | UndefinedType
+    serial_number: str | None | UndefinedType
+    sw_version: str | None | UndefinedType
+
+
 _cached_parse_url = lru_cache(maxsize=512)(URL)
 """Parse a URL and cache the result."""
 
 
-def _validate_configuration_url(value: Any) -> str | None:
-    """Validate and convert configuration_url."""
-    if value is None:
-        return None
+def _validate_str(name: str, value: Any) -> str | None | UndefinedType:
+    """Validate that a device registry string field has correct type."""
+    if value is UNDEFINED or value is None or isinstance(value, str):
+        return value
+    report_usage(
+        f"passes a non-string value of type {type(value).__name__} "
+        f"as {name} to the device registry",
+        core_behavior=ReportBehavior.LOG,
+        breaks_in_ha_version="2026.12.0",
+    )
+    return str(value)
 
-    url_as_str = str(value)
-    url = value if type(value) is URL else _cached_parse_url(url_as_str)
 
-    if url.scheme not in CONFIGURATION_URL_SCHEMES or not url.host:
-        raise ValueError(f"invalid configuration_url '{value}'")
-
-    return url_as_str
+def _validate_device_info_fields(
+    **fields: Unpack[_DeviceInfoFields],
+) -> _DeviceInfoFields:
+    """Validate device-info field values."""
+    configuration_url = fields["configuration_url"]
+    url: URL | None = None
+    if type(configuration_url) is URL:
+        url = configuration_url
+        configuration_url = str(configuration_url)
+    else:
+        configuration_url = _validate_str("configuration_url", configuration_url)
+        if isinstance(configuration_url, str):
+            url = _cached_parse_url(configuration_url)
+    if url is not None and (
+        url.scheme not in CONFIGURATION_URL_SCHEMES or not url.host
+    ):
+        raise ValueError(f"invalid configuration_url '{configuration_url}'")
+    return {
+        "configuration_url": configuration_url,
+        "hw_version": _validate_str("hw_version", fields["hw_version"]),
+        "manufacturer": _validate_str("manufacturer", fields["manufacturer"]),
+        "model": _validate_str("model", fields["model"]),
+        "model_id": _validate_str("model_id", fields["model_id"]),
+        "serial_number": _validate_str("serial_number", fields["serial_number"]),
+        "sw_version": _validate_str("sw_version", fields["sw_version"]),
+    }
 
 
 @lru_cache(maxsize=512)
@@ -864,8 +903,19 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         via_device: tuple[str, str] | None | UndefinedType = UNDEFINED,
     ) -> DeviceEntry:
         """Get device. Create if it doesn't exist."""
-        if configuration_url is not UNDEFINED:
-            configuration_url = _validate_configuration_url(configuration_url)
+        default_manufacturer = _validate_str(
+            "default_manufacturer", default_manufacturer
+        )
+        default_model = _validate_str("default_model", default_model)
+        validated_fields = _validate_device_info_fields(
+            configuration_url=configuration_url,
+            hw_version=hw_version,
+            manufacturer=manufacturer,
+            model=model,
+            model_id=model_id,
+            serial_number=serial_number,
+            sw_version=sw_version,
+        )
 
         config_entry = self.hass.config_entries.async_get_entry(config_entry_id)
         if config_entry is None:
@@ -891,27 +941,21 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         device_info: DeviceInfo = {  # type: ignore[assignment]
             key: val
             for key, val in (
-                ("configuration_url", configuration_url),
                 ("connections", connections),
                 ("default_manufacturer", default_manufacturer),
                 ("default_model", default_model),
                 ("default_name", default_name),
                 ("entry_type", entry_type),
-                ("hw_version", hw_version),
                 ("identifiers", identifiers),
-                ("manufacturer", manufacturer),
-                ("model", model),
-                ("model_id", model_id),
                 ("name", name),
-                ("serial_number", serial_number),
                 ("suggested_area", suggested_area),
-                ("sw_version", sw_version),
                 ("via_device", via_device),
+                *validated_fields.items(),
             )
             if val is not UNDEFINED
         }
 
-        device_info_type = _validate_device_info(config_entry, device_info)
+        device_info_type = _determine_device_info_type(config_entry, device_info)
 
         if identifiers is None or identifiers is UNDEFINED:
             identifiers = set()
@@ -963,10 +1007,10 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 name = config_entry.title
 
         if default_manufacturer is not UNDEFINED and device.manufacturer is None:
-            manufacturer = default_manufacturer
+            validated_fields["manufacturer"] = default_manufacturer
 
         if default_model is not UNDEFINED and device.model is None:
-            model = default_model
+            validated_fields["model"] = default_model
 
         if default_name is not UNDEFINED and device.name is None:
             name = default_name
@@ -990,22 +1034,16 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             allow_collisions=True,
             add_config_entry_id=config_entry_id,
             add_config_subentry_id=config_subentry_id,
-            configuration_url=configuration_url,
             device_info_type=device_info_type,
             disabled_by=disabled_by,
             entry_type=entry_type,
-            hw_version=hw_version,
             is_new=is_new,
-            manufacturer=manufacturer,
             merge_connections=connections or UNDEFINED,
             merge_identifiers=identifiers or UNDEFINED,
-            model=model,
-            model_id=model_id,
             name=name,
-            serial_number=serial_number,
             suggested_area=suggested_area,
-            sw_version=sw_version,
             via_device_id=via_device_id,
+            **validated_fields,
         )
 
         # This is safe because _async_update_device will always return a device
@@ -1249,9 +1287,6 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             )
             old_values["identifiers"] = old.identifiers
 
-        if configuration_url is not UNDEFINED:
-            configuration_url = _validate_configuration_url(configuration_url)
-
         for attr_name, value in (
             ("area_id", area_id),
             ("configuration_url", configuration_url),
@@ -1361,32 +1396,36 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 breaks_in_ha_version="2026.9.0",
             )
 
+        validated_fields = _validate_device_info_fields(
+            configuration_url=configuration_url,
+            hw_version=hw_version,
+            manufacturer=manufacturer,
+            model=model,
+            model_id=model_id,
+            serial_number=serial_number,
+            sw_version=sw_version,
+        )
+
         return self._async_update_device(
             device_id,
             add_config_entry_id=add_config_entry_id,
             add_config_subentry_id=add_config_subentry_id,
             area_id=area_id,
-            configuration_url=configuration_url,
             device_info_type=device_info_type,
             disabled_by=disabled_by,
             entry_type=entry_type,
-            hw_version=hw_version,
             labels=labels,
-            manufacturer=manufacturer,
             merge_connections=merge_connections,
             merge_identifiers=merge_identifiers,
-            model=model,
-            model_id=model_id,
             name_by_user=name_by_user,
             name=name,
             new_connections=new_connections,
             new_identifiers=new_identifiers,
             remove_config_entry_id=remove_config_entry_id,
             remove_config_subentry_id=remove_config_subentry_id,
-            serial_number=serial_number,
             suggested_area=suggested_area,
-            sw_version=sw_version,
             via_device_id=via_device_id,
+            **validated_fields,
         )
 
     @callback

--- a/tests/components/broadlink/test_device.py
+++ b/tests/components/broadlink/test_device.py
@@ -262,7 +262,7 @@ async def test_device_setup_registry(
     assert device_entry.name == device.name
     assert device_entry.model == device.model
     assert device_entry.manufacturer == device.manufacturer
-    assert device_entry.sw_version == device.fwversion
+    assert device_entry.sw_version == str(device.fwversion)
 
     for entry in er.async_entries_for_device(entity_registry, device_entry.id):
         assert (

--- a/tests/components/slide_local/snapshots/test_init.ambr
+++ b/tests/components/slide_local/snapshots/test_init.ambr
@@ -13,7 +13,7 @@
     }),
     'disabled_by': None,
     'entry_type': None,
-    'hw_version': 1,
+    'hw_version': '1',
     'id': <ANY>,
     'identifiers': set({
     }),
@@ -26,7 +26,7 @@
     'name_by_user': None,
     'primary_config_entry': <ANY>,
     'serial_number': '1234567890ab',
-    'sw_version': 2,
+    'sw_version': '2',
     'via_device_id': None,
   })
 # ---

--- a/tests/components/smarty/snapshots/test_init.ambr
+++ b/tests/components/smarty/snapshots/test_init.ambr
@@ -9,7 +9,7 @@
     }),
     'disabled_by': None,
     'entry_type': None,
-    'hw_version': 111,
+    'hw_version': '111',
     'id': <ANY>,
     'identifiers': set({
       tuple(
@@ -26,7 +26,7 @@
     'name_by_user': None,
     'primary_config_entry': <ANY>,
     'serial_number': None,
-    'sw_version': 127,
+    'sw_version': '127',
     'via_device_id': None,
   })
 # ---

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4914,6 +4914,61 @@ async def test_device_info_configuration_url_validation(
         )
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        "hw_version",
+        "manufacturer",
+        "model",
+        "model_id",
+        "serial_number",
+        "sw_version",
+    ],
+)
+@pytest.mark.parametrize(
+    ("value", "stored_value", "expected_log"),
+    [
+        (1.0, "1.0", "passes a non-string value of type float as {field}"),
+        ((1, 2), "(1, 2)", "passes a non-string value of type tuple as {field}"),
+        ("hw-1", "hw-1", ""),
+        (None, None, ""),
+    ],
+)
+async def test_device_info_string_field_validation(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    field: str,
+    value: Any,
+    stored_value: str | None,
+    expected_log: str,
+) -> None:
+    """Test string device info fields are validated and coerced."""
+    config_entry_1 = MockConfigEntry()
+    config_entry_1.add_to_hass(hass)
+    config_entry_2 = MockConfigEntry()
+    config_entry_2.add_to_hass(hass)
+
+    entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry_1.entry_id,
+        identifiers={("something", "1234")},
+        name="name",
+        **{field: value},
+    )
+    assert getattr(entry, field) == stored_value
+
+    update_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry_2.entry_id,
+        identifiers={("something", "5678")},
+        name="name",
+    )
+    updated = device_registry.async_update_device(update_device.id, **{field: value})
+    assert updated is not None
+    assert getattr(updated, field) == stored_value
+
+    assert expected_log.format(field=field) in caplog.text
+
+
 @pytest.mark.parametrize("load_registries", [False])
 async def test_loading_invalid_configuration_url_from_storage(
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate device info string fields in the registry.

Logs a deprecation warning and coerces non-string values to strings when validating the string-typed device info fields in the device registry. Integrations passing non-string values will need to be updated before the behaviour breaks in 2026.12.0.

This change will also improve the situation for device analytics.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
