### PR TITLE
Add siren platform support to Matter integration

### DIFF
--- a/homeassistant/components/matter/discovery.py
+++ b/homeassistant/components/matter/discovery.py
@@ -21,6 +21,7 @@ from .models import UNSET, MatterDiscoverySchema, MatterEntityInfo
 from .number import DISCOVERY_SCHEMAS as NUMBER_SCHEMAS
 from .select import DISCOVERY_SCHEMAS as SELECT_SCHEMAS
 from .sensor import DISCOVERY_SCHEMAS as SENSOR_SCHEMAS
+from .siren import DISCOVERY_SCHEMAS as SIREN_SCHEMAS
 from .switch import DISCOVERY_SCHEMAS as SWITCH_SCHEMAS
 from .update import DISCOVERY_SCHEMAS as UPDATE_SCHEMAS
 from .vacuum import DISCOVERY_SCHEMAS as VACUUM_SCHEMAS
@@ -39,6 +40,7 @@ DISCOVERY_SCHEMAS: dict[Platform, list[MatterDiscoverySchema]] = {
     Platform.NUMBER: NUMBER_SCHEMAS,
     Platform.SELECT: SELECT_SCHEMAS,
     Platform.SENSOR: SENSOR_SCHEMAS,
+    Platform.SIREN: SIREN_SCHEMAS,
     Platform.SWITCH: SWITCH_SCHEMAS,
     Platform.UPDATE: UPDATE_SCHEMAS,
     Platform.VACUUM: VACUUM_SCHEMAS,

--- a/homeassistant/components/matter/siren.py
+++ b/homeassistant/components/matter/siren.py
@@ -38,7 +38,6 @@ class MatterSiren(MatterEntity, SirenEntity):
     """Representation of a Matter siren."""
 
     entity_description: MatterSirenEntityDescription
-    _platform_translation_key = "siren"
     _attr_supported_features = SirenEntityFeature.TURN_ON | SirenEntityFeature.TURN_OFF
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -62,7 +61,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.SIREN,
         entity_description=MatterSirenEntityDescription(
             key="HeimanSiren",
-            name=None,
+            translation_key="siren",
         ),
         entity_class=MatterSiren,
         required_attributes=(HeimanCluster.Attributes.SirenActive,),

--- a/homeassistant/components/matter/siren.py
+++ b/homeassistant/components/matter/siren.py
@@ -1,0 +1,70 @@
+"""Matter sirens."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from matter_server.common.custom_clusters import HeimanCluster
+
+from homeassistant.components.siren import (
+    SirenEntity,
+    SirenEntityDescription,
+    SirenEntityFeature,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import MatterEntity, MatterEntityDescription
+from .helpers import MatterConfigEntry
+from .models import MatterDiscoverySchema
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: MatterConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Matter sirens from Config Entry."""
+    matter = config_entry.runtime_data.adapter
+    matter.register_platform_handler(Platform.SIREN, async_add_entities)
+
+
+@dataclass(frozen=True, kw_only=True)
+class MatterSirenEntityDescription(SirenEntityDescription, MatterEntityDescription):
+    """Describe Matter Siren entities."""
+
+
+class MatterSiren(MatterEntity, SirenEntity):
+    """Representation of a Matter siren."""
+
+    entity_description: MatterSirenEntityDescription
+    _platform_translation_key = "siren"
+    _attr_supported_features = SirenEntityFeature.TURN_ON | SirenEntityFeature.TURN_OFF
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the siren on."""
+        await self.write_attribute(value=1)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the siren off."""
+        await self.write_attribute(value=0)
+
+    @callback
+    def _update_from_device(self) -> None:
+        """Update from device."""
+        value = self.get_matter_attribute_value(self._entity_info.primary_attribute)
+        self._attr_is_on = bool(value)
+
+
+# Discovery schema(s) to map Matter Attributes to HA entities
+DISCOVERY_SCHEMAS = [
+    MatterDiscoverySchema(
+        platform=Platform.SIREN,
+        entity_description=MatterSirenEntityDescription(
+            key="HeimanSiren",
+            name=None,
+        ),
+        entity_class=MatterSiren,
+        required_attributes=(HeimanCluster.Attributes.SirenActive,),
+    ),
+]

--- a/homeassistant/components/matter/siren.py
+++ b/homeassistant/components/matter/siren.py
@@ -53,7 +53,7 @@ class MatterSiren(MatterEntity, SirenEntity):
     def _update_from_device(self) -> None:
         """Update from device."""
         value = self.get_matter_attribute_value(self._entity_info.primary_attribute)
-        self._attr_is_on = bool(value)
+        self._attr_is_on = bool(value) if value is not None else None
 
 
 # Discovery schema(s) to map Matter Attributes to HA entities

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -610,6 +610,11 @@
         "name": "Target opening position"
       }
     },
+    "siren": {
+      "siren": {
+        "name": "[%key:component::siren::title%]"
+      }
+    },
     "switch": {
       "child_lock": {
         "name": "Child lock"

--- a/tests/components/matter/snapshots/test_siren.ambr
+++ b/tests/components/matter/snapshots/test_siren.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_sirens[heiman_smoke_detector][siren.smoke_sensor-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'siren',
+    'entity_category': None,
+    'entity_id': 'siren.smoke_sensor',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <SirenEntityFeature: 3>,
+    'translation_key': 'siren',
+    'unique_id': '00000000000004D2-000000000000000B-MatterNodeDevice-1-HeimanSiren-302775297-20',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sirens[heiman_smoke_detector][siren.smoke_sensor-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smoke sensor',
+      'supported_features': <SirenEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'siren.smoke_sensor',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/matter/snapshots/test_siren.ambr
+++ b/tests/components/matter/snapshots/test_siren.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sirens[heiman_smoke_detector][siren.smoke_sensor-entry]
+# name: test_sirens[heiman_smoke_detector][siren.smoke_sensor_siren-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'siren',
     'entity_category': None,
-    'entity_id': 'siren.smoke_sensor',
+    'entity_id': 'siren.smoke_sensor_siren',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Siren',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Siren',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36,14 +36,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sirens[heiman_smoke_detector][siren.smoke_sensor-state]
+# name: test_sirens[heiman_smoke_detector][siren.smoke_sensor_siren-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smoke sensor',
+      'friendly_name': 'Smoke sensor Siren',
       'supported_features': <SirenEntityFeature: 3>,
     }),
     'context': <ANY>,
-    'entity_id': 'siren.smoke_sensor',
+    'entity_id': 'siren.smoke_sensor_siren',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/test_siren.py
+++ b/tests/components/matter/test_siren.py
@@ -1,0 +1,100 @@
+"""Test Matter siren entities."""
+
+from unittest.mock import MagicMock, call
+
+from matter_server.client.models.node import MatterNode
+from matter_server.common.custom_clusters import HeimanCluster
+from matter_server.common.helpers.util import create_attribute_path_from_attribute
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .common import (
+    set_node_attribute,
+    snapshot_matter_entities,
+    trigger_subscription_callback,
+)
+
+
+@pytest.mark.usefixtures("matter_devices")
+async def test_sirens(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test sirens."""
+    snapshot_matter_entities(hass, entity_registry, snapshot, Platform.SIREN)
+
+
+@pytest.mark.parametrize("node_fixture", ["heiman_smoke_detector"])
+async def test_turn_on(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test turning on the siren."""
+    state = hass.states.get("siren.smoke_sensor")
+    assert state
+    assert state.state == "on"
+
+    set_node_attribute(
+        matter_node,
+        1,
+        HeimanCluster.id,
+        HeimanCluster.Attributes.SirenActive.attribute_id,
+        0,
+    )
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("siren.smoke_sensor")
+    assert state
+    assert state.state == "off"
+
+    await hass.services.async_call(
+        "siren",
+        "turn_on",
+        {"entity_id": "siren.smoke_sensor"},
+        blocking=True,
+    )
+
+    assert matter_client.write_attribute.call_count == 1
+    assert matter_client.write_attribute.call_args == call(
+        node_id=matter_node.node_id,
+        attribute_path=create_attribute_path_from_attribute(
+            endpoint_id=1,
+            attribute=HeimanCluster.Attributes.SirenActive,
+        ),
+        value=1,
+    )
+
+
+@pytest.mark.parametrize("node_fixture", ["heiman_smoke_detector"])
+async def test_turn_off(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test turning off the siren."""
+    state = hass.states.get("siren.smoke_sensor")
+    assert state
+    assert state.state == "on"
+
+    await hass.services.async_call(
+        "siren",
+        "turn_off",
+        {"entity_id": "siren.smoke_sensor"},
+        blocking=True,
+    )
+
+    assert matter_client.write_attribute.call_count == 1
+    assert matter_client.write_attribute.call_args == call(
+        node_id=matter_node.node_id,
+        attribute_path=create_attribute_path_from_attribute(
+            endpoint_id=1,
+            attribute=HeimanCluster.Attributes.SirenActive,
+        ),
+        value=0,
+    )

--- a/tests/components/matter/test_siren.py
+++ b/tests/components/matter/test_siren.py
@@ -36,7 +36,7 @@ async def test_turn_on(
     matter_node: MatterNode,
 ) -> None:
     """Test turning on the siren."""
-    state = hass.states.get("siren.smoke_sensor")
+    state = hass.states.get("siren.smoke_sensor_siren")
     assert state
     assert state.state == "on"
 
@@ -49,14 +49,14 @@ async def test_turn_on(
     )
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("siren.smoke_sensor")
+    state = hass.states.get("siren.smoke_sensor_siren")
     assert state
     assert state.state == "off"
 
     await hass.services.async_call(
         "siren",
         "turn_on",
-        {"entity_id": "siren.smoke_sensor"},
+        {"entity_id": "siren.smoke_sensor_siren"},
         blocking=True,
     )
 
@@ -78,14 +78,14 @@ async def test_turn_off(
     matter_node: MatterNode,
 ) -> None:
     """Test turning off the siren."""
-    state = hass.states.get("siren.smoke_sensor")
+    state = hass.states.get("siren.smoke_sensor_siren")
     assert state
     assert state.state == "on"
 
     await hass.services.async_call(
         "siren",
         "turn_off",
-        {"entity_id": "siren.smoke_sensor"},
+        {"entity_id": "siren.smoke_sensor_siren"},
         blocking=True,
     )
 
@@ -116,6 +116,6 @@ async def test_unknown_state(
     )
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("siren.smoke_sensor")
+    state = hass.states.get("siren.smoke_sensor_siren")
     assert state
     assert state.state == "unknown"

--- a/tests/components/matter/test_siren.py
+++ b/tests/components/matter/test_siren.py
@@ -98,3 +98,24 @@ async def test_turn_off(
         ),
         value=0,
     )
+
+
+@pytest.mark.parametrize("node_fixture", ["heiman_smoke_detector"])
+async def test_unknown_state(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test that a None attribute value results in an unknown state."""
+    set_node_attribute(
+        matter_node,
+        1,
+        HeimanCluster.id,
+        HeimanCluster.Attributes.SirenActive.attribute_id,
+        None,
+    )
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("siren.smoke_sensor")
+    assert state
+    assert state.state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces native siren entity support for the Matter integration, exposing the `HeimanCluster.SirenActive` attribute as a proper `siren` platform entity.
Tested with Heiman HS1SA-M device and HeimanCluster.Attributes.SirenActive (Firmware: 4.3).

**What changed:**

- **New `siren.py` platform** — Adds `MatterSiren`, a `SirenEntity` subclass that reads and writes `HeimanCluster.Attributes.SirenActive` (integer attribute: `0` = off, `1` = on). Supports `turn_on` and `turn_off` via `write_attribute`.
- **`discovery.py`** — Registers the new `Platform.SIREN` in the discovery schema map.
- **`test_siren.py` + snapshot** — Adds snapshot test for the `heiman_smoke_detector` fixture, and parametrized tests for `turn_on` and `turn_off` verifying the correct `write_attribute` calls. Preserve unknown state when Matter siren attribute is None.

**Background**

The `HeimanCluster` is a vendor-specific Matter cluster used by Heiman devices (e.g. smoke detectors). Its `SirenActive` attribute controls whether the siren is active.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45233
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
