### PR TITLE
ElkM1 integration: Add time entity for settings

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -76,6 +76,7 @@ PLATFORMS = [
     Platform.SCENE,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
 ]
 
 

--- a/homeassistant/components/elkm1/time.py
+++ b/homeassistant/components/elkm1/time.py
@@ -57,7 +57,7 @@ class ElkTimeSetting(ElkAttachedEntity, TimeEntity):
         else:
             self._attr_available = False
             _LOGGER.warning(
-                "Setting type for '%s' differ between the ElkM1 and the entity. Restart the integration to fix",
+                "Setting type for '%s' differs between the ElkM1 and the entity. Restart the integration to fix",
                 self.entity_id,
             )
 

--- a/homeassistant/components/elkm1/time.py
+++ b/homeassistant/components/elkm1/time.py
@@ -1,0 +1,66 @@
+"""Support for ElkM1 time entities."""
+
+from datetime import time as dt_time
+import logging
+from typing import Any, cast
+
+from elkm1_lib.const import SettingFormat
+from elkm1_lib.elements import Element
+from elkm1_lib.settings import Setting
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import ElkM1ConfigEntry
+from .entity import ElkAttachedEntity, ElkEntity, create_elk_entities
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ElkM1ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Elk-M1 time platform."""
+    elk_data = config_entry.runtime_data
+    elk = elk_data.elk
+    entities: list[ElkEntity] = []
+    time_settings = [
+        setting
+        for setting in cast(list[Setting], elk.settings)
+        if setting.value_format == SettingFormat.TIME_OF_DAY
+    ]
+
+    create_elk_entities(
+        elk_data,
+        time_settings,
+        "setting",
+        ElkTimeSetting,
+        entities,
+    )
+    async_add_entities(entities)
+
+
+class ElkTimeSetting(ElkAttachedEntity, TimeEntity):
+    """Representation of an Elk-M1 Time Setting."""
+
+    _element: Setting
+
+    def _element_changed(self, element: Element, changeset: dict[str, Any]) -> None:
+        value = self._element.value
+        # Guard against the panel possibly changing the underlying
+        # type without us knowing about the change
+        if isinstance(value, tuple):
+            self._attr_native_value = dt_time(hour=value[0], minute=value[1])
+        else:
+            self._attr_available = False
+            _LOGGER.warning(
+                "Setting type for '%s' differ between the ElkM1 and the entity. Restart the integration to fix",
+                self.entity_id,
+            )
+
+    async def async_set_value(self, value: dt_time) -> None:
+        """Set the time of the setting."""
+        self._element.set((value.hour, value.minute))


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a time entity for Elk Settings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45235
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
