### PR TITLE
Bump python-duco-client to 0.5.0

### DIFF
--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "loggers": ["duco"],
   "quality_scale": "platinum",
-  "requirements": ["python-duco-client==0.4.2"],
+  "requirements": ["python-duco-client==0.5.0"],
   "zeroconf": [
     {
       "name": "duco [[][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][]].*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2596,7 +2596,7 @@ python-digitalocean==1.13.2
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.4.2
+python-duco-client==0.5.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2222,7 +2222,7 @@ python-citybikes==0.3.3
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.4.2
+python-duco-client==0.5.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2


### PR DESCRIPTION
## Proposed change

Bump `python-duco-client` from `0.4.2` to `0.5.0`.

The new release adds `async_detect_board_family()` — a standalone async helper that detects whether a Duco box runs the Connectivity Board or Communication and Print Board hardware family, without requiring an authenticated `DucoClient` instance. It also adds the `BoardFamily` StrEnum (`CONNECTIVITY_BOARD`, `COMMUNICATION_PRINT`) to the public API.

This bump is a prerequisite for a follow-up PR that uses board detection in the config flow to reject unsupported Communication and Print Board devices at setup time.

Changelog: https://github.com/ronaldvdmeer/python-duco-client/releases/tag/v0.5.0
Diff: https://github.com/ronaldvdmeer/python-duco-client/compare/v0.4.2...v0.5.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
