### PR TITLE
Fix sensors getting wrong unit from MeasuredValueType attribute in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -8,6 +8,7 @@ from pyoverkiz.enums import OverkizAttribute, OverkizState, UIWidget
 from pyoverkiz.types import StateType as OverkizStateType
 
 from homeassistant.components.sensor import (
+    DEVICE_CLASS_UNITS,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -604,9 +605,24 @@ class OverkizStateSensor(OverkizDescriptiveEntity, SensorEntity):
         if (unit := attrs[OverkizAttribute.CORE_MEASURED_VALUE_TYPE]) and (
             unit_value := unit.value_as_str
         ):
-            return OVERKIZ_UNIT_TO_HA.get(unit_value, default_unit)
+            ha_unit = OVERKIZ_UNIT_TO_HA.get(unit_value, default_unit)
+            if self._is_unit_valid_for_device_class(ha_unit):
+                return ha_unit
 
         return default_unit
+
+    def _is_unit_valid_for_device_class(self, unit: str) -> bool:
+        """Check if a unit is valid for this sensor's device class.
+
+        The device-level core:MeasuredValueType attribute describes the primary
+        sensor (e.g. luminance/temperature), but must not override the unit of
+        unrelated sensors on the same device (e.g. RSSI).
+        """
+        if not (device_class := self.entity_description.device_class):
+            return True
+        if (valid_units := DEVICE_CLASS_UNITS.get(device_class)) is None:
+            return True
+        return unit in valid_units
 
 
 class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -8,7 +8,6 @@ from pyoverkiz.enums import OverkizAttribute, OverkizState, UIWidget
 from pyoverkiz.types import StateType as OverkizStateType
 
 from homeassistant.components.sensor import (
-    DEVICE_CLASS_UNITS,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -605,24 +604,9 @@ class OverkizStateSensor(OverkizDescriptiveEntity, SensorEntity):
         if (unit := attrs[OverkizAttribute.CORE_MEASURED_VALUE_TYPE]) and (
             unit_value := unit.value_as_str
         ):
-            ha_unit = OVERKIZ_UNIT_TO_HA.get(unit_value, default_unit)
-            if self._is_unit_valid_for_device_class(ha_unit):
-                return ha_unit
+            return OVERKIZ_UNIT_TO_HA.get(unit_value, default_unit)
 
         return default_unit
-
-    def _is_unit_valid_for_device_class(self, unit: str) -> bool:
-        """Check if a unit is valid for this sensor's device class.
-
-        The device-level core:MeasuredValueType attribute describes the primary
-        sensor (e.g. luminance/temperature), but must not override the unit of
-        unrelated sensors on the same device (e.g. RSSI).
-        """
-        if not (device_class := self.entity_description.device_class):
-            return True
-        if (valid_units := DEVICE_CLASS_UNITS.get(device_class)) is None:
-            return True
-        return unit in valid_units
 
 
 class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):

--- a/tests/components/overkiz/snapshots/test_sensor.ambr
+++ b/tests/components/overkiz/snapshots/test_sensor.ambr
@@ -1810,7 +1810,7 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'io://1234-5678-1698/15702199#2-core:RSSILevelState',
-    'unit_of_measurement': 'dB',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
 # name: test_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][sensor.garden_radiator_bathroom_temperature_sensor_rssi_level-state]
@@ -1819,7 +1819,7 @@
       'device_class': 'signal_strength',
       'friendly_name': 'Garden Radiator Bathroom Temperature Sensor RSSI level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'dB',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.garden_radiator_bathroom_temperature_sensor_rssi_level',
@@ -2804,7 +2804,7 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'io://1234-5678-1698/9253412#2-core:RSSILevelState',
-    'unit_of_measurement': 'dB',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
 # name: test_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][sensor.living_room_radiator_study_temp_probe_rssi_level-state]
@@ -2813,7 +2813,7 @@
       'device_class': 'signal_strength',
       'friendly_name': 'Living Room Radiator Study Temp Probe RSSI level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'dB',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.living_room_radiator_study_temp_probe_rssi_level',
@@ -4182,7 +4182,7 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'io://1234-5678-1698/9187218#2-core:RSSILevelState',
-    'unit_of_measurement': 'dB',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
 # name: test_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][sensor.study_radiator_nursery_temp_probe_rssi_level-state]
@@ -4191,7 +4191,7 @@
       'device_class': 'signal_strength',
       'friendly_name': 'Study Radiator Nursery Temp Probe RSSI level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'dB',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.study_radiator_nursery_temp_probe_rssi_level',

--- a/tests/components/overkiz/snapshots/test_sensor.ambr
+++ b/tests/components/overkiz/snapshots/test_sensor.ambr
@@ -1810,7 +1810,7 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'io://1234-5678-1698/15702199#2-core:RSSILevelState',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    'unit_of_measurement': 'dB',
   })
 # ---
 # name: test_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][sensor.garden_radiator_bathroom_temperature_sensor_rssi_level-state]
@@ -1819,7 +1819,7 @@
       'device_class': 'signal_strength',
       'friendly_name': 'Garden Radiator Bathroom Temperature Sensor RSSI level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+      'unit_of_measurement': 'dB',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.garden_radiator_bathroom_temperature_sensor_rssi_level',
@@ -2804,7 +2804,7 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'io://1234-5678-1698/9253412#2-core:RSSILevelState',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    'unit_of_measurement': 'dB',
   })
 # ---
 # name: test_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][sensor.living_room_radiator_study_temp_probe_rssi_level-state]
@@ -2813,7 +2813,7 @@
       'device_class': 'signal_strength',
       'friendly_name': 'Living Room Radiator Study Temp Probe RSSI level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+      'unit_of_measurement': 'dB',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.living_room_radiator_study_temp_probe_rssi_level',
@@ -4182,7 +4182,7 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'io://1234-5678-1698/9187218#2-core:RSSILevelState',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    'unit_of_measurement': 'dB',
   })
 # ---
 # name: test_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][sensor.study_radiator_nursery_temp_probe_rssi_level-state]
@@ -4191,7 +4191,7 @@
       'device_class': 'signal_strength',
       'friendly_name': 'Study Radiator Nursery Temp Probe RSSI level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+      'unit_of_measurement': 'dB',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.study_radiator_nursery_temp_probe_rssi_level',

--- a/tests/components/overkiz/test_sensor.py
+++ b/tests/components/overkiz/test_sensor.py
@@ -44,7 +44,6 @@ COZYTOUCH_DHW = FixtureDevice(
     "io://1234-5678-5643/109286#2",
     "sensor.patio_water_heating_office_energy_meter_electric_energy_consumption",
 )
-
 SNAPSHOT_FIXTURES = [
     TEMPERATURE_SENSOR,
     TEMPERATURE_SENSOR_LOCAL,

--- a/tests/components/overkiz/test_sensor.py
+++ b/tests/components/overkiz/test_sensor.py
@@ -44,6 +44,7 @@ COZYTOUCH_DHW = FixtureDevice(
     "io://1234-5678-5643/109286#2",
     "sensor.patio_water_heating_office_energy_meter_electric_energy_consumption",
 )
+
 SNAPSHOT_FIXTURES = [
     TEMPERATURE_SENSOR,
     TEMPERATURE_SENSOR_LOCAL,


### PR DESCRIPTION
## Proposed change

Overkiz provides a device-level `core:MeasuredValueType` attribute which links to the 'main sensor', we don't know what the main sensor is and we should check if the value type is valid for this device class.

Fixes #140651

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
