### PR TITLE
Fix Z-Wave discovery crash with unknown node firmware version

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -1282,19 +1282,19 @@ def async_discover_single_value(
             continue
 
         # check firmware_version_range
-        if schema.firmware_version_range is not None and (
-            (
+        if schema.firmware_version_range is not None:
+            # skip schema if device firmware version is unknown
+            if value.node.firmware_version is None:
+                continue
+            node_firmware = AwesomeVersion(value.node.firmware_version)
+            if (
                 schema.firmware_version_range.min is not None
-                and schema.firmware_version_range.min_ver
-                > AwesomeVersion(value.node.firmware_version)
-            )
-            or (
+                and schema.firmware_version_range.min_ver > node_firmware
+            ) or (
                 schema.firmware_version_range.max is not None
-                and schema.firmware_version_range.max_ver
-                < AwesomeVersion(value.node.firmware_version)
-            )
-        ):
-            continue
+                and schema.firmware_version_range.max_ver < node_firmware
+            ):
+                continue
 
         # check device_class_generic
         # If the value has an endpoint but it is missing on the node

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1513,3 +1513,15 @@ def fibaro_fgms001_v2_8_fixture(
     node = Node(client, fibaro_fgms001_v2_8_state)
     client.driver.controller.nodes[node.node_id] = node
     return node
+
+
+@pytest.fixture(name="fibaro_fgms001_unknown_firmware")
+def fibaro_fgms001_unknown_firmware_fixture(
+    client: MagicMock, fibaro_fgms001_v2_8_state: NodeDataType
+) -> Node:
+    """Load FGMS001 node with no reported firmware version."""
+    state = copy.deepcopy(fibaro_fgms001_v2_8_state)
+    state.pop("firmwareVersion", None)
+    node = Node(client, state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -33,7 +33,7 @@ from homeassistant.components.zwave_js.discovery_data_template import (
     DynamicCurrentTempClimateDataTemplate,
 )
 from homeassistant.components.zwave_js.helpers import get_device_id
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
+from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY, ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -664,6 +664,40 @@ async def test_nabu_casa_zwa2_legacy(
     assert state.attributes["friendly_name"] == "Home Assistant Connect ZWA-2 LED", (
         "The LED should have the correct friendly name"
     )
+
+
+@pytest.mark.parametrize("platforms", [[Platform.BINARY_SENSOR, Platform.LIGHT]])
+async def test_fibaro_fgms001_unknown_firmware_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    fibaro_fgms001_unknown_firmware: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test setup completes when an FGMS001 node has no firmware version.
+
+    Regression test for a crash where comparing AwesomeVersion(None) to a
+    schema's firmware_version_range raised AwesomeVersionCompareException
+    and aborted setup of the whole config entry.
+    """
+    assert integration.state is ConfigEntryState.LOADED
+
+    device = device_registry.async_get_device(
+        identifiers={get_device_id(client.driver, fibaro_fgms001_unknown_firmware)}
+    )
+    assert device is not None
+
+    entries = er.async_entries_for_device(
+        entity_registry, device.id, include_disabled_entities=True
+    )
+    motion_entries = [
+        entry
+        for entry in entries
+        if entry.domain == BINARY_SENSOR_DOMAIN
+        and entry.original_device_class == BinarySensorDeviceClass.MOTION
+    ]
+    assert motion_entries == []
 
 
 @pytest.mark.parametrize("platforms", [[Platform.BINARY_SENSOR, Platform.LIGHT]])


### PR DESCRIPTION
## Proposed change

This fixes an issue (https://github.com/home-assistant/core/issues/169932) where the Z-Wave JS integration does not start if a "Fibaro FGMS001" motion sensor is part of the network but has no known firmware version. The issue is partly caused by this recent PR:
- https://github.com/home-assistant/core/pull/169276

This PR fixes the issue by skipping the version comparison if the device's firmware version is not known.
A regression test is also added.


### Explanation / AI summary

When a node has not reported its firmware version yet, `value.node.firmware_version` is `None`. Comparing `AwesomeVersion(None)` (an unknown-strategy version) to a schema's `min_ver`/`max_ver` raises `AwesomeVersionCompareException`, which aborts setup of the whole `zwave_js` entry.

This was not noticed until #169276 added the first schema using `FirmwareVersionRange(max="2.8")` for the Fibaro FGMS001 motion sensor. Users with FGMS001 sensors where the firmware version is unknown (for whatever reason) hit the crash on every setup after upgrading to 2026.5.0. 

To fix this, we now skip schemas with a `firmware_version_range` when the node's firmware version is not known. If a device is re-interviewed, discovery will run again, and the entity for that schema may be discovered.

(cc @AlCalzone)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169932
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
