### PR TITLE
prusalink: extract PrusaLinkEntityDescription base class

### DIFF
--- a/homeassistant/components/prusalink/binary_sensor.py
+++ b/homeassistant/components/prusalink/binary_sensor.py
@@ -15,27 +15,26 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import PrusaLinkConfigEntry, PrusaLinkUpdateCoordinator
-from .entity import PrusaLinkEntity
+from .entity import PrusaLinkEntity, PrusaLinkEntityDescription
 
 T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PrusaLinkBinarySensorEntityDescriptionMixin(Generic[T]):
     """Mixin for required keys."""
 
     value_fn: Callable[[T], bool]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PrusaLinkBinarySensorEntityDescription(
     BinarySensorEntityDescription,
     PrusaLinkBinarySensorEntityDescriptionMixin[T],
+    PrusaLinkEntityDescription,
     Generic[T],
 ):
     """Describes PrusaLink sensor entity."""
-
-    available_fn: Callable[[T], bool] = lambda _: True
 
 
 BINARY_SENSORS: dict[str, tuple[PrusaLinkBinarySensorEntityDescription, ...]] = {

--- a/homeassistant/components/prusalink/binary_sensor.py
+++ b/homeassistant/components/prusalink/binary_sensor.py
@@ -21,20 +21,14 @@ T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo)
 
 
 @dataclass(frozen=True, kw_only=True)
-class PrusaLinkBinarySensorEntityDescriptionMixin(Generic[T]):
-    """Mixin for required keys."""
-
-    value_fn: Callable[[T], bool]
-
-
-@dataclass(frozen=True, kw_only=True)
 class PrusaLinkBinarySensorEntityDescription(
     BinarySensorEntityDescription,
-    PrusaLinkBinarySensorEntityDescriptionMixin[T],
     PrusaLinkEntityDescription,
     Generic[T],
 ):
     """Describes PrusaLink sensor entity."""
+
+    value_fn: Callable[[T], bool]
 
 
 BINARY_SENSORS: dict[str, tuple[PrusaLinkBinarySensorEntityDescription, ...]] = {

--- a/homeassistant/components/prusalink/button.py
+++ b/homeassistant/components/prusalink/button.py
@@ -19,20 +19,14 @@ T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo)
 
 
 @dataclass(frozen=True, kw_only=True)
-class PrusaLinkButtonEntityDescriptionMixin(Generic[T]):
-    """Mixin for required keys."""
-
-    press_fn: Callable[[PrusaLink], Callable[[int], Coroutine[Any, Any, None]]]
-
-
-@dataclass(frozen=True, kw_only=True)
 class PrusaLinkButtonEntityDescription(
     ButtonEntityDescription,
-    PrusaLinkButtonEntityDescriptionMixin[T],
     PrusaLinkEntityDescription,
     Generic[T],
 ):
     """Describes PrusaLink button entity."""
+
+    press_fn: Callable[[PrusaLink], Callable[[int], Coroutine[Any, Any, None]]]
 
 
 BUTTONS: dict[str, tuple[PrusaLinkButtonEntityDescription, ...]] = {

--- a/homeassistant/components/prusalink/button.py
+++ b/homeassistant/components/prusalink/button.py
@@ -13,25 +13,26 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import PrusaLinkConfigEntry, PrusaLinkUpdateCoordinator
-from .entity import PrusaLinkEntity
+from .entity import PrusaLinkEntity, PrusaLinkEntityDescription
 
 T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PrusaLinkButtonEntityDescriptionMixin(Generic[T]):
     """Mixin for required keys."""
 
     press_fn: Callable[[PrusaLink], Callable[[int], Coroutine[Any, Any, None]]]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PrusaLinkButtonEntityDescription(
-    ButtonEntityDescription, PrusaLinkButtonEntityDescriptionMixin[T], Generic[T]
+    ButtonEntityDescription,
+    PrusaLinkButtonEntityDescriptionMixin[T],
+    PrusaLinkEntityDescription,
+    Generic[T],
 ):
     """Describes PrusaLink button entity."""
-
-    available_fn: Callable[[T], bool] = lambda _: True
 
 
 BUTTONS: dict[str, tuple[PrusaLinkButtonEntityDescription, ...]] = {
@@ -99,13 +100,6 @@ class PrusaLinkButtonEntity(PrusaLinkEntity, ButtonEntity):
         super().__init__(coordinator=coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
-
-    @property
-    def available(self) -> bool:
-        """Return if sensor is available."""
-        return super().available and self.entity_description.available_fn(
-            self.coordinator.data
-        )
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/prusalink/camera.py
+++ b/homeassistant/components/prusalink/camera.py
@@ -1,13 +1,22 @@
 """Camera entity for PrusaLink."""
 
+from dataclasses import dataclass
+
 from pyprusalink.types import PrinterState
 
-from homeassistant.components.camera import Camera
+from homeassistant.components.camera import Camera, CameraEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import PrusaLinkConfigEntry, PrusaLinkUpdateCoordinator
 from .entity import PrusaLinkEntity, PrusaLinkEntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class PrusaLinkCameraEntityDescription(
+    CameraEntityDescription, PrusaLinkEntityDescription
+):
+    """Describes PrusaLink camera entity."""
 
 
 async def async_setup_entry(
@@ -23,7 +32,7 @@ async def async_setup_entry(
 class PrusaLinkJobPreviewEntity(PrusaLinkEntity, Camera):
     """Defines a PrusaLink camera."""
 
-    entity_description = PrusaLinkEntityDescription(
+    entity_description = PrusaLinkCameraEntityDescription(
         key="job_preview",
         translation_key="job_preview",
         available_fn=lambda data: bool(

--- a/homeassistant/components/prusalink/camera.py
+++ b/homeassistant/components/prusalink/camera.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import PrusaLinkConfigEntry, PrusaLinkUpdateCoordinator
-from .entity import PrusaLinkEntity
+from .entity import PrusaLinkEntity, PrusaLinkEntityDescription
 
 
 async def async_setup_entry(
@@ -23,25 +23,23 @@ async def async_setup_entry(
 class PrusaLinkJobPreviewEntity(PrusaLinkEntity, Camera):
     """Defines a PrusaLink camera."""
 
+    entity_description = PrusaLinkEntityDescription(
+        key="job_preview",
+        translation_key="job_preview",
+        available_fn=lambda data: bool(
+            data.get("state") != PrinterState.IDLE.value
+            and (file := data.get("file"))
+            and file.get("refs", {}).get("thumbnail")
+        ),
+    )
     last_path = ""
     last_image: bytes
-    _attr_translation_key = "job_preview"
 
     def __init__(self, coordinator: PrusaLinkUpdateCoordinator) -> None:
         """Initialize a PrusaLink camera entity."""
         super().__init__(coordinator)
         Camera.__init__(self)
         self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}_job_preview"
-
-    @property
-    def available(self) -> bool:
-        """Get if camera is available."""
-        return (
-            super().available
-            and self.coordinator.data.get("state") != PrinterState.IDLE.value
-            and (file := self.coordinator.data.get("file"))
-            and file.get("refs", {}).get("thumbnail")
-        )
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/homeassistant/components/prusalink/entity.py
+++ b/homeassistant/components/prusalink/entity.py
@@ -1,16 +1,37 @@
 """The PrusaLink integration."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import PrusaLinkUpdateCoordinator
 
 
+@dataclass(frozen=True, kw_only=True)
+class PrusaLinkEntityDescription(EntityDescription):
+    """Base description for PrusaLink entities."""
+
+    available_fn: Callable[[Any], bool] = lambda _: True
+    supported_fn: Callable[[Any], bool] = lambda _: True
+
+
 class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):
     """Defines a base PrusaLink entity."""
 
     _attr_has_entity_name = True
+    entity_description: PrusaLinkEntityDescription
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.entity_description.available_fn(
+            self.coordinator.data
+        )
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -27,26 +27,26 @@ from homeassistant.util.dt import utcnow
 from homeassistant.util.variance import ignore_variance
 
 from .coordinator import PrusaLinkConfigEntry, PrusaLinkUpdateCoordinator
-from .entity import PrusaLinkEntity
+from .entity import PrusaLinkEntity, PrusaLinkEntityDescription
 
 T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PrusaLinkSensorEntityDescriptionMixin(Generic[T]):
     """Mixin for required keys."""
 
     value_fn: Callable[[T], datetime | StateType]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PrusaLinkSensorEntityDescription(
-    SensorEntityDescription, PrusaLinkSensorEntityDescriptionMixin[T], Generic[T]
+    SensorEntityDescription,
+    PrusaLinkSensorEntityDescriptionMixin[T],
+    PrusaLinkEntityDescription,
+    Generic[T],
 ):
     """Describes PrusaLink sensor entity."""
-
-    available_fn: Callable[[T], bool] = lambda _: True
-    supported_fn: Callable[[T], bool] = lambda _: True
 
 
 SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
@@ -275,10 +275,3 @@ class PrusaLinkSensorEntity(PrusaLinkEntity, SensorEntity):
     def native_value(self) -> datetime | StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
-
-    @property
-    def available(self) -> bool:
-        """Return if sensor is available."""
-        return super().available and self.entity_description.available_fn(
-            self.coordinator.data
-        )

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -33,20 +33,14 @@ T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo)
 
 
 @dataclass(frozen=True, kw_only=True)
-class PrusaLinkSensorEntityDescriptionMixin(Generic[T]):
-    """Mixin for required keys."""
-
-    value_fn: Callable[[T], datetime | StateType]
-
-
-@dataclass(frozen=True, kw_only=True)
 class PrusaLinkSensorEntityDescription(
     SensorEntityDescription,
-    PrusaLinkSensorEntityDescriptionMixin[T],
     PrusaLinkEntityDescription,
     Generic[T],
 ):
     """Describes PrusaLink sensor entity."""
+
+    value_fn: Callable[[T], datetime | StateType]
 
 
 SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {


### PR DESCRIPTION
## Proposed change

Extracts a shared `PrusaLinkEntityDescription` base class so the per-platform descriptions (sensor, binary_sensor, button, camera) no longer duplicate the `available_fn` field, and so the `available` property can live on `PrusaLinkEntity` instead of being copy-pasted across the per-platform entity classes.

- `PrusaLinkEntityDescription(EntityDescription)` in `entity.py` carries `available_fn` and `supported_fn`
- `PrusaLinkSensorEntityDescription`, `PrusaLinkBinarySensorEntityDescription`, `PrusaLinkButtonEntityDescription`, and the new `PrusaLinkCameraEntityDescription` all inherit from it (combined with their respective HA platform descriptions)
- `PrusaLinkEntity.available` reads `entity_description.available_fn` directly — no `getattr` fallback needed since the description type is known
- Camera, which previously had no entity description, now uses `PrusaLinkCameraEntityDescription` (which inherits from both `CameraEntityDescription` and `PrusaLinkEntityDescription`). Its job-data-dependent availability check is expressed as `available_fn` on the description, so the `available` override is gone too. The class-level `_attr_translation_key` is replaced by `translation_key="job_preview"` on the description.
- All description dataclasses are now `kw_only=True` so inherited fields with defaults compose cleanly with required fields.
- The `*EntityDescriptionMixin` classes are merged into the main description classes — they were only needed to keep required fields ahead of default fields in dataclass ordering, which no longer matters with `kw_only=True`.

### Notes for reviewers

- **Entity IDs are unchanged.** Sensor, binary_sensor, and button entity_ids are derived from `translation_key` (unchanged). Camera previously used `_attr_translation_key="job_preview"`; now `entity_description.translation_key="job_preview"` — same resulting entity_id (`camera.<device>_job_preview`).
- **Camera availability behavior is preserved.** The lambda short-circuits the same conditions in the same order as the previous override; the only intentional change is wrapping in `bool()` so the property's declared `bool` return type is satisfied (the previous version could return a truthy thumbnail string).
- **`kw_only=True` on the description dataclasses** doesn't change call sites since all existing instantiations already use keyword arguments. It's required so the inherited defaulted fields (`available_fn`, `supported_fn`) compose with the platform descriptions' required fields without dataclass field-ordering errors.
- **`PrusaLinkCameraEntityDescription`** combines `CameraEntityDescription` (HA's contract for `Camera` entities) and `PrusaLinkEntityDescription` (our shared predicates), mirroring the pattern used by the other platforms.

## Why

This is the canonical HA pattern for integrations with multiple entity platforms: a single base entity description carries the cross-platform predicates (`available_fn`, `supported_fn`) so each platform doesn't redefine them, and the `available` property lives on the shared base entity. Beyond removing duplication, it makes the typing precise — we can drop the `getattr` fallbacks I had added in #169310 because `entity_description` is now typed as `PrusaLinkEntityDescription` on the base.

Credit to @edenhaus for catching this during review of #169310 and pointing toward the right structure, and to @joostlek for the follow-up that we no longer need the Mixin classes once descriptions are `kw_only=True`. Splitting it into its own PR because the typing change touches `button.py` and `camera.py` which are otherwise unrelated to that PR's scope (binary sensors).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (31 passed)
- [x] mypy passes
- [x] There is no commented out code in this PR