### PR TITLE
Add board detection to Duco config flow

### DIFF
--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from duco import DucoClient, build_ssl_context
+from duco import BoardFamily, DucoClient, async_detect_board_family, build_ssl_context
 from duco.exceptions import DucoConnectionError, DucoError
 import voluptuous as vol
 
@@ -17,6 +17,11 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _UnsupportedBoardError(DucoError):
+    """Raised when the detected board family is not supported by this integration."""
+
 
 STEP_USER_SCHEMA = vol.Schema(
     {
@@ -45,6 +50,12 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             box_name, _ = await self._validate_input(discovery_info.ip)
         except DucoConnectionError:
             return self.async_abort(reason="cannot_connect")
+        except _UnsupportedBoardError:
+            _LOGGER.warning(
+                "Duco device discovered at %s (via DHCP) but its board type is not supported. Only the Connectivity Board (0000-4810) is supported",
+                discovery_info.ip,
+            )
+            return self.async_abort(reason="unsupported_board")
         except DucoError:
             _LOGGER.exception("Unexpected error discovering Duco box via DHCP")
             return self.async_abort(reason="unknown")
@@ -63,6 +74,12 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             box_name, mac = await self._validate_input(discovery_info.host)
         except DucoConnectionError:
             return self.async_abort(reason="cannot_connect")
+        except _UnsupportedBoardError:
+            _LOGGER.warning(
+                "Duco device discovered at %s (via zeroconf) but its board type is not supported. Only the Connectivity Board (0000-4810) is supported",
+                discovery_info.host,
+            )
+            return self.async_abort(reason="unsupported_board")
         except DucoError:
             _LOGGER.exception("Unexpected error discovering Duco box via zeroconf")
             return self.async_abort(reason="unknown")
@@ -104,6 +121,8 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
                 box_name, mac = await self._validate_input(user_input[CONF_HOST])
             except DucoConnectionError:
                 errors["base"] = "cannot_connect"
+            except _UnsupportedBoardError:
+                errors["base"] = "unsupported_board"
             except DucoError:
                 _LOGGER.exception("Unexpected error connecting to Duco box")
                 errors["base"] = "unknown"
@@ -135,6 +154,8 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
                 box_name, mac = await self._validate_input(user_input[CONF_HOST])
             except DucoConnectionError:
                 errors["base"] = "cannot_connect"
+            except _UnsupportedBoardError:
+                errors["base"] = "unsupported_board"
             except DucoError:
                 _LOGGER.exception("Unexpected error connecting to Duco box")
                 errors["base"] = "unknown"
@@ -158,9 +179,17 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
 
         Returns a tuple of (box_name, mac_address).
         """
+        session = async_get_clientsession(self.hass)
         ssl_context = await self.hass.async_add_executor_job(build_ssl_context)
+        board_family = await async_detect_board_family(
+            host=host,
+            session=session,
+            ssl_context=ssl_context,
+        )
+        if board_family is not BoardFamily.CONNECTIVITY_BOARD:
+            raise _UnsupportedBoardError
         client = DucoClient(
-            session=async_get_clientsession(self.hass),
+            session=session,
             host=host,
             ssl_context=ssl_context,
         )

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -6,11 +6,13 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unique_id_mismatch": "The device you entered belongs to a different Duco box.",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unsupported_board": "This device is not supported. Only Duco devices with a Connectivity Board (article 0000-4810) are supported."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unsupported_board": "[%key:component::duco::config::abort::unsupported_board%]"
     },
     "step": {
       "discovery_confirm": {

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 from duco.models import (
     ApiEndpointInfo,
     ApiInfo,
+    BoardFamily,
     BoardInfo,
     DiagComponent,
     DiagStatus,
@@ -200,11 +201,22 @@ def mock_nodes() -> list[Node]:
 
 
 @pytest.fixture
+def mock_detect_board_family() -> Generator[AsyncMock]:
+    """Mock async_detect_board_family returning CONNECTIVITY_BOARD by default."""
+    with patch(
+        "homeassistant.components.duco.config_flow.async_detect_board_family",
+        return_value=BoardFamily.CONNECTIVITY_BOARD,
+    ) as mock_detect:
+        yield mock_detect
+
+
+@pytest.fixture
 def mock_duco_client(
     mock_api_info: ApiInfo,
     mock_board_info: BoardInfo,
     mock_lan_info: LanInfo,
     mock_nodes: list[Node],
+    mock_detect_board_family: AsyncMock,
 ) -> Generator[AsyncMock]:
     """Return a mocked DucoClient used by both the integration and config flow."""
     with (

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -5,7 +5,7 @@ from ssl import SSLContext
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from duco.exceptions import DucoConnectionError, DucoError
-from duco.models import BoardInfo, LanInfo
+from duco.models import BoardFamily, BoardInfo, LanInfo
 import pytest
 
 from homeassistant.components.duco.const import DOMAIN
@@ -469,6 +469,10 @@ async def test_user_flow_builds_ssl_context_in_executor(
             return_value=mock_ssl_context,
         ) as mock_build,
         patch(
+            "homeassistant.components.duco.config_flow.async_detect_board_family",
+            return_value=BoardFamily.CONNECTIVITY_BOARD,
+        ) as mock_detect,
+        patch(
             "homeassistant.components.duco.config_flow.DucoClient",
             autospec=True,
         ) as mock_client_class,
@@ -486,8 +490,112 @@ async def test_user_flow_builds_ssl_context_in_executor(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     mock_build.assert_called_once()
+    mock_detect.assert_called_once_with(
+        host=TEST_HOST,
+        session=ANY,
+        ssl_context=mock_ssl_context,
+    )
     mock_client_class.assert_called_once_with(
         session=ANY,
         host=TEST_HOST,
         ssl_context=mock_ssl_context,
     )
+
+
+async def test_user_flow_unsupported_board(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_detect_board_family: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test user flow shows unsupported_board error for Communication and Print Board and recovers."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    mock_detect_board_family.return_value = BoardFamily.COMMUNICATION_PRINT
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "unsupported_board"}
+
+    mock_detect_board_family.return_value = BoardFamily.CONNECTIVITY_BOARD
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == TEST_MAC
+
+
+async def test_zeroconf_discovery_unsupported_board(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_detect_board_family: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test zeroconf discovery aborts for Communication and Print Board."""
+    mock_detect_board_family.return_value = BoardFamily.COMMUNICATION_PRINT
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unsupported_board"
+    assert "Duco device discovered at 192.168.1.100 (via zeroconf)" in caplog.text
+
+
+async def test_dhcp_discovery_unsupported_board(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_detect_board_family: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test DHCP discovery aborts for Communication and Print Board."""
+    mock_detect_board_family.return_value = BoardFamily.COMMUNICATION_PRINT
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DHCP_DISCOVERY,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unsupported_board"
+    assert "Duco device discovered at 192.168.1.100 (via DHCP)" in caplog.text
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_unsupported_board(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_detect_board_family: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow shows unsupported_board error for Communication and Print Board and recovers."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_detect_board_family.return_value = BoardFamily.COMMUNICATION_PRINT
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.50"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": "unsupported_board"}
+
+    mock_detect_board_family.return_value = BoardFamily.CONNECTIVITY_BOARD
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.200"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"


### PR DESCRIPTION
## Proposed change

Before setting up a Duco device, the config flow now calls `async_detect_board_family` (from `python-duco-client`) to verify that the device runs a Connectivity Board (0000-4810). If a different board family is detected, setup is aborted with a clear `unsupported_board` error instead of proceeding to create an unusable config entry.

The same guard is applied in all three entry points: the manual user flow, the DHCP discovery flow, and the Zeroconf discovery flow.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
