### PR TITLE
prusalink: expose printer location as suggested_area

### DIFF
--- a/homeassistant/components/prusalink/entity.py
+++ b/homeassistant/components/prusalink/entity.py
@@ -25,4 +25,5 @@ class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):
             serial_number=info_data.get("serial"),
             sw_version=version_data.get("firmware"),
             configuration_url=self.coordinator.api.client.host,
+            suggested_area=info_data.get("location"),
         )

--- a/homeassistant/components/prusalink/icons.json
+++ b/homeassistant/components/prusalink/icons.json
@@ -15,9 +15,6 @@
       "filename": {
         "default": "mdi:file-image-outline"
       },
-      "location": {
-        "default": "mdi:map-marker"
-      },
       "material": {
         "default": "mdi:palette-swatch-variant"
       },

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -216,13 +216,6 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
             entity_registry_enabled_default=False,
         ),
         PrusaLinkSensorEntityDescription[PrinterInfo](
-            key="info.location",
-            translation_key="location",
-            value_fn=lambda data: cast(str, data["location"]),
-            supported_fn=lambda data: data.get("location") is not None,
-            entity_registry_enabled_default=False,
-        ),
-        PrusaLinkSensorEntityDescription[PrinterInfo](
             key="info.min_extrusion_temp",
             translation_key="min_extrusion_temp",
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,

--- a/homeassistant/components/prusalink/strings.json
+++ b/homeassistant/components/prusalink/strings.json
@@ -54,9 +54,6 @@
       "heatbed_temperature": {
         "name": "Heatbed temperature"
       },
-      "location": {
-        "name": "Location"
-      },
       "material": {
         "name": "Material"
       },

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -12,7 +12,11 @@ from homeassistant.components.prusalink.config_flow import ConfigFlow
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, issue_registry as ir
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    issue_registry as ir,
+)
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -24,8 +28,9 @@ async def test_device_info(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
 ) -> None:
-    """Test device info is populated with serial number and firmware version."""
+    """Test device info is populated with serial number, firmware, and suggested area."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     device = device_registry.async_get_device(
@@ -34,6 +39,13 @@ async def test_device_info(
     assert device is not None
     assert device.serial_number == "serial-1337"
     assert device.sw_version == "6.1.2+11023"
+
+    # `location` from /api/v1/info is set as suggested_area; the device gets
+    # placed in that area (created on the fly when not pre-existing).
+    assert device.area_id is not None
+    area = area_registry.async_get_area(device.area_id)
+    assert area is not None
+    assert area.name == "Workshop"
 
 
 async def test_unloading(

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -335,15 +335,11 @@ async def test_axis_x_y_not_created_when_absent(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_location_and_min_extrusion_temp_sensors(
+async def test_min_extrusion_temp_sensor(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
 ) -> None:
-    """Test location and minimum extrusion temperature sensors from info endpoint."""
+    """Test minimum extrusion temperature sensor from info endpoint."""
     assert await async_setup_component(hass, "prusalink", {})
-
-    state = hass.states.get("sensor.mock_title_location")
-    assert state is not None
-    assert state.state == "Workshop"
 
     state = hass.states.get("sensor.mock_title_minimum_extrusion_temperature")
     assert state is not None
@@ -354,16 +350,14 @@ async def test_location_and_min_extrusion_temp_sensors(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_location_and_min_extrusion_temp_not_created_when_absent(
+async def test_min_extrusion_temp_not_created_when_absent(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_api: None,
     mock_info_api: dict[str, Any],
 ) -> None:
-    """Location and min extrusion temp sensors are not created when info fields are absent."""
-    del mock_info_api["location"]
+    """Min extrusion temp sensor is not created when the info field is absent."""
     del mock_info_api["min_extrusion_temp"]
     assert await async_setup_component(hass, "prusalink", {})
 
-    assert hass.states.get("sensor.mock_title_location") is None
     assert hass.states.get("sensor.mock_title_minimum_extrusion_temperature") is None


### PR DESCRIPTION
## Proposed change

Per @joostlek's review feedback on #169312: the printer's `location` field from `/api/v1/info` is a physical placement hint (e.g. "Workshop", "Garage"), which maps semantically to HA's `suggested_area` on `DeviceInfo` rather than to a sensor entity.

- Drop the `location` sensor entity (and its `strings.json` / `icons.json` entries)
- Set `suggested_area=info_data.get("location")` on `DeviceInfo` in `PrusaLinkEntity`, so the printer's configured location is used as a hint when the device is registered

### Why this is safe

- **Existing setups are unaffected.** `suggested_area` only influences a device's area at registration time; once the device exists, HA does not re-assign the area based on this value. Users who already configured an area for their printer keep that assignment.
- **New users get a sensible default.** The location string is proposed as an area on registration; HA matches an existing area by name or creates a new one.
- **Breaking impact of the sensor removal is small.** The sensor was added in #169312 (just merged), was default-disabled, and few users will have enabled it.

### Note for reviewers about `suggested_area` and the upcoming deprecation

`DeviceEntry.suggested_area` (reading from the registry) [is being deprecated and will be removed in HA Core 2026.9](https://developers.home-assistant.io/blog/2025/08/01/suggested-area-removed-from-deviceentry/). However, the blog post explicitly notes: *"Setting `suggested_area` in `DeviceInfo`, and passing `suggested_area` to `DeviceRegistry.async_get_or_create` is still supported and influences the area of created devices, although that may change in the future."* This PR uses the supported writing path; if HA introduces a different mechanism later, we'll adapt.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (31 passed)
- [x] mypy passes
- [x] There is no commented out code in this PR