### PR TITLE
Add active mode sensor for ViCare FloorHeating devices

### DIFF
--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -8,6 +8,7 @@ from typing import override
 
 from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
+from PyViCare.PyViCareFloorHeating import FloorHeating
 from PyViCare.PyViCareHeatingDevice import (
     HeatingDeviceWithComponent as PyViCareHeatingDeviceComponent,
 )
@@ -91,6 +92,18 @@ class ViCareSensorEntityDescription(SensorEntityDescription, ViCareRequiredKeysM
     """Describes ViCare sensor entity."""
 
     unit_getter: Callable[[PyViCareDevice], str | None] | None = None
+
+
+def _floor_heating_active_mode(api: PyViCareDevice) -> str:
+    """Return active mode for FloorHeating devices only.
+
+    The bare ``getActiveMode()`` name is shared with ``VentilationDevice`` (where
+    it is a deprecated alias for ``getActiveVentilationMode``); restricting by
+    instance type prevents a duplicate entity on ventilation hardware.
+    """
+    if not isinstance(api, FloorHeating):
+        raise PyViCareNotSupportedFeatureError("active_mode")
+    return api.getActiveMode()
 
 
 SUPPLY_TEMPERATURE_SENSOR: ViCareSensorEntityDescription = (
@@ -1153,6 +1166,13 @@ GLOBAL_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         value_getter=lambda api: api.getValvePosition(),
         entity_registry_enabled_default=False,
+    ),
+    ViCareSensorEntityDescription(
+        key="active_mode",
+        translation_key="active_mode",
+        device_class=SensorDeviceClass.ENUM,
+        options=["cooling", "heating", "standby"],
+        value_getter=_floor_heating_active_mode,
     ),
     ViCareSensorEntityDescription(
         key="fuel_need",

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -94,18 +94,6 @@ class ViCareSensorEntityDescription(SensorEntityDescription, ViCareRequiredKeysM
     unit_getter: Callable[[PyViCareDevice], str | None] | None = None
 
 
-def _floor_heating_active_mode(api: PyViCareDevice) -> str:
-    """Return active mode for FloorHeating devices only.
-
-    The bare ``getActiveMode()`` name is shared with ``VentilationDevice`` (where
-    it is a deprecated alias for ``getActiveVentilationMode``); restricting by
-    instance type prevents a duplicate entity on ventilation hardware.
-    """
-    if not isinstance(api, FloorHeating):
-        raise PyViCareNotSupportedFeatureError("active_mode")
-    return api.getActiveMode()
-
-
 SUPPLY_TEMPERATURE_SENSOR: ViCareSensorEntityDescription = (
     ViCareSensorEntityDescription(
         key="supply_temperature",
@@ -1168,13 +1156,6 @@ GLOBAL_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
     ),
     ViCareSensorEntityDescription(
-        key="active_mode",
-        translation_key="active_mode",
-        device_class=SensorDeviceClass.ENUM,
-        options=["cooling", "heating", "standby"],
-        value_getter=_floor_heating_active_mode,
-    ),
-    ViCareSensorEntityDescription(
         key="fuel_need",
         translation_key="fuel_need",
         state_class=SensorStateClass.MEASUREMENT,
@@ -1292,6 +1273,16 @@ GLOBAL_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
 
 CIRCUIT_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
     SUPPLY_TEMPERATURE_SENSOR,
+)
+
+FLOOR_HEATING_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
+    ViCareSensorEntityDescription(
+        key="active_mode",
+        translation_key="active_mode",
+        device_class=SensorDeviceClass.ENUM,
+        options=["cooling", "heating", "standby"],
+        value_getter=lambda api: api.getActiveMode(),
+    ),
 )
 
 BURNER_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
@@ -1529,6 +1520,18 @@ def _build_entities(
             for description in GLOBAL_SENSORS
             if is_supported(description.key, description.value_getter, device.api)
         )
+        # add device-class-specific entities
+        if isinstance(device.api, FloorHeating):
+            entities.extend(
+                ViCareSensor(
+                    description,
+                    get_device_serial(device.api),
+                    device.config,
+                    device.api,
+                )
+                for description in FLOOR_HEATING_SENSORS
+                if is_supported(description.key, description.value_getter, device.api)
+            )
         # add component entities
         for component_list, entity_description_list in (
             (get_circuits(device.api), CIRCUIT_SENSORS),

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -162,7 +162,7 @@
     },
     "sensor": {
       "active_mode": {
-        "name": "Active mode",
+        "name": "Mode",
         "state": {
           "cooling": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::cooling%]",
           "heating": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::heating%]",

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -161,6 +161,14 @@
       }
     },
     "sensor": {
+      "active_mode": {
+        "name": "Active mode",
+        "state": {
+          "cooling": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::cooling%]",
+          "heating": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::heating%]",
+          "standby": "[%key:common::state::standby%]"
+        }
+      },
       "boiler_supply_temperature": {
         "name": "Boiler supply temperature"
       },

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -164,8 +164,8 @@
       "active_mode": {
         "name": "Mode",
         "state": {
-          "cooling": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::cooling%]",
-          "heating": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::heating%]",
+          "cooling": "Cooling",
+          "heating": "Heating",
           "standby": "[%key:common::state::standby%]"
         }
       },

--- a/tests/components/vicare/snapshots/test_sensor.ambr
+++ b/tests/components/vicare/snapshots/test_sensor.ambr
@@ -1218,7 +1218,7 @@
     'state': '46',
   })
 # ---
-# name: test_all_entities[sensor.model11_active_mode-entry]
+# name: test_all_entities[sensor.model11_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1238,7 +1238,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.model11_active_mode',
+    'entity_id': 'sensor.model11_mode',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1246,12 +1246,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Active mode',
+    'object_id_base': 'Mode',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
-    'original_name': 'Active mode',
+    'original_name': 'Mode',
     'platform': 'vicare',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1261,11 +1261,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.model11_active_mode-state]
+# name: test_all_entities[sensor.model11_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
-      'friendly_name': 'model11 Active mode',
+      'friendly_name': 'model11 Mode',
       'options': list([
         'cooling',
         'heating',
@@ -1273,7 +1273,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.model11_active_mode',
+    'entity_id': 'sensor.model11_mode',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/vicare/snapshots/test_sensor.ambr
+++ b/tests/components/vicare/snapshots/test_sensor.ambr
@@ -1218,6 +1218,68 @@
     'state': '46',
   })
 # ---
+# name: test_all_entities[sensor.model11_active_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'cooling',
+        'heating',
+        'standby',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.model11_active_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active mode',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Active mode',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'active_mode',
+    'unique_id': 'gateway11_zigbee_################-active_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model11_active_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'model11 Active mode',
+      'options': list([
+        'cooling',
+        'heating',
+        'standby',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model11_active_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heating',
+  })
+# ---
 # name: test_all_entities[sensor.model11_signal_strength-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/vicare/snapshots/test_sensor.ambr
+++ b/tests/components/vicare/snapshots/test_sensor.ambr
@@ -1225,7 +1225,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cooling',
         'heating',
         'standby',
@@ -1264,9 +1264,9 @@
 # name: test_all_entities[sensor.model11_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'enum',
-      'friendly_name': 'model11 Mode',
-      'options': list([
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'model11 Mode',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cooling',
         'heating',
         'standby',


### PR DESCRIPTION
## Breaking change

<!-- Note: Remove this section if this PR is NOT a breaking change. -->


## Proposed change

Add an `active_mode` ENUM sensor entity (cooling / heating / standby) for ViCare `FloorHeating` Main devices. The state comes from `FloorHeating.getActiveMode()` (already in PyViCare), which returns the current operating mode of the floor-heating master controller.

Why: users with floor-heating systems currently see the FloorHeating Main device in HA but no indication whether it's actively heating, cooling, or idle, even though the Viessmann API exposes that state.

Implementation note: `getActiveMode()` is also a deprecated alias on `VentilationDevice` (where it returns ventilation modes like "ventilation" that aren't valid for the floor-heating ENUM). The `value_getter` therefore restricts itself to `FloorHeating` instances via `isinstance()` and raises `PyViCareNotSupportedFeatureError` for non-FloorHeating devices, so the integration's standard `is_supported` filter only creates the entity on FloorHeating Main devices.

Snapshot tests confirm only the FloorHeating Main fixture (`model11`) gets the entity. No PyViCare changes, no library bump.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr