### PR TITLE
Bump pyprusalink to 2.2.0

### DIFF
--- a/homeassistant/components/prusalink/manifest.json
+++ b/homeassistant/components/prusalink/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/prusalink",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["pyprusalink==2.1.1"]
+  "requirements": ["pyprusalink==2.2.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2440,7 +2440,7 @@ pyprof2calltree==1.4.5
 pyprosegur==0.0.14
 
 # homeassistant.components.prusalink
-pyprusalink==2.1.1
+pyprusalink==2.2.0
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2096,7 +2096,7 @@ pyprof2calltree==1.4.5
 pyprosegur==0.0.14
 
 # homeassistant.components.prusalink
-pyprusalink==2.1.1
+pyprusalink==2.2.0
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.3.1


### PR DESCRIPTION
## Proposed change

Bumps the `pyprusalink` requirement from `2.1.1` to `2.2.0`. The 2.2.0 release is purely additive — new types (`Storage`, `Transfer`, fixed `VersionInfo` to use `NotRequired`) and new methods (`continue_job`, `get_storage`, `get_transfer`, `cancel_transfer`). No breaking changes.

The release [is on PyPI](https://pypi.org/project/pyprusalink/2.2.0/) and bundles the following merged PRs:
- home-assistant-libs/pyprusalink#156 — `continue_job`
- home-assistant-libs/pyprusalink#157 — integration tests
- home-assistant-libs/pyprusalink#158 — extended status (`StatusJob`, `StatusStorage`)
- home-assistant-libs/pyprusalink#159 — `get_storage` / `Storage`
- home-assistant-libs/pyprusalink#160 — `get_transfer` / `cancel_transfer` / `Transfer`
- home-assistant-libs/pyprusalink#165 — `VersionInfo` types (use `NotRequired`)
- home-assistant-libs/pyprusalink#166 — consolidate test deps

This unblocks follow-up PRs to the integration that need the new methods (continue-job button, storage sensors, transfer sensor).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (31 passed)
- [x] Lint (ruff), mypy, and hassfest all pass
- [x] There is no commented out code in this PR