### PR TITLE
Skip offline devices instead of aborting ViCare diagnostics

### DIFF
--- a/homeassistant/components/vicare/diagnostics.py
+++ b/homeassistant/components/vicare/diagnostics.py
@@ -3,6 +3,8 @@
 import json
 from typing import Any
 
+from PyViCare.PyViCareUtils import PyViCareDeviceCommunicationError
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
@@ -30,11 +32,26 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
 
     def dump_devices() -> list[dict[str, Any]]:
-        """Dump devices."""
-        return [
-            json.loads(device.dump_secure())
-            for device in entry.runtime_data.client.all_devices
-        ]
+        """Dump devices, tolerating per-device communication failures."""
+        devices: list[dict[str, Any]] = []
+        for device in entry.runtime_data.client.all_devices:
+            try:
+                devices.append(json.loads(device.dump_secure()))
+            except PyViCareDeviceCommunicationError as err:
+                # One offline gateway must not abort the whole diagnostics dump.
+                devices.append(
+                    {
+                        "device": {
+                            "id": device.device_id,
+                            "modelId": device.device_model,
+                            "type": device.device_type,
+                            "status": device.status,
+                            "roles": device.roles,
+                        },
+                        "error": f"{type(err).__name__}: {err}",
+                    }
+                )
+        return devices
 
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),

--- a/tests/components/vicare/test_diagnostics.py
+++ b/tests/components/vicare/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+from PyViCare.PyViCareUtils import PyViCareDeviceCommunicationError
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
@@ -23,3 +24,30 @@ async def test_diagnostics(
     )
 
     assert diag == snapshot(exclude=props("created_at", "modified_at"))
+
+
+async def test_diagnostics_with_offline_device(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_vicare_gas_boiler: MagicMock,
+) -> None:
+    """Test that an offline gateway on one device does not abort diagnostics."""
+    config_entry = hass.config_entries.async_entries("vicare")[0]
+    devices = config_entry.runtime_data.client.all_devices
+
+    # Force the first device to fail with GATEWAY_OFFLINE; the rest must still dump.
+    devices[0].dump_secure = MagicMock(
+        side_effect=PyViCareDeviceCommunicationError(
+            {"extendedPayload": {"reason": "GATEWAY_OFFLINE"}}
+        )
+    )
+
+    diag = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_vicare_gas_boiler
+    )
+
+    assert len(diag["data"]) == len(devices)
+    error_entry = diag["data"][0]
+    assert "error" in error_entry
+    assert "GATEWAY_OFFLINE" in error_entry["error"]
+    assert error_entry["device"]["id"] == devices[0].device_id


### PR DESCRIPTION
## Breaking change

<!-- Note: Remove this section if this PR is NOT a breaking change. -->


## Proposed change

A single ViCare device whose gateway is offline raises `PyViCareDeviceCommunicationError` from `dump_secure()` and aborts the entire diagnostics download with a 500, hiding all the other devices in the same install. This makes the diagnostics endpoint useless exactly in the situations where users (or the integration's maintainers) most need to inspect the configuration.

This PR wraps each device dump in `try/except`. On `PyViCareDeviceCommunicationError` the entry falls back to the locally-known device metadata (`id`, `modelId`, `type`, `status`, `roles`) plus an `error` field. Healthy devices are unaffected.

Reported by the PyViCare maintainer (running a permanently dead gateway as a deliberate edge-case test rig).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr