### PR TITLE
Add Z-Wave battery low event entity

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -17,6 +17,7 @@ from zwave_js_server.exceptions import (
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.notification import (
+    BatteryNotification,
     EntryControlNotification,
     MultilevelSwitchNotification,
     NotificationNotification,
@@ -79,6 +80,7 @@ from .const import (
     ATTR_STATUS,
     ATTR_TEST_NODE_ID,
     ATTR_TYPE,
+    ATTR_URGENCY,
     ATTR_VALUE,
     ATTR_VALUE_RAW,
     CONF_ADDON_DEVICE,
@@ -965,7 +967,8 @@ class NodeEvents:
 
         driver = self.controller_events.driver_events.driver
         notification: (
-            EntryControlNotification
+            BatteryNotification
+            | EntryControlNotification
             | NotificationNotification
             | PowerLevelNotification
             | MultilevelSwitchNotification
@@ -985,7 +988,15 @@ class NodeEvents:
             ATTR_COMMAND_CLASS: notification.command_class,
         }
 
-        if isinstance(notification, EntryControlNotification):
+        if isinstance(notification, BatteryNotification):
+            event_data.update(
+                {
+                    ATTR_COMMAND_CLASS_NAME: "Battery",
+                    ATTR_EVENT_TYPE: notification.event_type,
+                    ATTR_URGENCY: notification.urgency,
+                }
+            )
+        elif isinstance(notification, EntryControlNotification):
             event_data.update(
                 {
                     ATTR_COMMAND_CLASS_NAME: "Entry Control",

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -828,6 +828,17 @@ class NodeEvents:
                 node,
             )
 
+        # Create a battery low event entity for each non-controller node that
+        # supports the Battery CC.
+        if not node.is_controller_node and any(
+            cc.id == CommandClass.BATTERY.value for cc in node.command_classes
+        ):
+            async_dispatcher_send(
+                self.hass,
+                f"{DOMAIN}_{self.config_entry.entry_id}_add_battery_low_event_entity",
+                node,
+            )
+
         # After ensuring the node is set up in HA, we should check if the node's
         # device config has changed, and if so, issue a repair registry entry for a
         # possible reinterview

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -85,6 +85,7 @@ ATTR_EVENT_TYPE_LABEL = "event_type_label"
 ATTR_DATA_TYPE_LABEL = "data_type_label"
 ATTR_NOTIFICATION_TYPE = "notification_type"
 ATTR_NOTIFICATION_EVENT = "notification_event"
+ATTR_URGENCY = "urgency"
 
 ATTR_NODE = "node"
 ATTR_ZWAVE_VALUE = "zwave_value"

--- a/homeassistant/components/zwave_js/event.py
+++ b/homeassistant/components/zwave_js/event.py
@@ -177,6 +177,13 @@ class ZWaveBatteryLowEventEntity(EventEntity):
             )
         )
         self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{self._base_unique_id}_remove_entity_on_interview_started",
+                self.async_remove,
+            )
+        )
+        self.async_on_remove(
             self.node.on("notification", self._async_handle_notification)
         )
 

--- a/homeassistant/components/zwave_js/event.py
+++ b/homeassistant/components/zwave_js/event.py
@@ -1,8 +1,12 @@
 """Support for Z-Wave controls using the event platform."""
 
 from dataclasses import dataclass
+from typing import Any
 
+from zwave_js_server.const.command_class.battery import BatteryReplacementStatus
 from zwave_js_server.model.driver import Driver
+from zwave_js_server.model.node import Node as ZwaveNode
+from zwave_js_server.model.notification import BatteryNotification
 from zwave_js_server.model.value import Value, ValueNotification
 
 from homeassistant.components.event import (
@@ -10,13 +14,14 @@ from homeassistant.components.event import (
     EventEntity,
     EventEntityDescription,
 )
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import ATTR_VALUE, DOMAIN
+from .const import ATTR_URGENCY, ATTR_VALUE, DOMAIN
 from .entity import NewZwaveDiscoveryInfo, ZWaveBaseEntity
+from .helpers import get_device_info, get_valueless_base_unique_id
 from .models import (
     NewZWaveDiscoverySchema,
     ZwaveJSConfigEntry,
@@ -49,11 +54,26 @@ async def async_setup_entry(
         ]
         async_add_entities(entities)
 
+    @callback
+    def async_add_battery_low_event_entity(node: ZwaveNode) -> None:
+        """Add a battery low event entity for the given node."""
+        driver = client.driver
+        assert driver is not None  # Driver is ready before platforms are loaded.
+        async_add_entities([ZWaveBatteryLowEventEntity(driver, node)])
+
     config_entry.async_on_unload(
         async_dispatcher_connect(
             hass,
             f"{DOMAIN}_{config_entry.entry_id}_add_{EVENT_DOMAIN}",
             async_add_event,
+        )
+    )
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"{DOMAIN}_{config_entry.entry_id}_add_battery_low_event_entity",
+            async_add_battery_low_event_entity,
         )
     )
 
@@ -113,6 +133,53 @@ class ZwaveEventEntity(ZWaveBaseEntity, EventEntity):
                 "value notification",
                 lambda event: self._async_handle_event(event["value_notification"]),
             )
+        )
+
+
+class ZWaveBatteryLowEventEntity(EventEntity):
+    """Representation of a Battery CC battery low event entity."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_event_types = [
+        BatteryReplacementStatus.SOON.name.lower(),
+        BatteryReplacementStatus.NOW.name.lower(),
+    ]
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_translation_key = "battery_low"
+
+    def __init__(self, driver: Driver, node: ZwaveNode) -> None:
+        """Initialize a Battery low event entity."""
+        self.node = node
+        self._base_unique_id = get_valueless_base_unique_id(driver, node)
+        self._attr_unique_id = f"{self._base_unique_id}.battery_low"
+        # device may not be precreated in main handler yet
+        self._attr_device_info = get_device_info(driver, node)
+
+    @callback
+    def _async_handle_notification(self, event: dict[str, Any]) -> None:
+        """Handle a node battery low notification."""
+        if not isinstance(
+            notification := event.get("notification"), BatteryNotification
+        ):
+            return
+        urgency = notification.urgency
+        if urgency is BatteryReplacementStatus.NO:
+            return
+        self._trigger_event(urgency.name.lower(), {ATTR_URGENCY: urgency.value})
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is added."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{self._base_unique_id}_remove_entity",
+                self.async_remove,
+            )
+        )
+        self.async_on_remove(
+            self.node.on("notification", self._async_handle_notification)
         )
 
 

--- a/homeassistant/components/zwave_js/event.py
+++ b/homeassistant/components/zwave_js/event.py
@@ -164,8 +164,6 @@ class ZWaveBatteryLowEventEntity(EventEntity):
         ):
             return
         urgency = notification.urgency
-        if urgency is BatteryReplacementStatus.NO:
-            return
         self._trigger_event(urgency.name.lower(), {ATTR_URGENCY: urgency.value})
         self.async_write_ha_state()
 

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -228,6 +228,19 @@
         "name": "Ping"
       }
     },
+    "event": {
+      "battery_low": {
+        "name": "Battery low",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "now": "Battery should be replaced now",
+              "soon": "Battery should be replaced soon"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "avg_signal_noise": {
         "name": "Avg. signal noise (channel {channel})"

--- a/tests/components/zwave_js/test_event.py
+++ b/tests/components/zwave_js/test_event.py
@@ -5,13 +5,20 @@ from datetime import timedelta
 from freezegun import freeze_time
 import pytest
 from zwave_js_server.event import Event
+from zwave_js_server.model.node import Node
 
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.components.event import ATTR_EVENT_TYPE
+from homeassistant.components.zwave_js.const import ATTR_URGENCY
+from homeassistant.const import STATE_UNKNOWN, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry
 
 BASIC_EVENT_VALUE_ENTITY = "event.honeywell_in_wall_smart_fan_control_event_value"
 CENTRAL_SCENE_ENTITY = "event.node_51_scene_002"
+BATTERY_LOW_EVENT_ENTITY = "event.keypad_v2_battery_low"
 
 
 @pytest.fixture
@@ -204,3 +211,124 @@ async def test_central_scene(
         ],
         "value": 1,
     }
+
+
+def _battery_notification_event(node_id: int, urgency: int) -> Event:
+    """Build a Battery CC notification event."""
+    return Event(
+        type="notification",
+        data={
+            "source": "node",
+            "event": "notification",
+            "nodeId": node_id,
+            "endpointIndex": 0,
+            "ccId": 128,  # Battery CC
+            "args": {
+                "eventType": "battery low",
+                "urgency": urgency,
+            },
+        },
+    )
+
+
+async def test_battery_low_event(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client,
+    ring_keypad: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test the Battery CC battery low event entity."""
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes["event_types"] == ["soon", "now"]
+
+    entity_entry = entity_registry.async_get(BATTERY_LOW_EVENT_ENTITY)
+    assert entity_entry
+    assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
+    assert entity_entry.translation_key == "battery_low"
+    assert entity_entry.unique_id.endswith(".battery_low")
+
+    fut = dt_util.now() + timedelta(minutes=1)
+    with freeze_time(fut):
+        ring_keypad.receive_event(
+            _battery_notification_event(ring_keypad.node_id, urgency=1)
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == dt_util.as_utc(fut).isoformat(timespec="milliseconds")
+    assert state.attributes[ATTR_EVENT_TYPE] == "soon"
+    assert state.attributes[ATTR_URGENCY] == 1
+
+    fut2 = fut + timedelta(hours=2)
+    with freeze_time(fut2):
+        ring_keypad.receive_event(
+            _battery_notification_event(ring_keypad.node_id, urgency=2)
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == dt_util.as_utc(fut2).isoformat(timespec="milliseconds")
+    assert state.attributes[ATTR_EVENT_TYPE] == "now"
+    assert state.attributes[ATTR_URGENCY] == 2
+
+
+async def test_battery_low_event_no_urgency_ignored(
+    hass: HomeAssistant,
+    client,
+    ring_keypad: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test that urgency=NO does not trigger the battery low event entity."""
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    ring_keypad.receive_event(
+        _battery_notification_event(ring_keypad.node_id, urgency=0)
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_battery_low_event_other_notifications_ignored(
+    hass: HomeAssistant,
+    client,
+    ring_keypad: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test that non-Battery CC notifications do not trigger the entity."""
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    # Notification CC (113) should be ignored by the battery low entity
+    other_event = Event(
+        type="notification",
+        data={
+            "source": "node",
+            "event": "notification",
+            "nodeId": ring_keypad.node_id,
+            "endpointIndex": 0,
+            "ccId": 113,
+            "args": {
+                "type": 7,
+                "label": "Home Security",
+                "event": 3,
+                "eventLabel": "Tampering, product cover removed",
+            },
+        },
+    )
+    ring_keypad.receive_event(other_event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/zwave_js/test_event.py
+++ b/tests/components/zwave_js/test_event.py
@@ -10,7 +10,12 @@ from zwave_js_server.model.node import Node
 
 from homeassistant.components.event import ATTR_EVENT_TYPE
 from homeassistant.components.zwave_js.const import ATTR_URGENCY
-from homeassistant.const import STATE_UNKNOWN, EntityCategory, Platform
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
@@ -312,3 +317,31 @@ async def test_battery_low_event_other_notifications_ignored(
     state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
     assert state
     assert state.state == STATE_UNKNOWN
+
+
+async def test_battery_low_event_removed_on_interview_started(
+    hass: HomeAssistant,
+    client: MagicMock,
+    ring_keypad: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test the entity is removed when the node starts a reinterview."""
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    ring_keypad.receive_event(
+        Event(
+            type="interview started",
+            data={
+                "source": "node",
+                "event": "interview started",
+                "nodeId": ring_keypad.node_id,
+            },
+        )
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
+    assert state
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/zwave_js/test_event.py
+++ b/tests/components/zwave_js/test_event.py
@@ -1,6 +1,7 @@
 """Test the Z-Wave JS event platform."""
 
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 from freezegun import freeze_time
 import pytest
@@ -234,7 +235,7 @@ def _battery_notification_event(node_id: int, urgency: int) -> Event:
 async def test_battery_low_event(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    client,
+    client: MagicMock,
     ring_keypad: Node,
     integration: MockConfigEntry,
 ) -> None:
@@ -279,7 +280,7 @@ async def test_battery_low_event(
 
 async def test_battery_low_event_other_notifications_ignored(
     hass: HomeAssistant,
-    client,
+    client: MagicMock,
     ring_keypad: Node,
     integration: MockConfigEntry,
 ) -> None:

--- a/tests/components/zwave_js/test_event.py
+++ b/tests/components/zwave_js/test_event.py
@@ -277,27 +277,6 @@ async def test_battery_low_event(
     assert state.attributes[ATTR_URGENCY] == 2
 
 
-async def test_battery_low_event_no_urgency_ignored(
-    hass: HomeAssistant,
-    client,
-    ring_keypad: Node,
-    integration: MockConfigEntry,
-) -> None:
-    """Test that urgency=NO does not trigger the battery low event entity."""
-    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
-    assert state
-    assert state.state == STATE_UNKNOWN
-
-    ring_keypad.receive_event(
-        _battery_notification_event(ring_keypad.node_id, urgency=0)
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(BATTERY_LOW_EVENT_ENTITY)
-    assert state
-    assert state.state == STATE_UNKNOWN
-
-
 async def test_battery_low_event_other_notifications_ignored(
     hass: HomeAssistant,
     client,

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -1,15 +1,16 @@
 """Test Z-Wave JS events."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
+from zwave_js_server.model.node import Node
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from tests.common import async_capture_events
+from tests.common import MockConfigEntry, async_capture_events
 
 
 @pytest.fixture
@@ -354,6 +355,43 @@ async def test_power_level_notification(
     assert events[0].data["test_node_id"] == 1
     assert events[0].data["status"] == 0
     assert events[0].data["acknowledged_frames"] == 2
+
+
+async def test_battery_notification(
+    hass: HomeAssistant,
+    hank_binary_switch: Node,
+    integration: MockConfigEntry,
+    client: MagicMock,
+) -> None:
+    """Test Battery CC notification bus events."""
+    # just pick a random node to fake the notification event
+    node = hank_binary_switch
+    events = async_capture_events(hass, "zwave_js_notification")
+
+    event = Event(
+        type="notification",
+        data={
+            "source": "node",
+            "event": "notification",
+            "nodeId": 32,
+            "endpointIndex": 0,
+            "ccId": 128,
+            "args": {
+                "eventType": "battery low",
+                "urgency": 1,
+            },
+        },
+    )
+    node.receive_event(event)
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["home_id"] == client.driver.controller.home_id
+    assert events[0].data["node_id"] == 32
+    assert events[0].data["endpoint"] == 0
+    assert events[0].data["command_class"] == CommandClass.BATTERY
+    assert events[0].data["command_class_name"] == "Battery"
+    assert events[0].data["event_type"] == "battery low"
+    assert events[0].data["urgency"] == 1
 
 
 async def test_unknown_notification(


### PR DESCRIPTION
**DRAFT + untested**; Read the paragraph below.

## Proposed change

This adds a new "Battery low" event entity for every Z-Wave node with the Battery CC. It triggers when a "Battery low" notification is sent. Unfortunately, I don't think this can currently be implemented in a clean way using the existing discovery schemas, as these notifications are not value-based, so the approach is similar to the node-based firmware update entities.

I'd really appreciate any suggestions or feedback here, or whether this approach is generally ok.


### AI summary

Adds an event entity to the Z-Wave integration that fires when a node sends a Battery CC "battery low" notification, and forwards the same notification to the existing `zwave_js_notification` bus event so it can be used in automation triggers.

Background:
- [zwave-js#7984](https://github.com/zwave-js/zwave-js/pull/7984) reworked Battery CC battery low handling. Instead of persisting a stale stateful `isLow` value, Z-Wave JS now emits a node-level `notification` event with `eventType: "battery low"` and an `urgency` field (`Soon` / `Now`).
- [zwave-js-server-python#1365](https://github.com/home-assistant-libs/zwave-js-server-python/pull/1365) added the `BatteryNotification` model and a `BatteryReplacementStatus` enum so HA can consume this directly.

This PR builds on those upstream changes:

- Adds `ZWaveBatteryLowEventEntity`, a diagnostic event entity created per non-controller node that supports the Battery CC. Wired up via the same dispatcher signal pattern used for other node-level entities (`ZWaveFirmwareUpdateEntity`, `ZWaveNodePingButton`, `ZWaveNodeStatusSensor`, …).
  - `event_types` are `soon` and `now`, matching the urgency levels actually emitted upstream.
  - Each Battery CC notification triggers the entity with `event_type` set to the urgency name and `urgency` (the integer value) exposed as a state attribute.
- Forwards `BatteryNotification` through the existing `async_on_notification` handler so the `zwave_js_notification` bus event also fires for Battery CC, with `command_class_name: "Battery"`, `event_type` ("battery low") and `urgency`. New `ATTR_URGENCY` constant.
- Adds translations for the new entity and the urgency states.
- Adds tests covering entity creation, both urgency levels, that non-Battery notifications are ignored, that the entity is removed on reinterview, and that the Battery CC notification is forwarded on the `zwave_js_notification` bus event.

Notes:

- The existing `(CommandClass.BATTERY, "isLow")` binary sensor mapping is kept for now, as older Z-Wave JS versions expose `isLow`.
  - Note: The Z-Wave JS version shipped with the official addon removed this a long time ago, so we can probably just remove it in a follow-up PR.
- One entity per node (not per endpoint). Battery CC is in practice on the root endpoint; the entity reacts to whichever endpoint emits the notification.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/135
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
