### PR TITLE
Sanitize MeteoAlarm alert attributes before restore-state saves

### DIFF
--- a/homeassistant/components/meteoalarm/binary_sensor.py
+++ b/homeassistant/components/meteoalarm/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import Any
 
 from meteoalertapi import Meteoalert
 import voluptuous as vol
@@ -38,6 +39,22 @@ PLATFORM_SCHEMA = BINARY_SENSOR_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
+
+
+def _sanitize_alert_data(value: Any) -> Any:
+    """Sanitize alert payload data for JSON serialization."""
+    if isinstance(value, str):
+        return value.encode("utf-8", "ignore").decode("utf-8")
+    if isinstance(value, dict):
+        return {
+            _sanitize_alert_data(key): _sanitize_alert_data(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize_alert_data(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_alert_data(item) for item in value)
+    return value
 
 
 def setup_platform(
@@ -82,5 +99,5 @@ class MeteoAlertBinarySensor(BinarySensorEntity):
             expiration_date = dt_util.parse_datetime(alert["expires"])
 
             if expiration_date is not None and expiration_date > dt_util.utcnow():
-                self._attr_extra_state_attributes = alert
+                self._attr_extra_state_attributes = _sanitize_alert_data(alert)
                 self._attr_is_on = True

--- a/tests/components/meteoalarm/__init__.py
+++ b/tests/components/meteoalarm/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the MeteoAlarm integration."""

--- a/tests/components/meteoalarm/test_binary_sensor.py
+++ b/tests/components/meteoalarm/test_binary_sensor.py
@@ -1,0 +1,36 @@
+"""Tests for the MeteoAlarm binary sensor."""
+
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.components.meteoalarm.binary_sensor import MeteoAlertBinarySensor
+from homeassistant.core import State
+from homeassistant.util import dt as dt_util
+
+
+class _MockMeteoAlertApi:
+    """Mock MeteoAlert API."""
+
+    def get_alert(self) -> dict[str, Any]:
+        """Return a single active alert."""
+        return {
+            "expires": (dt_util.utcnow() + timedelta(hours=1)).isoformat(),
+            "description": "valid prefix \ud83d valid suffix",
+            "event": "test-event",
+        }
+
+
+def test_meteoalarm_alert_attributes_are_json_serializable() -> None:
+    """Test alert attributes with surrogate characters are JSON serializable."""
+    entity = MeteoAlertBinarySensor(_MockMeteoAlertApi(), "meteoalarm")
+
+    entity.update()
+
+    assert entity.is_on
+    assert entity.extra_state_attributes is not None
+    assert "\ud83d" not in entity.extra_state_attributes["description"]
+    assert "valid prefix " in entity.extra_state_attributes["description"]
+    assert " valid suffix" in entity.extra_state_attributes["description"]
+    assert State(
+        "binary_sensor.meteoalarm", "on", entity.extra_state_attributes
+    ).json_fragment


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

MeteoAlarm alert text can contain invalid surrogate code points. Those values
were passed directly into state attributes, which could make Home Assistant's
restore-state save fail when serializing current states.

This sanitizes MeteoAlarm alert payload strings before publishing them as state
attributes, keeping the remaining alert data available while ensuring the
attributes can be serialized.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170101
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr